### PR TITLE
Yardian: combine state fetch and raise ConfigEntryAuthFailed

### DIFF
--- a/homeassistant/components/yardian/coordinator.py
+++ b/homeassistant/components/yardian/coordinator.py
@@ -6,15 +6,12 @@ import asyncio
 import datetime
 import logging
 
-from pyyardian import (
-    AsyncYardianClient,
-    NetworkException,
-    NotAuthorizedException,
-    YardianDeviceState,
-)
+from pyyardian import AsyncYardianClient, NetworkException, NotAuthorizedException
+from pyyardian.typing import OperationInfo
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -25,7 +22,22 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = datetime.timedelta(seconds=30)
 
 
-class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
+class YardianCombinedState:
+    """Combined device state for Yardian."""
+
+    def __init__(
+        self,
+        zones: list[list],
+        active_zones: set[int],
+        oper_info: OperationInfo,
+    ) -> None:
+        """Initialize combined state with zones, active_zones and oper_info."""
+        self.zones = zones
+        self.active_zones = active_zones
+        self.oper_info = oper_info
+
+
+class YardianUpdateCoordinator(DataUpdateCoordinator[YardianCombinedState]):
     """Coordinator for Yardian API calls."""
 
     config_entry: ConfigEntry
@@ -50,6 +62,7 @@ class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
         self.yid = entry.data["yid"]
         self._name = entry.title
         self._model = entry.data["model"]
+        self._serial = entry.data.get("serialNumber")
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -59,17 +72,42 @@ class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
             identifiers={(DOMAIN, self.yid)},
             manufacturer=MANUFACTURER,
             model=self._model,
+            serial_number=self._serial,
         )
 
-    async def _async_update_data(self) -> YardianDeviceState:
+    async def _async_update_data(self) -> YardianCombinedState:
         """Fetch data from Yardian device."""
         try:
             async with asyncio.timeout(10):
-                return await self.controller.fetch_device_state()
+                _LOGGER.debug(
+                    "Fetching Yardian device state for %s (controller=%s)",
+                    self._name,
+                    type(self.controller).__name__,
+                )
+                # Fetch device state and operation info; specific exceptions are
+                # handled by the outer block to avoid double-logging.
+                dev_state = await self.controller.fetch_device_state()
+                oper_info = await self.controller.fetch_oper_info()
+                oper_keys = list(oper_info.keys()) if hasattr(oper_info, "keys") else []
+                _LOGGER.debug(
+                    "Fetched Yardian data: zones=%s active=%s oper_keys=%s",
+                    len(getattr(dev_state, "zones", [])),
+                    len(getattr(dev_state, "active_zones", [])),
+                    oper_keys,
+                )
+                return YardianCombinedState(
+                    zones=dev_state.zones,
+                    active_zones=dev_state.active_zones,
+                    oper_info=oper_info,
+                )
 
         except TimeoutError as e:
-            raise UpdateFailed("Communication with Device was time out") from e
+            raise UpdateFailed("Timeout communicating with device") from e
         except NotAuthorizedException as e:
-            raise UpdateFailed("Invalid access token") from e
+            # Trigger reauth flow according to HA best practices
+            raise ConfigEntryAuthFailed("Invalid access token") from e
         except NetworkException as e:
-            raise UpdateFailed("Failed to communicate with Device") from e
+            raise UpdateFailed("Failed to communicate with device") from e
+        except Exception as e:  # safety net for tests to surface failure reason
+            _LOGGER.exception("Unexpected error while fetching Yardian data")
+            raise UpdateFailed(f"Unexpected error: {type(e).__name__}: {e}") from e

--- a/tests/components/yardian/test_coordinator.py
+++ b/tests/components/yardian/test_coordinator.py
@@ -1,0 +1,78 @@
+"""Tests for the Yardian coordinator."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pyyardian import NotAuthorizedException
+
+from homeassistant.components.yardian.const import DOMAIN
+from homeassistant.components.yardian.coordinator import (
+    YardianCombinedState,
+    YardianUpdateCoordinator,
+)
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.asyncio
+async def test_coordinator_combines_state(hass):
+    """Coordinator returns combined state from device and operation info."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "token",
+            "yid": "yardian-1",
+            "model": "PRO",
+        },
+        title="Yardian",
+        unique_id="yardian-1",
+    )
+    entry.add_to_hass(hass)
+
+    client = AsyncMock()
+    client.fetch_device_state.return_value = SimpleNamespace(
+        zones=[["Zone 1", 1]],
+        active_zones={0},
+    )
+    client.fetch_oper_info.return_value = {"iStandby": 1}
+
+    coordinator = YardianUpdateCoordinator(hass, entry, client)
+
+    state = await coordinator._async_update_data()
+
+    assert isinstance(state, YardianCombinedState)
+    assert state.zones == [["Zone 1", 1]]
+    assert state.active_zones == {0}
+    assert state.oper_info["iStandby"] == 1
+
+
+@pytest.mark.asyncio
+async def test_coordinator_raises_auth_failed(hass):
+    """Coordinator raises ConfigEntryAuthFailed on invalid auth."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "token",
+            "yid": "yardian-1",
+            "model": "PRO",
+        },
+        title="Yardian",
+        unique_id="yardian-1",
+    )
+    entry.add_to_hass(hass)
+
+    client = AsyncMock()
+    client.fetch_device_state.side_effect = NotAuthorizedException
+
+    coordinator = YardianUpdateCoordinator(hass, entry, client)
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()


### PR DESCRIPTION
## Summary
- fetch device state and operation info together for coordinator consumers
- raise ConfigEntryAuthFailed when the API rejects tokens so reauth flow starts
- cover the new behaviour with targeted coordinator tests