### PR TITLE
Fix logical error when user has no Roborock maps

### DIFF
--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -351,10 +351,9 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
     def _set_current_map(self) -> None:
         if (
             self.roborock_device_info.props.status is not None
-            and self.roborock_device_info.props.status.map_status is not None
+            and self.roborock_device_info.props.status.current_map is not None
         ):
-            # To get the current map flag, you bitshift the map_status right by 2.
-            self.current_map = self.roborock_device_info.props.status.map_status >> 2
+            self.current_map = self.roborock_device_info.props.status.current_map
 
     async def set_current_map_rooms(self) -> None:
         """Fetch all of the rooms for the current map and set on RoborockMapInfo."""

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -353,11 +353,8 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
             self.roborock_device_info.props.status is not None
             and self.roborock_device_info.props.status.map_status is not None
         ):
-            # The map status represents the map flag as flag * 4 + 3 -
-            # so we have to invert that in order to get the map flag that we can use to set the current map.
-            self.current_map = (
-                self.roborock_device_info.props.status.map_status - 3
-            ) // 4
+            # To get the current map flag, you bitshift the map_status right by 2.
+            self.current_map = self.roborock_device_info.props.status.map_status >> 2
 
     async def set_current_map_rooms(self) -> None:
         """Fetch all of the rooms for the current map and set on RoborockMapInfo."""
@@ -440,7 +437,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
             # If either of these fail, we don't care, and we want to continue.
             await asyncio.gather(*tasks, return_exceptions=True)
 
-        if len(self.maps) != 1:
+        if len(self.maps) > 1:
             # Set the map back to the map the user previously had selected so that it
             # does not change the end user's app.
             # Only needs to happen when we changed maps above.

--- a/tests/components/roborock/test_coordinator.py
+++ b/tests/components/roborock/test_coordinator.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
+from roborock import MultiMapsList
 from roborock.exceptions import RoborockException
 from vacuum_map_parser_base.config.color import SupportedColor
 
@@ -135,3 +136,30 @@ async def test_dynamic_local_scan_interval(
         async_fire_time_changed(hass, dt_util.utcnow() + interval)
 
     assert hass.states.get("sensor.roborock_s7_maxv_battery").state == "20"
+
+
+async def test_no_maps(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    bypass_api_fixture: None,
+) -> None:
+    """Test that a device with no maps is handled correctly."""
+    prop = copy.deepcopy(PROP)
+    prop.status.map_status = 252
+    with (
+        patch(
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_prop",
+            return_value=prop,
+        ),
+        patch(
+            "homeassistant.components.roborock.coordinator.RoborockMqttClientV1.get_multi_maps_list",
+            return_value=MultiMapsList(
+                max_multi_map=1, max_bak_map=1, multi_map_count=0, map_info=[]
+            ),
+        ),
+        patch(
+            "homeassistant.components.roborock.RoborockMqttClientV1.load_multi_map"
+        ) as load_map,
+    ):
+        await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    assert load_map.call_count == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a user has no maps, their map_status will be 252. Under the old system this returned '62' as the map code, however, '63' is the correct answer.

n >> 2 is roughly equivalent to (n -3)//4 for the map flags that users typically have, so this likely was not a problem. However, >>2 is the correct solution according to decompiled code, whereas n-3 //4 was reverse engineered.

As well, We do not want to load_multi_map when the user has no maps, so the check has been changed from != 1 to > 1.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
