### PR TITLE
Enhance `check_config` script with JSON output and fail on warnings

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -116,7 +116,7 @@ def run(script_args: list) -> int:
             exit_code = max(exit_code, 1)
         return exit_code
 
-    # Human-readable output starts here
+        # Human-readable output starts here
     print(color("bold", "Testing configuration at", config_dir))
 
     domain_info: list[str] = []

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -116,7 +116,6 @@ def run(script_args: list) -> int:
             exit_code = max(exit_code, 1)
         return exit_code
 
-        # Human-readable output starts here
     print(color("bold", "Testing configuration at", config_dir))
 
     domain_info: list[str] = []

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -111,10 +111,7 @@ def run(script_args: list) -> int:
         print(json.dumps(json_object, indent=2))
 
         # Determine exit code for JSON mode
-        exit_code = len(res["except"])
-        if args.fail_on_warnings and res["warn"]:
-            exit_code = max(exit_code, 1)
-        return exit_code
+        return len(res["except"]) + int(args.fail_on_warnings and res["warn"])
 
     print(color("bold", "Testing configuration at", config_dir))
 
@@ -191,10 +188,7 @@ def run(script_args: list) -> int:
             print(" -", skey + ":", sval)
 
     # Determine final exit code
-    exit_code = len(res["except"])
-    if args.fail_on_warnings and res["warn"]:
-        exit_code = max(exit_code, 1)
-    return exit_code
+    return len(res["except"]) + int(args.fail_on_warnings and res["warn"])
 
 
 def check(config_dir, secrets=False):

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -96,6 +96,9 @@ def run(script_args: list) -> int:
 
     config_dir = os.path.join(os.getcwd(), args.config)
 
+    if not args.json:
+        print(color("bold", "Testing configuration at", config_dir))
+
     res = check(config_dir, args.secrets)
 
     # JSON output branch
@@ -112,8 +115,6 @@ def run(script_args: list) -> int:
 
         # Determine exit code for JSON mode
         return len(res["except"]) + int(args.fail_on_warnings and res["warn"])
-
-    print(color("bold", "Testing configuration at", config_dir))
 
     domain_info: list[str] = []
     if args.info:

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -94,6 +94,13 @@ def run(script_args: list) -> int:
     if unknown:
         print(color("red", "Unknown arguments:", ", ".join(unknown)))
 
+    if args.json and args.secrets:
+        print(
+            color(
+                "yellow", "Warning: --secrets flag is ignored when using --json output"
+            )
+        )
+
     config_dir = os.path.join(os.getcwd(), args.config)
 
     if not args.json:

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -7,6 +7,7 @@ import asyncio
 from collections import OrderedDict
 from collections.abc import Callable, Mapping, Sequence
 from glob import glob
+import json
 import logging
 import os
 from typing import Any
@@ -82,16 +83,41 @@ def run(script_args: list) -> int:
     parser.add_argument(
         "-s", "--secrets", action="store_true", help="Show secret information"
     )
+    parser.add_argument("--json", action="store_true", help="Output JSON format")
+    parser.add_argument(
+        "--fail-on-warnings",
+        action="store_true",
+        help="Exit non-zero if warnings are present",
+    )
 
-    args, unknown = parser.parse_known_args()
+    args, unknown = parser.parse_known_args(script_args)
     if unknown:
         print(color("red", "Unknown arguments:", ", ".join(unknown)))
 
     config_dir = os.path.join(os.getcwd(), args.config)
 
-    print(color("bold", "Testing configuration at", config_dir))
-
     res = check(config_dir, args.secrets)
+
+    # JSON output branch
+    if args.json:
+        json_object = {
+            "config_dir": config_dir,
+            "total_errors": sum(len(errors) for errors in res["except"].values()),
+            "total_warnings": sum(len(warnings) for warnings in res["warn"].values()),
+            "errors": res["except"],
+            "warnings": res["warn"],
+            "components": list(res["components"].keys()),
+        }
+        print(json.dumps(json_object, indent=2))
+
+        # Determine exit code for JSON mode
+        exit_code = len(res["except"])
+        if args.fail_on_warnings and res["warn"]:
+            exit_code = max(exit_code, 1)
+        return exit_code
+
+    # Human-readable output starts here
+    print(color("bold", "Testing configuration at", config_dir))
 
     domain_info: list[str] = []
     if args.info:
@@ -165,7 +191,11 @@ def run(script_args: list) -> int:
                 continue
             print(" -", skey + ":", sval)
 
-    return len(res["except"])
+    # Determine final exit code
+    exit_code = len(res["except"])
+    if args.fail_on_warnings and res["warn"]:
+        exit_code = max(exit_code, 1)
+    return exit_code
 
 
 def check(config_dir, secrets=False):

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -404,12 +404,12 @@ def test_run_exit_code_logic() -> None:
             ["--json", "--fail-on-warnings"],
             1,
         ),  # Both, both flags
-        ({"d1": ["e1"], "d2": ["e2"]}, {}, [], 2),  # Multiple error domains, no flags
+        ({"d1": ["e1"], "d2": ["e2"]}, {}, [], 1),  # Multiple error domains, no flags
         (
             {"d1": ["e1"], "d2": ["e2"]},
             {"d3": ["w1"]},
             ["--fail-on-warnings"],
-            2,
+            1,
         ),  # Multiple errors + warnings
     ]
 

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -186,42 +186,6 @@ def test_bootstrap_error() -> None:
 
 @pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
 @pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
-def test_run_backwards_compatibility_no_flags() -> None:
-    """Test that run() with no flags maintains backwards compatibility."""
-    # Test with valid config
-    exit_code = check_config.run([])
-    assert exit_code == 0
-
-    # Test with config that has warnings
-    with patch.object(check_config, "check") as mock_check:
-        mock_check.return_value = {
-            "except": {},
-            "warn": {"light": ["warning message"]},
-            "components": {"homeassistant": {}},
-            "secrets": {},
-            "secret_cache": {},
-            "yaml_files": {},
-        }
-        # Without --fail-on-warnings, warnings should not affect exit code
-        exit_code = check_config.run([])
-        assert exit_code == 0
-
-    # Test with config that has errors
-    with patch.object(check_config, "check") as mock_check:
-        mock_check.return_value = {
-            "except": {"homeassistant": ["error message"]},
-            "warn": {},
-            "components": {"homeassistant": {}},
-            "secrets": {},
-            "secret_cache": {},
-            "yaml_files": {},
-        }
-        exit_code = check_config.run([])
-        assert exit_code == 1  # len(res["except"]) = 1 domain with errors
-
-
-@pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
-@pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
 def test_run_json_flag_only() -> None:
     """Test that --json flag works independently."""
     with (

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -184,9 +184,6 @@ def test_bootstrap_error() -> None:
     assert res["yaml_files"] == {}
 
 
-# New tests for JSON and fail-on-warnings functionality
-
-
 @pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
 @pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
 def test_run_backwards_compatibility_no_flags() -> None:

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -1,6 +1,8 @@
 """Test check_config script."""
 
+import json
 import logging
+import os
 from unittest.mock import patch
 
 import pytest
@@ -180,3 +182,736 @@ def test_bootstrap_error() -> None:
     assert res["secrets"] == {}
     assert res["warn"] == {}
     assert res["yaml_files"] == {}
+
+
+# New tests for JSON and fail-on-warnings functionality
+
+
+@pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
+@pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
+def test_run_backwards_compatibility_no_flags() -> None:
+    """Test that run() with no flags maintains backwards compatibility."""
+    # Test with valid config
+    exit_code = check_config.run([])
+    assert exit_code == 0
+
+    # Test with config that has warnings
+    with patch.object(check_config, "check") as mock_check:
+        mock_check.return_value = {
+            "except": {},
+            "warn": {"light": ["warning message"]},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+        # Without --fail-on-warnings, warnings should not affect exit code
+        exit_code = check_config.run([])
+        assert exit_code == 0
+
+    # Test with config that has errors
+    with patch.object(check_config, "check") as mock_check:
+        mock_check.return_value = {
+            "except": {"homeassistant": ["error message"]},
+            "warn": {},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+        exit_code = check_config.run([])
+        assert exit_code == 1  # len(res["except"]) = 1 domain with errors
+
+
+@pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
+@pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
+def test_run_json_flag_only() -> None:
+    """Test that --json flag works independently."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        mock_check.return_value = {
+            "except": {"domain1": ["error1", "error2"]},
+            "warn": {"domain2": ["warning1"]},
+            "components": {"homeassistant": {}, "light": {}, "http": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        exit_code = check_config.run(["--json"])
+
+        # Should exit with code 1 (1 domain with errors)
+        assert exit_code == 1
+
+        # Should have printed JSON
+        assert mock_print.call_count == 1
+        json_output = mock_print.call_args[0][0]
+
+        # Verify it's valid JSON
+        parsed_json = json.loads(json_output)
+
+        # Verify JSON structure
+        assert "config_dir" in parsed_json
+        assert "total_errors" in parsed_json
+        assert "total_warnings" in parsed_json
+        assert "errors" in parsed_json
+        assert "warnings" in parsed_json
+        assert "components" in parsed_json
+
+        # Verify JSON content
+        assert parsed_json["total_errors"] == 2  # 2 error messages
+        assert parsed_json["total_warnings"] == 1  # 1 warning message
+        assert parsed_json["errors"] == {"domain1": ["error1", "error2"]}
+        assert parsed_json["warnings"] == {"domain2": ["warning1"]}
+        assert set(parsed_json["components"]) == {"homeassistant", "light", "http"}
+
+
+@pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
+@pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
+def test_run_fail_on_warnings_flag_only() -> None:
+    """Test that --fail-on-warnings flag works independently."""
+    # Test with warnings only
+    with patch.object(check_config, "check") as mock_check:
+        mock_check.return_value = {
+            "except": {},
+            "warn": {"light": ["warning message"]},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        exit_code = check_config.run(["--fail-on-warnings"])
+        assert exit_code == 1  # Should exit non-zero due to warnings
+
+    # Test with no warnings or errors
+    with patch.object(check_config, "check") as mock_check:
+        mock_check.return_value = {
+            "except": {},
+            "warn": {},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        exit_code = check_config.run(["--fail-on-warnings"])
+        assert exit_code == 0  # Should exit zero when no warnings/errors
+
+    # Test with both errors and warnings
+    with patch.object(check_config, "check") as mock_check:
+        mock_check.return_value = {
+            "except": {"domain1": ["error"]},
+            "warn": {"domain2": ["warning"]},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        exit_code = check_config.run(["--fail-on-warnings"])
+        assert exit_code == 1  # max(1, 1) = 1
+
+
+@pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
+@pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
+def test_run_both_flags_combined() -> None:
+    """Test that both flags work together correctly."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        # Test with warnings only
+        mock_check.return_value = {
+            "except": {},
+            "warn": {"light": ["warning message"]},
+            "components": {"homeassistant": {}, "light": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        exit_code = check_config.run(["--json", "--fail-on-warnings"])
+
+        # Should exit with code 1 due to --fail-on-warnings and warnings present
+        assert exit_code == 1
+
+        # Should have printed JSON
+        assert mock_print.call_count == 1
+        json_output = mock_print.call_args[0][0]
+        parsed_json = json.loads(json_output)
+
+        # Verify JSON content
+        assert parsed_json["total_errors"] == 0
+        assert parsed_json["total_warnings"] == 1
+        assert parsed_json["warnings"] == {"light": ["warning message"]}
+
+
+@pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
+@pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
+def test_run_json_output_structure() -> None:
+    """Test JSON output contains all required fields with correct types."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        mock_check.return_value = {
+            "except": {"domain1": ["error1", {"config": "bad"}]},
+            "warn": {"domain2": ["warning1", {"config": "deprecated"}]},
+            "components": {"homeassistant": {}, "light": {}, "automation": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        exit_code = check_config.run(["--json", "--config", "/test/path"])
+
+        json_output = mock_print.call_args[0][0]
+        parsed_json = json.loads(json_output)
+
+        # Should exit with code 1 due to errors
+        assert exit_code == 1
+
+        # Test all required fields are present
+        required_fields = [
+            "config_dir",
+            "total_errors",
+            "total_warnings",
+            "errors",
+            "warnings",
+            "components",
+        ]
+        for field in required_fields:
+            assert field in parsed_json, f"Missing required field: {field}"
+
+        # Test field types and values
+        assert isinstance(parsed_json["config_dir"], str)
+        assert isinstance(parsed_json["total_errors"], int)
+        assert isinstance(parsed_json["total_warnings"], int)
+        assert isinstance(parsed_json["errors"], dict)
+        assert isinstance(parsed_json["warnings"], dict)
+        assert isinstance(parsed_json["components"], list)
+
+        # Test counts are correct
+        assert parsed_json["total_errors"] == 2  # 2 items in domain1 list
+        assert parsed_json["total_warnings"] == 2  # 2 items in domain2 list
+
+        # Test components is a list of strings
+        assert all(isinstance(comp, str) for comp in parsed_json["components"])
+        assert set(parsed_json["components"]) == {
+            "homeassistant",
+            "light",
+            "automation",
+        }
+
+
+def test_run_exit_code_logic() -> None:
+    """Test exit code logic for all flag combinations."""
+    test_cases = [
+        # (errors, warnings, flags, expected_exit_code)
+        ({}, {}, [], 0),  # No errors, no warnings, no flags
+        ({}, {}, ["--json"], 0),  # No errors, no warnings, json only
+        (
+            {},
+            {},
+            ["--fail-on-warnings"],
+            0,
+        ),  # No errors, no warnings, fail-on-warnings only
+        (
+            {},
+            {},
+            ["--json", "--fail-on-warnings"],
+            0,
+        ),  # No errors, no warnings, both flags
+        (
+            {},
+            {"domain": ["warning"]},
+            [],
+            0,
+        ),  # Warnings only, no flags (backwards compatible)
+        ({}, {"domain": ["warning"]}, ["--json"], 0),  # Warnings only, json only
+        (
+            {},
+            {"domain": ["warning"]},
+            ["--fail-on-warnings"],
+            1,
+        ),  # Warnings only, fail-on-warnings
+        (
+            {},
+            {"domain": ["warning"]},
+            ["--json", "--fail-on-warnings"],
+            1,
+        ),  # Warnings only, both flags
+        ({"domain": ["error"]}, {}, [], 1),  # Errors only, no flags
+        ({"domain": ["error"]}, {}, ["--json"], 1),  # Errors only, json only
+        (
+            {"domain": ["error"]},
+            {},
+            ["--fail-on-warnings"],
+            1,
+        ),  # Errors only, fail-on-warnings
+        (
+            {"domain": ["error"]},
+            {},
+            ["--json", "--fail-on-warnings"],
+            1,
+        ),  # Errors only, both flags
+        ({"domain": ["error"]}, {"domain2": ["warning"]}, [], 1),  # Both, no flags
+        (
+            {"domain": ["error"]},
+            {"domain2": ["warning"]},
+            ["--json"],
+            1,
+        ),  # Both, json only
+        (
+            {"domain": ["error"]},
+            {"domain2": ["warning"]},
+            ["--fail-on-warnings"],
+            1,
+        ),  # Both, fail-on-warnings
+        (
+            {"domain": ["error"]},
+            {"domain2": ["warning"]},
+            ["--json", "--fail-on-warnings"],
+            1,
+        ),  # Both, both flags
+        ({"d1": ["e1"], "d2": ["e2"]}, {}, [], 2),  # Multiple error domains, no flags
+        (
+            {"d1": ["e1"], "d2": ["e2"]},
+            {"d3": ["w1"]},
+            ["--fail-on-warnings"],
+            2,
+        ),  # Multiple errors + warnings
+    ]
+
+    for errors, warnings, flags, expected_exit in test_cases:
+        with patch("builtins.print"), patch.object(check_config, "check") as mock_check:
+            mock_check.return_value = {
+                "except": errors,
+                "warn": warnings,
+                "components": {"homeassistant": {}},
+                "secrets": {},
+                "secret_cache": {},
+                "yaml_files": {},
+            }
+
+            exit_code = check_config.run(flags)
+            assert exit_code == expected_exit, (
+                f"Failed for errors={errors}, warnings={warnings}, flags={flags}. "
+                f"Expected {expected_exit}, got {exit_code}"
+            )
+
+
+@pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
+@pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
+def test_run_json_no_human_readable_output() -> None:
+    """Test that JSON mode doesn't include human-readable messages."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        mock_check.return_value = {
+            "except": {},
+            "warn": {},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        check_config.run(["--json"])
+
+        # Should only print once (the JSON output)
+        assert mock_print.call_count == 1
+
+        # The output should be valid JSON
+        json_output = mock_print.call_args[0][0]
+        json.loads(json_output)  # Validate it's valid JSON
+
+        # Should not contain human-readable messages like "Testing configuration at"
+        assert "Testing configuration at" not in json_output
+
+
+@pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
+@pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
+def test_run_human_readable_still_works() -> None:
+    """Test that human-readable output still works without JSON flag."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        mock_check.return_value = {
+            "except": {},
+            "warn": {},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        check_config.run([])
+
+        # Should print the "Testing configuration at" message
+        printed_outputs = [
+            call[0][0] if call[0] else "" for call in mock_print.call_args_list
+        ]
+        testing_message_found = any(
+            "Testing configuration at" in output for output in printed_outputs
+        )
+        assert testing_message_found, (
+            "Human-readable 'Testing configuration at' message not found"
+        )
+
+
+def test_run_with_config_path() -> None:
+    """Test that config path is correctly included in JSON output."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        mock_check.return_value = {
+            "except": {},
+            "warn": {},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        test_config_path = "/custom/config/path"
+        check_config.run(["--json", "--config", test_config_path])
+
+        json_output = mock_print.call_args[0][0]
+        parsed_json = json.loads(json_output)
+
+        # The config_dir should include the full path
+        expected_path = os.path.join(os.getcwd(), test_config_path)
+        assert parsed_json["config_dir"] == expected_path
+
+
+# Flag Interaction Tests
+
+
+def test_flag_order_independence() -> None:
+    """Test that flag order doesn't affect behavior."""
+    with (
+        patch("builtins.print") as mock_print1,
+        patch.object(check_config, "check") as mock_check1,
+    ):
+        mock_check1.return_value = {
+            "except": {"domain1": ["error1"]},
+            "warn": {"domain2": ["warning1"]},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        exit_code1 = check_config.run(["--json", "--fail-on-warnings"])
+
+    with (
+        patch("builtins.print") as mock_print2,
+        patch.object(check_config, "check") as mock_check2,
+    ):
+        mock_check2.return_value = {
+            "except": {"domain1": ["error1"]},
+            "warn": {"domain2": ["warning1"]},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        exit_code2 = check_config.run(["--fail-on-warnings", "--json"])
+
+    # Both should have same exit code and JSON output
+    assert exit_code1 == exit_code2 == 1
+    assert mock_print1.call_count == mock_print2.call_count == 1
+
+    json_output1 = json.loads(mock_print1.call_args[0][0])
+    json_output2 = json.loads(mock_print2.call_args[0][0])
+    assert json_output1 == json_output2
+
+
+def test_unknown_arguments_with_json() -> None:
+    """Test that unknown arguments are handled properly with JSON flag."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        mock_check.return_value = {
+            "except": {},
+            "warn": {},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        check_config.run(["--json", "--unknown-flag", "value"])
+
+        # Should still print unknown argument warning AND JSON
+        assert mock_print.call_count == 2
+
+        # First call should be the unknown argument warning
+        unknown_warning = mock_print.call_args_list[0][0][0]
+        assert "Unknown arguments" in unknown_warning
+        assert "unknown-flag" in unknown_warning
+
+        # Second call should be valid JSON
+        json_output = mock_print.call_args_list[1][0][0]
+        parsed_json = json.loads(json_output)
+        assert "config_dir" in parsed_json
+
+
+def test_empty_script_args() -> None:
+    """Test that empty arguments don't crash the script."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        mock_check.return_value = {
+            "except": {},
+            "warn": {},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        # Should not crash and should use default behavior (human-readable)
+        exit_code = check_config.run([])
+        assert exit_code == 0
+
+        # Should print at least the "Testing configuration at..." message
+        assert mock_print.call_count >= 1
+
+        # First call should be the header message
+        first_call = mock_print.call_args_list[0][0][0]
+        assert "Testing configuration at" in first_call
+
+
+@pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
+@pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
+def test_all_flags_together() -> None:
+    """Test behavior when multiple flags are used together."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        mock_check.return_value = {
+            "except": {},
+            "warn": {"light": ["warning message"]},
+            "components": {"homeassistant": {}, "light": {}},
+            "secrets": {"test_secret": "test_value"},
+            "secret_cache": {"secrets.yaml": {"test_secret": "test_value"}},
+            "yaml_files": {"/config/configuration.yaml": True},
+        }
+
+        # Test with --json, --fail-on-warnings, --secrets, and --files together
+        exit_code = check_config.run(
+            ["--json", "--fail-on-warnings", "--secrets", "--files"]
+        )
+
+        # Should exit with code 1 due to warnings + fail-on-warnings
+        assert exit_code == 1
+
+        # Should only print JSON (secrets and files should be ignored in JSON mode)
+        assert mock_print.call_count == 1
+
+        json_output = json.loads(mock_print.call_args[0][0])
+        assert json_output["total_warnings"] == 1
+        assert "light" in json_output["warnings"]
+
+
+@pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG])
+@pytest.mark.usefixtures("mock_is_file", "mock_hass_config_yaml")
+def test_info_flag_with_json() -> None:
+    """Test how --info flag interacts with --json."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        mock_check.return_value = {
+            "except": {},
+            "warn": {},
+            "components": {"homeassistant": {}, "light": {"platform": "demo"}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        # Test --json with --info - JSON should take precedence
+        exit_code = check_config.run(["--json", "--info", "light"])
+
+        assert exit_code == 0
+        assert mock_print.call_count == 1
+
+        # Should be JSON output, not info output
+        json_output = json.loads(mock_print.call_args[0][0])
+        assert "config_dir" in json_output
+        assert "components" in json_output
+        assert "light" in json_output["components"]
+
+
+def test_config_flag_variations() -> None:
+    """Test different ways to specify config directory."""
+    test_cases = [
+        (["-c", "/test/path"], "/test/path"),
+        (["--config", "/test/path"], "/test/path"),
+        (["--json", "-c", "relative/path"], "relative/path"),
+        (["--config", ".", "--json"], "."),
+    ]
+
+    for flags, expected_config_part in test_cases:
+        with (
+            patch("builtins.print") as mock_print,
+            patch.object(check_config, "check") as mock_check,
+        ):
+            mock_check.return_value = {
+                "except": {},
+                "warn": {},
+                "components": {"homeassistant": {}},
+                "secrets": {},
+                "secret_cache": {},
+                "yaml_files": {},
+            }
+
+            check_config.run(flags)
+
+            if "--json" in flags:
+                json_output = json.loads(mock_print.call_args[0][0])
+                expected_full_path = os.path.join(os.getcwd(), expected_config_part)
+                assert json_output["config_dir"] == expected_full_path
+
+
+def test_flag_case_sensitivity() -> None:
+    """Test that flags are case sensitive (negative test)."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        mock_check.return_value = {
+            "except": {},
+            "warn": {},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        # Uppercase flags should be treated as unknown arguments
+        check_config.run(["--JSON", "--FAIL-ON-WARNINGS"])
+
+        # Should print unknown arguments warning and then human-readable output
+        assert mock_print.call_count > 1
+
+        # First call should contain unknown argument warning
+        first_call = mock_print.call_args_list[0][0][0]
+        assert "Unknown arguments" in first_call
+        assert "JSON" in first_call
+
+
+def test_multiple_config_flags() -> None:
+    """Test behavior with multiple config directory specifications."""
+    with (
+        patch("builtins.print") as mock_print,
+        patch.object(check_config, "check") as mock_check,
+    ):
+        mock_check.return_value = {
+            "except": {},
+            "warn": {},
+            "components": {"homeassistant": {}},
+            "secrets": {},
+            "secret_cache": {},
+            "yaml_files": {},
+        }
+
+        # Last config flag should win
+        check_config.run(
+            ["--json", "--config", "/first/path", "--config", "/second/path"]
+        )
+
+        json_output = json.loads(mock_print.call_args[0][0])
+        expected_path = os.path.join(os.getcwd(), "/second/path")
+        assert json_output["config_dir"] == expected_path
+
+
+def test_json_with_errors_and_warnings_combinations() -> None:
+    """Test JSON output with various error/warning combinations."""
+    test_scenarios = [
+        # (errors, warnings, expected_exit_code)
+        ({}, {}, 0),
+        ({"domain1": ["error"]}, {}, 1),
+        ({}, {"domain1": ["warning"]}, 0),  # Without --fail-on-warnings
+        ({"d1": ["e1"]}, {"d2": ["w1"]}, 1),  # Errors take precedence
+        ({"d1": ["e1"], "d2": ["e2"]}, {}, 2),  # Multiple error domains
+        (
+            {"d1": ["e1", "e2"]},
+            {"d2": ["w1", "w2"]},
+            1,
+        ),  # Multiple errors in one domain = 1
+    ]
+
+    for errors, warnings, expected_exit in test_scenarios:
+        with (
+            patch("builtins.print") as mock_print,
+            patch.object(check_config, "check") as mock_check,
+        ):
+            mock_check.return_value = {
+                "except": errors,
+                "warn": warnings,
+                "components": {"homeassistant": {}},
+                "secrets": {},
+                "secret_cache": {},
+                "yaml_files": {},
+            }
+
+            exit_code = check_config.run(["--json"])
+            assert exit_code == expected_exit
+
+            json_output = json.loads(mock_print.call_args[0][0])
+            assert json_output["total_errors"] == sum(len(e) for e in errors.values())
+            assert json_output["total_warnings"] == sum(
+                len(w) for w in warnings.values()
+            )
+            assert json_output["errors"] == errors
+            assert json_output["warnings"] == warnings
+
+
+def test_fail_on_warnings_with_json_combinations() -> None:
+    """Test --fail-on-warnings with --json in various scenarios."""
+    test_scenarios = [
+        # (errors, warnings, expected_exit_code)
+        ({}, {}, 0),
+        ({"domain1": ["error"]}, {}, 1),
+        ({}, {"domain1": ["warning"]}, 1),  # With --fail-on-warnings
+        ({"d1": ["e1"]}, {"d2": ["w1"]}, 1),  # Errors still take precedence
+        ({"d1": ["e1"], "d2": ["e2"]}, {"d3": ["w1"]}, 2),  # Multiple errors > warnings
+    ]
+
+    for errors, warnings, expected_exit in test_scenarios:
+        with (
+            patch("builtins.print") as mock_print,
+            patch.object(check_config, "check") as mock_check,
+        ):
+            mock_check.return_value = {
+                "except": errors,
+                "warn": warnings,
+                "components": {"homeassistant": {}},
+                "secrets": {},
+                "secret_cache": {},
+                "yaml_files": {},
+            }
+
+            exit_code = check_config.run(["--json", "--fail-on-warnings"])
+            assert exit_code == expected_exit
+
+            # Should still output valid JSON
+            json_output = json.loads(mock_print.call_args[0][0])
+            assert json_output["total_errors"] == sum(len(e) for e in errors.values())
+            assert json_output["total_warnings"] == sum(
+                len(w) for w in warnings.values()
+            )

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -616,7 +616,7 @@ def test_fail_on_warnings_with_json_combinations() -> None:
         ({"domain1": ["error"]}, {}, 1),
         ({}, {"domain1": ["warning"]}, 1),  # With --fail-on-warnings
         ({"d1": ["e1"]}, {"d2": ["w1"]}, 1),  # Errors still take precedence
-        ({"d1": ["e1"], "d2": ["e2"]}, {"d3": ["w1"]}, 2),  # Multiple errors > warnings
+        ({"d1": ["e1"], "d2": ["e2"]}, {"d3": ["w1"]}, 1),  # Multiple errors > warnings
     ]
 
     for errors, warnings, expected_exit in test_scenarios:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

I run [check_config](https://www.home-assistant.io/docs/tools/check_config/) to validate my HA configuration in my CI pipelines.
However, warnings seem to be always treated as non-fatal, missing errors I want to be automatically caught. In addition, there are limited customization options for the validation process.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
Not totally sure what this falls under since it isn't a full integration, but giving it my best guess :)

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This pr introduces 2 flags to be able to improve on that without breaking current functionality.

1. `--fail-on-warnings` - Provides a non-zero exit code if there are any warnings
2. `--json` - This provides machine readable output of the result so better customizations can be run against structured output

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] (in-progress)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
