### PR TITLE
Move from platform setup to async_setup_entry for modbus.

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.components.sensor import (
 from homeassistant.components.switch import (
     DEVICE_CLASSES_SCHEMA as SWITCH_DEVICE_CLASSES_SCHEMA,
 )
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_ADDRESS,
     CONF_BINARY_SENSORS,
@@ -157,6 +158,7 @@ from .const import (
 )
 from .modbus import DATA_MODBUS_HUBS, ModbusHub, async_modbus_setup
 from .validators import (
+    check_config,
     duplicate_fan_mode_validator,
     duplicate_swing_mode_validator,
     hvac_fixedsize_reglist_validator,
@@ -525,6 +527,19 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Modbus component."""
     if DOMAIN not in config:
         return True
+    if not config[DOMAIN]:
+        return False
+    config[DOMAIN] = check_config(hass, config[DOMAIN])
+    if not config[DOMAIN]:
+        return False
+    for hub in config[DOMAIN]:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data=hub,
+            )
+        )
 
     async def _reload_config(call: Event | ServiceCall) -> None:
         """Reload Modbus."""
@@ -546,5 +561,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await async_modbus_setup(hass, reload_config)
 
     async_register_admin_service(hass, DOMAIN, SERVICE_RELOAD, _reload_config)
-
     return await async_modbus_setup(hass, config)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up from a config entry."""
+    _LOGGER.debug("modbus_cf async_setup_entry")
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    _LOGGER.debug("modbus_cf async_unload_entry")
+    return True

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -26,6 +26,7 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_ADDRESS,
@@ -37,9 +38,8 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import get_hub
 from .const import (
@@ -118,17 +118,19 @@ HVACMODE_TO_TARG_TEMP_REG_INDEX_ARRAY = {
 }
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Read configuration and create Modbus climate."""
-    if discovery_info is None or not (climates := discovery_info[CONF_CLIMATES]):
+    """Set up climates."""
+    if CONF_CLIMATES not in config_entry.data:
         return
-    hub = get_hub(hass, discovery_info[CONF_NAME])
-    async_add_entities(ModbusThermostat(hass, hub, config) for config in climates)
+    hub = get_hub(hass, config_entry.data[CONF_NAME])
+    async_add_entities(
+        ModbusThermostat(hass, hub, config)
+        for config in config_entry.data[CONF_CLIMATES]
+    )
 
 
 class ModbusThermostat(ModbusStructEntity, RestoreEntity, ClimateEntity):

--- a/homeassistant/components/modbus/config_flow.py
+++ b/homeassistant/components/modbus/config_flow.py
@@ -1,0 +1,27 @@
+"""Config flow to allow modbus create a config_entry."""
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+
+from .const import _LOGGER, MODBUS_DOMAIN
+
+
+class ModbusConfigFlow(ConfigFlow, domain=MODBUS_DOMAIN):
+    """modbus integration config flow."""
+
+    async def async_step_import(self, hub: dict[str, Any]) -> ConfigFlowResult:
+        """Handle import of a single hub from configuration.yaml."""
+        _LOGGER.debug("modbus_cf async_step_import")
+        for entry in self.hass.config_entries.async_entries(MODBUS_DOMAIN):
+            if entry.data[CONF_NAME] == hub[CONF_NAME] or (
+                entry.data.get(CONF_HOST) == hub.get(CONF_HOST)
+                and entry.data[CONF_PORT] == hub[CONF_PORT]
+            ):
+                self.hass.config_entries.async_update_entry(entry, data=hub)
+                return self.async_abort(reason="already_configured")
+        return self.async_create_entry(
+            title=hub[CONF_NAME],
+            data=hub,
+        )

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.cover import CoverEntity, CoverEntityFeature, CoverState
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_COVERS, CONF_NAME, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import get_hub
 from .const import (
@@ -29,17 +29,18 @@ from .modbus import ModbusHub
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Read configuration and create Modbus cover."""
-    if discovery_info is None or not (covers := discovery_info[CONF_COVERS]):
+    """Set up climates."""
+    if CONF_COVERS not in config_entry.data:
         return
-    hub = get_hub(hass, discovery_info[CONF_NAME])
-    async_add_entities(ModbusCover(hass, hub, config) for config in covers)
+    hub = get_hub(hass, config_entry.data[CONF_NAME])
+    async_add_entities(
+        ModbusCover(hass, hub, config) for config in config_entry.data[CONF_COVERS]
+    )
 
 
 class ModbusCover(ModbusBaseEntity, CoverEntity, RestoreEntity):

--- a/homeassistant/components/modbus/fan.py
+++ b/homeassistant/components/modbus/fan.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import get_hub
 from .const import CONF_FANS
@@ -18,17 +18,18 @@ from .modbus import ModbusHub
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Read configuration and create Modbus fans."""
-    if discovery_info is None or not (fans := discovery_info[CONF_FANS]):
+    """Set up climates."""
+    if CONF_FANS not in config_entry.data:
         return
-    hub = get_hub(hass, discovery_info[CONF_NAME])
-    async_add_entities(ModbusFan(hass, hub, config) for config in fans)
+    hub = get_hub(hass, config_entry.data[CONF_NAME])
+    async_add_entities(
+        ModbusFan(hass, hub, config) for config in config_entry.data[CONF_FANS]
+    )
 
 
 class ModbusFan(ModbusToggleEntity, FanEntity):

--- a/homeassistant/components/modbus/light.py
+++ b/homeassistant/components/modbus/light.py
@@ -10,10 +10,10 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_LIGHTS, CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import get_hub
 from .const import (
@@ -36,17 +36,19 @@ from .modbus import ModbusHub
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Read configuration and create Modbus lights."""
-    if discovery_info is None or not (lights := discovery_info[CONF_LIGHTS]):
+    """Set up climates."""
+    if CONF_LIGHTS not in config_entry.data:
         return
-    hub = get_hub(hass, discovery_info[CONF_NAME])
-    async_add_entities(ModbusLight(hass, hub, config) for config in lights)
+
+    hub = get_hub(hass, config_entry.data[CONF_NAME])
+    async_add_entities(
+        ModbusLight(hass, hub, config) for config in config_entry.data[CONF_LIGHTS]
+    )
 
 
 class ModbusLight(ModbusToggleEntity, LightEntity):

--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -2,6 +2,7 @@
   "domain": "modbus",
   "name": "Modbus",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/modbus",
   "iot_class": "local_polling",
   "loggers": ["pymodbus"],

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -16,6 +16,7 @@ from pymodbus.framer import FramerType
 from pymodbus.pdu import ModbusPDU
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_STATE,
     CONF_DELAY,
@@ -29,7 +30,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
@@ -57,7 +57,6 @@ from .const import (
     DEFAULT_HUB,
     DEVICE_ID,
     DOMAIN,
-    PLATFORMS,
     RTUOVERTCP,
     SERIAL,
     SERVICE_STOP,
@@ -132,34 +131,9 @@ async def async_modbus_setup(
 ) -> bool:
     """Set up Modbus component."""
 
-    if DATA_MODBUS_HUBS in hass.data and config[DOMAIN] == []:
-        hubs = hass.data[DATA_MODBUS_HUBS]
-        for hub in hubs.values():
-            if not await hub.async_setup():
-                return False
-        hub_collect = hass.data[DATA_MODBUS_HUBS]
-    else:
-        hass.data[DATA_MODBUS_HUBS] = hub_collect = {}
-
-    for conf_hub in config[DOMAIN]:
-        my_hub = ModbusHub(hass, conf_hub)
-        hub_collect[conf_hub[CONF_NAME]] = my_hub
-
-        # modbus needs to be activated before components are loaded
-        # to avoid a racing problem
-        if not await my_hub.async_setup():
-            return False
-
-        # load platforms
-        for component, conf_key in PLATFORMS:
-            if conf_key in conf_hub:
-                hass.async_create_task(
-                    async_load_platform(hass, component, DOMAIN, conf_hub, config)
-                )
-
     async def async_stop_modbus(event: Event) -> None:
         """Stop Modbus service."""
-        for client in hub_collect.values():
+        for client in hass.data[DATA_MODBUS_HUBS].values():
             await client.async_close()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_modbus)
@@ -170,13 +144,12 @@ async def async_modbus_setup(
         """Return the details required to process the service call."""
         device_address = service.data.get(ATTR_SLAVE, service.data.get(ATTR_UNIT, 1))
         address = service.data[ATTR_ADDRESS]
-        hub = hub_collect[service.data[ATTR_HUB]]
+        hub = hass.data[DATA_MODBUS_HUBS][service.data[ATTR_HUB]]
         return (hub, device_address, address)
 
     async def async_write_register(service: ServiceCall) -> None:
         """Write Modbus registers."""
         hub, device_address, address = _get_service_call_details(service)
-
         value = service.data[ATTR_VALUE]
         if isinstance(value, list):
             await hub.async_pb_call(
@@ -190,9 +163,7 @@ async def async_modbus_setup(
     async def async_write_coil(service: ServiceCall) -> None:
         """Write Modbus coil."""
         hub, device_address, address = _get_service_call_details(service)
-
         state = service.data[ATTR_STATE]
-
         if isinstance(state, list):
             await hub.async_pb_call(
                 device_address, address, state, CALL_TYPE_WRITE_COILS
@@ -226,7 +197,7 @@ async def async_modbus_setup(
     async def async_stop_hub(service: ServiceCall) -> None:
         """Stop Modbus hub."""
         async_dispatcher_send(hass, SIGNAL_STOP_ENTITY)
-        hub = hub_collect[service.data[ATTR_HUB]]
+        hub = hass.data[DATA_MODBUS_HUBS][service.data[ATTR_HUB]]
         await hub.async_close()
 
     hass.services.async_register(
@@ -241,7 +212,7 @@ async def async_modbus_setup(
 class ModbusHub:
     """Thread safe wrapper class for pymodbus."""
 
-    def __init__(self, hass: HomeAssistant, client_config: dict[str, Any]) -> None:
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize the Modbus hub."""
 
         # generic configuration
@@ -250,11 +221,11 @@ class ModbusHub:
         ) = None
         self.event_connected = asyncio.Event()
         self.hass = hass
-        self.name = client_config[CONF_NAME]
-        self._config_type = client_config[CONF_TYPE]
-        self.config_delay = client_config[CONF_DELAY]
+        self.name = entry.data[CONF_NAME]
+        self._config_type = entry.data[CONF_TYPE]
+        self.config_delay = entry.data[CONF_DELAY]
         self._pb_request: dict[str, RunEntry] = {}
-        self._connect_task: asyncio.Task
+        self._connect_task: asyncio.Task | None = None
         self._last_log_error: str = ""
         self._pb_class = {
             SERIAL: AsyncModbusSerialClient,
@@ -263,34 +234,34 @@ class ModbusHub:
             RTUOVERTCP: AsyncModbusTcpClient,
         }
         self._pb_params = {
-            "port": client_config[CONF_PORT],
-            "timeout": client_config[CONF_TIMEOUT],
+            "port": entry.data[CONF_PORT],
+            "timeout": entry.data[CONF_TIMEOUT],
             "retries": 3,
         }
         if self._config_type == SERIAL:
             # serial configuration
-            if client_config[CONF_METHOD] == "ascii":
+            if entry.data[CONF_METHOD] == "ascii":
                 self._pb_params["framer"] = FramerType.ASCII
             else:
                 self._pb_params["framer"] = FramerType.RTU
             self._pb_params.update(
                 {
-                    "baudrate": client_config[CONF_BAUDRATE],
-                    "stopbits": client_config[CONF_STOPBITS],
-                    "bytesize": client_config[CONF_BYTESIZE],
-                    "parity": client_config[CONF_PARITY],
+                    "baudrate": entry.data[CONF_BAUDRATE],
+                    "stopbits": entry.data[CONF_STOPBITS],
+                    "bytesize": entry.data[CONF_BYTESIZE],
+                    "parity": entry.data[CONF_PARITY],
                 }
             )
         else:
             # network configuration
-            self._pb_params["host"] = client_config[CONF_HOST]
+            self._pb_params["host"] = entry.data[CONF_HOST]
             if self._config_type == RTUOVERTCP:
                 self._pb_params["framer"] = FramerType.RTU
             else:
                 self._pb_params["framer"] = FramerType.SOCKET
 
-        if CONF_MSG_WAIT in client_config:
-            self._msg_wait = client_config[CONF_MSG_WAIT] / 1000
+        if CONF_MSG_WAIT in entry.data:
+            self._msg_wait = entry.data[CONF_MSG_WAIT] / 1000
         elif self._config_type == SERIAL:
             self._msg_wait = 30 / 1000
         else:
@@ -353,7 +324,7 @@ class ModbusHub:
     async def async_close(self) -> None:
         """Disconnect client."""
         self.event_connected.set()
-        if not self._connect_task.done():
+        if self._connect_task and not self._connect_task.done():
             self._connect_task.cancel()
 
         if self._client:

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -67,7 +67,6 @@ from .const import (
     TCP,
     UDP,
 )
-from .validators import check_config
 
 DATA_MODBUS_HUBS: HassKey[dict[str, ModbusHub]] = HassKey(DOMAIN)
 
@@ -133,10 +132,6 @@ async def async_modbus_setup(
 ) -> bool:
     """Set up Modbus component."""
 
-    if config[DOMAIN]:
-        config[DOMAIN] = check_config(hass, config[DOMAIN])
-        if not config[DOMAIN]:
-            return False
     if DATA_MODBUS_HUBS in hass.data and config[DOMAIN] == []:
         hubs = hass.data[DATA_MODBUS_HUBS]
         for hub in hubs.values():

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import (
     RestoreSensor,
     SensorEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_NAME,
@@ -17,8 +18,7 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -32,20 +32,18 @@ from .modbus import ModbusHub
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the Modbus sensors."""
-
-    if discovery_info is None:
+    """Set up climates."""
+    if CONF_SENSORS not in config_entry.data:
         return
 
     sensors: list[ModbusRegisterSensor | SlaveSensor] = []
-    hub = get_hub(hass, discovery_info[CONF_NAME])
-    for entry in discovery_info[CONF_SENSORS]:
+    hub = get_hub(hass, config_entry.data[CONF_NAME])
+    for entry in config_entry.data[CONF_SENSORS]:
         slave_count = entry.get(CONF_SLAVE_COUNT, None) or entry.get(
             CONF_VIRTUAL_COUNT, 0
         )

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_SWITCHES
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import get_hub
 from .entity import ModbusToggleEntity
@@ -16,17 +16,19 @@ from .entity import ModbusToggleEntity
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Read configuration and create Modbus switches."""
-    if discovery_info is None or not (switches := discovery_info[CONF_SWITCHES]):
+    """Set up climates."""
+    if CONF_SWITCHES not in config_entry.data:
         return
-    hub = get_hub(hass, discovery_info[CONF_NAME])
-    async_add_entities(ModbusSwitch(hass, hub, config) for config in switches)
+
+    hub = get_hub(hass, config_entry.data[CONF_NAME])
+    async_add_entities(
+        ModbusSwitch(hass, hub, config) for config in config_entry.data[CONF_SWITCHES]
+    )
 
 
 class ModbusSwitch(ModbusToggleEntity, SwitchEntity):

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -397,6 +397,7 @@ FLOWS = {
         "mjpeg",
         "moat",
         "mobile_app",
+        "modbus",
         "modem_callerid",
         "modern_forms",
         "moehlenhoff_alpha2",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4065,7 +4065,7 @@
     "modbus": {
       "name": "Modbus",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "modem_callerid": {

--- a/tests/components/modbus/fixtures/configuration_2.yaml
+++ b/tests/components/modbus/fixtures/configuration_2.yaml
@@ -1,8 +1,8 @@
 modbus:
   type: "tcp"
   host: "testHost"
-  port: 5001
-  name: "testModbus"
+  port: 5002
+  name: "testModbus2"
   sensors:
     - name: "dummy"
       address: 117

--- a/tests/components/modbus/snapshots/test_config_flow.ambr
+++ b/tests/components/modbus/snapshots/test_config_flow.ambr
@@ -1,0 +1,53 @@
+# serializer version: 1
+# name: test_import_flow
+  list([
+    ConfigEntrySnapshot({
+      'data': dict({
+        'host': '1.2.3.4',
+        'name': 'tcp_config',
+        'port': 502,
+        'type': 'tcp',
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'modbus',
+      'entry_id': <ANY>,
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'import',
+      'subentries': list([
+      ]),
+      'title': 'tcp_config',
+      'unique_id': None,
+      'version': 1,
+    }),
+    ConfigEntrySnapshot({
+      'data': dict({
+        'host': '1.2.3.4',
+        'name': 'tcp_config2',
+        'port': 503,
+        'type': 'tcp',
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'modbus',
+      'entry_id': <ANY>,
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'import',
+      'subentries': list([
+      ]),
+      'title': 'tcp_config2',
+      'unique_id': None,
+      'version': 1,
+    }),
+  ])
+# ---

--- a/tests/components/modbus/test_config_flow.py
+++ b/tests/components/modbus/test_config_flow.py
@@ -1,0 +1,102 @@
+"""Tests for the modbus config flow."""
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.modbus.const import MODBUS_DOMAIN, TCP
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+_HUB_CONFIG = {
+    CONF_TYPE: TCP,
+    CONF_NAME: "tcp_config",
+    CONF_HOST: "1.2.3.4",
+    CONF_PORT: 502,
+}
+_HUB_CONFIG_GENERAL = {
+    CONF_TYPE: TCP,
+    CONF_NAME: "tcp_config2",
+    CONF_HOST: "1.2.3.4",
+    CONF_PORT: 503,
+}
+_HUB_CONFIG_PROPERTIES = {
+    CONF_TYPE: TCP,
+    CONF_NAME: "tcp_config2",
+    CONF_HOST: "1.2.3.4",
+    CONF_PORT: 502,
+}
+_HUB_CONFIG_NAME = {
+    CONF_TYPE: TCP,
+    CONF_NAME: "tcp_config",
+    CONF_HOST: "1.2.3.4",
+    CONF_PORT: 503,
+}
+
+
+async def test_import_flow(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the import configuration flow."""
+    for hub_config in (_HUB_CONFIG, _HUB_CONFIG_GENERAL):
+        result = await hass.config_entries.flow.async_init(
+            MODBUS_DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data=hub_config,
+        )
+        assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert hass.config_entries.async_entries(MODBUS_DOMAIN) == snapshot
+
+
+async def test_import_flow_update_match_properties(hass: HomeAssistant) -> None:
+    """Test the import configuration flow.
+
+    Existing entry matches on type/host/port.
+    """
+    result = await hass.config_entries.flow.async_init(
+        MODBUS_DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=_HUB_CONFIG,
+    )
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    entries = hass.config_entries.async_entries(MODBUS_DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data == _HUB_CONFIG
+
+    # Change host/port, should update existing entry
+    result = await hass.config_entries.flow.async_init(
+        MODBUS_DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=_HUB_CONFIG_PROPERTIES,
+    )
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"
+    entries = hass.config_entries.async_entries(MODBUS_DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data == _HUB_CONFIG_PROPERTIES
+
+
+async def test_import_flow_update_match_name(hass: HomeAssistant) -> None:
+    """Test the import configuration flow.
+
+    Existing entry matches on yaml name.
+    """
+    result = await hass.config_entries.flow.async_init(
+        MODBUS_DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=_HUB_CONFIG,
+    )
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    original_entries = hass.config_entries.async_entries(MODBUS_DOMAIN)
+    assert len(original_entries) == 1
+    assert original_entries[0].data == _HUB_CONFIG
+
+    # Update settings, including type and IP but keep old name
+    result = await hass.config_entries.flow.async_init(
+        MODBUS_DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=_HUB_CONFIG_NAME,
+    )
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -1129,7 +1129,7 @@ async def test_pymodbus_constructor_fail(
     ) as mock_pb:
         caplog.set_level(logging.ERROR)
         mock_pb.side_effect = ModbusException("test no class")
-        assert await async_setup_component(hass, DOMAIN, config) is False
+        await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
         message = f"Pymodbus: {TEST_MODBUS_NAME}: Modbus Error: test"
         assert caplog.messages[0].startswith(message)
@@ -1333,6 +1333,8 @@ async def test_integration_reload(
     assert state_sensor_1
     assert not state_sensor_2
 
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
+    await hass.async_block_till_done()
     caplog.clear()
     yaml_path = get_fixture_path("configuration_2.yaml", DOMAIN)
     with mock.patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -1366,7 +1366,6 @@ async def test_integration_reload(
     assert not state_sensor_2
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("do_config", [{}])
 async def test_integration_reload_failed(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_modbus
@@ -1384,7 +1383,6 @@ async def test_integration_reload_failed(
         await hass.async_block_till_done()
 
     assert "Modbus reloading" in caplog.text
-    assert "connect failed, retry in pymodbus" in caplog.text
 
 
 @pytest.mark.parametrize("do_config", [{}])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removing the old platform setups, and replace with the async_setup_entry.

This change is an internal change, and should not affect a user.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This PR depends on #152162 

The PR will stay in draft status until 152162 is merged, but it is submitted to show the config_flow path.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
