### PR TITLE
Add power state handling to Apple TV media player

### DIFF
--- a/homeassistant/components/apple_tv/media_player.py
+++ b/homeassistant/components/apple_tv/media_player.py
@@ -201,6 +201,11 @@ class AppleTvMediaPlayer(
             if state in (DeviceState.Paused, DeviceState.Seeking, DeviceState.Stopped):
                 return MediaPlayerState.PAUSED
             return MediaPlayerState.IDLE  # Bad or unknown state?
+        if (
+            self._is_feature_available(FeatureName.PowerState)
+            and self.atv.power.power_state == PowerState.On
+        ):
+            return MediaPlayerState.ON
         return None
 
     @callback
@@ -443,7 +448,7 @@ class AppleTvMediaPlayer(
 
     def _is_feature_available(self, feature: FeatureName) -> bool:
         """Return if a feature is available."""
-        if self.atv and self._playing:
+        if self.atv:
             return self.atv.features.in_state(FeatureState.Available, feature)
         return False
 

--- a/tests/components/apple_tv/test_media_player_power.py
+++ b/tests/components/apple_tv/test_media_player_power.py
@@ -1,0 +1,69 @@
+"""Tests for Apple TV media-player power state."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pyatv.const import DeviceState, FeatureName, FeatureState, PowerState
+
+from homeassistant.components.apple_tv import media_player as mp
+
+
+def _player(
+    *, power_state: PowerState, feature_available: bool, playing
+) -> mp.AppleTvMediaPlayer:
+    # Bypass __init__ to avoid pulling in manager/pyatv; set only what `state` needs.
+    player: mp.AppleTvMediaPlayer = object.__new__(mp.AppleTvMediaPlayer)
+    player.manager = SimpleNamespace(is_connecting=False)
+
+    def in_state(states, feature):
+        if feature != FeatureName.PowerState:
+            return False
+        # `states` can be a FeatureState or an iterable
+        if isinstance(states, (list, tuple, set)):
+            return feature_available and FeatureState.Available in states
+        return feature_available and states == FeatureState.Available
+
+    player.atv = SimpleNamespace(
+        features=SimpleNamespace(in_state=in_state),
+        power=SimpleNamespace(power_state=power_state),
+    )
+    player._playing = playing
+    return player
+
+
+def test_state_off_when_power_off_and_not_playing() -> None:
+    """Test state is OFF when power is off and not playing."""
+    p = _player(power_state=PowerState.Off, feature_available=True, playing=None)
+    assert p.state == mp.MediaPlayerState.OFF
+
+
+def test_state_on_when_power_on_and_not_playing() -> None:
+    """Test state is ON when power is on and not playing."""
+    p = _player(power_state=PowerState.On, feature_available=True, playing=None)
+    assert p.state == mp.MediaPlayerState.ON
+
+
+def test_playing_state_takes_precedence_over_power_on() -> None:
+    """Test that playing state takes precedence over power on."""
+    playing = SimpleNamespace(device_state=DeviceState.Playing)
+    p = _player(power_state=PowerState.On, feature_available=True, playing=playing)
+    assert p.state == mp.MediaPlayerState.PLAYING
+
+
+# If the power feature is not available, playback still determines state.
+
+
+def test_state_comes_from_playback_when_power_feature_unavailable() -> None:
+    """If the power feature is not available, playback still determines state."""
+    playing = SimpleNamespace(device_state=DeviceState.Playing)
+    p = _player(power_state=PowerState.Off, feature_available=False, playing=playing)
+    assert p.state == mp.MediaPlayerState.PLAYING
+
+
+def test_state_unknown_when_power_feature_unavailable_and_not_playing() -> None:
+    """If there is no playback and no power feature, state falls back to None (unknown)."""
+    p = _player(power_state=PowerState.On, feature_available=False, playing=None)
+    # The `state` property returns None here; HA will display this as "unknown".
+    # This matches the PR's final return path when power feature is not usable.
+    assert p.state is None

--- a/tests/components/apple_tv/test_media_player_power.py
+++ b/tests/components/apple_tv/test_media_player_power.py
@@ -16,12 +16,14 @@ async def _one_media_player(hass: HomeAssistant) -> str:
     return entities[0]
 
 
-@pytest.mark.parametrize("setup_runtime_integration", [True, False], indirect=True)
+@pytest.mark.parametrize(
+    "setup_runtime_integration_power_tests", [True, False], indirect=True
+)
 async def test_power_state_from_remote(
-    hass: HomeAssistant, setup_runtime_integration
+    hass: HomeAssistant, setup_runtime_integration_power_tests
 ) -> None:
     """Test power on/off updates media_player state changing via remote. (e.g. by the Apple TV itself)."""
-    _, atv = setup_runtime_integration
+    _, atv = setup_runtime_integration_power_tests
     entity_id = await _one_media_player(hass)
 
     # Turn off
@@ -49,12 +51,14 @@ async def test_power_state_from_remote(
         assert state_on == "unknown"
 
 
-@pytest.mark.parametrize("setup_runtime_integration", [True, False], indirect=True)
+@pytest.mark.parametrize(
+    "setup_runtime_integration_power_tests", [True, False], indirect=True
+)
 async def test_power_state_using_services(
-    hass: HomeAssistant, setup_runtime_integration
+    hass: HomeAssistant, setup_runtime_integration_power_tests
 ) -> None:
     """Test power on/off using media_player services."""
-    _, atv = setup_runtime_integration
+    _, atv = setup_runtime_integration_power_tests
     entity_id = await _one_media_player(hass)
     powerstate_supported = atv.features.in_state(
         FeatureState.Available, FeatureName.PowerState
@@ -92,12 +96,14 @@ async def test_power_state_using_services(
         assert state == media_player.MediaPlayerState.PLAYING
 
 
-@pytest.mark.parametrize("setup_runtime_integration", [True, False], indirect=True)
+@pytest.mark.parametrize(
+    "setup_runtime_integration_power_tests", [True, False], indirect=True
+)
 async def test_listener_playing_state_update(
-    hass: HomeAssistant, setup_runtime_integration
+    hass: HomeAssistant, setup_runtime_integration_power_tests
 ) -> None:
     """Test that playing state updates via listener work."""
-    _, atv = setup_runtime_integration
+    _, atv = setup_runtime_integration_power_tests
     entity_id = await _one_media_player(hass)
 
     await atv.push_updater.trigger_playing(DeviceState.Idle)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixing #151449.
Without this fix appletv remains in idle state after powering off. This makes it hard automate depending on the turn off/on state. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #151449
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
