### PR TITLE
Only load selected processes in systemmonitor

### DIFF
--- a/homeassistant/components/systemmonitor/binary_sensor.py
+++ b/homeassistant/components/systemmonitor/binary_sensor.py
@@ -9,8 +9,6 @@ import logging
 import sys
 from typing import Literal
 
-from psutil import NoSuchProcess
-
 from homeassistant.components.binary_sensor import (
     DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorDeviceClass,
@@ -25,7 +23,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
 from . import SystemMonitorConfigEntry
-from .const import CONF_PROCESS, DOMAIN
+from .const import CONF_PROCESS, DOMAIN, PROCESS_ERRORS
 from .coordinator import SystemMonitorCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -59,12 +57,8 @@ def get_process(entity: SystemMonitorSensor) -> bool:
             if entity.argument == proc.name():
                 state = True
                 break
-        except NoSuchProcess as err:
-            _LOGGER.warning(
-                "Failed to load process with ID: %s, old name: %s",
-                err.pid,
-                err.name,
-            )
+        except PROCESS_ERRORS:
+            continue
     return state
 
 

--- a/homeassistant/components/systemmonitor/const.py
+++ b/homeassistant/components/systemmonitor/const.py
@@ -1,5 +1,7 @@
 """Constants for System Monitor."""
 
+from psutil import AccessDenied, Error, NoSuchProcess, TimeoutExpired, ZombieProcess
+
 DOMAIN = "systemmonitor"
 
 CONF_INDEX = "index"
@@ -13,6 +15,8 @@ NET_IO_TYPES = [
     "packets_in",
     "packets_out",
 ]
+
+PROCESS_ERRORS = (NoSuchProcess, AccessDenied, Error, TimeoutExpired, ZombieProcess)
 
 # There might be additional keys to be added for different
 # platforms / hardware combinations.

--- a/homeassistant/components/systemmonitor/coordinator.py
+++ b/homeassistant/components/systemmonitor/coordinator.py
@@ -12,10 +12,13 @@ from psutil import Process
 from psutil._common import sdiskusage, shwtemp, snetio, snicaddr, sswap
 import psutil_home_assistant as ha_psutil
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import DEFAULT_SCAN_INTERVAL
 from homeassistant.helpers.update_coordinator import TimestampDataUpdateCoordinator
 from homeassistant.util import dt as dt_util
+
+from .const import CONF_PROCESS, PROCESS_ERRORS
 
 if TYPE_CHECKING:
     from . import SystemMonitorConfigEntry
@@ -82,6 +85,8 @@ class VirtualMemory(NamedTuple):
 
 class SystemMonitorCoordinator(TimestampDataUpdateCoordinator[SensorData]):
     """A System monitor Data Update Coordinator."""
+
+    config_entry: SystemMonitorConfigEntry
 
     def __init__(
         self,
@@ -203,11 +208,30 @@ class SystemMonitorCoordinator(TimestampDataUpdateCoordinator[SensorData]):
             self.boot_time = dt_util.utc_from_timestamp(self._psutil.boot_time())
             _LOGGER.debug("boot time: %s", self.boot_time)
 
-        processes = None
+        selected_processes: list[str] = []
         if self.update_subscribers[("processes", "")] or self._initial_update:
             processes = self._psutil.process_iter()
             _LOGGER.debug("processes: %s", processes)
-            processes = list(processes)
+            user_options: list[str] = self.config_entry.options.get(
+                BINARY_SENSOR_DOMAIN, {}
+            ).get(CONF_PROCESS, [])
+            for process in processes:
+                try:
+                    if process.name() in user_options:
+                        selected_processes.append(process)
+                except PROCESS_ERRORS as err:
+                    if not hasattr(err, "pid") or not hasattr(err, "name"):
+                        _LOGGER.warning(
+                            "Failed to load process: %s",
+                            str(err),
+                        )
+                    else:
+                        _LOGGER.warning(
+                            "Failed to load process with ID: %s, old name: %s",
+                            err.pid,
+                            err.name,
+                        )
+                    continue
 
         temps: dict[str, list[shwtemp]] = {}
         if self.update_subscribers[("temperatures", "")] or self._initial_update:
@@ -224,6 +248,6 @@ class SystemMonitorCoordinator(TimestampDataUpdateCoordinator[SensorData]):
             "io_counters": io_counters,
             "addresses": addresses,
             "boot_time": self.boot_time,
-            "processes": processes,
+            "processes": selected_processes,
             "temperatures": temps,
         }

--- a/homeassistant/components/systemmonitor/coordinator.py
+++ b/homeassistant/components/systemmonitor/coordinator.py
@@ -208,7 +208,7 @@ class SystemMonitorCoordinator(TimestampDataUpdateCoordinator[SensorData]):
             self.boot_time = dt_util.utc_from_timestamp(self._psutil.boot_time())
             _LOGGER.debug("boot time: %s", self.boot_time)
 
-        selected_processes: list[str] = []
+        selected_processes: list[Process] = []
         if self.update_subscribers[("processes", "")] or self._initial_update:
             processes = self._psutil.process_iter()
             _LOGGER.debug("processes: %s", processes)


### PR DESCRIPTION
## Breaking change


## Proposed change
Only keep the processes selected by the user in the coordinator data.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 