### PR TITLE
Fix Sonos Dialog Select type conversion part II

### DIFF
--- a/homeassistant/components/sonos/select.py
+++ b/homeassistant/components/sonos/select.py
@@ -59,17 +59,12 @@ async def async_setup_entry(
         for select_data in SELECT_TYPES:
             if select_data.speaker_model == speaker.model_name.upper():
                 if (
-                    state := getattr(speaker.soco, select_data.soco_attribute, None)
-                ) is not None:
-                    try:
-                        setattr(speaker, select_data.speaker_attribute, int(state))
-                        features.append(select_data)
-                    except ValueError:
-                        _LOGGER.error(
-                            "Invalid value for %s %s",
-                            select_data.speaker_attribute,
-                            state,
-                        )
+                    speaker.update_soco_int_attribute(
+                        select_data.soco_attribute, select_data.speaker_attribute
+                    )
+                    is not None
+                ):
+                    features.append(select_data)
         return features
 
     async def _async_create_entities(speaker: SonosSpeaker) -> None:
@@ -112,8 +107,9 @@ class SonosSelectEntity(SonosEntity, SelectEntity):
     @soco_error()
     def poll_state(self) -> None:
         """Poll the device for the current state."""
-        state = getattr(self.soco, self.soco_attribute)
-        setattr(self.speaker, self.speaker_attribute, state)
+        self.speaker.update_soco_int_attribute(
+            self.soco_attribute, self.speaker_attribute
+        )
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -283,10 +283,9 @@ class SonosSpeaker:
         Returns the integer value if successful, otherwise None. Do not call from
         async context as it is a blocking function.
         """
-        value: int | None
+        value: int | None = None
         if (state := getattr(self.soco, soco_attribute, None)) is None:
             _LOGGER.error("Missing value for %s", speaker_attribute)
-            value = None
         else:
             try:
                 value = int(state)
@@ -296,7 +295,6 @@ class SonosSpeaker:
                     speaker_attribute,
                     state,
                 )
-                value = None
         setattr(self, speaker_attribute, value)
         return value
 

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -275,6 +275,31 @@ class SonosSpeaker:
         """Write states for associated SonosEntity instances."""
         async_dispatcher_send(self.hass, f"{SONOS_STATE_UPDATED}-{self.soco.uid}")
 
+    def update_soco_int_attribute(
+        self, soco_attribute: str, speaker_attribute: str
+    ) -> int | None:
+        """Update an integer attribute from SoCo and set it on the speaker.
+
+        Returns the integer value if successful, otherwise None. Do not call from
+        async context as it is a blocking function.
+        """
+        state = getattr(self.soco, soco_attribute, None)
+        assert isinstance(state, str), (
+            f"Expected state to be str, got {type(state).__name__}"
+        )
+        try:
+            value = int(state)
+        except ValueError:
+            _LOGGER.error(
+                "Invalid value for %s %s",
+                speaker_attribute,
+                state,
+            )
+            setattr(self, speaker_attribute, None)
+            return None
+        setattr(self, speaker_attribute, value)
+        return value
+
     #
     # Properties
     #

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -283,9 +283,8 @@ class SonosSpeaker:
         Returns the integer value if successful, otherwise None. Do not call from
         async context as it is a blocking function.
         """
-        state = getattr(self.soco, soco_attribute, None)
         value: int | None
-        if state is None:
+        if (state := getattr(self.soco, soco_attribute, None)) is None:
             _LOGGER.error("Missing value for %s", speaker_attribute)
             value = None
         else:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -284,19 +284,20 @@ class SonosSpeaker:
         async context as it is a blocking function.
         """
         state = getattr(self.soco, soco_attribute, None)
-        assert isinstance(state, str), (
-            f"Expected state to be str, got {type(state).__name__}"
-        )
         value: int | None
-        try:
-            value = int(state)
-        except ValueError:
-            _LOGGER.error(
-                "Invalid value for %s %s",
-                speaker_attribute,
-                state,
-            )
+        if state is None:
+            _LOGGER.error("Missing value for %s", speaker_attribute)
             value = None
+        else:
+            try:
+                value = int(state)
+            except (TypeError, ValueError):
+                _LOGGER.error(
+                    "Invalid value for %s %s",
+                    speaker_attribute,
+                    state,
+                )
+                value = None
         setattr(self, speaker_attribute, value)
         return value
 

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -287,6 +287,7 @@ class SonosSpeaker:
         assert isinstance(state, str), (
             f"Expected state to be str, got {type(state).__name__}"
         )
+        value: int | None
         try:
             value = int(state)
         except ValueError:
@@ -295,8 +296,7 @@ class SonosSpeaker:
                 speaker_attribute,
                 state,
             )
-            setattr(self, speaker_attribute, None)
-            return None
+            value = None
         setattr(self, speaker_attribute, value)
         return value
 

--- a/tests/components/sonos/test_select.py
+++ b/tests/components/sonos/test_select.py
@@ -36,8 +36,8 @@ async def platform_binary_sensor_fixture():
 @pytest.mark.parametrize(
     ("level", "result"),
     [
-        (0, "off"),
-        (1, "low"),
+        ("0", "off"),
+        ("1", "low"),
         ("2", "medium"),
         ("3", "high"),
         ("4", "max"),
@@ -77,7 +77,7 @@ async def test_select_dialog_invalid_level(
 
     speaker_info["model_name"] = MODEL_SONOS_ARC_ULTRA.lower()
     soco.get_speaker_info.return_value = speaker_info
-    soco.dialog_level = 10
+    soco.dialog_level = "10"
 
     with caplog.at_level(logging.WARNING):
         await async_setup_sonos()
@@ -131,7 +131,7 @@ async def test_select_dialog_level_set(
 
     speaker_info["model_name"] = MODEL_SONOS_ARC_ULTRA.lower()
     soco.get_speaker_info.return_value = speaker_info
-    soco.dialog_level = 0
+    soco.dialog_level = "0"
 
     await async_setup_sonos()
 
@@ -170,12 +170,12 @@ async def test_select_dialog_level_event(
 
     speaker_info["model_name"] = MODEL_SONOS_ARC_ULTRA.lower()
     soco.get_speaker_info.return_value = speaker_info
-    soco.dialog_level = 0
+    soco.dialog_level = "0"
 
     await async_setup_sonos()
 
     event = create_rendering_control_event(soco)
-    event.variables[ATTR_DIALOG_LEVEL] = 3
+    event.variables[ATTR_DIALOG_LEVEL] = "3"
     soco.renderingControl.subscribe.return_value._callback(event)
     await hass.async_block_till_done(wait_background_tasks=True)
 

--- a/tests/components/sonos/test_select.py
+++ b/tests/components/sonos/test_select.py
@@ -88,6 +88,13 @@ async def test_select_dialog_invalid_level(
     assert dialog_level_state.state == STATE_UNKNOWN
 
 
+@pytest.mark.parametrize(
+    ("value", "result"),
+    [
+        ("invalid_integer", "Invalid value for dialog_level_enum invalid_integer"),
+        (None, "Missing value for dialog_level_enum"),
+    ],
+)
 async def test_select_dialog_value_error(
     hass: HomeAssistant,
     async_setup_sonos,
@@ -95,16 +102,18 @@ async def test_select_dialog_value_error(
     entity_registry: er.EntityRegistry,
     speaker_info: dict[str, str],
     caplog: pytest.LogCaptureFixture,
+    value: str | None,
+    result: str,
 ) -> None:
     """Test receiving a value from Sonos that is not convertible to an integer."""
 
     speaker_info["model_name"] = MODEL_SONOS_ARC_ULTRA.lower()
     soco.get_speaker_info.return_value = speaker_info
-    soco.dialog_level = "invalid_integer"
+    soco.dialog_level = value
 
     with caplog.at_level(logging.WARNING):
         await async_setup_sonos()
-    assert "Invalid value for dialog_level_enum invalid_integer" in caplog.text
+    assert result in caplog.text
 
     assert SELECT_DIALOG_LEVEL_ENTITY not in entity_registry.entities
 

--- a/tests/components/sonos/test_select.py
+++ b/tests/components/sonos/test_select.py
@@ -36,8 +36,8 @@ async def platform_binary_sensor_fixture():
 @pytest.mark.parametrize(
     ("level", "result"),
     [
-        ("0", "off"),
-        ("1", "low"),
+        (0, "off"),
+        (1, "low"),
         ("2", "medium"),
         ("3", "high"),
         ("4", "max"),
@@ -77,7 +77,7 @@ async def test_select_dialog_invalid_level(
 
     speaker_info["model_name"] = MODEL_SONOS_ARC_ULTRA.lower()
     soco.get_speaker_info.return_value = speaker_info
-    soco.dialog_level = "10"
+    soco.dialog_level = 10
 
     with caplog.at_level(logging.WARNING):
         await async_setup_sonos()
@@ -131,7 +131,7 @@ async def test_select_dialog_level_set(
 
     speaker_info["model_name"] = MODEL_SONOS_ARC_ULTRA.lower()
     soco.get_speaker_info.return_value = speaker_info
-    soco.dialog_level = "0"
+    soco.dialog_level = 0
 
     await async_setup_sonos()
 


### PR DESCRIPTION
## Proposed change

In #151649 we fixed the dialog select type conversion issue in the subscription branch; on further review, the change missed the branch used when polling the speaker (if subscriptions are not working.) This fix addresses that issue by consolidating the code into one method; and adds the missing tests for handling type conversion issues.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #151526
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
