### PR TITLE
Switchbot Cloud: Fix Roller Shade not work issue

### DIFF
--- a/homeassistant/components/switchbot_cloud/cover.py
+++ b/homeassistant/components/switchbot_cloud/cover.py
@@ -109,15 +109,13 @@ class SwitchBotCloudCoverRollerShade(SwitchBotCloudCover):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        await self.send_api_command(RollerShadeCommands.SET_POSITION, parameters=str(0))
+        await self.send_api_command(RollerShadeCommands.SET_POSITION, parameters=0)
         await asyncio.sleep(COVER_ENTITY_AFTER_COMMAND_REFRESH)
         await self.coordinator.async_request_refresh()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        await self.send_api_command(
-            RollerShadeCommands.SET_POSITION, parameters=str(100)
-        )
+        await self.send_api_command(RollerShadeCommands.SET_POSITION, parameters=100)
         await asyncio.sleep(COVER_ENTITY_AFTER_COMMAND_REFRESH)
         await self.coordinator.async_request_refresh()
 
@@ -126,7 +124,7 @@ class SwitchBotCloudCoverRollerShade(SwitchBotCloudCover):
         position: int | None = kwargs.get("position")
         if position is not None:
             await self.send_api_command(
-                RollerShadeCommands.SET_POSITION, parameters=str(100 - position)
+                RollerShadeCommands.SET_POSITION, parameters=(100 - position)
             )
             await asyncio.sleep(COVER_ENTITY_AFTER_COMMAND_REFRESH)
             await self.coordinator.async_request_refresh()

--- a/homeassistant/components/switchbot_cloud/entity.py
+++ b/homeassistant/components/switchbot_cloud/entity.py
@@ -44,7 +44,7 @@ class SwitchBotCloudEntity(CoordinatorEntity[SwitchBotCoordinator]):
         self,
         command: Commands,
         command_type: str = "command",
-        parameters: dict | str = "default",
+        parameters: dict | str | int = "default",
     ) -> None:
         """Send command to device."""
         await self._api.send_command(

--- a/tests/components/switchbot_cloud/test_cover.py
+++ b/tests/components/switchbot_cloud/test_cover.py
@@ -319,7 +319,7 @@ async def test_roller_shade_features(
             blocking=True,
         )
     mock_send_command.assert_called_once_with(
-        "cover-id-1", RollerShadeCommands.SET_POSITION, "command", "0"
+        "cover-id-1", RollerShadeCommands.SET_POSITION, "command", 0
     )
 
     await configure_integration(hass)
@@ -334,7 +334,7 @@ async def test_roller_shade_features(
             blocking=True,
         )
     mock_send_command.assert_called_once_with(
-        "cover-id-1", RollerShadeCommands.SET_POSITION, "command", "100"
+        "cover-id-1", RollerShadeCommands.SET_POSITION, "command", 100
     )
 
     await configure_integration(hass)
@@ -349,7 +349,7 @@ async def test_roller_shade_features(
             blocking=True,
         )
     mock_send_command.assert_called_once_with(
-        "cover-id-1", RollerShadeCommands.SET_POSITION, "command", "50"
+        "cover-id-1", RollerShadeCommands.SET_POSITION, "command", 50
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

1. Add allowed parameter types
2. Modify parameter type to fix bug


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fix #151950
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
