### PR TITLE
Refactor template engine: Extract raise_no_default() into helper module

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -82,6 +82,7 @@ from .context import (
     template_context_manager,
     template_cv,
 )
+from .helpers import raise_no_default
 from .render_info import RenderInfo, render_info_cv
 
 if TYPE_CHECKING:
@@ -1816,15 +1817,6 @@ def utcnow(hass: HomeAssistant) -> datetime:
         render_info.has_time = True
 
     return dt_util.utcnow()
-
-
-def raise_no_default(function: str, value: Any) -> NoReturn:
-    """Log warning if no default is specified."""
-    template, action = template_cv.get() or ("", "rendering or compiling")
-    raise ValueError(
-        f"Template error: {function} got invalid input '{value}' when {action} template"
-        f" '{template}' but no default was specified"
-    )
 
 
 def forgiving_round(value, precision=0, method="common", default=_SENTINEL):

--- a/homeassistant/helpers/template/extensions/math.py
+++ b/homeassistant/helpers/template/extensions/math.py
@@ -6,12 +6,12 @@ from collections.abc import Iterable
 from functools import wraps
 import math
 import statistics
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import TYPE_CHECKING, Any
 
 import jinja2
 from jinja2 import pass_environment
 
-from homeassistant.helpers.template.context import template_cv
+from homeassistant.helpers.template.helpers import raise_no_default
 
 from .base import BaseTemplateExtension, TemplateFunction
 
@@ -20,15 +20,6 @@ if TYPE_CHECKING:
 
 # Sentinel object for default parameter
 _SENTINEL = object()
-
-
-def raise_no_default(function: str, value: Any) -> NoReturn:
-    """Log warning if no default is specified."""
-    template, action = template_cv.get() or ("", "rendering or compiling")
-    raise ValueError(
-        f"Template error: {function} got invalid input '{value}' when {action} template"
-        f" '{template}' but no default was specified"
-    )
 
 
 class MathExtension(BaseTemplateExtension):

--- a/homeassistant/helpers/template/helpers.py
+++ b/homeassistant/helpers/template/helpers.py
@@ -1,0 +1,16 @@
+"""Template helper functions for Home Assistant."""
+
+from __future__ import annotations
+
+from typing import Any, NoReturn
+
+from .context import template_cv
+
+
+def raise_no_default(function: str, value: Any) -> NoReturn:
+    """Log warning if no default is specified."""
+    template, action = template_cv.get() or ("", "rendering or compiling")
+    raise ValueError(
+        f"Template error: {function} got invalid input '{value}' when {action} template"
+        f" '{template}' but no default was specified"
+    )

--- a/homeassistant/helpers/template/helpers.py
+++ b/homeassistant/helpers/template/helpers.py
@@ -8,7 +8,7 @@ from .context import template_cv
 
 
 def raise_no_default(function: str, value: Any) -> NoReturn:
-    """Log warning if no default is specified."""
+    """Raise ValueError when no default is specified for template functions."""
     template, action = template_cv.get() or ("", "rendering or compiling")
     raise ValueError(
         f"Template error: {function} got invalid input '{value}' when {action} template"

--- a/tests/helpers/template/test_helpers.py
+++ b/tests/helpers/template/test_helpers.py
@@ -1,0 +1,14 @@
+"""Test template helper functions."""
+
+import pytest
+
+from homeassistant.helpers.template.helpers import raise_no_default
+
+
+def test_raise_no_default() -> None:
+    """Test raise_no_default raises ValueError with correct message."""
+    with pytest.raises(
+        ValueError,
+        match="Template error: test got invalid input 'invalid' when rendering or compiling template '' but no default was specified",
+    ):
+        raise_no_default("test", "invalid")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Step 7 of many in an attempt to refactor our template engine from a huge monolith in a single file into something modular and maintainable.

This step moves `raise_no_default()` into a helper module. It already duplicated once in the recent refactoring to prevent circular imports, but for all next extensions we will run into it again.

This PR pull it out into it's own module.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
