### PR TITLE
Optimize ci caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ on:
         type: boolean
 
 env:
-  CACHE_VERSION: 8
+  CACHE_VERSION: 1
   UV_CACHE_VERSION: 1
   MYPY_CACHE_VERSION: 1
   HA_SHORT_VERSION: "2025.10"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -500,12 +500,14 @@ jobs:
         id: generate-uv-key
         run: |
           uv_version=$(cat requirements.txt | grep uv | cut -d '=' -f 3)
+          week=$(date -u '+%Y-%W')
+          key_suffix="${uv_version}-${week}-$(date -u '+%Y-%m-%dT%H:%M:%s')"
           echo "version=${uv_version}" >> $GITHUB_OUTPUT
-          echo "key=uv-${{ env.UV_CACHE_VERSION }}-${uv_version}-${{
-            env.HA_SHORT_VERSION }}-$(date -u '+%Y-%m-%dT%H:%M:%s')" >> $GITHUB_OUTPUT
+          echo "week=${week}" >> $GITHUB_OUTPUT
+          echo "key=uv-${{ env.UV_CACHE_VERSION }}-${key_suffix}" >> $GITHUB_OUTPUT
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: venv
           key: >-
@@ -513,7 +515,7 @@ jobs:
             needs.info.outputs.python_cache_key }}
       - name: Restore uv wheel cache
         if: steps.cache-venv.outputs.cache-hit != 'true'
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ${{ env.UV_CACHE_DIR }}
           key: >-
@@ -522,7 +524,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-uv-${{
             env.UV_CACHE_VERSION }}-${{ steps.generate-uv-key.outputs.version }}-${{
-            env.HA_SHORT_VERSION }}-
+            steps.generate-uv-key.outputs.week }}-
       - name: Check if apt cache exists
         id: cache-apt-check
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -578,6 +580,7 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Create Python virtual environment
+        id: create-venv
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           python -m venv venv
@@ -589,6 +592,24 @@ jobs:
           python -m script.gen_requirements_all ci
           uv pip install -r requirements_all_pytest.txt -r requirements_test.txt
           uv pip install -e . --config-settings editable_mode=compat
+      - name: Save base Python virtual environment
+        if: steps.create-venv.conclusion == 'success'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: venv
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-${{
+            needs.info.outputs.python_cache_key }}
+      - name: Save uv wheel cache
+        if: |
+          github.event_name != 'pull_request'
+          && steps.create-venv.conclusion == 'success'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ env.UV_CACHE_DIR }}
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-${{
+            steps.generate-uv-key.outputs.key }}
       - name: Dump pip freeze
         run: |
           python -m venv venv
@@ -891,7 +912,7 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-${{
             needs.info.outputs.python_cache_key }}
       - name: Restore mypy cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .mypy_cache
           key: >-
@@ -905,6 +926,7 @@ jobs:
         run: |
           echo "::add-matcher::.github/workflows/matchers/mypy.json"
       - name: Run mypy (fully)
+        id: mypy-full-run
         if: needs.info.outputs.test_full_suite == 'true'
         run: |
           . venv/bin/activate
@@ -917,6 +939,16 @@ jobs:
           . venv/bin/activate
           python --version
           mypy homeassistant/components/${{ needs.info.outputs.integrations_glob }}
+      - name: Save mypy cache
+        if: |
+          github.event_name != 'pull_request'
+          && steps.mypy-full-run.conclusion == 'success'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .mypy_cache
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-${{
+            steps.generate-mypy-key.outputs.key }}
 
   prepare-pytest-full:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Proposed change
Our cache usage regularly exceeds the 10GB provided by Github. With a few exceptions, that's not really an issue as Github cleans them up automatically. This happens once every 24h at the moment. So it's not uncommon to see the usage spike to +100GB at the end of the day. As there is a plan to provide additional paid caching space in the future, it might help to optimize our usage so we can probably evaluate the actual needs.

https://github.com/github/roadmap/issues/1029

**Changes in this PR**
- Don't store the `uv` cache for PR runs. It's by far the cache with the biggest individual size and for PRs just unnecessary. Those can reuse the cache from the last `dev` run. At most a dependency bump PR rebuilds an (expensive) dependency for every new CI run. Since most dependencies provide wheels for `x86_64` that isn't a huge deal though.
- Don't store `mypy` caches for partial runs and PRs. These caches aren't that big but it's usually more than fast enough to just reuse the cache from `dev` again.
- Reset `uv` cache more often. At the moment the cache is reset after every HA version bump. The result is that the cache grows much larger than it actually needs to be. E.g. at the moment a uv cache is `1.5GB`, a fresh one would be just `500MB`. I suggest we use week numbers instead, so that the cache will be reset every Monday morning. This is fairly simple to implement with `date -u '%Y-%W'`.

=> We'll likely continue to use way over the 10GB and still rely on Github to auto-remove old cache entries. _It's possible to build a workflow to remove old cache entires. It's probably just not worth it at this time._ The main goal here is to reduce the cache increase per day.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
