### PR TITLE
Add scene platform support to Niko Home Control integration

### DIFF
--- a/homeassistant/components/niko_home_control/__init__.py
+++ b/homeassistant/components/niko_home_control/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import entity_registry as er
 
 from .const import _LOGGER
 
-PLATFORMS: list[Platform] = [Platform.COVER, Platform.LIGHT]
+PLATFORMS: list[Platform] = [Platform.COVER, Platform.LIGHT, Platform.SCENE]
 
 type NikoHomeControlConfigEntry = ConfigEntry[NHCController]
 

--- a/homeassistant/components/niko_home_control/scene.py
+++ b/homeassistant/components/niko_home_control/scene.py
@@ -9,7 +9,6 @@ from nhc.scene import NHCScene
 from homeassistant.components.scene import BaseScene
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.util import dt as dt_util
 
 from . import NHCController, NikoHomeControlConfigEntry
 from .entity import NikoHomeControlEntity
@@ -38,14 +37,6 @@ class NikoHomeControlScene(NikoHomeControlEntity, BaseScene):
         """Set up the Niko Home Control scene platform."""
         super().__init__(action, controller, unique_id)
         self._attr_icon = "mdi:palette"
-        self._last_activated: str | None = None
-
-    @property
-    def extra_state_attributes(self):
-        """Return the state attributes."""
-        return {
-            "last_activated": self._last_activated,
-        }
 
     async def _async_activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""
@@ -53,4 +44,4 @@ class NikoHomeControlScene(NikoHomeControlEntity, BaseScene):
 
     def update_state(self) -> None:
         """Update HA state."""
-        self._last_activated = dt_util.now().isoformat()
+        self._async_record_activation()

--- a/homeassistant/components/niko_home_control/scene.py
+++ b/homeassistant/components/niko_home_control/scene.py
@@ -9,6 +9,7 @@ from nhc.scene import NHCScene
 from homeassistant.components.scene import BaseScene
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from . import NHCController, NikoHomeControlConfigEntry
 from .entity import NikoHomeControlEntity
@@ -37,6 +38,14 @@ class NikoHomeControlScene(NikoHomeControlEntity, BaseScene):
         """Set up the Niko Home Control scene platform."""
         super().__init__(action, controller, unique_id)
         self._attr_icon = "mdi:palette"
+        self._last_activated: str | None = None
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            "last_activated": self._last_activated,
+        }
 
     async def _async_activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""
@@ -44,4 +53,4 @@ class NikoHomeControlScene(NikoHomeControlEntity, BaseScene):
 
     def update_state(self) -> None:
         """Update HA state."""
-        self._async_record_activation()
+        self._last_activated = dt_util.now().isoformat()

--- a/homeassistant/components/niko_home_control/scene.py
+++ b/homeassistant/components/niko_home_control/scene.py
@@ -1,0 +1,49 @@
+"""Scene Platform for Niko Home Control."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nhc.scene import NHCScene
+
+from homeassistant.components.scene import BaseScene
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import NHCController, NikoHomeControlConfigEntry
+from .entity import NikoHomeControlEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: NikoHomeControlConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Niko Home Control scene entry."""
+    controller = entry.runtime_data
+
+    async_add_entities(
+        (NikoHomeControlScene)(scene, controller, entry.entry_id)
+        for scene in controller.scenes
+    )
+
+
+class NikoHomeControlScene(NikoHomeControlEntity, BaseScene):
+    """Representation of a Niko Home Control Scene."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, action: NHCScene, controller: NHCController, unique_id: str
+    ) -> None:
+        """Set up the Niko Home Control scene platform."""
+        super().__init__(action, controller, unique_id)
+        self._attr_icon = "mdi:palette"
+
+    async def _async_activate(self, **kwargs: Any) -> None:
+        """Activate scene. Try to get entities into requested state."""
+        await self._action.activate()
+
+    def update_state(self) -> None:
+        """Update HA state."""
+        self._async_record_activation()

--- a/homeassistant/components/niko_home_control/scene.py
+++ b/homeassistant/components/niko_home_control/scene.py
@@ -31,12 +31,13 @@ async def async_setup_entry(
 class NikoHomeControlScene(NikoHomeControlEntity, BaseScene):
     """Representation of a Niko Home Control Scene."""
 
+    _attr_name = None
+
     def __init__(
         self, action: NHCScene, controller: NHCController, unique_id: str
     ) -> None:
         """Set up the Niko Home Control scene platform."""
         super().__init__(action, controller, unique_id)
-        self._attr_icon = "mdi:palette"
 
     async def _async_activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""

--- a/homeassistant/components/niko_home_control/scene.py
+++ b/homeassistant/components/niko_home_control/scene.py
@@ -31,8 +31,6 @@ async def async_setup_entry(
 class NikoHomeControlScene(NikoHomeControlEntity, BaseScene):
     """Representation of a Niko Home Control Scene."""
 
-    _attr_has_entity_name = True
-
     def __init__(
         self, action: NHCScene, controller: NHCController, unique_id: str
     ) -> None:

--- a/homeassistant/components/niko_home_control/scene.py
+++ b/homeassistant/components/niko_home_control/scene.py
@@ -23,7 +23,7 @@ async def async_setup_entry(
     controller = entry.runtime_data
 
     async_add_entities(
-        (NikoHomeControlScene)(scene, controller, entry.entry_id)
+        NikoHomeControlScene(scene, controller, entry.entry_id)
         for scene in controller.scenes
     )
 

--- a/homeassistant/components/niko_home_control/scene.py
+++ b/homeassistant/components/niko_home_control/scene.py
@@ -33,12 +33,6 @@ class NikoHomeControlScene(NikoHomeControlEntity, BaseScene):
 
     _attr_name = None
 
-    def __init__(
-        self, action: NHCScene, controller: NHCController, unique_id: str
-    ) -> None:
-        """Set up the Niko Home Control scene platform."""
-        super().__init__(action, controller, unique_id)
-
     async def _async_activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""
         await self._action.activate()

--- a/homeassistant/components/niko_home_control/scene.py
+++ b/homeassistant/components/niko_home_control/scene.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from nhc.scene import NHCScene
-
 from homeassistant.components.scene import BaseScene
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import NHCController, NikoHomeControlConfigEntry
+from . import NikoHomeControlConfigEntry
 from .entity import NikoHomeControlEntity
 
 

--- a/tests/components/niko_home_control/conftest.py
+++ b/tests/components/niko_home_control/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 from nhc.cover import NHCCover
 from nhc.light import NHCLight
+from nhc.scene import NHCScene
 import pytest
 
 from homeassistant.components.niko_home_control.const import DOMAIN
@@ -62,8 +63,20 @@ def cover() -> NHCCover:
 
 
 @pytest.fixture
+def scene() -> NHCScene:
+    """Return a scene mock."""
+    mock = AsyncMock(spec=NHCScene)
+    mock.id = 4
+    mock.type = 0
+    mock.name = "scene"
+    mock.suggested_area = "room"
+    mock.state = 0
+    return mock
+
+
+@pytest.fixture
 def mock_niko_home_control_connection(
-    light: NHCLight, dimmable_light: NHCLight, cover: NHCCover
+    light: NHCLight, dimmable_light: NHCLight, cover: NHCCover, scene: NHCScene
 ) -> Generator[AsyncMock]:
     """Mock a NHC client."""
     with (
@@ -79,6 +92,7 @@ def mock_niko_home_control_connection(
         client = mock_client.return_value
         client.lights = [light, dimmable_light]
         client.covers = [cover]
+        client.scenes = [scene]
         client.connect = AsyncMock(return_value=True)
         yield client
 

--- a/tests/components/niko_home_control/snapshots/test_scene.ambr
+++ b/tests/components/niko_home_control/snapshots/test_scene.ambr
@@ -45,6 +45,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2025-09-22T19:05:01.534478+00:00',
+    'state': '2025-10-08T19:22:07.575082+00:00',
   })
 # ---

--- a/tests/components/niko_home_control/snapshots/test_scene.ambr
+++ b/tests/components/niko_home_control/snapshots/test_scene.ambr
@@ -1,0 +1,50 @@
+# serializer version: 1
+# name: test_entities[scene.scene_none-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'scene',
+    'entity_category': None,
+    'entity_id': 'scene.scene_none',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:palette',
+    'original_name': None,
+    'platform': 'niko_home_control',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01JFN93M7KRA38V5AMPCJ2JYYV-4',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[scene.scene_none-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'scene None',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'scene.scene_none',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-09-22T19:05:01.534478+00:00',
+  })
+# ---

--- a/tests/components/niko_home_control/snapshots/test_scene.ambr
+++ b/tests/components/niko_home_control/snapshots/test_scene.ambr
@@ -39,12 +39,13 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'scene None',
       'icon': 'mdi:palette',
+      'last_activated': None,
     }),
     'context': <ANY>,
     'entity_id': 'scene.scene_none',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2025-10-08T19:22:07.575082+00:00',
+    'state': 'unknown',
   })
 # ---

--- a/tests/components/niko_home_control/snapshots/test_scene.ambr
+++ b/tests/components/niko_home_control/snapshots/test_scene.ambr
@@ -39,13 +39,12 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'scene None',
       'icon': 'mdi:palette',
-      'last_activated': None,
     }),
     'context': <ANY>,
     'entity_id': 'scene.scene_none',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '2025-10-10T21:00:00+00:00',
   })
 # ---

--- a/tests/components/niko_home_control/snapshots/test_scene.ambr
+++ b/tests/components/niko_home_control/snapshots/test_scene.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_entities[scene.scene_none-entry]
+# name: test_entities[scene.scene-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -12,7 +12,7 @@
     'disabled_by': None,
     'domain': 'scene',
     'entity_category': None,
-    'entity_id': 'scene.scene_none',
+    'entity_id': 'scene.scene',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,7 +23,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:palette',
+    'original_icon': None,
     'original_name': None,
     'platform': 'niko_home_control',
     'previous_unique_id': None,
@@ -34,14 +34,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[scene.scene_none-state]
+# name: test_entities[scene.scene-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'scene None',
-      'icon': 'mdi:palette',
+      'friendly_name': 'scene',
     }),
     'context': <ANY>,
-    'entity_id': 'scene.scene_none',
+    'entity_id': 'scene.scene',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/niko_home_control/test_scene.py
+++ b/tests/components/niko_home_control/test_scene.py
@@ -1,0 +1,91 @@
+"""Tests for the Niko Home Control Scene platform."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import find_update_callback, setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_niko_home_control_connection: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    with patch(
+        "homeassistant.components.niko_home_control.PLATFORMS", [Platform.SCENE]
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize("scene_id", [0])
+async def test_activate_scene(
+    hass: HomeAssistant,
+    mock_niko_home_control_connection: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    scene_id: int,
+) -> None:
+    """Test activating the scene."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Resolve the created scene entity dynamically
+    entity_entries = er.async_entries_for_config_entry(
+        er.async_get(hass), mock_config_entry.entry_id
+    )
+    scene_entities = [e for e in entity_entries if e.domain == SCENE_DOMAIN]
+    assert scene_entities, "No scene entities registered"
+    entity_id = scene_entities[0].entity_id
+
+    await hass.services.async_call(
+        SCENE_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    mock_niko_home_control_connection.scenes[scene_id].activate.assert_called_once()
+
+
+async def test_updating(
+    hass: HomeAssistant,
+    mock_niko_home_control_connection: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    scene: AsyncMock,
+) -> None:
+    """Test scene state recording after activation."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Resolve the created scene entity dynamically
+    entity_entries = er.async_entries_for_config_entry(
+        er.async_get(hass), mock_config_entry.entry_id
+    )
+    scene_entities = [e for e in entity_entries if e.domain == SCENE_DOMAIN]
+    assert scene_entities, "No scene entities registered"
+    entity_id = scene_entities[0].entity_id
+
+    # Capture current state (could be unknown or a timestamp depending on implementation)
+    before = hass.states.get(entity_id)
+    assert before is not None
+
+    # Simulate a device-originated update for the scene (controller callback)
+    await find_update_callback(mock_niko_home_control_connection, scene.id)(0)
+    await hass.async_block_till_done()
+
+    after = hass.states.get(entity_id)
+    assert after is not None
+    # If integration records activation on updates, state should change and be a valid ISO timestamp
+    if after.state != before.state:
+        datetime.fromisoformat(after.state)

--- a/tests/components/niko_home_control/test_scene.py
+++ b/tests/components/niko_home_control/test_scene.py
@@ -78,15 +78,15 @@ async def test_updating(
     entity_id = scene_entities[0].entity_id
 
     # Capture current state (could be unknown or a timestamp depending on implementation)
-    before = hass.states.get(entity_id)
-    assert before is not None
+    before = hass.states.get(entity_id).attributes
 
     # Simulate a device-originated update for the scene (controller callback)
     await find_update_callback(mock_niko_home_control_connection, scene.id)(0)
     await hass.async_block_till_done()
 
-    after = hass.states.get(entity_id)
+    after = hass.states.get(entity_id).attributes
+
     assert after is not None
     # If integration records activation on updates, state should change and be a valid ISO timestamp
-    if after.state != before.state:
-        datetime.fromisoformat(after.state)
+    if after["last_activated"] != before["last_activated"]:
+        datetime.fromisoformat(after["last_activated"])

--- a/tests/components/niko_home_control/test_scene.py
+++ b/tests/components/niko_home_control/test_scene.py
@@ -38,13 +38,14 @@ async def test_activate_scene(
     mock_niko_home_control_connection: AsyncMock,
     mock_config_entry: MockConfigEntry,
     scene_id: int,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test activating the scene."""
     await setup_integration(hass, mock_config_entry)
 
     # Resolve the created scene entity dynamically
     entity_entries = er.async_entries_for_config_entry(
-        er.async_get(hass), mock_config_entry.entry_id
+        entity_registry, mock_config_entry.entry_id
     )
     scene_entities = [e for e in entity_entries if e.domain == SCENE_DOMAIN]
     assert scene_entities, "No scene entities registered"

--- a/tests/components/niko_home_control/test_scene.py
+++ b/tests/components/niko_home_control/test_scene.py
@@ -46,7 +46,7 @@ async def test_activate_scene(
     await hass.services.async_call(
         SCENE_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "scene.scene_none"},
+        {ATTR_ENTITY_ID: "scene.scene"},
         blocking=True,
     )
     mock_niko_home_control_connection.scenes[scene_id].activate.assert_called_once()

--- a/tests/components/niko_home_control/test_scene.py
+++ b/tests/components/niko_home_control/test_scene.py
@@ -1,6 +1,5 @@
 """Tests for the Niko Home Control Scene platform."""
 
-from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -80,6 +79,4 @@ async def test_updating(
 
     after = hass.states.get(entity_id)
     assert after is not None
-    # If integration records activation on updates, state should change and be a valid ISO timestamp
-    if after.state != before.state:
-        datetime.fromisoformat(after.state)
+    assert after.state != before.state

--- a/tests/components/niko_home_control/test_scene.py
+++ b/tests/components/niko_home_control/test_scene.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -45,11 +44,10 @@ async def test_activate_scene(
     """Test activating the scene."""
     await setup_integration(hass, mock_config_entry)
 
-
     await hass.services.async_call(
         SCENE_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "scene.scene_none")},
+        {ATTR_ENTITY_ID: "scene.scene_none"},
         blocking=True,
     )
     mock_niko_home_control_connection.scenes[scene_id].activate.assert_called_once()

--- a/tests/components/niko_home_control/test_scene.py
+++ b/tests/components/niko_home_control/test_scene.py
@@ -3,8 +3,8 @@
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
-from pytest_freezer import freezer as FrozenDateTimeFactory
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN

--- a/tests/components/niko_home_control/test_scene.py
+++ b/tests/components/niko_home_control/test_scene.py
@@ -45,18 +45,11 @@ async def test_activate_scene(
     """Test activating the scene."""
     await setup_integration(hass, mock_config_entry)
 
-    # Resolve the created scene entity dynamically
-    entity_entries = er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
-    scene_entities = [e for e in entity_entries if e.domain == SCENE_DOMAIN]
-    assert scene_entities, "No scene entities registered"
-    entity_id = scene_entities[0].entity_id
 
     await hass.services.async_call(
         SCENE_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: entity_id},
+        {ATTR_ENTITY_ID: "scene.scene_none")},
         blocking=True,
     )
     mock_niko_home_control_connection.scenes[scene_id].activate.assert_called_once()

--- a/tests/components/niko_home_control/test_scene.py
+++ b/tests/components/niko_home_control/test_scene.py
@@ -17,16 +17,15 @@ from . import find_update_callback, setup_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.freeze_time("2025-10-10 21:00:00")
 async def test_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
     mock_niko_home_control_connection: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test all entities."""
-    freezer.move_to("2025-10-10 21:00:00")
     with patch(
         "homeassistant.components.niko_home_control.PLATFORMS", [Platform.SCENE]
     ):


### PR DESCRIPTION
Introduces a new scene platform for the Niko Home Control integration by adding a scene entity and Logic.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes missing scenes in the niko home control integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #150633
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40953
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
