### PR TITLE
Add test to validate multiple host/port for modbus.

### DIFF
--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -696,7 +696,7 @@ async def test_no_duplicate_names(hass: HomeAssistant, do_config) -> None:
             },
             {
                 CONF_TYPE: TCP,
-                CONF_HOST: TEST_MODBUS_HOST,
+                CONF_HOST: TEST_MODBUS_HOST + "_1",
                 CONF_PORT: TEST_PORT_TCP,
                 CONF_NAME: f"{TEST_MODBUS_NAME} 2",
                 CONF_SENSORS: [
@@ -715,6 +715,32 @@ async def test_no_duplicate_names(hass: HomeAssistant, do_config) -> None:
                 CONF_PARITY: "E",
                 CONF_STOPBITS: 1,
                 CONF_NAME: f"{TEST_MODBUS_NAME} 3",
+                CONF_SENSORS: [
+                    {
+                        CONF_NAME: "dummy",
+                        CONF_ADDRESS: 9999,
+                    }
+                ],
+            },
+        ],
+        [
+            {
+                CONF_TYPE: TCP,
+                CONF_HOST: TEST_MODBUS_HOST,
+                CONF_PORT: TEST_PORT_TCP,
+                CONF_NAME: TEST_MODBUS_NAME,
+                CONF_SENSORS: [
+                    {
+                        CONF_NAME: "dummy",
+                        CONF_ADDRESS: 9999,
+                    }
+                ],
+            },
+            {
+                CONF_TYPE: TCP,
+                CONF_HOST: TEST_MODBUS_HOST,
+                CONF_PORT: TEST_PORT_TCP + 10,
+                CONF_NAME: f"{TEST_MODBUS_NAME} 2",
                 CONF_SENSORS: [
                     {
                         CONF_NAME: "dummy",
@@ -753,10 +779,111 @@ async def test_no_duplicate_names(hass: HomeAssistant, do_config) -> None:
         },
     ],
 )
-async def test_config_modbus(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_modbus_with_pymodbus
+async def test_config_modbus(hass: HomeAssistant, mock_modbus_with_pymodbus) -> None:
+    """Run configuration test for modbus."""
+    assert len(hass.data[DOMAIN])
+
+
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        [
+            {
+                CONF_TYPE: TCP,
+                CONF_HOST: TEST_MODBUS_HOST,
+                CONF_PORT: TEST_PORT_TCP,
+                CONF_NAME: TEST_MODBUS_NAME,
+                CONF_SENSORS: [
+                    {
+                        CONF_NAME: "dummy",
+                        CONF_ADDRESS: 9999,
+                    }
+                ],
+            },
+            {
+                CONF_NAME: TEST_MODBUS_NAME,
+                CONF_TYPE: SERIAL,
+                CONF_BAUDRATE: 9600,
+                CONF_BYTESIZE: 8,
+                CONF_METHOD: "rtu",
+                CONF_PORT: TEST_PORT_SERIAL,
+                CONF_PARITY: "E",
+                CONF_STOPBITS: 1,
+                CONF_SENSORS: [
+                    {
+                        CONF_NAME: "dummy",
+                        CONF_ADDRESS: 9999,
+                    }
+                ],
+            },
+        ],
+        [
+            {
+                CONF_TYPE: TCP,
+                CONF_HOST: TEST_MODBUS_HOST,
+                CONF_PORT: TEST_PORT_TCP,
+                CONF_NAME: TEST_MODBUS_NAME,
+                CONF_SENSORS: [
+                    {
+                        CONF_NAME: "dummy",
+                        CONF_ADDRESS: 9999,
+                    }
+                ],
+            },
+            {
+                CONF_TYPE: TCP,
+                CONF_HOST: TEST_MODBUS_HOST,
+                CONF_PORT: TEST_PORT_TCP,
+                CONF_NAME: TEST_MODBUS_NAME + "_1",
+                CONF_SENSORS: [
+                    {
+                        CONF_NAME: "dummy",
+                        CONF_ADDRESS: 9999,
+                    }
+                ],
+            },
+        ],
+        [
+            {
+                CONF_NAME: TEST_MODBUS_NAME,
+                CONF_TYPE: SERIAL,
+                CONF_BAUDRATE: 9600,
+                CONF_BYTESIZE: 8,
+                CONF_METHOD: "rtu",
+                CONF_PORT: TEST_PORT_SERIAL,
+                CONF_PARITY: "E",
+                CONF_STOPBITS: 1,
+                CONF_SENSORS: [
+                    {
+                        CONF_NAME: "dummy",
+                        CONF_ADDRESS: 9999,
+                    }
+                ],
+            },
+            {
+                CONF_NAME: TEST_MODBUS_NAME + "_1",
+                CONF_TYPE: SERIAL,
+                CONF_BAUDRATE: 9600,
+                CONF_BYTESIZE: 8,
+                CONF_METHOD: "rtu",
+                CONF_PORT: TEST_PORT_SERIAL,
+                CONF_PARITY: "E",
+                CONF_STOPBITS: 1,
+                CONF_SENSORS: [
+                    {
+                        CONF_NAME: "dummy",
+                        CONF_ADDRESS: 9999,
+                    }
+                ],
+            },
+        ],
+    ],
+)
+async def test_config_wrong_modbus(
+    hass: HomeAssistant, mock_modbus_with_pymodbus
 ) -> None:
     """Run configuration test for modbus."""
+    assert len(hass.data[DOMAIN]) == 1
 
 
 VALUE = "value"

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -780,10 +780,9 @@ async def test_no_duplicate_names(hass: HomeAssistant, do_config) -> None:
         },
     ],
 )
-async def test_config_modbus(hass: HomeAssistant, mock_modbus_with_pymodbus, issue_registry: ir.IssueRegistry) -> None:
+async def test_config_modbus(hass: HomeAssistant, mock_modbus_with_pymodbus) -> None:
     """Run configuration test for modbus."""
     assert len(hass.data[DOMAIN])
-    assert len(issue_registry.issues) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -883,7 +883,7 @@ async def test_config_modbus(hass: HomeAssistant, mock_modbus_with_pymodbus) -> 
     ],
 )
 async def test_config_wrong_modbus(
-    hass: HomeAssistant, mock_modbus_with_pymodbus
+    hass: HomeAssistant, mock_modbus_with_pymodbus, issue_registry: ir.IssueRegistry
 ) -> None:
     """Run configuration test for modbus."""
     assert len(hass.data[DOMAIN]) == 1

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -107,6 +107,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -788,6 +788,7 @@ async def test_config_modbus(hass: HomeAssistant, mock_modbus_with_pymodbus) -> 
     "do_config",
     [
         [
+            # Duplicate CONF_NAME
             {
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -779,9 +779,10 @@ async def test_no_duplicate_names(hass: HomeAssistant, do_config) -> None:
         },
     ],
 )
-async def test_config_modbus(hass: HomeAssistant, mock_modbus_with_pymodbus) -> None:
+async def test_config_modbus(hass: HomeAssistant, mock_modbus_with_pymodbus, issue_registry: ir.IssueRegistry) -> None:
     """Run configuration test for modbus."""
     assert len(hass.data[DOMAIN])
+    assert len(issue_registry.issues) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -819,6 +819,7 @@ async def test_config_modbus(hass: HomeAssistant, mock_modbus_with_pymodbus) -> 
             },
         ],
         [
+            # Duplicate CONF_HOST+CONF_PORT (for type != SERIAL)
             {
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -846,6 +846,7 @@ async def test_config_modbus(hass: HomeAssistant, mock_modbus_with_pymodbus) -> 
             },
         ],
         [
+            # Duplicate CONF_PORT (for type == SERIAL)
             {
                 CONF_NAME: TEST_MODBUS_NAME,
                 CONF_TYPE: SERIAL,

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -887,6 +887,8 @@ async def test_config_wrong_modbus(
 ) -> None:
     """Run configuration test for modbus."""
     assert len(hass.data[DOMAIN]) == 1
+    assert len(issue_registry.issues) == 1
+    assert (DOMAIN, "duplicate_modbus_entry") in issue_registry.issues
 
 
 VALUE = "value"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The test suite did not validate that using the same host/port in multiple hubs are not permitted, added test.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
