### PR TITLE
Fix resource and payload template in scrape

### DIFF
--- a/homeassistant/components/scrape/__init__.py
+++ b/homeassistant/components/scrape/__init__.py
@@ -78,7 +78,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         scan_interval: timedelta = resource_config.get(
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
         )
-        coordinator = ScrapeCoordinator(hass, None, rest, scan_interval)
+        coordinator = ScrapeCoordinator(
+            hass, None, rest, resource_config, scan_interval
+        )
 
         sensors: list[ConfigType] = resource_config.get(SENSOR_DOMAIN, [])
         if sensors:
@@ -108,6 +110,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ScrapeConfigEntry) -> bo
         hass,
         entry,
         rest,
+        rest_config,
         DEFAULT_SCAN_INTERVAL,
     )
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/scrape/coordinator.py
+++ b/homeassistant/components/scrape/coordinator.py
@@ -9,7 +9,9 @@ from typing import Any
 from bs4 import BeautifulSoup
 
 from homeassistant.components.rest import RestData
+from homeassistant.components.rest.const import CONF_PAYLOAD_TEMPLATE
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_RESOURCE_TEMPLATE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -40,16 +42,14 @@ class ScrapeCoordinator(DataUpdateCoordinator[BeautifulSoup]):
 
     async def _async_update_data(self) -> BeautifulSoup:
         """Fetch data from Rest."""
-        if "resource_template" in self._rest_config:
+        if CONF_RESOURCE_TEMPLATE in self._rest_config:
             self._rest.set_url(
                 self._rest_config["resource_template"].async_render(parse_result=False)
             )
-            if "payload_template" in self._rest_config:
-                self._rest.set_payload(
-                    self._rest_config["payload_template"].async_render(
-                        parse_result=False
-                    )
-                )
+        if CONF_PAYLOAD_TEMPLATE in self._rest_config:
+            self._rest.set_payload(
+                self._rest_config["payload_template"].async_render(parse_result=False)
+            )
         await self._rest.async_update()
         if (data := self._rest.data) is None:
             raise UpdateFailed("REST data is not available")

--- a/tests/components/scrape/test_init.py
+++ b/tests/components/scrape/test_init.py
@@ -162,7 +162,7 @@ async def test_resource_template(
     aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test setup with minimum configuration."""
+    """Test resource_template is evaluated on each scan."""
     hass.states.async_set("sensor.input_sensor", "localhost")
     aioclient_mock.get(
         "http://localhost",

--- a/tests/components/scrape/test_init.py
+++ b/tests/components/scrape/test_init.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.scrape.const import DEFAULT_SCAN_INTERVAL, DOMAIN
@@ -16,6 +18,7 @@ from homeassistant.util import dt as dt_util
 from . import MockRestData, return_integration_config
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import WebSocketGenerator
 
 
@@ -152,3 +155,41 @@ async def test_device_remove_devices(
     )
     response = await client.remove_device(dead_device_entry.id, loaded_entry.entry_id)
     assert response["success"]
+
+
+async def test_resource_template(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test setup with minimum configuration."""
+    hass.states.async_set("sensor.input_sensor", "localhost")
+    aioclient_mock.get(
+        "http://localhost",
+        status=HTTPStatus.OK,
+        text="<h1>First</h1>",
+    )
+    aioclient_mock.get(
+        "http://localhost2",
+        status=HTTPStatus.OK,
+        text="<h1>Second</h1>",
+    )
+
+    config = {
+        DOMAIN: {
+            "resource_template": "http://{{ states.sensor.input_sensor.state }}",
+            "verify_ssl": True,
+            "sensor": [{"select": "h1", "name": "template sensor"}],
+        }
+    }
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get("sensor.template_sensor")
+    assert state.state == "First"
+
+    hass.states.async_set("sensor.input_sensor", "localhost2")
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get("sensor.template_sensor")
+    assert state.state == "Second"


### PR DESCRIPTION
## Breaking change


## Proposed change
Fix resource and payload templates are evaluated on each run (not only startup).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #151496
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 