### PR TITLE
AI Task to store generated images in media dir

### DIFF
--- a/homeassistant/components/ai_task/media_source.py
+++ b/homeassistant/components/ai_task/media_source.py
@@ -2,21 +2,31 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from homeassistant.components.media_source import MediaSource, local_source
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import DATA_MEDIA_SOURCE, DOMAIN, IMAGE_DIR
 
 
 async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
     """Set up local media source."""
-    media_dir = hass.config.path(f"{DOMAIN}/{IMAGE_DIR}")
+    media_dirs = list(hass.config.media_dirs.values())
+
+    if not media_dirs:
+        raise HomeAssistantError(
+            "AI Task media source requires at least one media directory configured"
+        )
+
+    media_dir = Path(media_dirs[0]) / DOMAIN / IMAGE_DIR
 
     hass.data[DATA_MEDIA_SOURCE] = source = local_source.LocalSource(
         hass,
         DOMAIN,
         "AI Generated Images",
-        {IMAGE_DIR: media_dir},
+        {IMAGE_DIR: str(media_dir)},
         f"/{DOMAIN}",
     )
     return source

--- a/homeassistant/components/backup/const.py
+++ b/homeassistant/components/backup/const.py
@@ -26,7 +26,6 @@ EXCLUDE_FROM_BACKUP = [
     "tmp_backups/*.tar",
     "OZW_Log.txt",
     "tts/*",
-    "ai_task/*",
 ]
 
 EXCLUDE_DATABASE_FROM_BACKUP = [

--- a/tests/components/ai_task/test_media_source.py
+++ b/tests/components/ai_task/test_media_source.py
@@ -1,7 +1,11 @@
 """Test ai_task media source."""
 
+import pytest
+
 from homeassistant.components import media_source
+from homeassistant.components.ai_task.media_source import async_get_media_source
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 
 async def test_local_media_source(hass: HomeAssistant, init_components: None) -> None:
@@ -9,3 +13,26 @@ async def test_local_media_source(hass: HomeAssistant, init_components: None) ->
     item = await media_source.async_browse_media(hass, "media-source://")
 
     assert any(c.title == "AI Generated Images" for c in item.children)
+
+    source = await async_get_media_source(hass)
+    assert isinstance(source, media_source.local_source.LocalSource)
+    assert source.name == "AI Generated Images"
+    assert source.domain == "ai_task"
+    assert list(source.media_dirs) == ["image"]
+    # Depending on Docker, the default is one of the two paths
+    assert source.media_dirs["image"] in (
+        "/media/ai_task/image",
+        hass.config.path("media/ai_task/image"),
+    )
+    assert source.url_prefix == "/ai_task"
+
+    hass.config.media_dirs = {}
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="AI Task media source requires at least one media directory configured",
+    ):
+        await async_get_media_source(hass)
+
+
+# The following is from media_source/__init__.py for reference


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Had an offline discussion with @frenck and we agreed to store the AI generated images in the first media dir.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
