### PR TITLE
Improve Home Assistant Hardware flow

### DIFF
--- a/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
@@ -103,7 +103,7 @@ class HomeAssistantConnectZBT2ConfigFlow(
 
     VERSION = 1
     MINOR_VERSION = 1
-    BAUDRATE = 460800
+    ZIGBEE_BAUDRATE = 460800
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the config flow."""

--- a/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
@@ -103,6 +103,7 @@ class HomeAssistantConnectZBT2ConfigFlow(
 
     VERSION = 1
     MINOR_VERSION = 1
+    BAUDRATE = 460800
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the config flow."""

--- a/homeassistant/components/homeassistant_connect_zbt2/strings.json
+++ b/homeassistant/components/homeassistant_connect_zbt2/strings.json
@@ -112,6 +112,10 @@
         "menu_options": {
           "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_zigbee%]",
           "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_thread%]"
+        },
+        "menu_option_descriptions": {
+          "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_option_descriptions::pick_firmware_zigbee%]",
+          "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_option_descriptions::pick_firmware_thread%]"
         }
       },
       "confirm_zigbee": {
@@ -133,6 +137,29 @@
       "confirm_otbr": {
         "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::confirm_otbr::title%]",
         "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::confirm_otbr::description%]"
+      },
+      "zigbee_installation_type": {
+        "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::title%]",
+        "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::description%]",
+        "menu_options": {
+          "zigbee_intent_recommended": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_options::zigbee_intent_recommended%]",
+          "zigbee_intent_custom": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_options::zigbee_intent_custom%]"
+        },
+        "menu_option_descriptions": {
+          "zigbee_intent_recommended": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_option_descriptions::zigbee_intent_recommended%]",
+          "zigbee_intent_custom": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_option_descriptions::zigbee_intent_custom%]"
+        }
+      },
+      "zigbee_integration": {
+        "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::title%]",
+        "menu_options": {
+          "zigbee_integration_zha": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_options::zigbee_integration_zha%]",
+          "zigbee_integration_other": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_options::zigbee_integration_other%]"
+        },
+        "menu_option_descriptions": {
+          "zigbee_integration_zha": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_option_descriptions::zigbee_integration_zha%]",
+          "zigbee_integration_other": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_option_descriptions::zigbee_integration_other%]"
+        }
       }
     },
     "abort": {

--- a/homeassistant/components/homeassistant_connect_zbt2/strings.json
+++ b/homeassistant/components/homeassistant_connect_zbt2/strings.json
@@ -52,8 +52,12 @@
         "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::title%]",
         "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::description%]",
         "menu_options": {
-          "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_thread%]",
-          "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_zigbee%]"
+          "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_zigbee%]",
+          "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_thread%]"
+        },
+        "menu_option_descriptions": {
+          "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_option_descriptions::pick_firmware_zigbee%]",
+          "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_option_descriptions::pick_firmware_thread%]"
         }
       },
       "confirm_zigbee": {
@@ -75,6 +79,29 @@
       "confirm_otbr": {
         "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::confirm_otbr::title%]",
         "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::confirm_otbr::description%]"
+      },
+      "zigbee_installation_type": {
+        "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::title%]",
+        "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::description%]",
+        "menu_options": {
+          "zigbee_intent_recommended": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_options::zigbee_intent_recommended%]",
+          "zigbee_intent_custom": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_options::zigbee_intent_custom%]"
+        },
+        "menu_option_descriptions": {
+          "zigbee_intent_recommended": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_option_descriptions::zigbee_intent_recommended%]",
+          "zigbee_intent_custom": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_option_descriptions::zigbee_intent_custom%]"
+        }
+      },
+      "zigbee_integration": {
+        "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::title%]",
+        "menu_options": {
+          "zigbee_integration_zha": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_options::zigbee_integration_zha%]",
+          "zigbee_integration_other": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_options::zigbee_integration_other%]"
+        },
+        "menu_option_descriptions": {
+          "zigbee_integration_zha": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_option_descriptions::zigbee_integration_zha%]",
+          "zigbee_integration_other": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_option_descriptions::zigbee_integration_other%]"
+        }
       }
     },
     "error": {

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -652,7 +652,7 @@ class BaseFirmwareConfigFlow(BaseFirmwareInstallFlow, ConfigFlow):
         next_flow_id = zha_result["flow_id"]
 
         result = self._async_flow_finished()
-        result = (
+        return (
             self.async_create_entry(
                 title=result["title"] or self._hardware_name,
                 data=result["data"],
@@ -660,7 +660,6 @@ class BaseFirmwareConfigFlow(BaseFirmwareInstallFlow, ConfigFlow):
             )
             | result  # update all items with the child result
         )
-        return result
 
 
 class BaseFirmwareOptionsFlow(BaseFirmwareInstallFlow, OptionsFlow):

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -332,19 +332,19 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         return self.async_show_menu(
             step_id="zigbee_integration",
             menu_options=[
-                "zigbee_zha_integration",
-                "zigbee_other_integration",
+                "zigbee_integration_zha",
+                "zigbee_integration_other",
             ],
         )
 
-    async def async_step_zigbee_zha_integration(
+    async def async_step_zigbee_integration_zha(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Select ZHA integration."""
         self._zigbee_integration = ZigbeeIntegration.ZHA
         return await self._async_continue_picked_firmware()
 
-    async def async_step_zigbee_other_integration(
+    async def async_step_zigbee_integration_other(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Select other Zigbee integration."""

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -70,6 +70,7 @@ class ZigbeeIntegration(StrEnum):
 class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
     """Base flow to install firmware."""
 
+    BAUDRATE = 115200  # Default, subclasses may override
     _failed_addon_name: str
     _failed_addon_reason: str
     _picked_firmware_type: PickedFirmwareType
@@ -430,17 +431,15 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         result = await self.hass.config_entries.flow.async_init(
             ZHA_DOMAIN,
             context={"source": "hardware"},
-            data=(
-                {
-                    "name": self._hardware_name,
-                    "port": {
-                        "path": self._device,
-                        "baudrate": 115200,
-                        "flow_control": "hardware",
-                    },
-                    "radio_type": "ezsp",
-                }
-            ),
+            data={
+                "name": self._hardware_name,
+                "port": {
+                    "path": self._device,
+                    "baudrate": self.BAUDRATE,
+                    "flow_control": "hardware",
+                },
+                "radio_type": "ezsp",
+            },
         )
         _LOGGER.debug("ZHA flow result: %s", json.dumps(result))
         return self._continue_zha_flow(result)

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import asyncio
 from enum import StrEnum
-import json
 import logging
 from typing import Any
 
@@ -354,7 +353,6 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
 
     async def _async_continue_picked_firmware(self) -> ConfigFlowResult:
         """Continue to the picked firmware step."""
-        _LOGGER.debug("Probing all firmwares for: %s", self._picked_firmware_type)
         if not await self._probe_firmware_info():
             return self.async_abort(
                 reason="unsupported_firmware",
@@ -362,7 +360,6 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
             )
 
         if self._picked_firmware_type == PickedFirmwareType.ZIGBEE:
-            _LOGGER.debug("Installing firmware for: %s", self._picked_firmware_type)
             return await self.async_step_install_zigbee_firmware()
 
         if result := await self._ensure_thread_addon_setup():
@@ -410,14 +407,6 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         assert self._device is not None
         assert self._hardware_name is not None
 
-        _LOGGER.debug(
-            "Continuing Zigbee setup with integration %s", self._zigbee_integration
-        )
-        _LOGGER.debug(
-            "Probing Zigbee: %s, firmware for: %s",
-            ApplicationType.EZSP,
-            self._picked_firmware_type,
-        )
         if not await self._probe_firmware_info(probe_methods=(ApplicationType.EZSP,)):
             return self.async_abort(
                 reason="unsupported_firmware",
@@ -427,7 +416,6 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         if self._zigbee_integration == ZigbeeIntegration.OTHER:
             return self._async_flow_finished()
 
-        _LOGGER.debug("Starting ZHA config flow")
         result = await self.hass.config_entries.flow.async_init(
             ZHA_DOMAIN,
             context={"source": "hardware"},
@@ -441,7 +429,6 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
                 "radio_type": "ezsp",
             },
         )
-        _LOGGER.debug("ZHA flow result: %s", json.dumps(result))
         return self._continue_zha_flow(result)
 
     @callback
@@ -673,7 +660,6 @@ class BaseFirmwareConfigFlow(BaseFirmwareInstallFlow, ConfigFlow):
             )
             | result  # update all items with the child result
         )
-        _LOGGER.debug("Flow result: %s", json.dumps(result))
         return result
 
 

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -69,7 +69,7 @@ class ZigbeeIntegration(StrEnum):
 class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
     """Base flow to install firmware."""
 
-    BAUDRATE = 115200  # Default, subclasses may override
+    ZIGBEE_BAUDRATE = 115200  # Default, subclasses may override
     _failed_addon_name: str
     _failed_addon_reason: str
     _picked_firmware_type: PickedFirmwareType
@@ -423,7 +423,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
                 "name": self._hardware_name,
                 "port": {
                     "path": self._device,
-                    "baudrate": self.BAUDRATE,
+                    "baudrate": self.ZIGBEE_BAUDRATE,
                     "flow_control": "hardware",
                 },
                 "radio_type": "ezsp",

--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -3,11 +3,15 @@
     "options": {
       "step": {
         "pick_firmware": {
-          "title": "Pick your firmware",
-          "description": "Let's get started with setting up your {model}. Do you want to use it to set up a Zigbee or Thread network?",
+          "title": "Pick your protocol",
+          "description": "You can use your {model} for a Zigbee or Thread network. Please check what type of devices you want to add to Home Assistant. You can always change this later.",
           "menu_options": {
-            "pick_firmware_zigbee": "Zigbee",
-            "pick_firmware_thread": "Thread"
+            "pick_firmware_zigbee": "Use as Zigbee adapter",
+            "pick_firmware_thread": "Use as Thread adapter"
+          },
+          "menu_option_descriptions": {
+            "pick_firmware_zigbee": "Most common protocol.",
+            "pick_firmware_thread": "Often used for Matter over Thread devices."
           }
         },
         "confirm_zigbee": {
@@ -29,6 +33,29 @@
         "confirm_otbr": {
           "title": "OpenThread Border Router setup complete",
           "description": "Your {model} is now an OpenThread Border Router and will show up in the Thread integration."
+        },
+        "zigbee_installation_type": {
+          "title": "Set up Zigbee",
+          "description": "Choose the installation type for the Zigbee adapter.",
+          "menu_options": {
+            "zigbee_intent_recommended": "Recommended installation",
+            "zigbee_intent_custom": "Custom"
+          },
+          "menu_option_descriptions": {
+            "zigbee_intent_recommended": "Automatically install and configure Zigbee.",
+            "zigbee_intent_custom": "Manually install and configure Zigbee, for example with Zigbee2MQTT."
+          }
+        },
+        "zigbee_integration": {
+          "title": "Select Zigbee method",
+          "menu_options": {
+            "zigbee_integration_zha": "Zigbee Home Automation",
+            "zigbee_integration_other": "Other"
+          },
+          "menu_option_descriptions": {
+            "zigbee_integration_zha": "Lets Home Assistant control a Zigbee network.",
+            "zigbee_integration_other": "For example if you want to use the adapter with Zigbee2MQTT."
+          }
         }
       },
       "abort": {

--- a/homeassistant/components/homeassistant_sky_connect/strings.json
+++ b/homeassistant/components/homeassistant_sky_connect/strings.json
@@ -52,8 +52,12 @@
         "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::title%]",
         "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::description%]",
         "menu_options": {
-          "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_thread%]",
-          "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_zigbee%]"
+          "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_zigbee%]",
+          "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_thread%]"
+        },
+        "menu_option_descriptions": {
+          "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_option_descriptions::pick_firmware_zigbee%]",
+          "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_option_descriptions::pick_firmware_thread%]"
         }
       },
       "confirm_zigbee": {
@@ -75,6 +79,29 @@
       "confirm_otbr": {
         "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::confirm_otbr::title%]",
         "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::confirm_otbr::description%]"
+      },
+      "zigbee_installation_type": {
+        "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::title%]",
+        "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::description%]",
+        "menu_options": {
+          "zigbee_intent_recommended": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_options::zigbee_intent_recommended%]",
+          "zigbee_intent_custom": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_options::zigbee_intent_custom%]"
+        },
+        "menu_option_descriptions": {
+          "zigbee_intent_recommended": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_option_descriptions::zigbee_intent_recommended%]",
+          "zigbee_intent_custom": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_option_descriptions::zigbee_intent_custom%]"
+        }
+      },
+      "zigbee_integration": {
+        "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::title%]",
+        "menu_options": {
+          "zigbee_integration_zha": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_options::zigbee_integration_zha%]",
+          "zigbee_integration_other": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_options::zigbee_integration_other%]"
+        },
+        "menu_option_descriptions": {
+          "zigbee_integration_zha": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_option_descriptions::zigbee_integration_zha%]",
+          "zigbee_integration_other": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_option_descriptions::zigbee_integration_other%]"
+        }
       }
     },
     "error": {
@@ -112,6 +139,10 @@
         "menu_options": {
           "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_zigbee%]",
           "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_thread%]"
+        },
+        "menu_option_descriptions": {
+          "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_option_descriptions::pick_firmware_zigbee%]",
+          "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_option_descriptions::pick_firmware_thread%]"
         }
       },
       "confirm_zigbee": {
@@ -133,6 +164,29 @@
       "confirm_otbr": {
         "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::confirm_otbr::title%]",
         "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::confirm_otbr::description%]"
+      },
+      "zigbee_installation_type": {
+        "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::title%]",
+        "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::description%]",
+        "menu_options": {
+          "zigbee_intent_recommended": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_options::zigbee_intent_recommended%]",
+          "zigbee_intent_custom": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_options::zigbee_intent_custom%]"
+        },
+        "menu_option_descriptions": {
+          "zigbee_intent_recommended": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_option_descriptions::zigbee_intent_recommended%]",
+          "zigbee_intent_custom": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_option_descriptions::zigbee_intent_custom%]"
+        }
+      },
+      "zigbee_integration": {
+        "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::title%]",
+        "menu_options": {
+          "zigbee_integration_zha": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_options::zigbee_integration_zha%]",
+          "zigbee_integration_other": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_options::zigbee_integration_other%]"
+        },
+        "menu_option_descriptions": {
+          "zigbee_integration_zha": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_option_descriptions::zigbee_integration_zha%]",
+          "zigbee_integration_other": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_option_descriptions::zigbee_integration_other%]"
+        }
       }
     },
     "abort": {

--- a/homeassistant/components/homeassistant_yellow/config_flow.py
+++ b/homeassistant/components/homeassistant_yellow/config_flow.py
@@ -92,7 +92,7 @@ class YellowFirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
             firmware_name="Zigbee",
             expected_installed_firmware_type=ApplicationType.EZSP,
             step_id="install_zigbee_firmware",
-            next_step_id="confirm_zigbee",
+            next_step_id="pre_confirm_zigbee",
         )
 
     async def async_step_install_thread_firmware(

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -75,8 +75,12 @@
         "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::title%]",
         "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::description%]",
         "menu_options": {
-          "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_thread%]",
-          "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_zigbee%]"
+          "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_zigbee%]",
+          "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_options::pick_firmware_thread%]"
+        },
+        "menu_option_descriptions": {
+          "pick_firmware_zigbee": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_option_descriptions::pick_firmware_zigbee%]",
+          "pick_firmware_thread": "[%key:component::homeassistant_hardware::firmware_picker::options::step::pick_firmware::menu_option_descriptions::pick_firmware_thread%]"
         }
       },
       "confirm_zigbee": {
@@ -98,6 +102,29 @@
       "confirm_otbr": {
         "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::confirm_otbr::title%]",
         "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::confirm_otbr::description%]"
+      },
+      "zigbee_installation_type": {
+        "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::title%]",
+        "description": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::description%]",
+        "menu_options": {
+          "zigbee_intent_recommended": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_options::zigbee_intent_recommended%]",
+          "zigbee_intent_custom": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_options::zigbee_intent_custom%]"
+        },
+        "menu_option_descriptions": {
+          "zigbee_intent_recommended": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_option_descriptions::zigbee_intent_recommended%]",
+          "zigbee_intent_custom": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_installation_type::menu_option_descriptions::zigbee_intent_custom%]"
+        }
+      },
+      "zigbee_integration": {
+        "title": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::title%]",
+        "menu_options": {
+          "zigbee_integration_zha": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_options::zigbee_integration_zha%]",
+          "zigbee_integration_other": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_options::zigbee_integration_other%]"
+        },
+        "menu_option_descriptions": {
+          "zigbee_integration_zha": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_option_descriptions::zigbee_integration_zha%]",
+          "zigbee_integration_other": "[%key:component::homeassistant_hardware::firmware_picker::options::step::zigbee_integration::menu_option_descriptions::zigbee_integration_other%]"
+        }
       }
     },
     "error": {

--- a/tests/components/homeassistant_connect_zbt2/test_config_flow.py
+++ b/tests/components/homeassistant_connect_zbt2/test_config_flow.py
@@ -23,41 +23,114 @@ from .common import USB_DATA_ZBT2
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize(
-    ("step", "usb_data", "model", "fw_type", "fw_version"),
-    [
-        (
-            STEP_PICK_FIRMWARE_ZIGBEE,
-            USB_DATA_ZBT2,
-            "Home Assistant Connect ZBT-2",
-            ApplicationType.EZSP,
-            "7.4.4.0 build 0",
-        ),
-        (
-            STEP_PICK_FIRMWARE_THREAD,
-            USB_DATA_ZBT2,
-            "Home Assistant Connect ZBT-2",
-            ApplicationType.SPINEL,
-            "2.4.4.0",
-        ),
-    ],
-)
-async def test_config_flow(
-    step: str,
-    usb_data: UsbServiceInfo,
-    model: str,
-    fw_type: ApplicationType,
-    fw_version: str,
+async def test_config_flow_zigbee(
     hass: HomeAssistant,
 ) -> None:
-    """Test the config flow for Connect ZBT-2."""
+    """Test Zigbee config flow for Connect ZBT-2."""
+    fw_type = ApplicationType.EZSP
+    fw_version = "7.4.4.0 build 0"
+    model = "Home Assistant Connect ZBT-2"
+    usb_data = USB_DATA_ZBT2
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "pick_firmware"
-    assert result["description_placeholders"]["model"] == model
+    description_placeholders = result["description_placeholders"]
+    assert description_placeholders is not None
+    assert description_placeholders["model"] == model
+
+    async def mock_install_firmware_step(
+        self,
+        fw_update_url: str,
+        fw_type: str,
+        firmware_name: str,
+        expected_installed_firmware_type: ApplicationType,
+        step_id: str,
+        next_step_id: str,
+    ) -> ConfigFlowResult:
+        if next_step_id == "start_otbr_addon":
+            next_step_id = "pre_confirm_otbr"
+
+        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
+
+    with (
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._ensure_thread_addon_setup",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._install_firmware_step",
+            autospec=True,
+            side_effect=mock_install_firmware_step,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.probe_silabs_firmware_info",
+            return_value=FirmwareInfo(
+                device=usb_data.device,
+                firmware_type=fw_type,
+                firmware_version=fw_version,
+                owners=[],
+                source="probe",
+            ),
+        ),
+    ):
+        pick_result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
+        )
+
+        assert pick_result["type"] is FlowResultType.MENU
+        assert pick_result["step_id"] == "zigbee_installation_type"
+
+        create_result = await hass.config_entries.flow.async_configure(
+            pick_result["flow_id"],
+            user_input={"next_step_id": "zigbee_intent_recommended"},
+        )
+
+    assert create_result["type"] is FlowResultType.CREATE_ENTRY
+    config_entry = create_result["result"]
+    assert config_entry.data == {
+        "firmware": fw_type.value,
+        "firmware_version": fw_version,
+        "device": usb_data.device,
+        "manufacturer": usb_data.manufacturer,
+        "pid": usb_data.pid,
+        "product": usb_data.description,
+        "serial_number": usb_data.serial_number,
+        "vid": usb_data.vid,
+    }
+
+    flows = hass.config_entries.flow.async_progress()
+
+    # Ensure a ZHA discovery flow has been created
+    assert len(flows) == 1
+    zha_flow = flows[0]
+    assert zha_flow["handler"] == "zha"
+    assert zha_flow["context"]["source"] == "hardware"
+    assert zha_flow["step_id"] == "confirm"
+
+
+async def test_config_flow_thread(
+    hass: HomeAssistant,
+) -> None:
+    """Test Thread config flow for Connect ZBT-2."""
+    fw_type = ApplicationType.SPINEL
+    fw_version = "2.4.4.0"
+    model = "Home Assistant Connect ZBT-2"
+    usb_data = USB_DATA_ZBT2
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "usb"}, data=usb_data
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "pick_firmware"
+    description_placeholders = result["description_placeholders"]
+    assert description_placeholders is not None
+    assert description_placeholders["model"] == model
 
     async def mock_install_firmware_step(
         self,
@@ -96,13 +169,11 @@ async def test_config_flow(
     ):
         confirm_result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"next_step_id": step},
+            user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
         )
 
         assert confirm_result["type"] is FlowResultType.FORM
-        assert confirm_result["step_id"] == (
-            "confirm_zigbee" if step == STEP_PICK_FIRMWARE_ZIGBEE else "confirm_otbr"
-        )
+        assert confirm_result["step_id"] == "confirm_otbr"
 
         create_result = await hass.config_entries.flow.async_configure(
             confirm_result["flow_id"], user_input={}
@@ -123,15 +194,7 @@ async def test_config_flow(
 
     flows = hass.config_entries.flow.async_progress()
 
-    if step == STEP_PICK_FIRMWARE_ZIGBEE:
-        # Ensure a ZHA discovery flow has been created
-        assert len(flows) == 1
-        zha_flow = flows[0]
-        assert zha_flow["handler"] == "zha"
-        assert zha_flow["context"]["source"] == "hardware"
-        assert zha_flow["step_id"] == "confirm"
-    else:
-        assert len(flows) == 0
+    assert len(flows) == 0
 
 
 @pytest.mark.parametrize(
@@ -167,17 +230,38 @@ async def test_options_flow(
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "pick_firmware"
-    assert result["description_placeholders"]["firmware_type"] == "spinel"
-    assert result["description_placeholders"]["model"] == model
+    description_placeholders = result["description_placeholders"]
+    assert description_placeholders is not None
+    assert description_placeholders["firmware_type"] == "spinel"
+    assert description_placeholders["model"] == model
 
-    async def mock_async_step_pick_firmware_zigbee(self, data):
-        return await self.async_step_pre_confirm_zigbee()
+    async def mock_install_firmware_step(
+        self,
+        fw_update_url: str,
+        fw_type: str,
+        firmware_name: str,
+        expected_installed_firmware_type: ApplicationType,
+        step_id: str,
+        next_step_id: str,
+    ) -> ConfigFlowResult:
+        if next_step_id == "start_otbr_addon":
+            next_step_id = "pre_confirm_otbr"
+
+        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
 
     with (
         patch(
-            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareOptionsFlow.async_step_pick_firmware_zigbee",
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.guess_hardware_owners",
+            return_value=[],
+        ),
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareOptionsFlow._ensure_thread_addon_setup",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareOptionsFlow._install_firmware_step",
             autospec=True,
-            side_effect=mock_async_step_pick_firmware_zigbee,
+            side_effect=mock_install_firmware_step,
         ),
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.probe_silabs_firmware_info",
@@ -190,16 +274,17 @@ async def test_options_flow(
             ),
         ),
     ):
-        confirm_result = await hass.config_entries.options.async_configure(
+        pick_result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
         )
 
-        assert confirm_result["type"] is FlowResultType.FORM
-        assert confirm_result["step_id"] == "confirm_zigbee"
+        assert pick_result["type"] is FlowResultType.MENU
+        assert pick_result["step_id"] == "zigbee_installation_type"
 
         create_result = await hass.config_entries.options.async_configure(
-            confirm_result["flow_id"], user_input={}
+            pick_result["flow_id"],
+            user_input={"next_step_id": "zigbee_intent_recommended"},
         )
 
     assert create_result["type"] is FlowResultType.CREATE_ENTRY

--- a/tests/components/homeassistant_hardware/test_config_flow_failures.py
+++ b/tests/components/homeassistant_hardware/test_config_flow_failures.py
@@ -39,18 +39,9 @@ async def fixture_mock_supervisor_client(supervisor_client: AsyncMock):
     "ignore_translations_for_mock_domains",
     ["test_firmware_domain"],
 )
-@pytest.mark.parametrize(
-    "next_step",
-    [
-        STEP_PICK_FIRMWARE_ZIGBEE,
-        STEP_PICK_FIRMWARE_THREAD,
-    ],
-)
 @pytest.mark.usefixtures("addon_store_info")
-async def test_config_flow_cannot_probe_firmware(
-    next_step: str, hass: HomeAssistant
-) -> None:
-    """Test failure case when firmware cannot be probed."""
+async def test_config_flow_cannot_probe_firmware_zigbee(hass: HomeAssistant) -> None:
+    """Test failure case when firmware cannot be probed for zigbee."""
 
     with mock_firmware_info(
         hass,
@@ -61,13 +52,174 @@ async def test_config_flow_cannot_probe_firmware(
             TEST_DOMAIN, context={"source": "hardware"}
         )
 
+        assert result["type"] is FlowResultType.MENU
+        assert result["step_id"] == "pick_firmware"
+
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"next_step_id": next_step},
+            user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
+        )
+
+        assert result["type"] is FlowResultType.MENU
+        assert result["step_id"] == "zigbee_installation_type"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"next_step_id": "zigbee_intent_recommended"},
         )
 
         assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "unsupported_firmware"
+
+
+@pytest.mark.parametrize(
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
+)
+async def test_cannot_probe_after_install_zigbee(hass: HomeAssistant) -> None:
+    """Test unsupported firmware after install for Zigbee."""
+    init_result = await hass.config_entries.flow.async_init(
+        TEST_DOMAIN, context={"source": "hardware"}
+    )
+
+    assert init_result["type"] is FlowResultType.MENU
+    assert init_result["step_id"] == "pick_firmware"
+
+    with mock_firmware_info(
+        hass,
+        probe_app_type=ApplicationType.SPINEL,
+        flash_app_type=ApplicationType.EZSP,
+    ):
+        # Pick the menu option: we are flashing the firmware
+        pick_result = await hass.config_entries.flow.async_configure(
+            init_result["flow_id"],
+            user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
+        )
+
+        assert pick_result["type"] is FlowResultType.MENU
+        assert pick_result["step_id"] == "zigbee_installation_type"
+
+        pick_result = await hass.config_entries.flow.async_configure(
+            pick_result["flow_id"],
+            user_input={"next_step_id": "zigbee_intent_recommended"},
+        )
+
+        assert pick_result["type"] is FlowResultType.SHOW_PROGRESS
+        assert pick_result["progress_action"] == "install_firmware"
+        assert pick_result["step_id"] == "install_zigbee_firmware"
+
+    with mock_firmware_info(
+        hass,
+        probe_app_type=None,
+        flash_app_type=ApplicationType.EZSP,
+    ):
+        create_result = await consume_progress_flow(
+            hass,
+            flow_id=pick_result["flow_id"],
+            valid_step_ids=("install_zigbee_firmware",),
+        )
+
+    assert create_result["type"] is FlowResultType.ABORT
+    assert create_result["reason"] == "unsupported_firmware"
+
+
+@pytest.mark.parametrize(
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
+)
+@pytest.mark.usefixtures("addon_store_info")
+async def test_config_flow_cannot_probe_firmware_thread(hass: HomeAssistant) -> None:
+    """Test failure case when firmware cannot be probed for thread."""
+
+    with mock_firmware_info(
+        hass,
+        probe_app_type=None,
+    ):
+        # Start the flow
+        result = await hass.config_entries.flow.async_init(
+            TEST_DOMAIN, context={"source": "hardware"}
+        )
+
+        assert result["type"] is FlowResultType.MENU
+        assert result["step_id"] == "pick_firmware"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
+        )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "unsupported_firmware"
+
+
+@pytest.mark.parametrize(
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
+)
+@pytest.mark.usefixtures("addon_store_info")
+async def test_cannot_probe_after_install_thread(hass: HomeAssistant) -> None:
+    """Test unsupported firmware after install for thread."""
+    init_result = await hass.config_entries.flow.async_init(
+        TEST_DOMAIN, context={"source": "hardware"}
+    )
+
+    assert init_result["type"] is FlowResultType.MENU
+    assert init_result["step_id"] == "pick_firmware"
+
+    with mock_firmware_info(
+        hass,
+        probe_app_type=ApplicationType.EZSP,
+        flash_app_type=ApplicationType.SPINEL,
+    ) as (mock_otbr_manager, _):
+        # Pick the menu option
+        pick_result = await hass.config_entries.flow.async_configure(
+            init_result["flow_id"],
+            user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
+        )
+
+        assert pick_result["type"] is FlowResultType.SHOW_PROGRESS
+        assert pick_result["progress_action"] == "install_addon"
+        assert pick_result["step_id"] == "install_otbr_addon"
+        description_placeholders = pick_result["description_placeholders"]
+        assert description_placeholders is not None
+        assert description_placeholders["firmware_type"] == "ezsp"
+        assert description_placeholders["model"] == TEST_HARDWARE_NAME
+
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        mock_otbr_manager.async_get_addon_info.return_value = AddonInfo(
+            available=True,
+            hostname=None,
+            options={
+                "device": "",
+                "baudrate": 460800,
+                "flow_control": True,
+                "autoflash_firmware": False,
+            },
+            state=AddonState.NOT_RUNNING,
+            update_available=False,
+            version="1.2.3",
+        )
+
+    with mock_firmware_info(
+        hass,
+        probe_app_type=None,
+        flash_app_type=ApplicationType.SPINEL,
+    ):
+        # Progress the flow, it is now installing firmware
+        result = await consume_progress_flow(
+            hass,
+            flow_id=pick_result["flow_id"],
+            valid_step_ids=(
+                "pick_firmware_thread",
+                "install_otbr_addon",
+                "install_thread_firmware",
+                "start_otbr_addon",
+            ),
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unsupported_firmware"
 
 
 @pytest.mark.parametrize(
@@ -353,6 +505,9 @@ async def test_config_flow_firmware_index_download_fails_and_required(
         TEST_DOMAIN, context={"source": "hardware"}
     )
 
+    assert init_result["type"] is FlowResultType.MENU
+    assert init_result["step_id"] == "pick_firmware"
+
     with (
         mock_firmware_info(
             hass,
@@ -365,6 +520,14 @@ async def test_config_flow_firmware_index_download_fails_and_required(
         pick_result = await hass.config_entries.flow.async_configure(
             init_result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
+        )
+
+        assert pick_result["type"] is FlowResultType.MENU
+        assert pick_result["step_id"] == "zigbee_installation_type"
+
+        pick_result = await hass.config_entries.flow.async_configure(
+            pick_result["flow_id"],
+            user_input={"next_step_id": "zigbee_intent_recommended"},
         )
 
         assert pick_result["type"] is FlowResultType.ABORT
@@ -382,6 +545,9 @@ async def test_config_flow_firmware_download_fails_and_required(
         TEST_DOMAIN, context={"source": "hardware"}
     )
 
+    assert init_result["type"] is FlowResultType.MENU
+    assert init_result["step_id"] == "pick_firmware"
+
     with (
         mock_firmware_info(
             hass,
@@ -394,6 +560,14 @@ async def test_config_flow_firmware_download_fails_and_required(
         pick_result = await hass.config_entries.flow.async_configure(
             init_result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
+        )
+
+        assert pick_result["type"] is FlowResultType.MENU
+        assert pick_result["step_id"] == "zigbee_installation_type"
+
+        pick_result = await hass.config_entries.flow.async_configure(
+            pick_result["flow_id"],
+            user_input={"next_step_id": "zigbee_intent_recommended"},
         )
 
         assert pick_result["type"] is FlowResultType.ABORT

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -30,40 +30,140 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    ("step", "usb_data", "model", "fw_type", "fw_version"),
+    ("usb_data", "model"),
     [
         (
-            STEP_PICK_FIRMWARE_ZIGBEE,
             USB_DATA_SKY,
             "Home Assistant SkyConnect",
-            ApplicationType.EZSP,
-            "7.4.4.0 build 0",
         ),
         (
-            STEP_PICK_FIRMWARE_THREAD,
             USB_DATA_ZBT1,
             "Home Assistant Connect ZBT-1",
-            ApplicationType.SPINEL,
-            "2.4.4.0",
         ),
     ],
 )
-async def test_config_flow(
-    step: str,
+async def test_config_flow_zigbee(
     usb_data: UsbServiceInfo,
     model: str,
-    fw_type: ApplicationType,
-    fw_version: str,
     hass: HomeAssistant,
 ) -> None:
-    """Test the config flow for SkyConnect."""
+    """Test the config flow for SkyConnect with Zigbee."""
+    fw_type = ApplicationType.EZSP
+    fw_version = "7.4.4.0 build 0"
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "pick_firmware"
-    assert result["description_placeholders"]["model"] == model
+    description_placeholders = result["description_placeholders"]
+    assert description_placeholders is not None
+    assert description_placeholders["model"] == model
+
+    async def mock_install_firmware_step(
+        self,
+        fw_update_url: str,
+        fw_type: str,
+        firmware_name: str,
+        expected_installed_firmware_type: ApplicationType,
+        step_id: str,
+        next_step_id: str,
+    ) -> ConfigFlowResult:
+        if next_step_id == "start_otbr_addon":
+            next_step_id = "pre_confirm_otbr"
+
+        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
+
+    with (
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._ensure_thread_addon_setup",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._install_firmware_step",
+            autospec=True,
+            side_effect=mock_install_firmware_step,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.probe_silabs_firmware_info",
+            return_value=FirmwareInfo(
+                device=usb_data.device,
+                firmware_type=fw_type,
+                firmware_version=fw_version,
+                owners=[],
+                source="probe",
+            ),
+        ),
+    ):
+        pick_result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
+        )
+
+        assert pick_result["type"] is FlowResultType.MENU
+        assert pick_result["step_id"] == "zigbee_installation_type"
+
+        create_result = await hass.config_entries.flow.async_configure(
+            pick_result["flow_id"],
+            user_input={"next_step_id": "zigbee_intent_recommended"},
+        )
+
+    assert create_result["type"] is FlowResultType.CREATE_ENTRY
+    config_entry = create_result["result"]
+    assert config_entry.data == {
+        "firmware": fw_type.value,
+        "firmware_version": fw_version,
+        "device": usb_data.device,
+        "manufacturer": usb_data.manufacturer,
+        "pid": usb_data.pid,
+        "description": usb_data.description,
+        "product": usb_data.description,
+        "serial_number": usb_data.serial_number,
+        "vid": usb_data.vid,
+    }
+
+    flows = hass.config_entries.flow.async_progress()
+
+    # Ensure a ZHA discovery flow has been created
+    assert len(flows) == 1
+    zha_flow = flows[0]
+    assert zha_flow["handler"] == "zha"
+    assert zha_flow["context"]["source"] == "hardware"
+    assert zha_flow["step_id"] == "confirm"
+
+
+@pytest.mark.parametrize(
+    ("usb_data", "model"),
+    [
+        (
+            USB_DATA_SKY,
+            "Home Assistant SkyConnect",
+        ),
+        (
+            USB_DATA_ZBT1,
+            "Home Assistant Connect ZBT-1",
+        ),
+    ],
+)
+async def test_config_flow_thread(
+    usb_data: UsbServiceInfo,
+    model: str,
+    hass: HomeAssistant,
+) -> None:
+    """Test the config flow for SkyConnect with Thread."""
+    fw_type = ApplicationType.SPINEL
+    fw_version = "2.4.4.0"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "usb"}, data=usb_data
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "pick_firmware"
+    description_placeholders = result["description_placeholders"]
+    assert description_placeholders is not None
+    assert description_placeholders["model"] == model
 
     async def mock_install_firmware_step(
         self,
@@ -102,13 +202,11 @@ async def test_config_flow(
     ):
         confirm_result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"next_step_id": step},
+            user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
         )
 
         assert confirm_result["type"] is FlowResultType.FORM
-        assert confirm_result["step_id"] == (
-            "confirm_zigbee" if step == STEP_PICK_FIRMWARE_ZIGBEE else "confirm_otbr"
-        )
+        assert confirm_result["step_id"] == ("confirm_otbr")
 
         create_result = await hass.config_entries.flow.async_configure(
             confirm_result["flow_id"], user_input={}
@@ -130,15 +228,7 @@ async def test_config_flow(
 
     flows = hass.config_entries.flow.async_progress()
 
-    if step == STEP_PICK_FIRMWARE_ZIGBEE:
-        # Ensure a ZHA discovery flow has been created
-        assert len(flows) == 1
-        zha_flow = flows[0]
-        assert zha_flow["handler"] == "zha"
-        assert zha_flow["context"]["source"] == "hardware"
-        assert zha_flow["step_id"] == "confirm"
-    else:
-        assert len(flows) == 0
+    assert len(flows) == 0
 
 
 @pytest.mark.parametrize(
@@ -175,17 +265,38 @@ async def test_options_flow(
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "pick_firmware"
-    assert result["description_placeholders"]["firmware_type"] == "spinel"
-    assert result["description_placeholders"]["model"] == model
+    description_placeholders = result["description_placeholders"]
+    assert description_placeholders is not None
+    assert description_placeholders["firmware_type"] == "spinel"
+    assert description_placeholders["model"] == model
 
-    async def mock_async_step_pick_firmware_zigbee(self, data):
-        return await self.async_step_pre_confirm_zigbee()
+    async def mock_install_firmware_step(
+        self,
+        fw_update_url: str,
+        fw_type: str,
+        firmware_name: str,
+        expected_installed_firmware_type: ApplicationType,
+        step_id: str,
+        next_step_id: str,
+    ) -> ConfigFlowResult:
+        if next_step_id == "start_otbr_addon":
+            next_step_id = "pre_confirm_otbr"
+
+        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
 
     with (
         patch(
-            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareOptionsFlow.async_step_pick_firmware_zigbee",
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.guess_hardware_owners",
+            return_value=[],
+        ),
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareOptionsFlow._ensure_thread_addon_setup",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareOptionsFlow._install_firmware_step",
             autospec=True,
-            side_effect=mock_async_step_pick_firmware_zigbee,
+            side_effect=mock_install_firmware_step,
         ),
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.probe_silabs_firmware_info",
@@ -198,16 +309,17 @@ async def test_options_flow(
             ),
         ),
     ):
-        confirm_result = await hass.config_entries.options.async_configure(
+        pick_result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
         )
 
-        assert confirm_result["type"] is FlowResultType.FORM
-        assert confirm_result["step_id"] == "confirm_zigbee"
+        assert pick_result["type"] is FlowResultType.MENU
+        assert pick_result["step_id"] == "zigbee_installation_type"
 
         create_result = await hass.config_entries.options.async_configure(
-            confirm_result["flow_id"], user_input={}
+            pick_result["flow_id"],
+            user_input={"next_step_id": "zigbee_intent_recommended"},
         )
 
     assert create_result["type"] is FlowResultType.CREATE_ENTRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add recommended and custom installation type menu selection to simplify the choice between using ZHA and using another integration with the adapter in the hardware integration flow.
- Picking "recommended" or picking ZHA after picking "custom" will start the ZHA flow and continue with that flow after the hardware integration flow is done.

TODO:

- [x] Update translation strings for all hardware integrations to use the new required strings.
- [x] Add tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
