### PR TITLE
Use initial received WebSocket state in Bang & Olufsen

### DIFF
--- a/homeassistant/components/bang_olufsen/__init__.py
+++ b/homeassistant/components/bang_olufsen/__init__.py
@@ -73,10 +73,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: BangOlufsenConfigEntry) 
     # Add the websocket and API client
     entry.runtime_data = BangOlufsenData(websocket, client)
 
-    # Start WebSocket connection
-    await client.connect_notifications(remote_control=True, reconnect=True)
-
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Start WebSocket connection once the platforms have been loaded.
+    # This ensures that the initial WebSocket notifications are dispatched to entities
+    await client.connect_notifications(remote_control=True, reconnect=True)
 
     return True
 

--- a/homeassistant/components/bang_olufsen/media_player.py
+++ b/homeassistant/components/bang_olufsen/media_player.py
@@ -125,7 +125,8 @@ async def async_setup_entry(
     async_add_entities(
         new_entities=[
             BangOlufsenMediaPlayer(config_entry, config_entry.runtime_data.client)
-        ]
+        ],
+        update_before_add=True,
     )
 
     # Register actions.
@@ -266,33 +267,7 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
             self._software_status.software_version,
         )
 
-        # Get overall device state once. This is handled by WebSocket events the rest of the time.
-        product_state = await self._client.get_product_state()
-
-        # Get volume information.
-        if product_state.volume:
-            self._volume = product_state.volume
-
-        # Get all playback information.
-        # Ensure that the metadata is not None upon startup
-        if product_state.playback:
-            if product_state.playback.metadata:
-                self._playback_metadata = product_state.playback.metadata
-                self._remote_leader = product_state.playback.metadata.remote_leader
-            if product_state.playback.progress:
-                self._playback_progress = product_state.playback.progress
-            if product_state.playback.source:
-                self._source_change = product_state.playback.source
-            if product_state.playback.state:
-                self._playback_state = product_state.playback.state
-                # Set initial state
-                if self._playback_state.value:
-                    self._state = self._playback_state.value
-
         self._attr_media_position_updated_at = utcnow()
-
-        # Get the highest resolution available of the given images.
-        self._media_image = get_highest_resolution_artwork(self._playback_metadata)
 
         # If the device has been updated with new sources, then the API will fail here.
         await self._async_update_sources()

--- a/tests/components/bang_olufsen/conftest.py
+++ b/tests/components/bang_olufsen/conftest.py
@@ -76,6 +76,39 @@ def mock_config_entry_core() -> MockConfigEntry:
     )
 
 
+async def mock_websocket_connection(
+    hass: HomeAssistant, mock_mozart_client: AsyncMock
+) -> None:
+    """Register and receive initial WebSocket notifications."""
+
+    # Currently only add notifications that are used.
+
+    # Register callbacks.
+    volume_callback = mock_mozart_client.get_volume_notifications.call_args[0][0]
+    source_change_callback = (
+        mock_mozart_client.get_source_change_notifications.call_args[0][0]
+    )
+    playback_state_callback = (
+        mock_mozart_client.get_playback_state_notifications.call_args[0][0]
+    )
+    playback_metadata_callback = (
+        mock_mozart_client.get_playback_metadata_notifications.call_args[0][0]
+    )
+
+    # Trigger callbacks. Try to use existing data
+    volume_callback(mock_mozart_client.get_product_state.return_value.volume)
+    source_change_callback(
+        mock_mozart_client.get_product_state.return_value.playback.source
+    )
+    playback_state_callback(
+        mock_mozart_client.get_product_state.return_value.playback.state
+    )
+    playback_metadata_callback(
+        mock_mozart_client.get_product_state.return_value.playback.metadata
+    )
+    await hass.async_block_till_done()
+
+
 @pytest.fixture(name="integration")
 async def integration_fixture(
     hass: HomeAssistant,
@@ -87,6 +120,8 @@ async def integration_fixture(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
+
+    await mock_websocket_connection(hass, mock_mozart_client)
 
 
 @pytest.fixture

--- a/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
+++ b/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
@@ -64,6 +64,8 @@
           'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
         ]),
         'media_content_type': 'music',
+        'repeat': 'off',
+        'shuffle': False,
         'sound_mode': 'Test Listening Mode (123)',
         'sound_mode_list': list([
           'Test Listening Mode (123)',
@@ -76,9 +78,10 @@
           'HDMI A',
         ]),
         'supported_features': 2095933,
+        'volume_level': 0.0,
       }),
       'entity_id': 'media_player.beosound_balance_11111111',
-      'state': 'playing',
+      'state': 'idle',
     }),
     'websocket_connected': False,
   })

--- a/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
+++ b/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
@@ -78,10 +78,9 @@
           'HDMI A',
         ]),
         'supported_features': 2095933,
-        'volume_level': 0.0,
       }),
       'entity_id': 'media_player.beosound_balance_11111111',
-      'state': 'idle',
+      'state': 'playing',
     }),
     'websocket_connected': False,
   })

--- a/tests/components/bang_olufsen/snapshots/test_media_player.ambr
+++ b/tests/components/bang_olufsen/snapshots/test_media_player.ambr
@@ -47,7 +47,7 @@
     'state': 'playing',
   })
 # ---
-# name: test_async_beolink_expand[all_discovered-True-None-log_messages0-2]
+# name: test_async_beolink_expand[all_discovered-True-None-log_messages0-3]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'beolink': dict({
@@ -96,7 +96,7 @@
     'state': 'playing',
   })
 # ---
-# name: test_async_beolink_expand[all_discovered-True-expand_side_effect1-log_messages1-2]
+# name: test_async_beolink_expand[all_discovered-True-expand_side_effect1-log_messages1-3]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'beolink': dict({
@@ -145,7 +145,7 @@
     'state': 'playing',
   })
 # ---
-# name: test_async_beolink_expand[beolink_jids-parameter_value2-None-log_messages2-1]
+# name: test_async_beolink_expand[beolink_jids-parameter_value2-None-log_messages2-2]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'beolink': dict({
@@ -194,7 +194,7 @@
     'state': 'playing',
   })
 # ---
-# name: test_async_beolink_expand[beolink_jids-parameter_value3-expand_side_effect3-log_messages3-1]
+# name: test_async_beolink_expand[beolink_jids-parameter_value3-expand_side_effect3-log_messages3-2]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'beolink': dict({
@@ -412,6 +412,8 @@
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
       'media_content_type': <MediaType.MUSIC: 'music'>,
+      'repeat': <RepeatMode.OFF: 'off'>,
+      'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
       'sound_mode_list': list([
         'Test Listening Mode (123)',
@@ -458,6 +460,8 @@
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
       'media_content_type': <MediaType.MUSIC: 'music'>,
+      'repeat': <RepeatMode.OFF: 'off'>,
+      'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
       'sound_mode_list': list([
         'Test Listening Mode (123)',
@@ -504,6 +508,8 @@
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
       'media_content_type': <MediaType.MUSIC: 'music'>,
+      'repeat': <RepeatMode.OFF: 'off'>,
+      'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
       'sound_mode_list': list([
         'Test Listening Mode (123)',
@@ -647,6 +653,8 @@
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
       'media_content_type': <MediaType.MUSIC: 'music'>,
+      'repeat': <RepeatMode.OFF: 'off'>,
+      'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
       'sound_mode_list': list([
         'Test Listening Mode (123)',
@@ -659,13 +667,14 @@
         'HDMI A',
       ]),
       'supported_features': <MediaPlayerEntityFeature: 2095933>,
+      'volume_level': 0.0,
     }),
     'context': <ANY>,
     'entity_id': 'media_player.beoconnect_core_22222222',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'playing',
+    'state': 'idle',
   })
 # ---
 # name: test_async_join_players[group_members1-0-1]
@@ -742,6 +751,8 @@
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
       'media_content_type': <MediaType.MUSIC: 'music'>,
+      'repeat': <RepeatMode.OFF: 'off'>,
+      'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
       'sound_mode_list': list([
         'Test Listening Mode (123)',
@@ -754,13 +765,14 @@
         'HDMI A',
       ]),
       'supported_features': <MediaPlayerEntityFeature: 2095933>,
+      'volume_level': 0.0,
     }),
     'context': <ANY>,
     'entity_id': 'media_player.beoconnect_core_22222222',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'playing',
+    'state': 'idle',
   })
 # ---
 # name: test_async_join_players_invalid[source0-group_members0-expected_result0-invalid_source]
@@ -789,6 +801,8 @@
       ]),
       'media_content_type': <MediaType.MUSIC: 'music'>,
       'media_position': 0,
+      'repeat': <RepeatMode.OFF: 'off'>,
+      'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
       'sound_mode_list': list([
         'Test Listening Mode (123)',
@@ -836,6 +850,8 @@
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
       'media_content_type': <MediaType.MUSIC: 'music'>,
+      'repeat': <RepeatMode.OFF: 'off'>,
+      'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
       'sound_mode_list': list([
         'Test Listening Mode (123)',
@@ -848,13 +864,14 @@
         'HDMI A',
       ]),
       'supported_features': <MediaPlayerEntityFeature: 2095933>,
+      'volume_level': 0.0,
     }),
     'context': <ANY>,
     'entity_id': 'media_player.beoconnect_core_22222222',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'playing',
+    'state': 'idle',
   })
 # ---
 # name: test_async_join_players_invalid[source1-group_members1-expected_result1-invalid_grouping_entity]
@@ -882,6 +899,8 @@
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
       'media_content_type': <MediaType.MUSIC: 'music'>,
+      'repeat': <RepeatMode.OFF: 'off'>,
+      'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
       'sound_mode_list': list([
         'Test Listening Mode (123)',
@@ -929,6 +948,8 @@
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
       'media_content_type': <MediaType.MUSIC: 'music'>,
+      'repeat': <RepeatMode.OFF: 'off'>,
+      'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
       'sound_mode_list': list([
         'Test Listening Mode (123)',
@@ -941,13 +962,14 @@
         'HDMI A',
       ]),
       'supported_features': <MediaPlayerEntityFeature: 2095933>,
+      'volume_level': 0.0,
     }),
     'context': <ANY>,
     'entity_id': 'media_player.beoconnect_core_22222222',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'playing',
+    'state': 'idle',
   })
 # ---
 # name: test_async_unjoin_player
@@ -1021,6 +1043,8 @@
         'media_player.beosound_balance_11111111',
       ]),
       'media_content_type': <MediaType.MUSIC: 'music'>,
+      'repeat': <RepeatMode.OFF: 'off'>,
+      'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
       'sound_mode_list': list([
         'Test Listening Mode (123)',
@@ -1067,6 +1091,8 @@
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
       'media_content_type': <MediaType.MUSIC: 'music'>,
+      'repeat': <RepeatMode.OFF: 'off'>,
+      'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
       'sound_mode_list': list([
         'Test Listening Mode (123)',
@@ -1079,12 +1105,13 @@
         'HDMI A',
       ]),
       'supported_features': <MediaPlayerEntityFeature: 2095933>,
+      'volume_level': 0.0,
     }),
     'context': <ANY>,
     'entity_id': 'media_player.beoconnect_core_22222222',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'playing',
+    'state': 'idle',
   })
 # ---

--- a/tests/components/bang_olufsen/test_diagnostics.py
+++ b/tests/components/bang_olufsen/test_diagnostics.py
@@ -5,11 +5,12 @@ from syrupy.filters import props
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
+
+from .const import TEST_BUTTON_EVENT_ENTITY_ID
+
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
-
-from .const import TEST_BUTTON_EVENT_ENTITY_ID
 
 
 async def test_async_get_config_entry_diagnostics(

--- a/tests/components/bang_olufsen/test_diagnostics.py
+++ b/tests/components/bang_olufsen/test_diagnostics.py
@@ -5,12 +5,11 @@ from syrupy.filters import props
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
-
-from .const import TEST_BUTTON_EVENT_ENTITY_ID
-
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
+
+from .const import TEST_BUTTON_EVENT_ENTITY_ID
 
 
 async def test_async_get_config_entry_diagnostics(

--- a/tests/components/bang_olufsen/test_diagnostics.py
+++ b/tests/components/bang_olufsen/test_diagnostics.py
@@ -6,9 +6,10 @@ from syrupy.filters import props
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 
+from .conftest import mock_websocket_connection
 from .const import TEST_BUTTON_EVENT_ENTITY_ID
 
-from tests.common import MockConfigEntry
+from tests.common import AsyncMock, MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
@@ -19,6 +20,7 @@ async def test_async_get_config_entry_diagnostics(
     hass_client: ClientSessionGenerator,
     integration: None,
     mock_config_entry: MockConfigEntry,
+    mock_mozart_client: AsyncMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""
@@ -26,6 +28,9 @@ async def test_async_get_config_entry_diagnostics(
     # Enable an Event entity
     entity_registry.async_update_entity(TEST_BUTTON_EVENT_ENTITY_ID, disabled_by=None)
     hass.config_entries.async_schedule_reload(mock_config_entry.entry_id)
+
+    # Re-trigger WebSocket events after the reload
+    await mock_websocket_connection(hass, mock_mozart_client)
 
     result = await get_diagnostics_for_config_entry(
         hass, hass_client, mock_config_entry

--- a/tests/components/bang_olufsen/test_event.py
+++ b/tests/components/bang_olufsen/test_event.py
@@ -16,6 +16,7 @@ from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 
+from .conftest import mock_websocket_connection
 from .const import TEST_BUTTON_EVENT_ENTITY_ID
 
 from tests.common import MockConfigEntry
@@ -61,6 +62,7 @@ async def test_button_event_creation_beoconnect_core(
     # Load entry
     mock_config_entry_core.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry_core.entry_id)
+    await mock_websocket_connection(hass, mock_mozart_client)
 
     # Check number of entities
     # The media_player entity should be the only available


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This was previously a PR that was marked as stale: https://github.com/home-assistant/core/pull/139249 . This PR is a rebased version of that one that also omits some of the unnecessary testing changes, making fewer overall changes.

The Bang & Olufsen integration relies on a WebSocket listener for most state updates. Once a connection is established, a set of notifications are sent that represent the current state of the device.

Currently these initial notifications are not used, as the connection is established before any entities are ready to receive them.

This PR ensures that platforms are loaded before the WebSocket connection is established. This also means that a REST API call can be removed from the media_player's `_initialize()` method.

The removal of this REST API calls caused testing to break as there was no longer any initial state, so a WebSocket connection mock function was added.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
