### PR TITLE
Handle wrong ESPHome device without encryption appearing at the configured IP

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -138,6 +138,16 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             return await self._async_authenticate_or_add()
 
         if error is None and entry_data.get(CONF_NOISE_PSK):
+            # Device was configured with encryption but now connects without it.
+            # Check if it's the same device before offering to remove encryption.
+            if self._reauth_entry.unique_id and self._device_mac:
+                expected_mac = format_mac(self._reauth_entry.unique_id)
+                actual_mac = format_mac(self._device_mac)
+                if expected_mac != actual_mac:
+                    # Different device at the same IP - do not offer to remove encryption
+                    return self._async_abort_wrong_device(
+                        self._reauth_entry, expected_mac, actual_mac
+                    )
             return await self.async_step_reauth_encryption_removed_confirm()
         return await self.async_step_reauth_confirm()
 
@@ -508,6 +518,28 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             CONF_DEVICE_NAME: self._device_name,
         }
 
+    @callback
+    def _async_abort_wrong_device(
+        self, entry: ConfigEntry, expected_mac: str, actual_mac: str
+    ) -> ConfigFlowResult:
+        """Abort flow because a different device was found at the IP address."""
+        assert self._host is not None
+        assert self._device_name is not None
+        if self.source == SOURCE_RECONFIGURE:
+            reason = "reconfigure_wrong_device"
+        else:
+            reason = "reauth_wrong_device"
+        return self.async_abort(
+            reason=reason,
+            description_placeholders={
+                "name": entry.data.get(CONF_DEVICE_NAME, entry.title),
+                "host": self._host,
+                "expected_mac": expected_mac,
+                "unexpected_mac": actual_mac,
+                "unexpected_device_name": self._device_name,
+            },
+        )
+
     async def _async_validated_connection(self) -> ConfigFlowResult:
         """Handle validated connection."""
         if self.source == SOURCE_RECONFIGURE:
@@ -539,17 +571,10 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         # Reauth was triggered a while ago, and since than
         # a new device resides at the same IP address.
         assert self._device_name is not None
-        return self.async_abort(
-            reason="reauth_unique_id_changed",
-            description_placeholders={
-                "name": self._reauth_entry.data.get(
-                    CONF_DEVICE_NAME, self._reauth_entry.title
-                ),
-                "host": self._host,
-                "expected_mac": format_mac(self._reauth_entry.unique_id),
-                "unexpected_mac": format_mac(self.unique_id),
-                "unexpected_device_name": self._device_name,
-            },
+        return self._async_abort_wrong_device(
+            self._reauth_entry,
+            format_mac(self._reauth_entry.unique_id),
+            format_mac(self.unique_id),
         )
 
     async def _async_reconfig_validated_connection(self) -> ConfigFlowResult:
@@ -589,17 +614,10 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         if self._reconfig_entry.data.get(CONF_DEVICE_NAME) == self._device_name:
             self._entry_with_name_conflict = self._reconfig_entry
             return await self.async_step_name_conflict()
-        return self.async_abort(
-            reason="reconfigure_unique_id_changed",
-            description_placeholders={
-                "name": self._reconfig_entry.data.get(
-                    CONF_DEVICE_NAME, self._reconfig_entry.title
-                ),
-                "host": self._host,
-                "expected_mac": format_mac(self._reconfig_entry.unique_id),
-                "unexpected_mac": format_mac(self.unique_id),
-                "unexpected_device_name": self._device_name,
-            },
+        return self._async_abort_wrong_device(
+            self._reconfig_entry,
+            format_mac(self._reconfig_entry.unique_id),
+            format_mac(self.unique_id),
         )
 
     async def async_step_encryption_key(

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -526,9 +526,9 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         assert self._host is not None
         assert self._device_name is not None
         if self.source == SOURCE_RECONFIGURE:
-            reason = "reconfigure_wrong_device"
+            reason = "reconfigure_unique_id_changed"
         else:
-            reason = "reauth_wrong_device"
+            reason = "reauth_unique_id_changed"
         return self.async_abort(
             reason=reason,
             description_placeholders={


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If an ESPHome config entry exists for a device with noise encryption is offline, and a new device without encryption appears at the same IP address, we would prompt to remove encryption.

Instead we should do nothing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #152675
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
