### PR TITLE
Remove unit= and add device_id= for modbus services.

### DIFF
--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -107,7 +107,7 @@ UDP = "udp"
 # service call attributes
 ATTR_ADDRESS = CONF_ADDRESS
 ATTR_HUB = "hub"
-ATTR_UNIT = "unit"
+ATTR_DEVICE_ADDRESS = "device_address"
 ATTR_SLAVE = "slave"
 ATTR_VALUE = "value"
 

--- a/homeassistant/components/modbus/services.yaml
+++ b/homeassistant/components/modbus/services.yaml
@@ -18,6 +18,12 @@ write_coil:
         number:
           min: 1
           max: 255
+    device_address:
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 255
     hub:
       example: "hub1"
       default: "modbus_hub"
@@ -32,6 +38,12 @@ write_register:
           min: 0
           max: 65535
     slave:
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 255
+    device_address:
       required: false
       selector:
         number:

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -17,8 +17,12 @@
           "description": "State to write."
         },
         "slave": {
-          "name": "Server",
-          "description": "Address of the Modbus unit/server."
+          "name": "device address",
+          "description": "Address of the Modbus device (please rename to device_address, will soon be removed)."
+        },
+        "device_address": {
+          "name": "device address",
+          "description": "Address of the Modbus device."
         },
         "hub": {
           "name": "Hub",
@@ -31,12 +35,16 @@
       "description": "Writes to a Modbus holding register.",
       "fields": {
         "address": {
-          "name": "[%key:component::modbus::services::write_coil::fields::address::name%]",
+          "name": "Address",
           "description": "Address of the holding register to write to."
         },
         "slave": {
-          "name": "[%key:component::modbus::services::write_coil::fields::slave::name%]",
-          "description": "[%key:component::modbus::services::write_coil::fields::slave::description%]"
+          "name": "Device address",
+          "description": "Address of the Modbus device (please rename to device_address, will soon be removed)."
+        },
+        "device_address": {
+          "name": "Device address",
+          "description": "Address of the Modbus device."
         },
         "value": {
           "name": "Value",
@@ -44,7 +52,7 @@
         },
         "hub": {
           "name": "[%key:component::modbus::services::write_coil::fields::hub::name%]",
-          "description": "[%key:component::modbus::services::write_coil::fields::hub::description%]"
+          "description": "hub containing the device with the holding register being written to."
         }
       }
     },
@@ -54,7 +62,7 @@
       "fields": {
         "hub": {
           "name": "[%key:component::modbus::services::write_coil::fields::hub::name%]",
-          "description": "[%key:component::modbus::services::write_coil::fields::hub::description%]"
+          "description": "hub to be stopped."
         }
       }
     },
@@ -64,7 +72,7 @@
       "fields": {
         "hub": {
           "name": "[%key:component::modbus::services::write_coil::fields::hub::name%]",
-          "description": "[%key:component::modbus::services::write_coil::fields::hub::description%]"
+          "description": "hub to be restarted."
         }
       }
     }

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -27,9 +27,9 @@ from homeassistant import config as hass_config
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.modbus.const import (
     ATTR_ADDRESS,
+    ATTR_DEVICE_ADDRESS,
     ATTR_HUB,
     ATTR_SLAVE,
-    ATTR_UNIT,
     ATTR_VALUE,
     CALL_TYPE_COIL,
     CALL_TYPE_DISCRETE,
@@ -960,7 +960,8 @@ SERVICE = "service"
     "do_slave",
     [
         ATTR_SLAVE,
-        ATTR_UNIT,
+        ATTR_DEVICE_ADDRESS,
+        "unit",
     ],
 )
 async def test_pb_service_write(
@@ -1525,7 +1526,7 @@ async def test_pb_service_write_no_slave(
     caplog: pytest.LogCaptureFixture,
     mock_modbus_with_pymodbus,
 ) -> None:
-    """Run test for service write_register in case of missing slave/unit parameter."""
+    """Run test for service write_register in case of missing slave/device_address parameter."""
 
     func_name = {
         CALL_TYPE_WRITE_COIL: mock_modbus_with_pymodbus.write_coil,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
unit= have for a very long time been removed from documentation including strings and services, now it also removed from the code.

slave= is still present and legal to use, however it will soon be removed.

device_id= is the new device address (id).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
https://github.com/home-assistant/home-assistant.io/pull/40917

- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
