### PR TITLE
Add dc:title support for Sonos sharelinks

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -540,7 +540,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         if share_link.is_share_link(media_id):
             # Pass the title to SoCo to fill metadata.
             # Use empty string, if no title is provided.
-            title = kwargs.get("extra", {}).pop("title", "")
+            title = kwargs.get("extra", {}).get("title", "")
             soco_kwargs = {"dc_title": title}
             if enqueue == MediaPlayerEnqueue.ADD:
                 share_link.add_share_link_to_queue(

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -659,7 +659,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         media_id: str,
         enqueue: MediaPlayerEnqueue,
         title: str,
-    ):
+    ) -> None:
         share_link = self.coordinator.share_link
         kwargs = {}
         if title:

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -26,6 +26,7 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_ARTIST,
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_ENQUEUE,
+    ATTR_MEDIA_EXTRA,
     ATTR_MEDIA_TITLE,
     BrowseMedia,
     MediaPlayerDeviceClass,
@@ -540,7 +541,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         if share_link.is_share_link(media_id):
             # Pass the title to SoCo to fill metadata.
             # Use empty string, if no title is provided.
-            title = kwargs.get("extra", {}).get("title", "")
+            title = kwargs.get(ATTR_MEDIA_EXTRA, {}).get("title", "")
             soco_kwargs = {"dc_title": title}
             if enqueue == MediaPlayerEnqueue.ADD:
                 share_link.add_share_link_to_queue(

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -538,9 +538,13 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
 
         share_link = self.coordinator.share_link
         if share_link.is_share_link(media_id):
+            # Pass the title to SoCo to fill metadata.
+            # Use empty string, if no title is provided.
+            title = kwargs.get("extra", {}).pop("title", "")
+            soco_kwargs = {"dc_title": title}
             if enqueue == MediaPlayerEnqueue.ADD:
                 share_link.add_share_link_to_queue(
-                    media_id, timeout=LONG_SERVICE_TIMEOUT
+                    media_id, timeout=LONG_SERVICE_TIMEOUT, **soco_kwargs
                 )
             elif enqueue in (
                 MediaPlayerEnqueue.NEXT,
@@ -548,14 +552,14 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
             ):
                 pos = (self.media.queue_position or 0) + 1
                 new_pos = share_link.add_share_link_to_queue(
-                    media_id, position=pos, timeout=LONG_SERVICE_TIMEOUT
+                    media_id, position=pos, timeout=LONG_SERVICE_TIMEOUT, **soco_kwargs
                 )
                 if enqueue == MediaPlayerEnqueue.PLAY:
                     soco.play_from_queue(new_pos - 1)
             elif enqueue == MediaPlayerEnqueue.REPLACE:
                 soco.clear_queue()
                 share_link.add_share_link_to_queue(
-                    media_id, timeout=LONG_SERVICE_TIMEOUT
+                    media_id, timeout=LONG_SERVICE_TIMEOUT, **soco_kwargs
                 )
                 soco.play_from_queue(0)
         elif media_type == MEDIA_TYPE_DIRECTORY:

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -466,7 +466,6 @@ async def test_play_media_share_link_next(
             ATTR_MEDIA_CONTENT_TYPE: "playlist",
             ATTR_MEDIA_CONTENT_ID: _share_link,
             ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.NEXT,
-            ATTR_MEDIA_EXTRA: {"title": _share_link_title},
         },
         blocking=True,
     )
@@ -482,8 +481,8 @@ async def test_play_media_share_link_next(
         soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["position"] == 1
     )
     assert (
-        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["dc_title"]
-        == _share_link_title
+        "dc_title"
+        not in soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs
     )
 
 
@@ -503,7 +502,6 @@ async def test_play_media_share_link_play(
             ATTR_MEDIA_CONTENT_TYPE: "playlist",
             ATTR_MEDIA_CONTENT_ID: _share_link,
             ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.PLAY,
-            ATTR_MEDIA_EXTRA: {"title": _share_link_title},
         },
         blocking=True,
     )
@@ -517,10 +515,6 @@ async def test_play_media_share_link_play(
     )
     assert (
         soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["position"] == 1
-    )
-    assert (
-        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["dc_title"]
-        == _share_link_title
     )
     assert soco_mock.play_from_queue.call_count == 1
     soco_mock.play_from_queue.assert_called_with(9)
@@ -542,7 +536,6 @@ async def test_play_media_share_link_replace(
             ATTR_MEDIA_CONTENT_TYPE: "playlist",
             ATTR_MEDIA_CONTENT_ID: _share_link,
             ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.REPLACE,
-            ATTR_MEDIA_EXTRA: {"title": _share_link_title},
         },
         blocking=True,
     )
@@ -554,10 +547,6 @@ async def test_play_media_share_link_replace(
     assert (
         soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["timeout"]
         == LONG_SERVICE_TIMEOUT
-    )
-    assert (
-        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["dc_title"]
-        == _share_link_title
     )
     assert soco_mock.play_from_queue.call_count == 1
     soco_mock.play_from_queue.assert_called_with(0)

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -415,6 +415,7 @@ async def test_play_media_lib_track_add(
 
 
 _share_link: str = "spotify:playlist:abcdefghij0123456789XY"
+_share_link_title: str = "playlist title"
 
 
 async def test_play_media_share_link_add(
@@ -432,6 +433,7 @@ async def test_play_media_share_link_add(
             ATTR_MEDIA_CONTENT_TYPE: "playlist",
             ATTR_MEDIA_CONTENT_ID: _share_link,
             ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.ADD,
+            ATTR_MEDIA_EXTRA: {"title": _share_link_title},
         },
         blocking=True,
     )
@@ -442,6 +444,10 @@ async def test_play_media_share_link_add(
     assert (
         soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["timeout"]
         == LONG_SERVICE_TIMEOUT
+    )
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["dc_title"]
+        == _share_link_title
     )
 
 
@@ -460,6 +466,7 @@ async def test_play_media_share_link_next(
             ATTR_MEDIA_CONTENT_TYPE: "playlist",
             ATTR_MEDIA_CONTENT_ID: _share_link,
             ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.NEXT,
+            ATTR_MEDIA_EXTRA: {"title": _share_link_title},
         },
         blocking=True,
     )
@@ -473,6 +480,10 @@ async def test_play_media_share_link_next(
     )
     assert (
         soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["position"] == 1
+    )
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["dc_title"]
+        == _share_link_title
     )
 
 
@@ -492,6 +503,7 @@ async def test_play_media_share_link_play(
             ATTR_MEDIA_CONTENT_TYPE: "playlist",
             ATTR_MEDIA_CONTENT_ID: _share_link,
             ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.PLAY,
+            ATTR_MEDIA_EXTRA: {"title": _share_link_title},
         },
         blocking=True,
     )
@@ -505,6 +517,10 @@ async def test_play_media_share_link_play(
     )
     assert (
         soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["position"] == 1
+    )
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["dc_title"]
+        == _share_link_title
     )
     assert soco_mock.play_from_queue.call_count == 1
     soco_mock.play_from_queue.assert_called_with(9)
@@ -526,6 +542,7 @@ async def test_play_media_share_link_replace(
             ATTR_MEDIA_CONTENT_TYPE: "playlist",
             ATTR_MEDIA_CONTENT_ID: _share_link,
             ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.REPLACE,
+            ATTR_MEDIA_EXTRA: {"title": _share_link_title},
         },
         blocking=True,
     )
@@ -537,6 +554,10 @@ async def test_play_media_share_link_replace(
     assert (
         soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["timeout"]
         == LONG_SERVICE_TIMEOUT
+    )
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["dc_title"]
+        == _share_link_title
     )
     assert soco_mock.play_from_queue.call_count == 1
     soco_mock.play_from_queue.assert_called_with(0)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
SoCo 0.30.12 introduces the possibility to send a dc:title for sharelinks.
When using this for playlists, the media_playlist attribute is filled correctly with the playlist title..
To fill the dc:title, the title needs to be provided as kwargs["dc_title"].
This PR provides an implementation to fill kwargs["dc_title"] based on kwargs["extra"]["title].

For this functionality to work, #152797 needs to be merged first.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #152305
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
