### PR TITLE
Handle unparsable responses during HomeKit Controller initial polling

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -337,7 +337,14 @@ class HKDevice:
             # We need to explicitly poll characteristics to get fresh sensor readings
             # before processing the entity map and creating devices.
             # Use poll_all=True since entities haven't registered their characteristics yet.
-            await self.async_update(poll_all=True)
+            try:
+                await self.async_update(poll_all=True)
+            except ValueError as exc:
+                _LOGGER.debug(
+                    "Accessory %s responded with unparsable response, first update was skipped: %s",
+                    self.unique_id,
+                    exc,
+                )
 
         await self.async_process_entity_map()
 

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -639,7 +639,7 @@ async def test_async_setup_handles_unparsable_response(
             """Mock that raises ValueError to simulate unparsable response."""
             raise ValueError(
                 "Unable to parse text",
-                "Error processing token: filename. Filename missing or too long?",
+                ("Error processing token: filename. Filename missing or too long?"),
             )
 
         # Set up the platform and add paired device
@@ -661,7 +661,8 @@ async def test_async_setup_handles_unparsable_response(
         with mock.patch.object(
             pairing, "get_characteristics", mock_get_characteristics
         ):
-            # Set up the config entry (this will trigger async_setup with poll_all=True)
+            # Set up the config entry - this will trigger async_setup
+            # with poll_all=True
             await hass.config_entries.async_setup(config_entry.entry_id)
             await hass.async_block_till_done()
 
@@ -672,7 +673,8 @@ async def test_async_setup_handles_unparsable_response(
         )
         assert "Error processing token: filename" in caplog.text
 
-        # Verify that setup completed (entities were still created despite the polling error)
-        # The light entity should exist even though initial polling failed
+        # Verify that setup completed - entities were still created
+        # despite the polling error. The light entity should exist even
+        # though initial polling failed
         state = hass.states.get("light.testdevice")
         assert state is not None

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -6,7 +6,7 @@ from typing import Any
 from unittest import mock
 
 from aiohomekit.controller import TransportType
-from aiohomekit.model import Accessory
+from aiohomekit.model import Accessories, Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import Service, ServicesTypes
 from aiohomekit.testing import FakeController
@@ -616,3 +616,63 @@ async def test_characteristic_polling_batching(
     assert len(get_chars_calls[1]) == 1, (
         f"Second batch should have exactly 1 characteristic, got {len(get_chars_calls[1])}"
     )
+
+
+async def test_async_setup_handles_unparsable_response(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that async_setup handles ValueError from unparsable accessory responses."""
+    with caplog.at_level("DEBUG", logger="homeassistant.components.homekit_controller"):
+        # Load a simple accessory
+        accessories = Accessories()
+        accessory = Accessory.create_with_info(
+            1, "TestDevice", "example.com", "Test", "0001", "0.1"
+        )
+        service = accessory.add_service(ServicesTypes.LIGHTBULB)
+        on_char = service.add_char(CharacteristicsTypes.ON)
+        on_char.value = False
+        accessories.add_accessory(accessory)
+
+        async def mock_get_characteristics(
+            chars: set[tuple[int, int]], **kwargs: Any
+        ) -> dict[tuple[int, int], dict[str, Any]]:
+            """Mock that raises ValueError to simulate unparsable response."""
+            raise ValueError(
+                "Unable to parse text",
+                "Error processing token: filename. Filename missing or too long?",
+            )
+
+        # Set up the platform and add paired device
+        fake_controller = await setup_platform(hass)
+        await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
+
+        config_entry = MockConfigEntry(
+            version=1,
+            domain="homekit_controller",
+            entry_id="TestData",
+            data={"AccessoryPairingID": "00:00:00:00:00:00"},
+            title="test",
+        )
+        config_entry.add_to_hass(hass)
+
+        # Get the pairing and patch its get_characteristics
+        pairing = fake_controller.pairings["00:00:00:00:00:00"]
+
+        with mock.patch.object(
+            pairing, "get_characteristics", mock_get_characteristics
+        ):
+            # Set up the config entry (this will trigger async_setup with poll_all=True)
+            await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        # Verify the debug message was logged
+        assert (
+            "responded with unparsable response, first update was skipped"
+            in caplog.text
+        )
+        assert "Error processing token: filename" in caplog.text
+
+        # Verify that setup completed (entities were still created despite the polling error)
+        # The light entity should exist even though initial polling failed
+        state = hass.states.get("light.testdevice")
+        assert state is not None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds error handling for HomeKit accessories that return unparsable responses during the initial polling at setup.

Some HomeKit accessories with buggy firmware (e.g., SIMPLEconnect fans) return error text instead of valid JSON when queried for their characteristics. This causes a `ValueError` during setup and prevents the integration from loading.

The fix catches `ValueError` exceptions during the initial `async_update(poll_all=True)` call in `async_setup`, logs a debug message, and allows setup to continue. This means affected users will have stale cached data at startup (same behavior as before 2025.9.2 when the initial polling fix was added), but their devices will continue to work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #152240 fixes #152640
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr