### PR TITLE
Add TriggerConfig to reduce ambiguity

### DIFF
--- a/homeassistant/components/zwave_js/triggers/event.py
+++ b/homeassistant/components/zwave_js/triggers/event.py
@@ -139,11 +139,13 @@ class EventTrigger(Trigger):
 
     @classmethod
     async def async_validate_complete_config(
-        cls, hass: HomeAssistant, config: ConfigType
+        cls, hass: HomeAssistant, complete_config: ConfigType
     ) -> ConfigType:
         """Validate complete config."""
-        config = move_top_level_schema_fields_to_options(config, _OPTIONS_SCHEMA_DICT)
-        return await super().async_validate_complete_config(hass, config)
+        complete_config = move_top_level_schema_fields_to_options(
+            complete_config, _OPTIONS_SCHEMA_DICT
+        )
+        return await super().async_validate_complete_config(hass, complete_config)
 
     @classmethod
     async def async_validate_config(
@@ -170,10 +172,10 @@ class EventTrigger(Trigger):
 
         return config
 
-    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+    def __init__(self, hass: HomeAssistant, complete_config: ConfigType) -> None:
         """Initialize trigger."""
         self._hass = hass
-        self._options = config[CONF_OPTIONS]
+        self._options = complete_config[CONF_OPTIONS]
 
     async def async_attach(
         self,

--- a/homeassistant/components/zwave_js/triggers/event.py
+++ b/homeassistant/components/zwave_js/triggers/event.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.trigger import (
     Trigger,
     TriggerActionType,
+    TriggerConfig,
     TriggerData,
     TriggerInfo,
     move_top_level_schema_fields_to_options,
@@ -173,7 +174,7 @@ class EventTrigger(Trigger):
 
         return config
 
-    def __init__(self, hass: HomeAssistant, config: Trigger.Config) -> None:
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
         """Initialize trigger."""
         self._hass = hass
         assert config.options is not None

--- a/homeassistant/components/zwave_js/triggers/event.py
+++ b/homeassistant/components/zwave_js/triggers/event.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import functools
+from typing import Any
 
 from pydantic import ValidationError
 import voluptuous as vol
@@ -126,7 +127,7 @@ class EventTrigger(Trigger):
     """Z-Wave JS event trigger."""
 
     _hass: HomeAssistant
-    _options: ConfigType
+    _options: dict[str, Any]
 
     _event_source: str
     _event_name: str
@@ -172,10 +173,11 @@ class EventTrigger(Trigger):
 
         return config
 
-    def __init__(self, hass: HomeAssistant, complete_config: ConfigType) -> None:
+    def __init__(self, hass: HomeAssistant, config: Trigger.Config) -> None:
         """Initialize trigger."""
         self._hass = hass
-        self._options = complete_config[CONF_OPTIONS]
+        assert config.options is not None
+        self._options = config.options
 
     async def async_attach(
         self,

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.trigger import (
     Trigger,
     TriggerActionType,
+    TriggerConfig,
     TriggerInfo,
     move_top_level_schema_fields_to_options,
 )
@@ -242,7 +243,7 @@ class ValueUpdatedTrigger(Trigger):
         """Validate config."""
         return await async_validate_trigger_config(hass, config)
 
-    def __init__(self, hass: HomeAssistant, config: Trigger.Config) -> None:
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
         """Initialize trigger."""
         self._hass = hass
         assert config.options is not None

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -226,11 +226,13 @@ class ValueUpdatedTrigger(Trigger):
 
     @classmethod
     async def async_validate_complete_config(
-        cls, hass: HomeAssistant, config: ConfigType
+        cls, hass: HomeAssistant, complete_config: ConfigType
     ) -> ConfigType:
         """Validate complete config."""
-        config = move_top_level_schema_fields_to_options(config, _OPTIONS_SCHEMA_DICT)
-        return await super().async_validate_complete_config(hass, config)
+        complete_config = move_top_level_schema_fields_to_options(
+            complete_config, _OPTIONS_SCHEMA_DICT
+        )
+        return await super().async_validate_complete_config(hass, complete_config)
 
     @classmethod
     async def async_validate_config(
@@ -239,10 +241,10 @@ class ValueUpdatedTrigger(Trigger):
         """Validate config."""
         return await async_validate_trigger_config(hass, config)
 
-    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+    def __init__(self, hass: HomeAssistant, complete_config: ConfigType) -> None:
         """Initialize trigger."""
         self._hass = hass
-        self._options = config[CONF_OPTIONS]
+        self._options = complete_config[CONF_OPTIONS]
 
     async def async_attach(
         self,

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import functools
+from typing import Any
 
 import voluptuous as vol
 from zwave_js_server.const import CommandClass
@@ -222,7 +223,7 @@ class ValueUpdatedTrigger(Trigger):
     """Z-Wave JS value updated trigger."""
 
     _hass: HomeAssistant
-    _options: ConfigType
+    _options: dict[str, Any]
 
     @classmethod
     async def async_validate_complete_config(
@@ -241,10 +242,11 @@ class ValueUpdatedTrigger(Trigger):
         """Validate config."""
         return await async_validate_trigger_config(hass, config)
 
-    def __init__(self, hass: HomeAssistant, complete_config: ConfigType) -> None:
+    def __init__(self, hass: HomeAssistant, config: Trigger.Config) -> None:
         """Initialize trigger."""
         self._hass = hass
-        self._options = complete_config[CONF_OPTIONS]
+        assert config.options is not None
+        self._options = config.options
 
     async def async_attach(
         self,

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -178,14 +178,6 @@ _TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
 class Trigger(abc.ABC):
     """Trigger class."""
 
-    @dataclass(slots=True, frozen=True)
-    class Config:
-        """Trigger config."""
-
-        key: str  # The key used to identify the trigger, e.g. "zwave.event"
-        target: dict[str, Any] | None = None
-        options: dict[str, Any] | None = None
-
     @classmethod
     async def async_validate_complete_config(
         cls, hass: HomeAssistant, complete_config: ConfigType
@@ -218,7 +210,7 @@ class Trigger(abc.ABC):
     ) -> ConfigType:
         """Validate config."""
 
-    def __init__(self, hass: HomeAssistant, config: Config) -> None:
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
         """Initialize trigger."""
 
     @abc.abstractmethod
@@ -254,6 +246,15 @@ class TriggerProtocol(Protocol):
         trigger_info: TriggerInfo,
     ) -> CALLBACK_TYPE:
         """Attach a trigger."""
+
+
+@dataclass(slots=True, frozen=True)
+class TriggerConfig:
+    """Trigger config."""
+
+    key: str  # The key used to identify the trigger, e.g. "zwave.event"
+    target: dict[str, Any] | None = None
+    options: dict[str, Any] | None = None
 
 
 class TriggerActionType(Protocol):
@@ -563,7 +564,7 @@ async def async_initialize_triggers(
             trigger_cls = trigger_descriptors[relative_trigger_key]
             trigger = trigger_cls(
                 hass,
-                Trigger.Config(
+                TriggerConfig(
                     key=trigger_key,
                     target=conf.get(CONF_TARGET),
                     options=conf.get(CONF_OPTIONS),

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -182,7 +182,6 @@ class Trigger(abc.ABC):
     class Config:
         """Trigger config."""
 
-        key: str  # The key used to identify the trigger type, e.g. "zwave.event"
         target: dict[str, Any] | None = None
         options: dict[str, Any] | None = None
 
@@ -564,9 +563,7 @@ async def async_initialize_triggers(
             trigger = trigger_cls(
                 hass,
                 Trigger.Config(
-                    key=trigger_key,
-                    target=conf.get(CONF_TARGET),
-                    options=conf.get(CONF_OPTIONS),
+                    target=conf.get(CONF_TARGET), options=conf.get(CONF_OPTIONS)
                 ),
             )
             coro = trigger.async_attach(action_wrapper, info)

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -182,7 +182,7 @@ class Trigger(abc.ABC):
     class Config:
         """Trigger config."""
 
-        key: str  # The key used to identify the trigger type, e.g. "zwave.event"
+        key: str  # The key used to identify the trigger, e.g. "zwave.event"
         target: dict[str, Any] | None = None
         options: dict[str, Any] | None = None
 

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -182,6 +182,7 @@ class Trigger(abc.ABC):
     class Config:
         """Trigger config."""
 
+        key: str  # The key used to identify the trigger type, e.g. "zwave.event"
         target: dict[str, Any] | None = None
         options: dict[str, Any] | None = None
 
@@ -563,7 +564,9 @@ async def async_initialize_triggers(
             trigger = trigger_cls(
                 hass,
                 Trigger.Config(
-                    target=conf.get(CONF_TARGET), options=conf.get(CONF_OPTIONS)
+                    key=trigger_key,
+                    target=conf.get(CONF_TARGET),
+                    options=conf.get(CONF_OPTIONS),
                 ),
             )
             coro = trigger.async_attach(action_wrapper, info)

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -180,7 +180,7 @@ class Trigger(abc.ABC):
 
     @classmethod
     async def async_validate_complete_config(
-        cls, hass: HomeAssistant, config: ConfigType
+        cls, hass: HomeAssistant, complete_config: ConfigType
     ) -> ConfigType:
         """Validate complete config.
 
@@ -189,19 +189,19 @@ class Trigger(abc.ABC):
         This method should be overridden by triggers that need to migrate
         from the old-style config.
         """
-        config = _TRIGGER_SCHEMA(config)
+        complete_config = _TRIGGER_SCHEMA(complete_config)
 
         specific_config: ConfigType = {}
         for key in (CONF_OPTIONS, CONF_TARGET):
-            if key in config:
-                specific_config[key] = config.pop(key)
+            if key in complete_config:
+                specific_config[key] = complete_config.pop(key)
         specific_config = await cls.async_validate_config(hass, specific_config)
 
         for key in (CONF_OPTIONS, CONF_TARGET):
             if key in specific_config:
-                config[key] = specific_config[key]
+                complete_config[key] = specific_config[key]
 
-        return config
+        return complete_config
 
     @classmethod
     @abc.abstractmethod
@@ -210,7 +210,7 @@ class Trigger(abc.ABC):
     ) -> ConfigType:
         """Validate config."""
 
-    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+    def __init__(self, hass: HomeAssistant, complete_config: ConfigType) -> None:
         """Initialize trigger."""
 
     @abc.abstractmethod

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.trigger import (
     PluggableAction,
     Trigger,
     TriggerActionType,
+    TriggerConfig,
     TriggerInfo,
     _async_get_trigger_platform,
     async_initialize_triggers,
@@ -535,7 +536,7 @@ async def test_platform_multiple_triggers(hass: HomeAssistant) -> None:
             """Validate config."""
             return config
 
-        def __init__(self, hass: HomeAssistant, config: Trigger.Config) -> None:
+        def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
             """Initialize trigger."""
 
     class MockTrigger1(MockTrigger):

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -535,7 +535,7 @@ async def test_platform_multiple_triggers(hass: HomeAssistant) -> None:
             """Validate config."""
             return config
 
-        def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+        def __init__(self, hass: HomeAssistant, complete_config: ConfigType) -> None:
             """Initialize trigger."""
 
     class MockTrigger1(MockTrigger):
@@ -612,13 +612,13 @@ async def test_platform_migrate_trigger(hass: HomeAssistant) -> None:
 
         @classmethod
         async def async_validate_complete_config(
-            cls, hass: HomeAssistant, config: ConfigType
+            cls, hass: HomeAssistant, complete_config: ConfigType
         ) -> ConfigType:
             """Validate complete config."""
-            config = move_top_level_schema_fields_to_options(
-                config, OPTIONS_SCHEMA_DICT
+            complete_config = move_top_level_schema_fields_to_options(
+                complete_config, OPTIONS_SCHEMA_DICT
             )
-            return await super().async_validate_complete_config(hass, config)
+            return await super().async_validate_complete_config(hass, complete_config)
 
         @classmethod
         async def async_validate_config(

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -535,7 +535,7 @@ async def test_platform_multiple_triggers(hass: HomeAssistant) -> None:
             """Validate config."""
             return config
 
-        def __init__(self, hass: HomeAssistant, complete_config: ConfigType) -> None:
+        def __init__(self, hass: HomeAssistant, config: Trigger.Config) -> None:
             """Initialize trigger."""
 
     class MockTrigger1(MockTrigger):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#151314 splits "config" for the trigger-specific config and "complete config" for the full one. Having `config` in `__init__` refer to something different than `config` in `async_validate_config()` is confusing.
This PR introduces a new type Trigger.Config used in `__init__` to make it clear that it is not the same `config` as the one in `async_validate_config()`. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
