### PR TITLE
Enable thread migration for ZBT integration

### DIFF
--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -274,8 +274,8 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
 
         return self.async_show_progress_done(next_step_id=next_step_id)
 
-    async def _configure_and_start_addon(self) -> None:
-        """Configure and start the addon."""
+    async def _configure_and_start_otbr_addon(self) -> None:
+        """Configure and start the OTBR addon."""
 
         # Before we start the addon, confirm that the correct firmware is running
         # and populate `self._probed_firmware_info` with the correct information
@@ -556,7 +556,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
 
         if not self.addon_start_task:
             self.addon_start_task = self.hass.async_create_task(
-                self._configure_and_start_addon()
+                self._configure_and_start_otbr_addon()
             )
 
         if not self.addon_start_task.done():

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -274,6 +274,45 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
 
         return self.async_show_progress_done(next_step_id=next_step_id)
 
+    async def _configure_and_start_addon(self) -> None:
+        """Configure and start the addon."""
+
+        # Before we start the addon, confirm that the correct firmware is running
+        # and populate `self._probed_firmware_info` with the correct information
+        if not await self._probe_firmware_info(probe_methods=(ApplicationType.SPINEL,)):
+            raise AbortFlow(
+                "unsupported_firmware",
+                description_placeholders=self._get_translation_placeholders(),
+            )
+
+        otbr_manager = get_otbr_addon_manager(self.hass)
+        addon_info = await self._async_get_addon_info(otbr_manager)
+
+        assert self._device is not None
+        new_addon_config = {
+            **addon_info.options,
+            "device": self._device,
+            "baudrate": 460800,
+            "flow_control": True,
+            "autoflash_firmware": False,
+        }
+
+        _LOGGER.debug("Reconfiguring OTBR addon with %s", new_addon_config)
+
+        try:
+            await otbr_manager.async_set_addon_options(new_addon_config)
+        except AddonError as err:
+            _LOGGER.error(err)
+            raise AbortFlow(
+                "addon_set_config_failed",
+                description_placeholders={
+                    **self._get_translation_placeholders(),
+                    "addon_name": otbr_manager.addon_name,
+                },
+            ) from err
+
+        await otbr_manager.async_start_addon_waiting()
+
     async def async_step_firmware_download_failed(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -453,18 +492,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
             return await self.async_step_install_otbr_addon()
 
         if addon_info.state == AddonState.RUNNING:
-            # We only fail setup if we have an instance of OTBR running *and* it's
-            # pointing to different hardware
-            if addon_info.options["device"] != self._device:
-                return self.async_abort(
-                    reason="otbr_addon_already_running",
-                    description_placeholders={
-                        **self._get_translation_placeholders(),
-                        "addon_name": otbr_manager.addon_name,
-                    },
-                )
-
-            # Otherwise, stop the addon before continuing to flash firmware
+            # Stop the addon before continuing to flash firmware
             await otbr_manager.async_stop_addon()
 
         return None
@@ -527,43 +555,8 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         otbr_manager = get_otbr_addon_manager(self.hass)
 
         if not self.addon_start_task:
-            # Before we start the addon, confirm that the correct firmware is running
-            # and populate `self._probed_firmware_info` with the correct information
-            if not await self._probe_firmware_info(
-                probe_methods=(ApplicationType.SPINEL,)
-            ):
-                return self.async_abort(
-                    reason="unsupported_firmware",
-                    description_placeholders=self._get_translation_placeholders(),
-                )
-
-            addon_info = await self._async_get_addon_info(otbr_manager)
-
-            assert self._device is not None
-            new_addon_config = {
-                **addon_info.options,
-                "device": self._device,
-                "baudrate": 460800,
-                "flow_control": True,
-                "autoflash_firmware": False,
-            }
-
-            _LOGGER.debug("Reconfiguring OTBR addon with %s", new_addon_config)
-
-            try:
-                await otbr_manager.async_set_addon_options(new_addon_config)
-            except AddonError as err:
-                _LOGGER.error(err)
-                raise AbortFlow(
-                    "addon_set_config_failed",
-                    description_placeholders={
-                        **self._get_translation_placeholders(),
-                        "addon_name": otbr_manager.addon_name,
-                    },
-                ) from err
-
             self.addon_start_task = self.hass.async_create_task(
-                otbr_manager.async_start_addon_waiting()
+                self._configure_and_start_addon()
             )
 
         if not self.addon_start_task.done():

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -575,7 +575,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         except (AddonError, AbortFlow) as err:
             _LOGGER.error(err)
             self._failed_addon_name = otbr_manager.addon_name
-            self._failed_addon_reason = "addon_start_failed"
+            self._failed_addon_reason = getattr(err, "reason", "addon_start_failed")
             return self.async_show_progress_done(next_step_id="addon_operation_failed")
         finally:
             self.addon_start_task = None

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -575,7 +575,9 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         except (AddonError, AbortFlow) as err:
             _LOGGER.error(err)
             self._failed_addon_name = otbr_manager.addon_name
-            self._failed_addon_reason = getattr(err, "reason", "addon_start_failed")
+            self._failed_addon_reason = (
+                err.reason if isinstance(err, AbortFlow) else "addon_start_failed"
+            )
             return self.async_show_progress_done(next_step_id="addon_operation_failed")
         finally:
             self.addon_start_task = None

--- a/tests/components/homeassistant_hardware/test_config_flow_failures.py
+++ b/tests/components/homeassistant_hardware/test_config_flow_failures.py
@@ -281,47 +281,6 @@ async def test_config_flow_thread_addon_info_fails(hass: HomeAssistant) -> None:
     "ignore_translations_for_mock_domains",
     ["test_firmware_domain"],
 )
-async def test_config_flow_thread_addon_already_configured(hass: HomeAssistant) -> None:
-    """Test failure case when the Thread addon is already running."""
-    result = await hass.config_entries.flow.async_init(
-        TEST_DOMAIN, context={"source": "hardware"}
-    )
-
-    with mock_firmware_info(
-        hass,
-        probe_app_type=ApplicationType.EZSP,
-        otbr_addon_info=AddonInfo(
-            available=True,
-            hostname=None,
-            options={
-                "device": TEST_DEVICE + "2",  # A different device
-            },
-            state=AddonState.RUNNING,
-            update_available=False,
-            version="1.0.0",
-        ),
-    ) as (mock_otbr_manager, _):
-        mock_otbr_manager.async_install_addon_waiting = AsyncMock(
-            side_effect=AddonError()
-        )
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
-        )
-
-        # Cannot install addon
-        assert result["type"] == FlowResultType.ABORT
-        assert result["reason"] == "otbr_addon_already_running"
-
-
-@pytest.mark.parametrize(
-    "ignore_translations_for_mock_domains",
-    ["test_firmware_domain"],
-)
 async def test_config_flow_thread_addon_install_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon cannot be installed."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Continuation of #152532 . Remove the explicit fail on existing OTBR and just update the config with the new device.

Also moved the set config code into the progress step to improve UX

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zigpy/backlog/issues/28
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
