### PR TITLE
Fix manual updating of Nord Pool sensors

### DIFF
--- a/homeassistant/components/nordpool/coordinator.py
+++ b/homeassistant/components/nordpool/coordinator.py
@@ -71,6 +71,9 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
         self.unsub = async_track_point_in_utc_time(
             self.hass, self.fetch_data, self.get_next_interval(dt_util.utcnow())
         )
+        if self.config_entry.pref_disable_polling and not initial:
+            self.async_update_listeners()
+            return
         try:
             data = await self.handle_data(initial)
         except UpdateFailed as err:
@@ -95,9 +98,6 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
 
     async def _async_update_data(self) -> DeliveryPeriodsData:
         """Fetch the latest data from the source."""
-        if self.unsub:
-            self.unsub()
-            self.unsub = None
         return await self.handle_data()
 
     async def api_call(self, retry: int = 3) -> DeliveryPeriodsData | None:

--- a/homeassistant/components/nordpool/coordinator.py
+++ b/homeassistant/components/nordpool/coordinator.py
@@ -71,21 +71,34 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
         self.unsub = async_track_point_in_utc_time(
             self.hass, self.fetch_data, self.get_next_interval(dt_util.utcnow())
         )
+        try:
+            data = await self.handle_data(initial)
+        except UpdateFailed as err:
+            self.async_set_update_error(err)
+            return
+        self.async_set_updated_data(data)
+
+    async def handle_data(self, initial: bool = False) -> DeliveryPeriodsData:
+        """Fetch data from Nord Pool."""
         data = await self.api_call()
         if data and data.entries:
             current_day = dt_util.utcnow().strftime("%Y-%m-%d")
             for entry in data.entries:
                 if entry.requested_date == current_day:
                     LOGGER.debug("Data for current day found")
-                    self.async_set_updated_data(data)
-                    return
+                    return data
         if data and not data.entries and not initial:
             # Empty response, use cache
             LOGGER.debug("No data entries received")
-            return
-        self.async_set_update_error(
-            UpdateFailed(translation_domain=DOMAIN, translation_key="no_day_data")
-        )
+            return self.data
+        raise UpdateFailed(translation_domain=DOMAIN, translation_key="no_day_data")
+
+    async def _async_update_data(self) -> DeliveryPeriodsData:
+        """Fetch the latest data from the source."""
+        if self.unsub:
+            self.unsub()
+            self.unsub = None
+        return await self.handle_data()
 
     async def api_call(self, retry: int = 3) -> DeliveryPeriodsData | None:
         """Make api call to retrieve data with retry if failure."""

--- a/homeassistant/components/nordpool/sensor.py
+++ b/homeassistant/components/nordpool/sensor.py
@@ -34,8 +34,11 @@ def validate_prices(
     index: int,
 ) -> float | None:
     """Validate and return."""
-    if (result := func(entity)[area][index]) is not None:
-        return result / 1000
+    try:
+        if (result := func(entity)[area][index]) is not None:
+            return result / 1000
+    except KeyError:
+        return None
     return None
 
 

--- a/tests/components/nordpool/test_coordinator.py
+++ b/tests/components/nordpool/test_coordinator.py
@@ -16,10 +16,15 @@ from pynordpool import (
 )
 import pytest
 
+from homeassistant.components.homeassistant import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    SERVICE_UPDATE_ENTITY,
+)
 from homeassistant.components.nordpool.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 from . import ENTRY_CONFIG
 
@@ -34,12 +39,12 @@ async def test_coordinator(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the Nord Pool coordinator with errors."""
+    await async_setup_component(hass, HOMEASSISTANT_DOMAIN, {})
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         source=SOURCE_USER,
         data=ENTRY_CONFIG,
     )
-
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -88,7 +93,7 @@ async def test_coordinator(
         # Empty responses does not raise
         assert mock_data.call_count == 3
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.94949"
+        assert state.state == "1.04203"
         assert "Empty response" in caplog.text
 
     with (
@@ -141,6 +146,50 @@ async def test_coordinator(
     await hass.async_block_till_done()
     state = hass.states.get("sensor.nord_pool_se3_current_price")
     assert state.state == "1.81983"
+
+    # Test manual polling
+    hass.config_entries.async_update_entry(
+        entry=config_entry, pref_disable_polling=True
+    )
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    freezer.tick(timedelta(hours=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.nord_pool_se3_current_price")
+    assert state.state == "1.01177"
+
+    # Prices should update without any polling made (read from cache)
+    freezer.tick(timedelta(hours=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.nord_pool_se3_current_price")
+    assert state.state == "0.83553"
+
+    # Test manually updating the data
+    with (
+        patch(
+            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_periods",
+            wraps=get_client.async_get_delivery_periods,
+        ) as mock_data,
+    ):
+        await hass.services.async_call(
+            HOMEASSISTANT_DOMAIN,
+            SERVICE_UPDATE_ENTITY,
+            {ATTR_ENTITY_ID: "sensor.nord_pool_se3_current_price"},
+            blocking=True,
+        )
+        assert mock_data.call_count == 1
+
+    freezer.tick(timedelta(hours=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.nord_pool_se3_current_price")
+    assert state.state == "0.79619"
+
+    hass.config_entries.async_update_entry(
+        entry=config_entry, pref_disable_polling=False
+    )
+    await hass.config_entries.async_reload(config_entry.entry_id)
 
     with (
         patch(


### PR DESCRIPTION
## Breaking change


## Proposed change
Fixes manual updating of sensors (and data) in Nord Pool.
Also fixes a bug related to not updating the listeners on a certain error.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #151440
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 