### PR TITLE
Use the common `unique_id` schema in the Shelly button platform

### DIFF
--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -29,6 +29,7 @@ from .coordinator import ShellyBlockCoordinator, ShellyConfigEntry, ShellyRpcCoo
 from .entity import get_entity_block_device_info, get_entity_rpc_device_info
 from .utils import (
     async_remove_orphaned_entities,
+    format_ble_addr,
     get_blu_trv_device_info,
     get_device_entry_gen,
     get_rpc_entity_name,
@@ -297,7 +298,7 @@ class ShellyBluTrvButton(ShellyBaseButton):
         ble_addr: str = config["addr"]
         fw_ver = coordinator.device.status[key].get("fw_ver")
 
-        self._attr_unique_id = f"{ble_addr}_{description.key}"
+        self._attr_unique_id = f"{format_ble_addr(ble_addr)}-{key}-{description.key}"
         self._attr_device_info = get_blu_trv_device_info(
             config, ble_addr, coordinator.mac, fw_ver
         )

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -23,7 +23,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import slugify
 
 from .const import DOMAIN, LOGGER, SHELLY_GAS_MODELS
 from .coordinator import ShellyBlockCoordinator, ShellyConfigEntry, ShellyRpcCoordinator
@@ -114,12 +113,10 @@ def async_migrate_unique_ids(
     if not entity_entry.entity_id.startswith("button"):
         return None
 
-    device_name = slugify(coordinator.device.name)
-
     for key in ("reboot", "self_test", "mute", "unmute"):
-        old_unique_id = f"{device_name}_{key}"
+        old_unique_id = f"{coordinator.mac}_{key}"
         if entity_entry.unique_id == old_unique_id:
-            new_unique_id = f"{coordinator.mac}_{key}"
+            new_unique_id = f"{coordinator.mac}-{key}"
             LOGGER.debug(
                 "Migrating unique_id for %s entity from [%s] to [%s]",
                 entity_entry.entity_id,

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -286,7 +286,7 @@ class ShellyButton(ShellyBaseButton):
         """Initialize Shelly button."""
         super().__init__(coordinator, description)
 
-        self._attr_unique_id = f"{coordinator.mac}_{description.key}"
+        self._attr_unique_id = f"{coordinator.mac}-{description.key}"
         if isinstance(coordinator, ShellyBlockCoordinator):
             self._attr_device_info = get_entity_block_device_info(coordinator)
         else:

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -918,3 +918,8 @@ def remove_empty_sub_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
             dev_reg.async_update_device(
                 device.id, remove_config_entry_id=entry.entry_id
             )
+
+
+def format_ble_addr(ble_addr: str) -> str:
+    """Format BLE address to use in unique_id."""
+    return ble_addr.replace(":", "").upper()

--- a/tests/components/shelly/snapshots/test_button.ambr
+++ b/tests/components/shelly/snapshots/test_button.ambr
@@ -30,7 +30,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'calibrate',
-    'unique_id': 'f8:44:77:25:f0:dd_calibrate',
+    'unique_id': 'F8447725F0DD-blutrv:200-calibrate',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/shelly/snapshots/test_button.ambr
+++ b/tests/components/shelly/snapshots/test_button.ambr
@@ -78,7 +78,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '123456789ABC_reboot',
+    'unique_id': '123456789ABC-reboot',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -422,7 +422,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '123456789ABC_reboot',
+    'unique_id': '123456789ABC-reboot',
     'unit_of_measurement': None,
   })
 # ---
@@ -1672,7 +1672,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '123456789ABC_reboot',
+    'unique_id': '123456789ABC-reboot',
     'unit_of_measurement': None,
   })
 # ---
@@ -2935,7 +2935,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '123456789ABC_reboot',
+    'unique_id': '123456789ABC-reboot',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -33,7 +33,7 @@ async def test_block_button(
     assert state.state == STATE_UNKNOWN
 
     assert (entry := entity_registry.async_get(entity_id))
-    assert entry.unique_id == "123456789ABC_reboot"
+    assert entry.unique_id == "123456789ABC-reboot"
 
     await hass.services.async_call(
         BUTTON_DOMAIN,

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -379,3 +379,34 @@ async def test_wall_display_virtual_button(
         blocking=True,
     )
     mock_rpc_device.button_trigger.assert_called_once_with(200, "single_push")
+
+
+async def test_migrate_unique_id_blu_trv(
+    hass: HomeAssistant,
+    mock_blu_trv: Mock,
+    entity_registry: EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test migration of unique_id for BLU TRV button."""
+    entry = await init_integration(hass, 3, model=MODEL_BLU_GATEWAY_G3, skip_setup=True)
+
+    old_unique_id = "f8:44:77:25:f0:dd_calibrate"
+
+    entity = entity_registry.async_get_or_create(
+        suggested_object_id="trv_name_calibrate",
+        disabled_by=None,
+        domain=BUTTON_DOMAIN,
+        platform=DOMAIN,
+        unique_id=old_unique_id,
+        config_entry=entry,
+    )
+    assert entity.unique_id == old_unique_id
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_entry = entity_registry.async_get("button.trv_name_calibrate")
+    assert entity_entry
+    assert entity_entry.unique_id == "F8447725F0DD-blutrv:200-calibrate"
+
+    assert "Migrating unique_id for button.trv_name_calibrate" in caplog.text

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -136,9 +136,9 @@ async def test_rpc_button_reauth_error(
 @pytest.mark.parametrize(
     ("gen", "old_unique_id", "new_unique_id", "migration"),
     [
-        (2, "test_name_reboot", "123456789ABC_reboot", True),
-        (1, "test_name_reboot", "123456789ABC_reboot", True),
-        (2, "123456789ABC_reboot", "123456789ABC_reboot", False),
+        (2, "123456789ABC_reboot", "123456789ABC-reboot", True),
+        (1, "123456789ABC_reboot", "123456789ABC-reboot", True),
+        (2, "123456789ABC-reboot", "123456789ABC-reboot", False),
     ],
 )
 async def test_migrate_unique_id(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `unique_id` schema of the button platform is incompatible with our `async_remove_orphaned_entities` method, which causes an exception.

```
2025-09-21 11:56:22.223 ERROR (MainThread) [homeassistant.components.button] Error while setting up shelly platform for button: list index out of range
Traceback (most recent call last):
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity_platform.py", line 451, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/button.py", line 192, in async_setup_entry
    async_remove_orphaned_entities(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        hass,
        ^^^^^
    ...<3 lines>...
        virtual_button_component_ids,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/utils.py", line 705, in async_remove_orphaned_entities
    orphaned_entities.append(entity.unique_id.split("-", 1)[1])
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

This PR migrates the entity's unique_id to the common schema.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
