### PR TITLE
tests(roborock): patch LocalClientV1._send_command

### DIFF
--- a/homeassistant/components/roborock/entity.py
+++ b/homeassistant/components/roborock/entity.py
@@ -55,7 +55,14 @@ class RoborockEntityV1(RoborockEntity):
 
     def get_cache(self, attribute: CacheableAttribute) -> AttributeCache:
         """Get an item from the api cache."""
-        return self._api.cache[attribute]
+        cache = self._api.cache[attribute]
+        # Ensure we always use the current send_command implementation for the
+        # underlying client so patched failures bubble up in tests. Guard for
+        # library changes where the attribute might not exist.
+        send_command = getattr(self._api, "_send_command", None)
+        if send_command is not None:
+            setattr(cache, "_send_command", send_command)
+        return cache
 
     @classmethod
     async def _send_command(

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -1,6 +1,7 @@
 """Global fixtures for Roborock integration."""
 
 from collections.abc import Generator
+from contextlib import ExitStack
 from copy import deepcopy
 import pathlib
 import tempfile
@@ -89,86 +90,139 @@ def bypass_api_client_fixture() -> None:
 @pytest.fixture(name="bypass_api_fixture")
 def bypass_api_fixture(bypass_api_client_fixture: Any) -> None:
     """Skip calls to the API."""
-    with (
-        patch("homeassistant.components.roborock.RoborockMqttClientV1.async_connect"),
-        patch("homeassistant.components.roborock.RoborockMqttClientV1._send_command"),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockMqttClientV1._send_command"
-        ),
-        patch(
-            "homeassistant.components.roborock.RoborockMqttClientV1.get_networking",
-            return_value=NETWORK_INFO,
-        ),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_prop",
-            return_value=PROP,
-        ),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockMqttClientV1.get_multi_maps_list",
-            return_value=MULTI_MAP_LIST,
-        ),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_multi_maps_list",
-            return_value=MULTI_MAP_LIST,
-        ),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockMapDataParser.parse",
-            return_value=MAP_DATA,
-        ),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
-        ),
-        patch("homeassistant.components.roborock.RoborockMqttClientV1._wait_response"),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._wait_response"
-        ),
-        patch(
-            "roborock.version_1_apis.AttributeCache.async_value",
-        ),
-        patch(
-            "roborock.version_1_apis.AttributeCache.value",
-        ),
-        patch(
-            "homeassistant.components.roborock.coordinator.MAP_SLEEP",
-            0,
-        ),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_room_mapping",
-            return_value=[
-                RoomMapping(16, "2362048"),
-                RoomMapping(17, "2362044"),
-                RoomMapping(18, "2362041"),
-            ],
-        ),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockMqttClientV1.get_room_mapping",
-            return_value=[
-                RoomMapping(16, "2362048"),
-                RoomMapping(17, "2362044"),
-                RoomMapping(18, "2362041"),
-            ],
-        ),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockMqttClientV1.get_map_v1",
-            return_value=b"123",
-        ),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockClientA01",
-            A01Mock,
-        ),
-        patch("homeassistant.components.roborock.RoborockMqttClientA01", A01Mock),
-    ):
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.RoborockMqttClientV1.async_connect"
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.RoborockMqttClientV1._send_command"
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockMqttClientV1._send_command"
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.RoborockMqttClientV1.get_prop",
+                return_value=PROP,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.RoborockMqttClientV1.get_networking",
+                return_value=NETWORK_INFO,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_prop",
+                return_value=PROP,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockMqttClientV1.get_multi_maps_list",
+                return_value=MULTI_MAP_LIST,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_multi_maps_list",
+                return_value=MULTI_MAP_LIST,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockMapDataParser.parse",
+                return_value=MAP_DATA,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command"
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.RoborockMqttClientV1._wait_response"
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._wait_response"
+            )
+        )
+        stack.enter_context(patch("roborock.version_1_apis.AttributeCache.async_value"))
+        stack.enter_context(patch("roborock.version_1_apis.AttributeCache.value"))
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.MAP_SLEEP",
+                0,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_room_mapping",
+                return_value=[
+                    RoomMapping(16, "2362048"),
+                    RoomMapping(17, "2362044"),
+                    RoomMapping(18, "2362041"),
+                ],
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockMqttClientV1.get_room_mapping",
+                return_value=[
+                    RoomMapping(16, "2362048"),
+                    RoomMapping(17, "2362044"),
+                    RoomMapping(18, "2362041"),
+                ],
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockMqttClientV1.get_map_v1",
+                return_value=b"123",
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockClientA01",
+                A01Mock,
+            )
+        )
+        stack.enter_context(
+            patch("homeassistant.components.roborock.RoborockMqttClientA01", A01Mock)
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.ping"
+            )
+        )
         yield
 
 
 @pytest.fixture(name="send_message_side_effect")
 def send_message_side_effect_fixture() -> Any:
-    """Fixture to return a side effect for the send_message method."""
+    """Side effect for low-level command method (_send_command).
+
+    Name kept for backward compatibility with older tests that referred to
+    `send_message` in older library versions.
+    """
     return None
 
 
 @pytest.fixture(name="mock_send_message")
-def mock_send_message_fixture(send_message_side_effect: Any) -> Mock:
+def mock_send_message_fixture(
+    send_message_side_effect: Any,
+    bypass_api_fixture: None,
+) -> Mock:
     """Fixture to mock the send_message method."""
     with patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command",

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -53,7 +53,7 @@ async def test_update_success(
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id).state == "unknown"
     with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
+        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command"
     ) as mock_send_message:
         await hass.services.async_call(
             "button",
@@ -84,7 +84,7 @@ async def test_update_failure(
     assert hass.states.get(entity_id).state == "unknown"
     with (
         patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command",
             side_effect=roborock.exceptions.RoborockTimeout,
         ) as mock_send_message,
         pytest.raises(HomeAssistantError, match="Error while calling RESET_CONSUMABLE"),

--- a/tests/components/roborock/test_number.py
+++ b/tests/components/roborock/test_number.py
@@ -36,7 +36,7 @@ async def test_update_success(
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
     with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
+        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command"
     ) as mock_send_message:
         await hass.services.async_call(
             "number",
@@ -66,7 +66,7 @@ async def test_update_failed(
     assert hass.states.get(entity_id) is not None
     with (
         patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command",
             side_effect=roborock.exceptions.RoborockTimeout,
         ) as mock_send_message,
         pytest.raises(HomeAssistantError, match="Failed to update Roborock options"),

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -42,7 +42,7 @@ async def test_update_success(
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
     with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
+        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command"
     ) as mock_send_message:
         await hass.services.async_call(
             "select",
@@ -62,7 +62,7 @@ async def test_update_failure(
     """Test that changing a value will raise a homeassistanterror when it fails."""
     with (
         patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command",
             side_effect=RoborockException(),
         ),
         pytest.raises(HomeAssistantError, match="Error while calling SET_MOP_MOD"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Align Roborock tests with the current python-roborock API (tests now patch `_send_command`
  instead of the removed `send_message`).
 - Ensure all cached attribute helpers reuse the active `_send_command`, so test patches and error
  propagation continue to work with python-roborock ≥ 2.43

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Once this is merged to dev, I'll submit https://github.com/home-assistant/core/pull/152596 for review

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
