### PR TITLE
Auto select first active wake word

### DIFF
--- a/homeassistant/components/esphome/select.py
+++ b/homeassistant/components/esphome/select.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from dataclasses import replace
 
 from aioesphomeapi import EntityInfo, SelectInfo, SelectState
@@ -191,17 +190,7 @@ class EsphomeAssistSatelliteWakeWordSelect(
             self.async_write_ha_state()
             return
 
-        self._wake_words = {}
-        wake_word_counts: dict[str, int] = Counter()
-        for available_ww in sorted(config.available_wake_words, key=lambda ww: ww.id):
-            ww_count = wake_word_counts[available_ww.wake_word] + 1
-            ww_option_text = available_ww.wake_word
-            if ww_count > 1:
-                ww_option_text = f"{ww_option_text} ({ww_count})"
-
-            self._wake_words[ww_option_text] = available_ww.id
-            wake_word_counts[available_ww.wake_word] = ww_count
-
+        self._wake_words = {w.wake_word: w.id for w in config.available_wake_words}
         self._attr_options = [NO_WAKE_WORD, *sorted(self._wake_words)]
 
         option = self._attr_current_option

--- a/tests/components/esphome/test_assist_satellite.py
+++ b/tests/components/esphome/test_assist_satellite.py
@@ -1887,10 +1887,10 @@ async def test_wake_word_select(
     assert satellite is not None
     assert satellite.async_get_configuration().active_wake_words == ["hey_jarvis"]
 
-    # No wake word should be selected by default
+    # First wake word should be selected by default
     state = hass.states.get("select.test_wake_word")
     assert state is not None
-    assert state.state == NO_WAKE_WORD
+    assert state.state == "Hey Jarvis"
 
     # Changing the select should set the active wake word
     await hass.services.async_call(
@@ -1954,6 +1954,21 @@ async def test_wake_word_select(
 
     # Only primary wake word remains
     assert satellite.async_get_configuration().active_wake_words == ["okay_nabu"]
+
+    # Remove the primary wake word
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: "select.test_wake_word", "option": NO_WAKE_WORD},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    async with asyncio.timeout(1):
+        await configuration_set.wait()
+
+    # No active wake word remain
+    assert not satellite.async_get_configuration().active_wake_words
 
 
 async def test_secondary_pipeline(

--- a/tests/components/esphome/test_select.py
+++ b/tests/components/esphome/test_select.py
@@ -254,39 +254,3 @@ async def test_wake_word_select_first_active_wake_word(
     state_2 = hass.states.get("select.test_wake_word_2")
     assert state_2 is not None
     assert state_2.state == NO_WAKE_WORD
-
-
-async def test_wake_word_select_same_name(
-    hass: HomeAssistant,
-    mock_client: APIClient,
-    mock_esphome_device: MockESPHomeDeviceType,
-) -> None:
-    """Test wake word select supports multiple wake words with the same name."""
-    device_config = AssistSatelliteConfiguration(
-        available_wake_words=[
-            AssistSatelliteWakeWord("okay_nabu", "Okay Nabu", ["en"]),
-            AssistSatelliteWakeWord("okay_nabu_other", "Okay Nabu", ["en"]),
-        ],
-        active_wake_words=["okay_nabu_other"],
-        max_active_wake_words=1,
-    )
-    mock_client.get_voice_assistant_configuration.return_value = device_config
-
-    mock_device = await mock_esphome_device(
-        mock_client=mock_client,
-        device_info={
-            "voice_assistant_feature_flags": VoiceAssistantFeature.VOICE_ASSISTANT
-            | VoiceAssistantFeature.ANNOUNCE
-        },
-    )
-    await hass.async_block_till_done()
-
-    satellite = get_satellite_entity(hass, mock_device.device_info.mac_address)
-    assert satellite is not None
-
-    # Second "Okay Nabu" should be selected
-    state = hass.states.get(
-        "select.test_wake_word",
-    )
-    assert state is not None
-    assert state.state == "Okay Nabu (2)"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With the support of dual wake words and the "no wake word", we need to be more careful about selecting the correct wake word. This PR automatically selects the first active wake word if the device reports only one active (most devices in the wild). If the user picks "No wake word", the device should report no active wake words the next time it connects.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
