### PR TITLE
2025.9.4

### DIFF
--- a/homeassistant/components/asuswrt/bridge.py
+++ b/homeassistant/components/asuswrt/bridge.py
@@ -120,10 +120,16 @@ class AsusWrtBridge(ABC):
 
     def __init__(self, host: str) -> None:
         """Initialize Bridge."""
+        self._configuration_url = f"http://{host}"
         self._host = host
         self._firmware: str | None = None
         self._label_mac: str | None = None
         self._model: str | None = None
+
+    @property
+    def configuration_url(self) -> str:
+        """Return configuration URL."""
+        return self._configuration_url
 
     @property
     def host(self) -> str:
@@ -359,6 +365,7 @@ class AsusWrtHttpBridge(AsusWrtBridge):
         # get main router properties
         if mac := _identity.mac:
             self._label_mac = format_mac(mac)
+        self._configuration_url = self._api.webpanel
         self._firmware = str(_identity.firmware)
         self._model = _identity.model
 

--- a/homeassistant/components/asuswrt/manifest.json
+++ b/homeassistant/components/asuswrt/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["aioasuswrt", "asusrouter", "asyncssh"],
-  "requirements": ["aioasuswrt==1.4.0", "asusrouter==1.20.1"]
+  "requirements": ["aioasuswrt==1.4.0", "asusrouter==1.21.0"]
 }

--- a/homeassistant/components/asuswrt/router.py
+++ b/homeassistant/components/asuswrt/router.py
@@ -388,11 +388,11 @@ class AsusWrtRouter:
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
         info = DeviceInfo(
+            configuration_url=self._api.configuration_url,
             identifiers={(DOMAIN, self._entry.unique_id or "AsusWRT")},
             name=self.host,
             model=self._api.model or "Asus Router",
             manufacturer="Asus",
-            configuration_url=f"http://{self.host}",
         )
         if self._api.firmware:
             info["sw_version"] = self._api.firmware

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -92,7 +92,11 @@ from homeassistant.components.http.ban import (
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.network import is_cloud_connection
+from homeassistant.helpers.network import (
+    NoURLAvailableError,
+    get_url,
+    is_cloud_connection,
+)
 from homeassistant.util.network import is_local
 
 from . import indieauth
@@ -125,11 +129,18 @@ class WellKnownOAuthInfoView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Return the well known OAuth2 authorization info."""
+        hass = request.app[KEY_HASS]
+        # Some applications require absolute urls, so we prefer using the
+        # current requests url if possible, with fallback to a relative url.
+        try:
+            url_prefix = get_url(hass, require_current_request=True)
+        except NoURLAvailableError:
+            url_prefix = ""
         return self.json(
             {
-                "authorization_endpoint": "/auth/authorize",
-                "token_endpoint": "/auth/token",
-                "revocation_endpoint": "/auth/revoke",
+                "authorization_endpoint": f"{url_prefix}/auth/authorize",
+                "token_endpoint": f"{url_prefix}/auth/token",
+                "revocation_endpoint": f"{url_prefix}/auth/revoke",
                 "response_types_supported": ["code"],
                 "service_documentation": (
                     "https://developers.home-assistant.io/docs/auth_api"

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -18,7 +18,7 @@
     "bleak==1.0.1",
     "bleak-retry-connector==4.4.3",
     "bluetooth-adapters==2.1.0",
-    "bluetooth-auto-recovery==1.5.2",
+    "bluetooth-auto-recovery==1.5.3",
     "bluetooth-data-tools==1.28.2",
     "dbus-fast==2.44.3",
     "habluetooth==5.6.4"

--- a/homeassistant/components/emoncms/manifest.json
+++ b/homeassistant/components/emoncms/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/emoncms",
   "iot_class": "local_polling",
-  "requirements": ["pyemoncms==0.1.2"]
+  "requirements": ["pyemoncms==0.1.3"]
 }

--- a/homeassistant/components/emoncms_history/manifest.json
+++ b/homeassistant/components/emoncms_history/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/emoncms_history",
   "iot_class": "local_polling",
   "quality_scale": "legacy",
-  "requirements": ["pyemoncms==0.1.2"]
+  "requirements": ["pyemoncms==0.1.3"]
 }

--- a/homeassistant/components/habitica/manifest.json
+++ b/homeassistant/components/habitica/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["habiticalib"],
   "quality_scale": "platinum",
-  "requirements": ["habiticalib==0.4.4"]
+  "requirements": ["habiticalib==0.4.5"]
 }

--- a/homeassistant/components/habitica/manifest.json
+++ b/homeassistant/components/habitica/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["habiticalib"],
   "quality_scale": "platinum",
-  "requirements": ["habiticalib==0.4.3"]
+  "requirements": ["habiticalib==0.4.4"]
 }

--- a/homeassistant/components/holiday/manifest.json
+++ b/homeassistant/components/holiday/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/holiday",
   "iot_class": "local_polling",
-  "requirements": ["holidays==0.79", "babel==2.15.0"]
+  "requirements": ["holidays==0.80", "babel==2.15.0"]
 }

--- a/homeassistant/components/holiday/manifest.json
+++ b/homeassistant/components/holiday/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/holiday",
   "iot_class": "local_polling",
-  "requirements": ["holidays==0.80", "babel==2.15.0"]
+  "requirements": ["holidays==0.81", "babel==2.15.0"]
 }

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -14,6 +14,6 @@
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
   "iot_class": "local_push",
   "loggers": ["aiohomekit", "commentjson"],
-  "requirements": ["aiohomekit==3.2.16"],
+  "requirements": ["aiohomekit==3.2.17"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."]
 }

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -14,6 +14,6 @@
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
   "iot_class": "local_push",
   "loggers": ["aiohomekit", "commentjson"],
-  "requirements": ["aiohomekit==3.2.15"],
+  "requirements": ["aiohomekit==3.2.16"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."]
 }

--- a/homeassistant/components/imeon_inverter/manifest.json
+++ b/homeassistant/components/imeon_inverter/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["imeon_inverter_api==0.3.16"],
+  "requirements": ["imeon_inverter_api==0.4.0"],
   "ssdp": [
     {
       "manufacturer": "IMEON",

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -118,27 +118,31 @@ COVER_KNX_SCHEMA = AllSerializeFirst(
     vol.Schema(
         {
             "section_binary_control": KNXSectionFlat(),
-            vol.Optional(CONF_GA_UP_DOWN): GASelector(state=False),
+            vol.Optional(CONF_GA_UP_DOWN): GASelector(state=False, valid_dpt="1"),
             vol.Optional(CoverConf.INVERT_UPDOWN): selector.BooleanSelector(),
             "section_stop_control": KNXSectionFlat(),
-            vol.Optional(CONF_GA_STOP): GASelector(state=False),
-            vol.Optional(CONF_GA_STEP): GASelector(state=False),
+            vol.Optional(CONF_GA_STOP): GASelector(state=False, valid_dpt="1"),
+            vol.Optional(CONF_GA_STEP): GASelector(state=False, valid_dpt="1"),
             "section_position_control": KNXSectionFlat(collapsible=True),
-            vol.Optional(CONF_GA_POSITION_SET): GASelector(state=False),
-            vol.Optional(CONF_GA_POSITION_STATE): GASelector(write=False),
+            vol.Optional(CONF_GA_POSITION_SET): GASelector(
+                state=False, valid_dpt="5.001"
+            ),
+            vol.Optional(CONF_GA_POSITION_STATE): GASelector(
+                write=False, valid_dpt="5.001"
+            ),
             vol.Optional(CoverConf.INVERT_POSITION): selector.BooleanSelector(),
             "section_tilt_control": KNXSectionFlat(collapsible=True),
-            vol.Optional(CONF_GA_ANGLE): GASelector(),
+            vol.Optional(CONF_GA_ANGLE): GASelector(valid_dpt="5.001"),
             vol.Optional(CoverConf.INVERT_ANGLE): selector.BooleanSelector(),
             "section_travel_time": KNXSectionFlat(),
-            vol.Optional(
+            vol.Required(
                 CoverConf.TRAVELLING_TIME_UP, default=25
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=0, max=1000, step=0.1, unit_of_measurement="s"
                 )
             ),
-            vol.Optional(
+            vol.Required(
                 CoverConf.TRAVELLING_TIME_DOWN, default=25
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
@@ -310,7 +314,7 @@ LIGHT_KNX_SCHEMA = AllSerializeFirst(
 SWITCH_KNX_SCHEMA = vol.Schema(
     {
         "section_switch": KNXSectionFlat(),
-        vol.Required(CONF_GA_SWITCH): GASelector(write_required=True),
+        vol.Required(CONF_GA_SWITCH): GASelector(write_required=True, valid_dpt="1"),
         vol.Optional(CONF_INVERT, default=False): selector.BooleanSelector(),
         vol.Optional(CONF_RESPOND_TO_READ, default=False): selector.BooleanSelector(),
         vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),

--- a/homeassistant/components/lamarzocco/__init__.py
+++ b/homeassistant/components/lamarzocco/__init__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import uuid
 
 from packaging import version
 from pylamarzocco import (
@@ -11,6 +12,7 @@ from pylamarzocco import (
 )
 from pylamarzocco.const import FirmwareType
 from pylamarzocco.exceptions import AuthFail, RequestNotSuccessful
+from pylamarzocco.util import InstallationKey, generate_installation_key
 
 from homeassistant.components.bluetooth import async_discovered_service_info
 from homeassistant.const import (
@@ -25,7 +27,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import CONF_USE_BLUETOOTH, DOMAIN
+from .const import CONF_INSTALLATION_KEY, CONF_USE_BLUETOOTH, DOMAIN
 from .coordinator import (
     LaMarzoccoConfigEntry,
     LaMarzoccoConfigUpdateCoordinator,
@@ -60,6 +62,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LaMarzoccoConfigEntry) -
     cloud_client = LaMarzoccoCloudClient(
         username=entry.data[CONF_USERNAME],
         password=entry.data[CONF_PASSWORD],
+        installation_key=InstallationKey.from_json(entry.data[CONF_INSTALLATION_KEY]),
         client=async_create_clientsession(hass),
     )
 
@@ -166,45 +169,37 @@ async def async_migrate_entry(
     hass: HomeAssistant, entry: LaMarzoccoConfigEntry
 ) -> bool:
     """Migrate config entry."""
-    if entry.version > 3:
+    if entry.version > 4:
         # guard against downgrade from a future version
         return False
 
-    if entry.version == 1:
+    if entry.version in (1, 2):
         _LOGGER.error(
-            "Migration from version 1 is no longer supported, please remove and re-add the integration"
+            "Migration from version 1 or 2 is no longer supported, please remove and re-add the integration"
         )
         return False
 
-    if entry.version == 2:
+    if entry.version == 3:
+        installation_key = generate_installation_key(str(uuid.uuid4()).lower())
         cloud_client = LaMarzoccoCloudClient(
             username=entry.data[CONF_USERNAME],
             password=entry.data[CONF_PASSWORD],
+            installation_key=installation_key,
         )
         try:
-            things = await cloud_client.list_things()
+            await cloud_client.async_register_client()
         except (AuthFail, RequestNotSuccessful) as exc:
             _LOGGER.error("Migration failed with error %s", exc)
             return False
-        v3_data = {
-            CONF_USERNAME: entry.data[CONF_USERNAME],
-            CONF_PASSWORD: entry.data[CONF_PASSWORD],
-            CONF_TOKEN: next(
-                (
-                    thing.ble_auth_token
-                    for thing in things
-                    if thing.serial_number == entry.unique_id
-                ),
-                None,
-            ),
-        }
-        if CONF_MAC in entry.data:
-            v3_data[CONF_MAC] = entry.data[CONF_MAC]
+
         hass.config_entries.async_update_entry(
             entry,
-            data=v3_data,
-            version=3,
+            data={
+                **entry.data,
+                CONF_INSTALLATION_KEY: installation_key.to_json(),
+            },
+            version=4,
         )
-        _LOGGER.debug("Migrated La Marzocco config entry to version 2")
+        _LOGGER.debug("Migrated La Marzocco config entry to version 4")
 
     return True

--- a/homeassistant/components/lamarzocco/config_flow.py
+++ b/homeassistant/components/lamarzocco/config_flow.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from collections.abc import Mapping
 import logging
 from typing import Any
+import uuid
 
 from aiohttp import ClientSession
 from pylamarzocco import LaMarzoccoCloudClient
 from pylamarzocco.exceptions import AuthFail, RequestNotSuccessful
 from pylamarzocco.models import Thing
+from pylamarzocco.util import InstallationKey, generate_installation_key
 import voluptuous as vol
 
 from homeassistant.components.bluetooth import (
@@ -45,7 +47,7 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .const import CONF_USE_BLUETOOTH, DOMAIN
+from .const import CONF_INSTALLATION_KEY, CONF_USE_BLUETOOTH, DOMAIN
 from .coordinator import LaMarzoccoConfigEntry
 
 CONF_MACHINE = "machine"
@@ -57,9 +59,10 @@ _LOGGER = logging.getLogger(__name__)
 class LmConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for La Marzocco."""
 
-    VERSION = 3
+    VERSION = 4
 
     _client: ClientSession
+    _installation_key: InstallationKey
 
     def __init__(self) -> None:
         """Initialize the config flow."""
@@ -84,12 +87,17 @@ class LmConfigFlow(ConfigFlow, domain=DOMAIN):
             }
 
             self._client = async_create_clientsession(self.hass)
+            self._installation_key = generate_installation_key(
+                str(uuid.uuid4()).lower()
+            )
             cloud_client = LaMarzoccoCloudClient(
                 username=data[CONF_USERNAME],
                 password=data[CONF_PASSWORD],
                 client=self._client,
+                installation_key=self._installation_key,
             )
             try:
+                await cloud_client.async_register_client()
                 things = await cloud_client.list_things()
             except AuthFail:
                 _LOGGER.debug("Server rejected login credentials")
@@ -184,6 +192,7 @@ class LmConfigFlow(ConfigFlow, domain=DOMAIN):
                     title=selected_device.name,
                     data={
                         **self._config,
+                        CONF_INSTALLATION_KEY: self._installation_key.to_json(),
                         CONF_TOKEN: self._things[serial_number].ble_auth_token,
                     },
                 )

--- a/homeassistant/components/lamarzocco/config_flow.py
+++ b/homeassistant/components/lamarzocco/config_flow.py
@@ -35,7 +35,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.selector import (
     SelectOptionDict,
     SelectSelector,
@@ -47,6 +46,7 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
+from . import create_client_session
 from .const import CONF_INSTALLATION_KEY, CONF_USE_BLUETOOTH, DOMAIN
 from .coordinator import LaMarzoccoConfigEntry
 
@@ -86,7 +86,7 @@ class LmConfigFlow(ConfigFlow, domain=DOMAIN):
                 **user_input,
             }
 
-            self._client = async_create_clientsession(self.hass)
+            self._client = create_client_session(self.hass)
             self._installation_key = generate_installation_key(
                 str(uuid.uuid4()).lower()
             )

--- a/homeassistant/components/lamarzocco/const.py
+++ b/homeassistant/components/lamarzocco/const.py
@@ -5,3 +5,4 @@ from typing import Final
 DOMAIN: Final = "lamarzocco"
 
 CONF_USE_BLUETOOTH: Final = "use_bluetooth"
+CONF_INSTALLATION_KEY: Final = "installation_key"

--- a/homeassistant/components/lamarzocco/manifest.json
+++ b/homeassistant/components/lamarzocco/manifest.json
@@ -37,5 +37,5 @@
   "iot_class": "cloud_push",
   "loggers": ["pylamarzocco"],
   "quality_scale": "platinum",
-  "requirements": ["pylamarzocco==2.0.11"]
+  "requirements": ["pylamarzocco==2.1.0"]
 }

--- a/homeassistant/components/miele/coordinator.py
+++ b/homeassistant/components/miele/coordinator.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio.timeouts
+import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
+from aiohttp import ClientResponseError
 from pymiele import MieleAction, MieleAPI, MieleDevice
 
 from homeassistant.config_entries import ConfigEntry
@@ -66,7 +67,22 @@ class MieleDataUpdateCoordinator(DataUpdateCoordinator[MieleCoordinatorData]):
             self.devices = devices
             actions = {}
             for device_id in devices:
-                actions_json = await self.api.get_actions(device_id)
+                try:
+                    actions_json = await self.api.get_actions(device_id)
+                except ClientResponseError as err:
+                    _LOGGER.debug(
+                        "Error fetching actions for device %s: Status: %s, Message: %s",
+                        device_id,
+                        err.status,
+                        err.message,
+                    )
+                    actions_json = {}
+                except TimeoutError:
+                    _LOGGER.debug(
+                        "Timeout fetching actions for device %s",
+                        device_id,
+                    )
+                    actions_json = {}
                 actions[device_id] = MieleAction(actions_json)
             return MieleCoordinatorData(devices=devices, actions=actions)
 

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/opower",
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
-  "requirements": ["opower==0.15.4"]
+  "requirements": ["opower==0.15.5"]
 }

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -410,7 +410,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
     @soco_error()
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
-        self.soco.volume = int(volume * 100)
+        self.soco.volume = int(round(volume * 100))
 
     @soco_error(UPNP_ERRORS_TO_IGNORE)
     def set_shuffle(self, shuffle: bool) -> None:

--- a/homeassistant/components/waterfurnace/manifest.json
+++ b/homeassistant/components/waterfurnace/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["waterfurnace"],
   "quality_scale": "legacy",
-  "requirements": ["waterfurnace==1.1.0"]
+  "requirements": ["waterfurnace==1.2.0"]
 }

--- a/homeassistant/components/workday/manifest.json
+++ b/homeassistant/components/workday/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "loggers": ["holidays"],
   "quality_scale": "internal",
-  "requirements": ["holidays==0.79"]
+  "requirements": ["holidays==0.80"]
 }

--- a/homeassistant/components/workday/manifest.json
+++ b/homeassistant/components/workday/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "loggers": ["holidays"],
   "quality_scale": "internal",
-  "requirements": ["holidays==0.80"]
+  "requirements": ["holidays==0.81"]
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2025
 MINOR_VERSION: Final = 9
-PATCH_VERSION: Final = "3"
+PATCH_VERSION: Final = "4"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 2)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -23,7 +23,7 @@ bcrypt==4.3.0
 bleak-retry-connector==4.4.3
 bleak==1.0.1
 bluetooth-adapters==2.1.0
-bluetooth-auto-recovery==1.5.2
+bluetooth-auto-recovery==1.5.3
 bluetooth-data-tools==1.28.2
 cached-ipaddress==0.10.0
 certifi>=2021.5.30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant"
-version = "2025.9.3"
+version = "2025.9.4"
 license = "Apache-2.0"
 license-files = ["LICENSE*", "homeassistant/backports/LICENSE*"]
 description = "Open-source home automation platform running on Python 3."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -655,7 +655,7 @@ bluemaestro-ble==0.4.1
 bluetooth-adapters==2.1.0
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==1.5.2
+bluetooth-auto-recovery==1.5.3
 
 # homeassistant.components.bluetooth
 # homeassistant.components.ld2410_ble

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -271,7 +271,7 @@ aiohasupervisor==0.3.2
 aiohomeconnect==0.19.0
 
 # homeassistant.components.homekit_controller
-aiohomekit==3.2.15
+aiohomekit==3.2.16
 
 # homeassistant.components.mcp_server
 aiohttp_sse==2.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1175,7 +1175,7 @@ hole==0.9.0
 
 # homeassistant.components.holiday
 # homeassistant.components.workday
-holidays==0.79
+holidays==0.80
 
 # homeassistant.components.frontend
 home-assistant-frontend==20250903.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1962,7 +1962,7 @@ pyegps==0.2.5
 
 # homeassistant.components.emoncms
 # homeassistant.components.emoncms_history
-pyemoncms==0.1.2
+pyemoncms==0.1.3
 
 # homeassistant.components.enphase_envoy
 pyenphase==2.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1175,7 +1175,7 @@ hole==0.9.0
 
 # homeassistant.components.holiday
 # homeassistant.components.workday
-holidays==0.80
+holidays==0.81
 
 # homeassistant.components.frontend
 home-assistant-frontend==20250903.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1131,7 +1131,7 @@ ha-philipsjs==3.2.2
 ha-silabs-firmware-client==0.2.0
 
 # homeassistant.components.habitica
-habiticalib==0.4.3
+habiticalib==0.4.4
 
 # homeassistant.components.bluetooth
 habluetooth==5.6.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -528,7 +528,7 @@ arris-tg2492lg==2.2.0
 asmog==0.0.6
 
 # homeassistant.components.asuswrt
-asusrouter==1.20.1
+asusrouter==1.21.0
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.dlna_dms

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2103,7 +2103,7 @@ pykwb==0.0.8
 pylacrosse==0.4
 
 # homeassistant.components.lamarzocco
-pylamarzocco==2.0.11
+pylamarzocco==2.1.0
 
 # homeassistant.components.lastfm
 pylast==5.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1131,7 +1131,7 @@ ha-philipsjs==3.2.2
 ha-silabs-firmware-client==0.2.0
 
 # homeassistant.components.habitica
-habiticalib==0.4.4
+habiticalib==0.4.5
 
 # homeassistant.components.bluetooth
 habluetooth==5.6.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -271,7 +271,7 @@ aiohasupervisor==0.3.2
 aiohomeconnect==0.19.0
 
 # homeassistant.components.homekit_controller
-aiohomekit==3.2.16
+aiohomekit==3.2.17
 
 # homeassistant.components.mcp_server
 aiohttp_sse==2.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1629,7 +1629,7 @@ openwrt-luci-rpc==1.1.17
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.opower
-opower==0.15.4
+opower==0.15.5
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3090,7 +3090,7 @@ wallbox==0.9.0
 watchdog==6.0.0
 
 # homeassistant.components.waterfurnace
-waterfurnace==1.1.0
+waterfurnace==1.2.0
 
 # homeassistant.components.watergate
 watergate-local-api==2024.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1241,7 +1241,7 @@ igloohome-api==0.1.1
 ihcsdk==2.8.5
 
 # homeassistant.components.imeon_inverter
-imeon_inverter_api==0.3.16
+imeon_inverter_api==0.4.0
 
 # homeassistant.components.imgw_pib
 imgw_pib==1.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1024,7 +1024,7 @@ hole==0.9.0
 
 # homeassistant.components.holiday
 # homeassistant.components.workday
-holidays==0.80
+holidays==0.81
 
 # homeassistant.components.frontend
 home-assistant-frontend==20250903.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -992,7 +992,7 @@ ha-philipsjs==3.2.2
 ha-silabs-firmware-client==0.2.0
 
 # homeassistant.components.habitica
-habiticalib==0.4.3
+habiticalib==0.4.4
 
 # homeassistant.components.bluetooth
 habluetooth==5.6.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1748,7 +1748,7 @@ pykrakenapi==0.1.8
 pykulersky==0.5.8
 
 # homeassistant.components.lamarzocco
-pylamarzocco==2.0.11
+pylamarzocco==2.1.0
 
 # homeassistant.components.lastfm
 pylast==5.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1024,7 +1024,7 @@ hole==0.9.0
 
 # homeassistant.components.holiday
 # homeassistant.components.workday
-holidays==0.79
+holidays==0.80
 
 # homeassistant.components.frontend
 home-assistant-frontend==20250903.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -256,7 +256,7 @@ aiohasupervisor==0.3.2
 aiohomeconnect==0.19.0
 
 # homeassistant.components.homekit_controller
-aiohomekit==3.2.15
+aiohomekit==3.2.16
 
 # homeassistant.components.mcp_server
 aiohttp_sse==2.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -256,7 +256,7 @@ aiohasupervisor==0.3.2
 aiohomeconnect==0.19.0
 
 # homeassistant.components.homekit_controller
-aiohomekit==3.2.16
+aiohomekit==3.2.17
 
 # homeassistant.components.mcp_server
 aiohttp_sse==2.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -586,7 +586,7 @@ bluemaestro-ble==0.4.1
 bluetooth-adapters==2.1.0
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==1.5.2
+bluetooth-auto-recovery==1.5.3
 
 # homeassistant.components.bluetooth
 # homeassistant.components.ld2410_ble

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -492,7 +492,7 @@ aranet4==2.5.1
 arcam-fmj==1.8.2
 
 # homeassistant.components.asuswrt
-asusrouter==1.20.1
+asusrouter==1.21.0
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.dlna_dms

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1385,7 +1385,7 @@ openhomedevice==2.2.0
 openwebifpy==4.3.1
 
 # homeassistant.components.opower
-opower==0.15.4
+opower==0.15.5
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -992,7 +992,7 @@ ha-philipsjs==3.2.2
 ha-silabs-firmware-client==0.2.0
 
 # homeassistant.components.habitica
-habiticalib==0.4.4
+habiticalib==0.4.5
 
 # homeassistant.components.bluetooth
 habluetooth==5.6.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1075,7 +1075,7 @@ ifaddr==0.2.0
 igloohome-api==0.1.1
 
 # homeassistant.components.imeon_inverter
-imeon_inverter_api==0.3.16
+imeon_inverter_api==0.4.0
 
 # homeassistant.components.imgw_pib
 imgw_pib==1.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1637,7 +1637,7 @@ pyegps==0.2.5
 
 # homeassistant.components.emoncms
 # homeassistant.components.emoncms_history
-pyemoncms==0.1.2
+pyemoncms==0.1.3
 
 # homeassistant.components.enphase_envoy
 pyenphase==2.3.0

--- a/tests/components/asuswrt/conftest.py
+++ b/tests/components/asuswrt/conftest.py
@@ -12,6 +12,7 @@ import pytest
 
 from .common import (
     ASUSWRT_BASE,
+    HOST,
     MOCK_MACS,
     PROTOCOL_HTTP,
     PROTOCOL_SSH,
@@ -154,6 +155,9 @@ def mock_controller_connect_http(mock_devices_http):
 
         # Simulate connection status
         instance.connected = True
+
+        # Set the webpanel address
+        instance.webpanel = f"http://{HOST}:80"
 
         # Identity
         instance.async_get_identity.return_value = AsusDevice(

--- a/tests/components/auth/test_login_flow.py
+++ b/tests/components/auth/test_login_flow.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.core import HomeAssistant
+from homeassistant.core_config import async_process_ha_core_config
 
 from . import BASE_CONFIG, async_setup_auth
 
@@ -371,19 +372,54 @@ async def test_login_exist_user_ip_changes(
     assert response == {"message": "IP address changed"}
 
 
+@pytest.mark.usefixtures("current_request_with_host")  # Has example.com host
+@pytest.mark.parametrize(
+    ("config", "expected_url_prefix"),
+    [
+        (
+            {
+                "internal_url": "http://192.168.1.100:8123",
+                # Current request matches external url
+                "external_url": "https://example.com",
+            },
+            "https://example.com",
+        ),
+        (
+            {
+                # Current request matches internal url
+                "internal_url": "https://example.com",
+                "external_url": "https://other.com",
+            },
+            "https://example.com",
+        ),
+        (
+            {
+                # Current request does not match either url
+                "internal_url": "https://other.com",
+                "external_url": "https://again.com",
+            },
+            "",
+        ),
+    ],
+    ids=["external_url", "internal_url", "no_match"],
+)
 async def test_well_known_auth_info(
-    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+    config: dict[str, str],
+    expected_url_prefix: str,
 ) -> None:
-    """Test logging in and the ip address changes results in an rejection."""
+    """Test the well-known OAuth authorization server endpoint with different URL configurations."""
+    await async_process_ha_core_config(hass, config)
     client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
     resp = await client.get(
         "/.well-known/oauth-authorization-server",
     )
     assert resp.status == 200
     assert await resp.json() == {
-        "authorization_endpoint": "/auth/authorize",
-        "token_endpoint": "/auth/token",
-        "revocation_endpoint": "/auth/revoke",
+        "authorization_endpoint": f"{expected_url_prefix}/auth/authorize",
+        "token_endpoint": f"{expected_url_prefix}/auth/token",
+        "revocation_endpoint": f"{expected_url_prefix}/auth/revoke",
         "response_types_supported": ["code"],
         "service_documentation": "https://developers.home-assistant.io/docs/auth_api",
     }

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -13,6 +13,9 @@ from aiohomekit.testing import FakeController
 import pytest
 
 from homeassistant.components.climate import ATTR_CURRENT_TEMPERATURE
+from homeassistant.components.homekit_controller.connection import (
+    MAX_CHARACTERISTICS_PER_REQUEST,
+)
 from homeassistant.components.homekit_controller.const import (
     DEBOUNCE_COOLDOWN,
     DOMAIN,
@@ -377,9 +380,15 @@ async def test_poll_firmware_version_only_all_watchable_accessory_mode(
         state = await helper.poll_and_get_state()
         assert state.state == STATE_OFF
         assert mock_get_characteristics.call_count == 2
-        # Verify everything is polled
-        assert mock_get_characteristics.call_args_list[0][0][0] == {(1, 10), (1, 11)}
-        assert mock_get_characteristics.call_args_list[1][0][0] == {(1, 10), (1, 11)}
+        # Verify everything is polled (convert to set for comparison since batching changes the type)
+        assert set(mock_get_characteristics.call_args_list[0][0][0]) == {
+            (1, 10),
+            (1, 11),
+        }
+        assert set(mock_get_characteristics.call_args_list[1][0][0]) == {
+            (1, 10),
+            (1, 11),
+        }
 
         # Test device goes offline
         helper.pairing.available = False
@@ -526,3 +535,84 @@ async def test_poll_all_on_startup_refreshes_stale_values(
     state = hass.states.get("climate.homew")
     assert state is not None
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 22.5
+
+
+async def test_characteristic_polling_batching(
+    hass: HomeAssistant, get_next_aid: Callable[[], int]
+) -> None:
+    """Test that characteristic polling is batched to MAX_CHARACTERISTICS_PER_REQUEST."""
+
+    # Create a large accessory with many characteristics (more than 49)
+    def create_large_accessory_with_many_chars(accessory: Accessory) -> None:
+        """Create an accessory with many characteristics to test batching."""
+        # Add multiple services with many characteristics each
+        for service_num in range(10):  # 10 services
+            service = accessory.add_service(
+                ServicesTypes.LIGHTBULB, name=f"Light {service_num}"
+            )
+            # Each lightbulb service gets several characteristics
+            service.add_char(CharacteristicsTypes.ON)
+            service.add_char(CharacteristicsTypes.BRIGHTNESS)
+            service.add_char(CharacteristicsTypes.HUE)
+            service.add_char(CharacteristicsTypes.SATURATION)
+            service.add_char(CharacteristicsTypes.COLOR_TEMPERATURE)
+            # Set initial values
+            for char in service.characteristics:
+                if char.type != CharacteristicsTypes.IDENTIFY:
+                    char.value = 0
+
+    helper = await setup_test_component(
+        hass, get_next_aid(), create_large_accessory_with_many_chars
+    )
+
+    # Track the get_characteristics calls
+    get_chars_calls = []
+    original_get_chars = helper.pairing.get_characteristics
+
+    async def mock_get_characteristics(chars):
+        """Mock get_characteristics to track batch sizes."""
+        get_chars_calls.append(list(chars))
+        return await original_get_chars(chars)
+
+    # Clear any calls from setup
+    get_chars_calls.clear()
+
+    # Patch get_characteristics to track calls
+    with mock.patch.object(
+        helper.pairing, "get_characteristics", side_effect=mock_get_characteristics
+    ):
+        # Trigger an update through time_changed which simulates regular polling
+        # time_changed expects seconds, not a datetime
+        await time_changed(hass, 300)  # 5 minutes in seconds
+        await hass.async_block_till_done()
+
+    # We created 10 lightbulb services with 5 characteristics each = 50 total
+    # Plus any base accessory characteristics that are pollable
+    # This should result in exactly 2 batches
+    assert len(get_chars_calls) == 2, (
+        f"Should have made exactly 2 batched calls, got {len(get_chars_calls)}"
+    )
+
+    # Check that no batch exceeded MAX_CHARACTERISTICS_PER_REQUEST
+    for i, batch in enumerate(get_chars_calls):
+        assert len(batch) <= MAX_CHARACTERISTICS_PER_REQUEST, (
+            f"Batch {i} size {len(batch)} exceeded maximum {MAX_CHARACTERISTICS_PER_REQUEST}"
+        )
+
+    # Verify the total number of characteristics polled
+    total_chars = sum(len(batch) for batch in get_chars_calls)
+    # Each lightbulb has: ON, BRIGHTNESS, HUE, SATURATION, COLOR_TEMPERATURE = 5
+    # 10 lightbulbs = 50 characteristics
+    assert total_chars == 50, (
+        f"Should have polled exactly 50 characteristics, got {total_chars}"
+    )
+
+    # The first batch should be full (49 characteristics)
+    assert len(get_chars_calls[0]) == 49, (
+        f"First batch should have exactly 49 characteristics, got {len(get_chars_calls[0])}"
+    )
+
+    # The second batch should have exactly 1 characteristic
+    assert len(get_chars_calls[1]) == 1, (
+        f"Second batch should have exactly 1 characteristic, got {len(get_chars_calls[1])}"
+    )

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -111,6 +111,12 @@
         'options': dict({
           'passive': True,
           'state': False,
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
           'write': dict({
             'required': False,
           }),
@@ -140,6 +146,12 @@
         'options': dict({
           'passive': True,
           'state': False,
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
           'write': dict({
             'required': False,
           }),
@@ -153,6 +165,12 @@
         'options': dict({
           'passive': True,
           'state': False,
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
           'write': dict({
             'required': False,
           }),
@@ -172,6 +190,12 @@
         'options': dict({
           'passive': True,
           'state': False,
+          'validDPTs': list([
+            dict({
+              'main': 5,
+              'sub': 1,
+            }),
+          ]),
           'write': dict({
             'required': False,
           }),
@@ -187,6 +211,12 @@
           'state': dict({
             'required': False,
           }),
+          'validDPTs': list([
+            dict({
+              'main': 5,
+              'sub': 1,
+            }),
+          ]),
           'write': False,
         }),
         'required': False,
@@ -216,6 +246,12 @@
           'state': dict({
             'required': False,
           }),
+          'validDPTs': list([
+            dict({
+              'main': 5,
+              'sub': 1,
+            }),
+          ]),
           'write': dict({
             'required': False,
           }),
@@ -242,8 +278,7 @@
       dict({
         'default': 25,
         'name': 'travelling_time_up',
-        'optional': True,
-        'required': False,
+        'required': True,
         'selector': dict({
           'number': dict({
             'max': 1000.0,
@@ -258,8 +293,7 @@
       dict({
         'default': 25,
         'name': 'travelling_time_down',
-        'optional': True,
-        'required': False,
+        'required': True,
         'selector': dict({
           'number': dict({
             'max': 1000.0,
@@ -746,6 +780,12 @@
           'state': dict({
             'required': False,
           }),
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
           'write': dict({
             'required': True,
           }),

--- a/tests/components/lamarzocco/__init__.py
+++ b/tests/components/lamarzocco/__init__.py
@@ -54,3 +54,6 @@ def get_bluetooth_service_info(model: ModelName, serial: str) -> BluetoothServic
         service_uuids=[],
         source="local",
     )
+
+
+MOCK_INSTALLATION_KEY = '{"secret": "K9ZW2vlMSb3QXmhySx4pxAbTHujWj3VZ01Jn3D/sO98=", "private_key": "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg8iotE8El786F6kHuEL8GyYhjDB7oo06vNhQwtewF37yhRANCAAQCLb9lHskiavvfkI4H2B+WsdkusfgBBFuFNRrGV8bqPMra1TK5myb/ecdZfHJBBJrcbdt90QMDmXQm5L3muXXe", "installation_id": "4e966f3f-2abc-49c4-a362-3cd3346f1a87"}'

--- a/tests/components/lamarzocco/conftest.py
+++ b/tests/components/lamarzocco/conftest.py
@@ -12,13 +12,14 @@ from pylamarzocco.models import (
     ThingSettings,
     ThingStatistics,
 )
+from pylamarzocco.util import InstallationKey
 import pytest
 
-from homeassistant.components.lamarzocco.const import DOMAIN
+from homeassistant.components.lamarzocco.const import CONF_INSTALLATION_KEY, DOMAIN
 from homeassistant.const import CONF_ADDRESS, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 
-from . import SERIAL_DICT, USER_INPUT, async_init_integration
+from . import MOCK_INSTALLATION_KEY, SERIAL_DICT, USER_INPUT, async_init_integration
 
 from tests.common import MockConfigEntry, load_json_object_fixture
 
@@ -31,11 +32,12 @@ def mock_config_entry(
     return MockConfigEntry(
         title="My LaMarzocco",
         domain=DOMAIN,
-        version=3,
+        version=4,
         data=USER_INPUT
         | {
             CONF_ADDRESS: "000000000000",
             CONF_TOKEN: "token",
+            CONF_INSTALLATION_KEY: MOCK_INSTALLATION_KEY,
         },
         unique_id=mock_lamarzocco.serial_number,
     )
@@ -49,6 +51,22 @@ async def init_integration(
     await async_init_integration(hass, mock_config_entry)
 
     return mock_config_entry
+
+
+@pytest.fixture(autouse=True)
+def mock_generate_installation_key() -> Generator[MagicMock]:
+    """Return a mocked generate_installation_key."""
+    with (
+        patch(
+            "homeassistant.components.lamarzocco.generate_installation_key",
+            return_value=InstallationKey.from_json(MOCK_INSTALLATION_KEY),
+        ) as mock_generate,
+        patch(
+            "homeassistant.components.lamarzocco.config_flow.generate_installation_key",
+            new=mock_generate,
+        ),
+    ):
+        yield mock_generate
 
 
 @pytest.fixture

--- a/tests/components/lamarzocco/test_config_flow.py
+++ b/tests/components/lamarzocco/test_config_flow.py
@@ -9,7 +9,11 @@ from pylamarzocco.exceptions import AuthFail, RequestNotSuccessful
 import pytest
 
 from homeassistant.components.lamarzocco.config_flow import CONF_MACHINE
-from homeassistant.components.lamarzocco.const import CONF_USE_BLUETOOTH, DOMAIN
+from homeassistant.components.lamarzocco.const import (
+    CONF_INSTALLATION_KEY,
+    CONF_USE_BLUETOOTH,
+    DOMAIN,
+)
 from homeassistant.config_entries import (
     SOURCE_BLUETOOTH,
     SOURCE_DHCP,
@@ -23,7 +27,12 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from . import USER_INPUT, async_init_integration, get_bluetooth_service_info
+from . import (
+    MOCK_INSTALLATION_KEY,
+    USER_INPUT,
+    async_init_integration,
+    get_bluetooth_service_info,
+)
 
 from tests.common import MockConfigEntry
 
@@ -68,6 +77,7 @@ async def __do_sucessful_machine_selection_step(
     assert result["data"] == {
         **USER_INPUT,
         CONF_TOKEN: None,
+        CONF_INSTALLATION_KEY: MOCK_INSTALLATION_KEY,
     }
     assert result["result"].unique_id == "GS012345"
 
@@ -344,6 +354,7 @@ async def test_bluetooth_discovery(
         **USER_INPUT,
         CONF_MAC: "aa:bb:cc:dd:ee:ff",
         CONF_TOKEN: "dummyToken",
+        CONF_INSTALLATION_KEY: MOCK_INSTALLATION_KEY,
     }
 
 
@@ -407,6 +418,7 @@ async def test_bluetooth_discovery_errors(
         **USER_INPUT,
         CONF_MAC: "aa:bb:cc:dd:ee:ff",
         CONF_TOKEN: None,
+        CONF_INSTALLATION_KEY: MOCK_INSTALLATION_KEY,
     }
 
 
@@ -438,6 +450,7 @@ async def test_dhcp_discovery(
         **USER_INPUT,
         CONF_ADDRESS: "aabbccddeeff",
         CONF_TOKEN: None,
+        CONF_INSTALLATION_KEY: MOCK_INSTALLATION_KEY,
     }
 
 

--- a/tests/components/lamarzocco/test_init.py
+++ b/tests/components/lamarzocco/test_init.py
@@ -8,15 +8,11 @@ from pylamarzocco.models import WebSocketDetails
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.lamarzocco.config_flow import CONF_MACHINE
-from homeassistant.components.lamarzocco.const import DOMAIN
+from homeassistant.components.lamarzocco.const import CONF_INSTALLATION_KEY, DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
     CONF_ADDRESS,
-    CONF_HOST,
     CONF_MAC,
-    CONF_MODEL,
-    CONF_NAME,
     CONF_TOKEN,
     EVENT_HOMEASSISTANT_STOP,
 )
@@ -27,7 +23,12 @@ from homeassistant.helpers import (
     issue_registry as ir,
 )
 
-from . import USER_INPUT, async_init_integration, get_bluetooth_service_info
+from . import (
+    MOCK_INSTALLATION_KEY,
+    USER_INPUT,
+    async_init_integration,
+    get_bluetooth_service_info,
+)
 
 from tests.common import MockConfigEntry
 
@@ -129,66 +130,65 @@ async def test_v1_migration_fails(
     assert entry_v1.state is ConfigEntryState.MIGRATION_ERROR
 
 
-async def test_v2_migration(
+async def test_v4_migration(
     hass: HomeAssistant,
     mock_lamarzocco: MagicMock,
 ) -> None:
-    """Test v2 -> v3 Migration."""
+    """Test v3 -> v4 Migration."""
 
-    entry_v2 = MockConfigEntry(
+    entry_v3 = MockConfigEntry(
         domain=DOMAIN,
-        version=2,
+        version=3,
         unique_id=mock_lamarzocco.serial_number,
         data={
             **USER_INPUT,
-            CONF_HOST: "192.168.1.24",
-            CONF_NAME: "La Marzocco",
-            CONF_MODEL: ModelName.GS3_MP.value,
-            CONF_MAC: "aa:bb:cc:dd:ee:ff",
+            CONF_ADDRESS: "000000000000",
+            CONF_TOKEN: "token",
         },
     )
-    entry_v2.add_to_hass(hass)
+    entry_v3.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(entry_v2.entry_id)
-    assert entry_v2.state is ConfigEntryState.LOADED
-    assert entry_v2.version == 3
-    assert dict(entry_v2.data) == {
+    assert await hass.config_entries.async_setup(entry_v3.entry_id)
+    assert entry_v3.state is ConfigEntryState.LOADED
+    assert entry_v3.version == 4
+    assert dict(entry_v3.data) == {
         **USER_INPUT,
-        CONF_MAC: "aa:bb:cc:dd:ee:ff",
-        CONF_TOKEN: None,
+        CONF_ADDRESS: "000000000000",
+        CONF_TOKEN: "token",
+        CONF_INSTALLATION_KEY: MOCK_INSTALLATION_KEY,
     }
 
 
 async def test_migration_errors(
     hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
     mock_cloud_client: MagicMock,
     mock_lamarzocco: MagicMock,
 ) -> None:
     """Test errors during migration."""
 
-    mock_cloud_client.list_things.side_effect = RequestNotSuccessful("Error")
+    mock_cloud_client.async_register_client.side_effect = RequestNotSuccessful("Error")
 
-    entry_v2 = MockConfigEntry(
+    entry_v3 = MockConfigEntry(
         domain=DOMAIN,
-        version=2,
+        version=3,
         unique_id=mock_lamarzocco.serial_number,
         data={
             **USER_INPUT,
-            CONF_MACHINE: mock_lamarzocco.serial_number,
+            CONF_ADDRESS: "000000000000",
+            CONF_TOKEN: "token",
         },
     )
-    entry_v2.add_to_hass(hass)
+    entry_v3.add_to_hass(hass)
 
-    assert not await hass.config_entries.async_setup(entry_v2.entry_id)
-    assert entry_v2.state is ConfigEntryState.MIGRATION_ERROR
+    assert not await hass.config_entries.async_setup(entry_v3.entry_id)
+    assert entry_v3.state is ConfigEntryState.MIGRATION_ERROR
 
 
 async def test_config_flow_entry_migration_downgrade(
     hass: HomeAssistant,
 ) -> None:
     """Test that config entry fails setup if the version is from the future."""
-    entry = MockConfigEntry(domain=DOMAIN, version=4)
+    entry = MockConfigEntry(domain=DOMAIN, version=5)
     entry.add_to_hass(hass)
 
     assert not await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1101,11 +1101,11 @@ async def test_volume(
     await hass.services.async_call(
         MP_DOMAIN,
         SERVICE_VOLUME_SET,
-        {ATTR_ENTITY_ID: "media_player.zone_a", ATTR_MEDIA_VOLUME_LEVEL: 0.30},
+        {ATTR_ENTITY_ID: "media_player.zone_a", ATTR_MEDIA_VOLUME_LEVEL: 0.57},
         blocking=True,
     )
     # SoCo uses 0..100 for its range.
-    assert soco.volume == 30
+    assert soco.volume == 57
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Bump habiticalib to v0.4.4 ([@tr4nt0r] - [#151332]) ([habitica docs]) (dependency)
- Bump habiticalib to v0.4.5 ([@tr4nt0r] - [#151720]) ([habitica docs]) (dependency)
- Fix bug with the hardcoded configuration_url (asuswrt) ([@Vaskivskyi] - [#151858]) ([asuswrt docs])
- Fix HomeKit Controller overwhelming resource-limited devices by batching characteristic polling ([@bdraco] - [#152209]) ([homekit_controller docs])
- Upgrade waterfurnace to 1.2.0 ([@sdague] - [#152241]) ([waterfurnace docs]) (dependency)
- Bump aiohomekit to 3.2.16 ([@bdraco] - [#152255]) ([homekit_controller docs]) (dependency)
- Bump bluetooth-auto-recovery to 1.5.3 ([@bdraco] - [#152256]) ([bluetooth docs]) (dependency)
- Add proper error handling for /actions endpoint for miele ([@astrandb] - [#152290]) ([miele docs])
- Bump aiohomekit to 3.2.17 ([@bdraco] - [#152297]) ([homekit_controller docs]) (dependency)
- Update authorization server to prefer absolute urls ([@allenporter] - [#152313]) ([auth docs])
- Bump imeon_inverter_api to 0.4.0 ([@Imeon-Energy] - [#152351]) ([imeon_inverter docs]) (dependency)
- Bump pylamarzocco to 2.1.0 ([@zweckj] - [#152364]) ([lamarzocco docs]) (dependency)
- Add La Marzocco specific client headers ([@zweckj] - [#152419]) ([lamarzocco docs])
- Fix KNX UI schema missing DPT ([@farmio] - [#152430]) ([knx docs])
- Bump pyemoncms to 0.1.3 ([@alexandrecuer] - [#152436]) ([emoncms docs]) ([emoncms_history docs]) (dependency)
- Fix Sonos set_volume float precision issue ([@PeteRager] - [#152493]) ([sonos docs])
- Bump opower to 0.15.5 ([@tronikos] - [#152531]) ([opower docs]) (dependency)
- Bump holidays to 0.80 ([@gjohansson-ST] - [#152306]) ([workday docs]) ([holiday docs]) (dependency)
- Bump holidays to 0.81 ([@gjohansson-ST] - [#152569]) ([workday docs]) ([holiday docs]) (dependency)
- Bump asusrouter to 1.21.0 ([@Vaskivskyi] - [#151607]) ([asuswrt docs]) (dependency)

[#151263]: https://github.com/home-assistant/core/pull/151263
[#151332]: https://github.com/home-assistant/core/pull/151332
[#151607]: https://github.com/home-assistant/core/pull/151607
[#151720]: https://github.com/home-assistant/core/pull/151720
[#151766]: https://github.com/home-assistant/core/pull/151766
[#151858]: https://github.com/home-assistant/core/pull/151858
[#152198]: https://github.com/home-assistant/core/pull/152198
[#152209]: https://github.com/home-assistant/core/pull/152209
[#152237]: https://github.com/home-assistant/core/pull/152237
[#152241]: https://github.com/home-assistant/core/pull/152241
[#152255]: https://github.com/home-assistant/core/pull/152255
[#152256]: https://github.com/home-assistant/core/pull/152256
[#152290]: https://github.com/home-assistant/core/pull/152290
[#152297]: https://github.com/home-assistant/core/pull/152297
[#152306]: https://github.com/home-assistant/core/pull/152306
[#152313]: https://github.com/home-assistant/core/pull/152313
[#152351]: https://github.com/home-assistant/core/pull/152351
[#152364]: https://github.com/home-assistant/core/pull/152364
[#152419]: https://github.com/home-assistant/core/pull/152419
[#152430]: https://github.com/home-assistant/core/pull/152430
[#152436]: https://github.com/home-assistant/core/pull/152436
[#152493]: https://github.com/home-assistant/core/pull/152493
[#152531]: https://github.com/home-assistant/core/pull/152531
[#152569]: https://github.com/home-assistant/core/pull/152569
[@Imeon-Energy]: https://github.com/Imeon-Energy
[@PeteRager]: https://github.com/PeteRager
[@Vaskivskyi]: https://github.com/Vaskivskyi
[@alexandrecuer]: https://github.com/alexandrecuer
[@allenporter]: https://github.com/allenporter
[@astrandb]: https://github.com/astrandb
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@farmio]: https://github.com/farmio
[@frenck]: https://github.com/frenck
[@gjohansson-ST]: https://github.com/gjohansson-ST
[@sdague]: https://github.com/sdague
[@tr4nt0r]: https://github.com/tr4nt0r
[@tronikos]: https://github.com/tronikos
[@zweckj]: https://github.com/zweckj
[ai_task docs]: https://www.home-assistant.io/integrations/ai_task/
[airgradient docs]: https://www.home-assistant.io/integrations/airgradient/
[airos docs]: https://www.home-assistant.io/integrations/airos/
[asuswrt docs]: https://www.home-assistant.io/integrations/asuswrt/
[auth docs]: https://www.home-assistant.io/integrations/auth/
[bluetooth docs]: https://www.home-assistant.io/integrations/bluetooth/
[emoncms docs]: https://www.home-assistant.io/integrations/emoncms/
[emoncms_history docs]: https://www.home-assistant.io/integrations/emoncms_history/
[habitica docs]: https://www.home-assistant.io/integrations/habitica/
[holiday docs]: https://www.home-assistant.io/integrations/holiday/
[homekit_controller docs]: https://www.home-assistant.io/integrations/homekit_controller/
[imeon_inverter docs]: https://www.home-assistant.io/integrations/imeon_inverter/
[knx docs]: https://www.home-assistant.io/integrations/knx/
[lamarzocco docs]: https://www.home-assistant.io/integrations/lamarzocco/
[miele docs]: https://www.home-assistant.io/integrations/miele/
[opower docs]: https://www.home-assistant.io/integrations/opower/
[sonos docs]: https://www.home-assistant.io/integrations/sonos/
[waterfurnace docs]: https://www.home-assistant.io/integrations/waterfurnace/
[workday docs]: https://www.home-assistant.io/integrations/workday/