### PR TITLE
Fix APT cache restore failures in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -523,18 +523,18 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-uv-${{
             env.UV_CACHE_VERSION }}-${{ steps.generate-uv-key.outputs.version }}-${{
             env.HA_SHORT_VERSION }}-
-      - name: Restore apt cache
-        id: cache-apt-restore
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Check if apt cache exists
+        id: cache-apt-check
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
+          lookup-only: true
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Initialize apt cache
-        if: steps.cache-apt-restore.outputs.cache-hit != 'true'
-        id: cache-apt
+        if: steps.cache-apt-check.outputs.cache-hit != 'true'
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
@@ -543,11 +543,11 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
-        if: steps.cache-venv.outputs.cache-hit != 'true' || steps.cache-apt-restore.outputs.cache-hit != 'true'
+        if: steps.cache-venv.outputs.cache-hit != 'true' || steps.cache-apt-check.outputs.cache-hit != 'true'
         timeout-minutes: 10
         run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          if [[ "${{ steps.cache-apt-restore.outputs.cache-hit }}" != 'true' ]]; then
+          if [[ "${{ steps.cache-apt-check.outputs.cache-hit }}" != 'true' ]]; then
             mkdir -p ${{ env.APT_CACHE_DIR }}
             mkdir -p ${{ env.APT_LIST_CACHE_DIR }}
           fi
@@ -572,7 +572,7 @@ jobs:
             libswscale-dev \
             libudev-dev
 
-          if [[ "${{ steps.cache-apt-restore.outputs.cache-hit }}" != 'true' ]]; then
+          if [[ "${{ steps.cache-apt-check.outputs.cache-hit }}" != 'true' ]]; then
             sudo chmod -R 755 ${{ env.APT_CACHE_BASE }}
           fi
       - name: Create Python virtual environment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -524,7 +524,16 @@ jobs:
             env.UV_CACHE_VERSION }}-${{ steps.generate-uv-key.outputs.version }}-${{
             env.HA_SHORT_VERSION }}-
       - name: Restore apt cache
-        if: steps.cache-venv.outputs.cache-hit != 'true'
+        id: cache-apt-restore
+        uses: actions/cache/restore@v4.2.4
+        with:
+          path: |
+            ${{ env.APT_CACHE_DIR }}
+            ${{ env.APT_LIST_CACHE_DIR }}
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
+      - name: Initialize apt cache
+        if: steps.cache-apt-restore.outputs.cache-hit != 'true'
         id: cache-apt
         uses: actions/cache@v4.2.4
         with:
@@ -534,7 +543,7 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
-        if: steps.cache-venv.outputs.cache-hit != 'true'
+        if: steps.cache-apt-restore.outputs.cache-hit != 'true'
         timeout-minutes: 10
         run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
@@ -929,7 +938,6 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
-          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
@@ -1003,7 +1011,6 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
-          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
@@ -1150,7 +1157,6 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
-          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
@@ -1304,7 +1310,6 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
-          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
@@ -1479,7 +1484,6 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
-          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -533,15 +533,6 @@ jobs:
             ${{ env.APT_LIST_CACHE_DIR }}
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
-      - name: Save apt cache
-        if: steps.cache-apt-check.outputs.cache-hit != 'true'
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: |
-            ${{ env.APT_CACHE_DIR }}
-            ${{ env.APT_LIST_CACHE_DIR }}
-          key: >-
-            ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
         if: |
           steps.cache-venv.outputs.cache-hit != 'true'
@@ -577,6 +568,15 @@ jobs:
           if [[ "${{ steps.cache-apt-check.outputs.cache-hit }}" != 'true' ]]; then
             sudo chmod -R 755 ${{ env.APT_CACHE_BASE }}
           fi
+      - name: Save apt cache
+        if: steps.cache-apt-check.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            ${{ env.APT_CACHE_DIR }}
+            ${{ env.APT_LIST_CACHE_DIR }}
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -627,6 +627,7 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
@@ -939,6 +940,7 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
@@ -1012,6 +1014,7 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
@@ -1158,6 +1161,7 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
@@ -1311,6 +1315,7 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
@@ -1485,6 +1490,7 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -543,7 +543,9 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
-        if: steps.cache-venv.outputs.cache-hit != 'true' || steps.cache-apt-check.outputs.cache-hit != 'true'
+        if: |
+          steps.cache-venv.outputs.cache-hit != 'true'
+          || steps.cache-apt-check.outputs.cache-hit != 'true'
         timeout-minutes: 10
         run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -525,7 +525,7 @@ jobs:
             env.HA_SHORT_VERSION }}-
       - name: Restore apt cache
         id: cache-apt-restore
-        uses: actions/cache/restore@v4.2.4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
             ${{ env.APT_CACHE_DIR }}
@@ -535,7 +535,7 @@ jobs:
       - name: Initialize apt cache
         if: steps.cache-apt-restore.outputs.cache-hit != 'true'
         id: cache-apt
-        uses: actions/cache@v4.2.4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
             ${{ env.APT_CACHE_DIR }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -625,7 +625,6 @@ jobs:
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}
-          fail-on-cache-miss: true
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -543,11 +543,11 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
-        if: steps.cache-apt-restore.outputs.cache-hit != 'true'
+        if: steps.cache-venv.outputs.cache-hit != 'true' || steps.cache-apt-restore.outputs.cache-hit != 'true'
         timeout-minutes: 10
         run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          if [[ "${{ steps.cache-apt.outputs.cache-hit }}" != 'true' ]]; then
+          if [[ "${{ steps.cache-apt-restore.outputs.cache-hit }}" != 'true' ]]; then
             mkdir -p ${{ env.APT_CACHE_DIR }}
             mkdir -p ${{ env.APT_LIST_CACHE_DIR }}
           fi
@@ -572,7 +572,7 @@ jobs:
             libswscale-dev \
             libudev-dev
 
-          if [[ "${{ steps.cache-apt.outputs.cache-hit }}" != 'true' ]]; then
+          if [[ "${{ steps.cache-apt-restore.outputs.cache-hit }}" != 'true' ]]; then
             sudo chmod -R 755 ${{ env.APT_CACHE_BASE }}
           fi
       - name: Create Python virtual environment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -533,7 +533,7 @@ jobs:
             ${{ env.APT_LIST_CACHE_DIR }}
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
-      - name: Initialize apt cache
+      - name: Save apt cache
         if: steps.cache-apt-check.outputs.cache-hit != 'true'
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -527,7 +527,7 @@ jobs:
         id: cache-apt-check
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
-          lookup-only: true
+          lookup-only: ${{ steps.cache-venv.outputs.cache-hit == 'true' }}
           path: |
             ${{ env.APT_CACHE_DIR }}
             ${{ env.APT_LIST_CACHE_DIR }}


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix APT caching added in #152113. When Python requirements haven't been changed for a while and GitHub decides to push out the APT cache, the cache is not created in the first `actions/cache` step and the other restore steps fail to fetch it. To avoid this, attempt to restore the cache first, and conditionally execute cache-creating steps based whether it was hit or not. Also, just in case, don't fail if restoring the cache fails, in case the cache was evicted mid-workflow.

This should also remove the need to bump the cache version in case that the builder is changed, mentioned in the previous PR, as the builder bump should force recreation of the cache as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
