### PR TITLE
Bump python roborock  to 2.44.1

### DIFF
--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -19,7 +19,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==2.18.2",
+    "python-roborock==2.44.0",
     "vacuum-map-parser-roborock==0.1.4"
   ]
 }

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -19,7 +19,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==2.44.0",
+    "python-roborock==2.44.1",
     "vacuum-map-parser-roborock==0.1.4"
   ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2522,7 +2522,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==2.44.0
+python-roborock==2.44.1
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.44

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2522,7 +2522,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==2.18.2
+python-roborock==2.44.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.44

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2095,7 +2095,7 @@ python-pooldose==0.5.0
 python-rabbitair==0.0.8
 
 # homeassistant.components.roborock
-python-roborock==2.18.2
+python-roborock==2.44.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.44

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2095,7 +2095,7 @@ python-pooldose==0.5.0
 python-rabbitair==0.0.8
 
 # homeassistant.components.roborock
-python-roborock==2.44.0
+python-roborock==2.44.1
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.44

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -87,7 +87,7 @@ def bypass_api_client_fixture() -> None:
 
 
 @pytest.fixture(name="bypass_api_fixture")
-def bypass_api_fixture(bypass_api_client_fixture: Any) -> None:
+def bypass_api_fixture(bypass_api_client_fixture: Any, mock_send_message: Mock) -> None:
     """Skip calls to the API."""
     with (
         patch("homeassistant.components.roborock.RoborockMqttClientV1.async_connect"),
@@ -116,7 +116,7 @@ def bypass_api_fixture(bypass_api_client_fixture: Any) -> None:
             return_value=MAP_DATA,
         ),
         patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_message"
         ),
         patch("homeassistant.components.roborock.RoborockMqttClientV1._wait_response"),
         patch(

--- a/tests/components/roborock/snapshots/test_diagnostics.ambr
+++ b/tests/components/roborock/snapshots/test_diagnostics.ambr
@@ -32,8 +32,6 @@
     'coordinators': dict({
       '**REDACTED-0**': dict({
         'api': dict({
-          'misc_info': dict({
-          }),
         }),
         'roborock_device_info': dict({
           'device': dict({
@@ -319,8 +317,6 @@
       }),
       '**REDACTED-1**': dict({
         'api': dict({
-          'misc_info': dict({
-          }),
         }),
         'roborock_device_info': dict({
           'device': dict({
@@ -606,8 +602,6 @@
       }),
       '**REDACTED-2**': dict({
         'api': dict({
-          'misc_info': dict({
-          }),
         }),
         'roborock_device_info': dict({
           'device': dict({
@@ -969,8 +963,6 @@
       }),
       '**REDACTED-3**': dict({
         'api': dict({
-          'misc_info': dict({
-          }),
         }),
         'roborock_device_info': dict({
           'device': dict({

--- a/tests/components/roborock/test_number.py
+++ b/tests/components/roborock/test_number.py
@@ -1,9 +1,9 @@
 """Test Roborock Number platform."""
 
-from unittest.mock import patch
+from unittest.mock import Mock
 
 import pytest
-import roborock
+from roborock.exceptions import RoborockTimeout
 
 from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
 from homeassistant.const import Platform
@@ -31,20 +31,18 @@ async def test_update_success(
     setup_entry: MockConfigEntry,
     entity_id: str,
     value: float,
+    mock_send_message: Mock,
 ) -> None:
     """Test allowed changing values for number entities."""
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
-    with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
-    ) as mock_send_message:
-        await hass.services.async_call(
-            "number",
-            SERVICE_SET_VALUE,
-            service_data={ATTR_VALUE: value},
-            blocking=True,
-            target={"entity_id": entity_id},
-        )
+    await hass.services.async_call(
+        "number",
+        SERVICE_SET_VALUE,
+        service_data={ATTR_VALUE: value},
+        blocking=True,
+        target={"entity_id": entity_id},
+    )
     assert mock_send_message.assert_called_once
 
 
@@ -54,23 +52,19 @@ async def test_update_success(
         ("number.roborock_s7_maxv_volume", 3.0),
     ],
 )
+@pytest.mark.parametrize("send_message_side_effect", [RoborockTimeout])
 async def test_update_failed(
     hass: HomeAssistant,
     bypass_api_fixture,
     setup_entry: MockConfigEntry,
     entity_id: str,
     value: float,
+    mock_send_message: Mock,
 ) -> None:
     """Test allowed changing values for number entities."""
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
-    with (
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
-            side_effect=roborock.exceptions.RoborockTimeout,
-        ) as mock_send_message,
-        pytest.raises(HomeAssistantError, match="Failed to update Roborock options"),
-    ):
+    with pytest.raises(HomeAssistantError, match="Failed to update Roborock options"):
         await hass.services.async_call(
             "number",
             SERVICE_SET_VALUE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump python roborock  to 2.44.0

Changes: https://github.com/Python-roborock/python-roborock/compare/v2.18.2...v2.44.1

This includes some changes to the test patching to account for internal method renames.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
