### PR TITLE
Handle toggling of the 'expose_to_ha' setting in Music Assistant integration

### DIFF
--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -146,7 +146,7 @@ async def async_setup_entry(  # noqa: C901
             )
 
     # register listener for new players
-    async def handle_player_added(event: MassEvent) -> None:
+    def handle_player_added(event: MassEvent) -> None:
         """Handle Mass Player Added event."""
         if TYPE_CHECKING:
             assert event.object_id is not None
@@ -168,7 +168,7 @@ async def async_setup_entry(  # noqa: C901
         add_player(player)
 
     # register listener for removed players
-    async def handle_player_removed(event: MassEvent) -> None:
+    def handle_player_removed(event: MassEvent) -> None:
         """Handle Mass Player Removed event."""
         if event.object_id is None:
             return
@@ -179,9 +179,9 @@ async def async_setup_entry(  # noqa: C901
     )
 
     # register listener for player configs (to handle toggling of the 'expose_to_ha' setting)
-    async def handle_player_config_updated(event: MassEvent) -> None:
+    def handle_player_config_updated(event: MassEvent) -> None:
         """Handle Mass Player Config Updated event."""
-        if event.object_id is None:
+        if event.object_id is None or not event.data:
             return
         player_id = event.object_id
         player_config = PlayerConfig.from_dict(event.data)

--- a/homeassistant/components/music_assistant/const.py
+++ b/homeassistant/components/music_assistant/const.py
@@ -65,5 +65,6 @@ ATTR_STREAM_TITLE = "stream_title"
 ATTR_PROVIDER = "provider"
 ATTR_ITEM_ID = "item_id"
 
+ATTR_CONF_EXPOSE_PLAYER_TO_HA = "expose_player_to_ha"
 
 LOGGER = logging.getLogger(__package__)

--- a/tests/components/music_assistant/common.py
+++ b/tests/components/music_assistant/common.py
@@ -186,15 +186,15 @@ async def trigger_subscription_callback(
         ):
             continue
 
-        event = MassEvent(
+        mass_event = MassEvent(
             event=event,
             object_id=object_id,
             data=data,
         )
         if inspect.iscoroutinefunction(cb_func):
-            await cb_func(event)
+            await cb_func(mass_event)
         else:
-            cb_func(event)
+            cb_func(mass_event)
 
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change

Music Assistant has a configuration setting to toggle if a player should be exposed to HA.
Toggling this setting required a reload of the integration which is less convenient.
This PR adds a bit of logic to handle toggling this setting dynamically.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
