### PR TITLE
Add async_get_image helper to Image integration

### DIFF
--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -105,6 +105,20 @@ async def _async_get_image(image_entity: ImageEntity, timeout: int) -> Image:
     raise HomeAssistantError("Unable to get image")
 
 
+async def async_get_image(
+    hass: HomeAssistant,
+    entity_id: str,
+    timeout: int = 10,
+) -> Image:
+    """Fetch an image from an image entity."""
+    component = hass.data[DATA_COMPONENT]
+
+    if (image := component.get_entity(entity_id)) is None:
+        raise HomeAssistantError(f"Image entity {entity_id} not found")
+
+    return await _async_get_image(image, timeout)
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the image component."""
     component = hass.data[DATA_COMPONENT] = EntityComponent[ImageEntity](

--- a/tests/components/ai_task/test_task.py
+++ b/tests/components/ai_task/test_task.py
@@ -187,7 +187,11 @@ async def test_generate_data_mixed_attachments(
         patch(
             "homeassistant.components.camera.async_get_image",
             return_value=Image(content_type="image/jpeg", content=b"fake_camera_jpeg"),
-        ) as mock_get_image,
+        ) as mock_get_camera_image,
+        patch(
+            "homeassistant.components.image.async_get_image",
+            return_value=Image(content_type="image/jpeg", content=b"fake_image_jpeg"),
+        ) as mock_get_image_image,
         patch(
             "homeassistant.components.media_source.async_resolve_media",
             return_value=media_source.PlayMedia(
@@ -208,6 +212,10 @@ async def test_generate_data_mixed_attachments(
                     "media_content_type": "image/jpeg",
                 },
                 {
+                    "media_content_id": "media-source://image/image.floorplan",
+                    "media_content_type": "image/jpeg",
+                },
+                {
                     "media_content_id": "media-source://media_player/video.mp4",
                     "media_content_type": "video/mp4",
                 },
@@ -215,7 +223,8 @@ async def test_generate_data_mixed_attachments(
         )
 
     # Verify both methods were called
-    mock_get_image.assert_called_once_with(hass, "camera.front_door")
+    mock_get_camera_image.assert_called_once_with(hass, "camera.front_door")
+    mock_get_image_image.assert_called_once_with(hass, "image.floorplan")
     mock_resolve_media.assert_called_once_with(
         hass, "media-source://media_player/video.mp4", None
     )
@@ -224,7 +233,7 @@ async def test_generate_data_mixed_attachments(
     assert len(mock_ai_task_entity.mock_generate_data_tasks) == 1
     task = mock_ai_task_entity.mock_generate_data_tasks[0]
     assert task.attachments is not None
-    assert len(task.attachments) == 2
+    assert len(task.attachments) == 3
 
     # Check camera attachment
     camera_attachment = task.attachments[0]
@@ -240,6 +249,18 @@ async def test_generate_data_mixed_attachments(
     content = await hass.async_add_executor_job(camera_attachment.path.read_bytes)
     assert content == b"fake_camera_jpeg"
 
+    # Check image attachment
+    image_attachment = task.attachments[1]
+    assert image_attachment.media_content_id == "media-source://image/image.floorplan"
+    assert image_attachment.mime_type == "image/jpeg"
+    assert isinstance(image_attachment.path, Path)
+    assert image_attachment.path.suffix == ".jpg"
+
+    # Verify image snapshot content
+    assert image_attachment.path.exists()
+    content = await hass.async_add_executor_job(image_attachment.path.read_bytes)
+    assert content == b"fake_image_jpeg"
+
     # Trigger clean up
     async_fire_time_changed(
         hass,
@@ -249,9 +270,10 @@ async def test_generate_data_mixed_attachments(
 
     # Verify the temporary file cleaned up
     assert not camera_attachment.path.exists()
+    assert not image_attachment.path.exists()
 
     # Check regular media attachment
-    media_attachment = task.attachments[1]
+    media_attachment = task.attachments[2]
     assert media_attachment.media_content_id == "media-source://media_player/video.mp4"
     assert media_attachment.mime_type == "video/mp4"
     assert media_attachment.path == Path("/media/test.mp4")

--- a/tests/components/image/test_init.py
+++ b/tests/components/image/test_init.py
@@ -407,6 +407,15 @@ async def test_image_stream(
     await close_future
 
 
+async def test_get_image_action(hass: HomeAssistant, mock_image_platform: None) -> None:
+    """Test get_image action."""
+    image_data = await image.async_get_image(hass, "image.test")
+    assert image_data == image.Image(content_type="image/jpeg", content=b"Test")
+
+    with pytest.raises(HomeAssistantError, match="not found"):
+        await image.async_get_image(hass, "image.unknown")
+
+
 async def test_snapshot_service(hass: HomeAssistant) -> None:
     """Test snapshot service."""
     mopen = mock_open()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When we forked the `image` integration from the `camera` integration, we did not move over the `async_get_image` helper. This PR adds it back.

As a use case, see how AI Task can now get data from both camera and image entities with exactly the same code.

_I added a use case for this new method in this PR to show how it will be used. Let me know if we prefer to split that out._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
