### PR TITLE
Add missing content type to backup http endpoint

### DIFF
--- a/homeassistant/components/backup/http.py
+++ b/homeassistant/components/backup/http.py
@@ -8,7 +8,7 @@ import threading
 from typing import IO, cast
 
 from aiohttp import BodyPartReader
-from aiohttp.hdrs import CONTENT_DISPOSITION
+from aiohttp.hdrs import CONTENT_DISPOSITION, CONTENT_TYPE
 from aiohttp.web import FileResponse, Request, Response, StreamResponse
 from multidict import istr
 
@@ -76,7 +76,8 @@ class DownloadBackupView(HomeAssistantView):
             return Response(status=HTTPStatus.NOT_FOUND)
 
         headers = {
-            CONTENT_DISPOSITION: f"attachment; filename={slugify(backup.name)}.tar"
+            CONTENT_DISPOSITION: f"attachment; filename={slugify(backup.name)}.tar",
+            CONTENT_TYPE: "application/x-tar",
         }
 
         try:

--- a/tests/components/backup/test_http.py
+++ b/tests/components/backup/test_http.py
@@ -4,11 +4,13 @@ import asyncio
 from collections.abc import AsyncIterator
 from io import BytesIO, StringIO
 import json
+import re
 import tarfile
 from typing import Any
 from unittest.mock import patch
 
 from aiohttp import web
+from aiohttp.hdrs import CONTENT_DISPOSITION, CONTENT_TYPE
 import pytest
 
 from homeassistant.components.backup import (
@@ -166,10 +168,19 @@ async def _test_downloading_encrypted_backup(
     agent_id: str,
 ) -> None:
     """Test downloading an encrypted backup file."""
+
+    def assert_tar_download_response(resp: web.Response) -> None:
+        assert resp.status == 200
+        assert resp.headers.get(CONTENT_TYPE, "") == "application/x-tar"
+        assert re.match(
+            r"attachment; filename=.*\.tar", resp.headers.get(CONTENT_DISPOSITION, "")
+        )
+
     # Try downloading without supplying a password
     client = await hass_client()
     resp = await client.get(f"/api/backup/download/c0cb53bd?agent_id={agent_id}")
-    assert resp.status == 200
+    assert_tar_download_response(resp)
+
     backup = await resp.read()
     # We expect a valid outer tar file, but the inner tar file is encrypted and
     # can't be read
@@ -187,7 +198,7 @@ async def _test_downloading_encrypted_backup(
     resp = await client.get(
         f"/api/backup/download/c0cb53bd?agent_id={agent_id}&password=wrong"
     )
-    assert resp.status == 200
+    assert_tar_download_response(resp)
     backup = await resp.read()
     # We expect a truncated outer tar file
     with (
@@ -200,7 +211,7 @@ async def _test_downloading_encrypted_backup(
     resp = await client.get(
         f"/api/backup/download/c0cb53bd?agent_id={agent_id}&password=hunter2"
     )
-    assert resp.status == 200
+    assert_tar_download_response(resp)
     backup = await resp.read()
     # We expect a valid outer tar file, the inner tar file is decrypted and can be read
     with (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The http endpoint to download a backup file was only setting up `CONTENT_DISPOSITION` and even if the extension `.tar` is within the disposition the `guesser` in `FileResponse` from `aiohttp` is not able to set the `CONTENT_TYPE` properly and setting it to the default `FALLBACK_CONTENT_TYPE = "application/octet-stream"`.

This is causing the download of a backup file from the Android application to be interpreted as a binary and not a tarball. On android we are also using a guesser `URLUtil.guessFileName(url, contentDisposition, mimetype)` from the webkit library based on the [Rfc6266](https://datatracker.ietf.org/doc/html/rfc6266).

```java
    @NonNull
    private static String guessFileNameRfc6266(
            @NonNull String url, @Nullable String contentDisposition, @Nullable String mimeType) {
        String filename = getFilenameSuggestion(url, contentDisposition);
        // Split filename between base and extension
        // Add an extension if filename does not have one
        String extensionFromMimeType = suggestExtensionFromMimeType(mimeType);

        if (filename.indexOf('.') < 0) {
            // Filename does not have an extension, use the suggested one.
            return filename + extensionFromMimeType;
        }

        // Filename already contains at least one dot.
        // Compare the last segment of the extension against the mime type.
        // If there's a mismatch, add the suggested extension instead.
        if (mimeType != null && extensionDifferentFromMimeType(filename, mimeType)) {
            return filename + extensionFromMimeType;
        }
        return filename;
    }
```

As you can see in the function if the `mimeType` is not the same as the one deduced from the `filename` extracted from the disposition then it uses the one from the mime type. So instead of a `backup.tar` we create a `backup.bin` which is wrong.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
