### PR TITLE
fix logic of renson fan.turn_on to be compatible with automatic mode

### DIFF
--- a/homeassistant/components/renson/fan.py
+++ b/homeassistant/components/renson/fan.py
@@ -168,8 +168,7 @@ class RensonFan(RensonEntity, FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn on the fan."""
-        if percentage is None:
-            percentage = 1
+        """If the percentage is None, turn manual level off (to auto)."""
 
         await self.async_set_percentage(percentage)
 
@@ -188,6 +187,8 @@ class RensonFan(RensonEntity, FanEntity):
 
         if percentage == 0:
             cmd = Level.HOLIDAY
+        elif percentage is None: # turn manual level off (to auto)
+            cmd = Level.OFF
         else:
             speed = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
             cmd = CMD_MAPPING[speed]
@@ -198,8 +199,13 @@ class RensonFan(RensonEntity, FanEntity):
             await self.hass.async_add_executor_job(
                 self.api.set_breeze, cmd, breeze_temp, True
             )
+
+            _LOGGER.debug("Set Breeze %s %s", cmd, breeze_temp)
+
         else:
             await self.hass.async_add_executor_job(self.api.set_manual_level, cmd)
+
+            _LOGGER.debug("Set Manual Level %s", cmd)
 
         await self.coordinator.async_request_refresh()
 

--- a/homeassistant/components/renson/fan.py
+++ b/homeassistant/components/renson/fan.py
@@ -187,7 +187,7 @@ class RensonFan(RensonEntity, FanEntity):
 
         if percentage == 0:
             cmd = Level.HOLIDAY
-        elif percentage is None: # turn manual level off (to auto)
+        elif percentage is None:  # turn manual level off (to auto)
             cmd = Level.OFF
         else:
             speed = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

In the renson Integration, when using the action fan.turn_on:
up until now, if the percentage is filled in as 0 (not empty), the manual level level is put to 1.
From now on:
percentage 0 -> holiday mode
percentage 1 -> level 1
percentage empty -> auto mode

## Proposed change

In the fan.turn_on action, there was no way to exit the holiday mode without setting a manual level.
I propose to add the functionality that the fan is turned on in auto mode when the percentage is not filled in, instead of level 1.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes 150549

## Checklist
- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
