### PR TITLE
Use already cached data in Nord Pool if valid

### DIFF
--- a/homeassistant/components/nordpool/__init__.py
+++ b/homeassistant/components/nordpool/__init__.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
     await cleanup_device(hass, config_entry)
 
     coordinator = NordPoolDataUpdateCoordinator(hass, config_entry)
-    await coordinator.fetch_data(dt_util.utcnow())
+    await coordinator.fetch_data(dt_util.utcnow(), True)
     if not coordinator.last_update_success:
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,

--- a/homeassistant/components/nordpool/coordinator.py
+++ b/homeassistant/components/nordpool/coordinator.py
@@ -13,7 +13,6 @@ from pynordpool import (
     DeliveryPeriodEntry,
     DeliveryPeriodsData,
     NordPoolClient,
-    NordPoolEmptyResponseError,
     NordPoolError,
     NordPoolResponseError,
 )
@@ -22,7 +21,7 @@ from homeassistant.const import CONF_CURRENCY
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_point_in_utc_time
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .const import CONF_AREAS, DOMAIN, LOGGER
@@ -67,13 +66,12 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
             self.unsub()
             self.unsub = None
 
-    async def fetch_data(self, now: datetime) -> None:
+    async def fetch_data(self, now: datetime, initial: bool = False) -> None:
         """Fetch data from Nord Pool."""
         self.unsub = async_track_point_in_utc_time(
             self.hass, self.fetch_data, self.get_next_interval(dt_util.utcnow())
         )
         data = await self.api_call()
-
         if data and data.entries:
             current_day = dt_util.utcnow().strftime("%Y-%m-%d")
             for entry in data.entries:
@@ -81,7 +79,13 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
                     LOGGER.debug("Data for current day found")
                     self.async_set_updated_data(data)
                     return
-        self.async_set_update_error(NordPoolEmptyResponseError("No current day data"))
+        if data and not data.entries and not initial:
+            # Empty response, use cache
+            LOGGER.debug("No data entries received")
+            return
+        self.async_set_update_error(
+            UpdateFailed(translation_domain=DOMAIN, translation_key="no_day_data")
+        )
 
     async def api_call(self, retry: int = 3) -> DeliveryPeriodsData | None:
         """Make api call to retrieve data with retry if failure."""
@@ -104,7 +108,13 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
         ) as error:
             LOGGER.debug("Connection error: %s", error)
             if self.data is None:
-                self.async_set_update_error(error)  # type: ignore[unreachable]
+                self.async_set_update_error(  # type: ignore[unreachable]
+                    UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="could_not_fetch_data",
+                        translation_placeholders={"error": str(error)},
+                    )
+                )
             return self.data
 
         return data

--- a/homeassistant/components/nordpool/strings.json
+++ b/homeassistant/components/nordpool/strings.json
@@ -157,6 +157,12 @@
     },
     "connection_error": {
       "message": "There was a connection error connecting to the API. Try again later."
+    },
+    "no_day_data": {
+      "message": "Data for current day is missing"
+    },
+    "could_not_fetch_data": {
+      "message": "Data could not be retrieved: {error}"
     }
   }
 }

--- a/tests/components/nordpool/test_coordinator.py
+++ b/tests/components/nordpool/test_coordinator.py
@@ -58,7 +58,7 @@ async def test_coordinator(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_data.call_count == 1
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == "0.92505"
 
     with (
         patch(
@@ -72,7 +72,7 @@ async def test_coordinator(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_data.call_count == 1
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == "0.94949"
         assert "Authentication error" in caplog.text
 
     with (
@@ -103,7 +103,7 @@ async def test_coordinator(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_data.call_count == 1
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == "1.25889"
         assert "error" in caplog.text
 
     with (
@@ -118,7 +118,7 @@ async def test_coordinator(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_data.call_count == 1
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == "1.81645"
         assert "error" in caplog.text
 
     with (
@@ -133,7 +133,7 @@ async def test_coordinator(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_data.call_count == 1
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == "2.51265"
         assert "Response error" in caplog.text
 
     freezer.tick(timedelta(hours=1))
@@ -141,3 +141,16 @@ async def test_coordinator(
     await hass.async_block_till_done()
     state = hass.states.get("sensor.nord_pool_se3_current_price")
     assert state.state == "1.81983"
+
+    with (
+        patch(
+            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
+            side_effect=NordPoolError("error"),
+        ) as mock_data,
+    ):
+        freezer.tick(timedelta(hours=48))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert mock_data.call_count == 1
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == STATE_UNAVAILABLE

--- a/tests/components/nordpool/test_coordinator.py
+++ b/tests/components/nordpool/test_coordinator.py
@@ -88,7 +88,7 @@ async def test_coordinator(
         # Empty responses does not raise
         assert mock_data.call_count == 3
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == "0.94949"
         assert "Empty response" in caplog.text
 
     with (
@@ -154,3 +154,4 @@ async def test_coordinator(
         assert mock_data.call_count == 1
         state = hass.states.get("sensor.nord_pool_se3_current_price")
         assert state.state == STATE_UNAVAILABLE
+        assert "Data for current day is missing" in caplog.text


### PR DESCRIPTION
## Breaking change


## Proposed change
Use the previous data in Nord Pool if a refresh fails (until valid dates are not present anymore).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #151440
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 