### PR TITLE
Move hardware thread add-on install after firmware install

### DIFF
--- a/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
@@ -90,7 +90,7 @@ class ZBT2FirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
             firmware_name="OpenThread",
             expected_installed_firmware_type=ApplicationType.SPINEL,
             step_id="install_thread_firmware",
-            next_step_id="start_otbr_addon",
+            next_step_id="finish_thread_installation",
         )
 
 

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -106,7 +106,7 @@ class SkyConnectFirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
             firmware_name="OpenThread",
             expected_installed_firmware_type=ApplicationType.SPINEL,
             step_id="install_thread_firmware",
-            next_step_id="start_otbr_addon",
+            next_step_id="finish_thread_installation",
         )
 
 

--- a/homeassistant/components/homeassistant_yellow/config_flow.py
+++ b/homeassistant/components/homeassistant_yellow/config_flow.py
@@ -105,7 +105,7 @@ class YellowFirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
             firmware_name="OpenThread",
             expected_installed_firmware_type=ApplicationType.SPINEL,
             step_id="install_thread_firmware",
-            next_step_id="start_otbr_addon",
+            next_step_id="finish_thread_installation",
         )
 
 

--- a/tests/components/homeassistant_connect_zbt2/test_config_flow.py
+++ b/tests/components/homeassistant_connect_zbt2/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the Home Assistant Connect ZBT-2 config flow."""
 
-from unittest.mock import patch
+from collections.abc import Generator
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
@@ -21,6 +22,16 @@ from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from .common import USB_DATA_ZBT2
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="supervisor")
+def mock_supervisor_fixture() -> Generator[None]:
+    """Mock Supervisor."""
+    with patch(
+        "homeassistant.components.homeassistant_hardware.firmware_config_flow.is_hassio",
+        return_value=True,
+    ):
+        yield
 
 
 async def test_config_flow_zigbee(
@@ -51,16 +62,9 @@ async def test_config_flow_zigbee(
         step_id: str,
         next_step_id: str,
     ) -> ConfigFlowResult:
-        if next_step_id == "start_otbr_addon":
-            next_step_id = "pre_confirm_otbr"
-
-        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
+        return await getattr(self, f"async_step_{next_step_id}")()
 
     with (
-        patch(
-            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._ensure_thread_addon_setup",
-            return_value=None,
-        ),
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._install_firmware_step",
             autospec=True,
@@ -113,8 +117,10 @@ async def test_config_flow_zigbee(
     assert zha_flow["step_id"] == "confirm"
 
 
+@pytest.mark.usefixtures("addon_installed", "supervisor")
 async def test_config_flow_thread(
     hass: HomeAssistant,
+    start_addon: AsyncMock,
 ) -> None:
     """Test Thread config flow for Connect ZBT-2."""
     fw_type = ApplicationType.SPINEL
@@ -141,16 +147,9 @@ async def test_config_flow_thread(
         step_id: str,
         next_step_id: str,
     ) -> ConfigFlowResult:
-        if next_step_id == "start_otbr_addon":
-            next_step_id = "pre_confirm_otbr"
-
-        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
+        return await getattr(self, f"async_step_{next_step_id}")()
 
     with (
-        patch(
-            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._ensure_thread_addon_setup",
-            return_value=None,
-        ),
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._install_firmware_step",
             autospec=True,
@@ -167,11 +166,23 @@ async def test_config_flow_thread(
             ),
         ),
     ):
-        confirm_result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
         )
 
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
+        assert result["step_id"] == "start_otbr_addon"
+
+        # Make sure the flow continues when the progress task is done.
+        await hass.async_block_till_done()
+
+        confirm_result = await hass.config_entries.flow.async_configure(
+            result["flow_id"]
+        )
+
+        assert start_addon.call_count == 1
+        assert start_addon.call_args == call("core_openthread_border_router")
         assert confirm_result["type"] is FlowResultType.FORM
         assert confirm_result["step_id"] == "confirm_otbr"
 
@@ -244,19 +255,12 @@ async def test_options_flow(
         step_id: str,
         next_step_id: str,
     ) -> ConfigFlowResult:
-        if next_step_id == "start_otbr_addon":
-            next_step_id = "pre_confirm_otbr"
-
-        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
+        return await getattr(self, f"async_step_{next_step_id}")()
 
     with (
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.guess_hardware_owners",
             return_value=[],
-        ),
-        patch(
-            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareOptionsFlow._ensure_thread_addon_setup",
-            return_value=None,
         ),
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareOptionsFlow._install_firmware_step",

--- a/tests/components/homeassistant_hardware/test_config_flow_failures.py
+++ b/tests/components/homeassistant_hardware/test_config_flow_failures.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 from aiohttp import ClientError
 import pytest
 
-from homeassistant.components.hassio import AddonError, AddonInfo, AddonState
+from homeassistant.components.hassio import AddonError
 from homeassistant.components.homeassistant_hardware.firmware_config_flow import (
     STEP_PICK_FIRMWARE_THREAD,
     STEP_PICK_FIRMWARE_ZIGBEE,
@@ -13,6 +13,7 @@ from homeassistant.components.homeassistant_hardware.firmware_config_flow import
 from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
+    OwningAddon,
     OwningIntegration,
 )
 from homeassistant.core import HomeAssistant
@@ -44,7 +45,6 @@ async def test_config_flow_cannot_probe_firmware_zigbee(hass: HomeAssistant) -> 
     """Test failure case when firmware cannot be probed for zigbee."""
 
     with mock_firmware_info(
-        hass,
         probe_app_type=None,
     ):
         # Start the flow
@@ -77,7 +77,7 @@ async def test_config_flow_cannot_probe_firmware_zigbee(hass: HomeAssistant) -> 
     ["test_firmware_domain"],
 )
 async def test_cannot_probe_after_install_zigbee(hass: HomeAssistant) -> None:
-    """Test unsupported firmware after install for Zigbee."""
+    """Test unsupported firmware after firmware install for Zigbee."""
     init_result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": "hardware"}
     )
@@ -86,7 +86,6 @@ async def test_cannot_probe_after_install_zigbee(hass: HomeAssistant) -> None:
     assert init_result["step_id"] == "pick_firmware"
 
     with mock_firmware_info(
-        hass,
         probe_app_type=ApplicationType.SPINEL,
         flash_app_type=ApplicationType.EZSP,
     ):
@@ -109,7 +108,6 @@ async def test_cannot_probe_after_install_zigbee(hass: HomeAssistant) -> None:
         assert pick_result["step_id"] == "install_zigbee_firmware"
 
     with mock_firmware_info(
-        hass,
         probe_app_type=None,
         flash_app_type=ApplicationType.EZSP,
     ):
@@ -132,7 +130,6 @@ async def test_config_flow_cannot_probe_firmware_thread(hass: HomeAssistant) -> 
     """Test failure case when firmware cannot be probed for thread."""
 
     with mock_firmware_info(
-        hass,
         probe_app_type=None,
     ):
         # Start the flow
@@ -156,9 +153,9 @@ async def test_config_flow_cannot_probe_firmware_thread(hass: HomeAssistant) -> 
     "ignore_translations_for_mock_domains",
     ["test_firmware_domain"],
 )
-@pytest.mark.usefixtures("addon_store_info")
+@pytest.mark.usefixtures("addon_installed")
 async def test_cannot_probe_after_install_thread(hass: HomeAssistant) -> None:
-    """Test unsupported firmware after install for thread."""
+    """Test unsupported firmware after firmware install for thread."""
     init_result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": "hardware"}
     )
@@ -167,10 +164,9 @@ async def test_cannot_probe_after_install_thread(hass: HomeAssistant) -> None:
     assert init_result["step_id"] == "pick_firmware"
 
     with mock_firmware_info(
-        hass,
         probe_app_type=ApplicationType.EZSP,
         flash_app_type=ApplicationType.SPINEL,
-    ) as (mock_otbr_manager, _):
+    ):
         # Pick the menu option
         pick_result = await hass.config_entries.flow.async_configure(
             init_result["flow_id"],
@@ -178,31 +174,14 @@ async def test_cannot_probe_after_install_thread(hass: HomeAssistant) -> None:
         )
 
         assert pick_result["type"] is FlowResultType.SHOW_PROGRESS
-        assert pick_result["progress_action"] == "install_addon"
-        assert pick_result["step_id"] == "install_otbr_addon"
+        assert pick_result["progress_action"] == "install_firmware"
+        assert pick_result["step_id"] == "install_thread_firmware"
         description_placeholders = pick_result["description_placeholders"]
         assert description_placeholders is not None
         assert description_placeholders["firmware_type"] == "ezsp"
         assert description_placeholders["model"] == TEST_HARDWARE_NAME
 
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-        mock_otbr_manager.async_get_addon_info.return_value = AddonInfo(
-            available=True,
-            hostname=None,
-            options={
-                "device": "",
-                "baudrate": 460800,
-                "flow_control": True,
-                "autoflash_firmware": False,
-            },
-            state=AddonState.NOT_RUNNING,
-            update_available=False,
-            version="1.2.3",
-        )
-
     with mock_firmware_info(
-        hass,
         probe_app_type=None,
         flash_app_type=ApplicationType.SPINEL,
     ):
@@ -232,15 +211,13 @@ async def test_config_flow_thread_not_hassio(hass: HomeAssistant) -> None:
         TEST_DOMAIN, context={"source": "hardware"}
     )
 
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "pick_firmware"
+
     with mock_firmware_info(
-        hass,
         is_hassio=False,
         probe_app_type=ApplicationType.EZSP,
     ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
@@ -253,20 +230,23 @@ async def test_config_flow_thread_not_hassio(hass: HomeAssistant) -> None:
     "ignore_translations_for_mock_domains",
     ["test_firmware_domain"],
 )
-async def test_config_flow_thread_addon_info_fails(hass: HomeAssistant) -> None:
-    """Test failure case when flasher addon cannot be installed."""
+async def test_config_flow_thread_addon_info_fails(
+    hass: HomeAssistant,
+    addon_store_info: AsyncMock,
+) -> None:
+    """Test addon info fails before firmware install."""
+
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": "hardware"}
     )
 
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "pick_firmware"
+
     with mock_firmware_info(
-        hass,
         probe_app_type=ApplicationType.EZSP,
-    ) as (mock_otbr_manager, _):
-        mock_otbr_manager.async_get_addon_info.side_effect = AddonError()
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
+    ):
+        addon_store_info.side_effect = AddonError()
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
@@ -277,30 +257,44 @@ async def test_config_flow_thread_addon_info_fails(hass: HomeAssistant) -> None:
         assert result["reason"] == "addon_info_failed"
 
 
+@pytest.mark.usefixtures("addon_not_installed")
 @pytest.mark.parametrize(
     "ignore_translations_for_mock_domains",
     ["test_firmware_domain"],
 )
-async def test_config_flow_thread_addon_install_fails(hass: HomeAssistant) -> None:
+async def test_config_flow_thread_addon_install_fails(
+    hass: HomeAssistant,
+    install_addon: AsyncMock,
+) -> None:
     """Test failure case when flasher addon cannot be installed."""
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": "hardware"}
     )
 
-    with mock_firmware_info(
-        hass,
-        probe_app_type=ApplicationType.EZSP,
-    ) as (mock_otbr_manager, _):
-        mock_otbr_manager.async_install_addon_waiting = AsyncMock(
-            side_effect=AddonError()
-        )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "pick_firmware"
 
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
+    with mock_firmware_info(
+        probe_app_type=ApplicationType.EZSP,
+    ):
+        install_addon.side_effect = AddonError()
+
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
+        )
+
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
+        assert result["step_id"] == "install_thread_firmware"
+        assert result["progress_action"] == "install_firmware"
+
+        result = await consume_progress_flow(
+            hass,
+            flow_id=result["flow_id"],
+            valid_step_ids=(
+                "install_otbr_addon",
+                "install_thread_firmware",
+            ),
         )
 
         # Cannot install addon
@@ -308,42 +302,30 @@ async def test_config_flow_thread_addon_install_fails(hass: HomeAssistant) -> No
         assert result["reason"] == "addon_install_failed"
 
 
+@pytest.mark.usefixtures("addon_installed")
 @pytest.mark.parametrize(
     "ignore_translations_for_mock_domains",
     ["test_firmware_domain"],
 )
-async def test_config_flow_thread_addon_set_config_fails(hass: HomeAssistant) -> None:
+async def test_config_flow_thread_addon_set_config_fails(
+    hass: HomeAssistant,
+    set_addon_options: AsyncMock,
+) -> None:
     """Test failure case when flasher addon cannot be configured."""
     init_result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": "hardware"}
     )
 
+    assert init_result["type"] is FlowResultType.MENU
+    assert init_result["step_id"] == "pick_firmware"
+
     with mock_firmware_info(
-        hass,
         probe_app_type=ApplicationType.EZSP,
-    ) as (mock_otbr_manager, _):
-
-        async def install_addon() -> None:
-            mock_otbr_manager.async_get_addon_info.return_value = AddonInfo(
-                available=True,
-                hostname=None,
-                options={"device": TEST_DEVICE},
-                state=AddonState.NOT_RUNNING,
-                update_available=False,
-                version="1.0.0",
-            )
-
-        mock_otbr_manager.async_install_addon_waiting = AsyncMock(
-            side_effect=install_addon
-        )
-        mock_otbr_manager.async_set_addon_options = AsyncMock(side_effect=AddonError())
-
-        confirm_result = await hass.config_entries.flow.async_configure(
-            init_result["flow_id"], user_input={}
-        )
+    ):
+        set_addon_options.side_effect = AddonError()
 
         pick_thread_result = await hass.config_entries.flow.async_configure(
-            confirm_result["flow_id"],
+            init_result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
         )
 
@@ -361,36 +343,29 @@ async def test_config_flow_thread_addon_set_config_fails(hass: HomeAssistant) ->
         assert pick_thread_progress_result["reason"] == "addon_set_config_failed"
 
 
+@pytest.mark.usefixtures("addon_installed")
 @pytest.mark.parametrize(
     "ignore_translations_for_mock_domains",
     ["test_firmware_domain"],
 )
-async def test_config_flow_thread_flasher_run_fails(hass: HomeAssistant) -> None:
+async def test_config_flow_thread_flasher_run_fails(
+    hass: HomeAssistant,
+    start_addon: AsyncMock,
+) -> None:
     """Test failure case when flasher addon fails to run."""
+    start_addon.side_effect = AddonError()
     init_result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": "hardware"}
     )
 
+    assert init_result["type"] is FlowResultType.MENU
+    assert init_result["step_id"] == "pick_firmware"
+
     with mock_firmware_info(
-        hass,
         probe_app_type=ApplicationType.EZSP,
-        otbr_addon_info=AddonInfo(
-            available=True,
-            hostname=None,
-            options={"device": TEST_DEVICE},
-            state=AddonState.NOT_RUNNING,
-            update_available=False,
-            version="1.0.0",
-        ),
-    ) as (mock_otbr_manager, _):
-        mock_otbr_manager.async_start_addon_waiting = AsyncMock(
-            side_effect=AddonError()
-        )
-        confirm_result = await hass.config_entries.flow.async_configure(
-            init_result["flow_id"], user_input={}
-        )
+    ):
         pick_thread_result = await hass.config_entries.flow.async_configure(
-            confirm_result["flow_id"],
+            init_result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
         )
 
@@ -408,6 +383,7 @@ async def test_config_flow_thread_flasher_run_fails(hass: HomeAssistant) -> None
         assert pick_thread_progress_result["reason"] == "addon_start_failed"
 
 
+@pytest.mark.usefixtures("addon_running")
 @pytest.mark.parametrize(
     "ignore_translations_for_mock_domains",
     ["test_firmware_domain"],
@@ -418,24 +394,15 @@ async def test_config_flow_thread_confirmation_fails(hass: HomeAssistant) -> Non
         TEST_DOMAIN, context={"source": "hardware"}
     )
 
+    assert init_result["type"] is FlowResultType.MENU
+    assert init_result["step_id"] == "pick_firmware"
+
     with mock_firmware_info(
-        hass,
         probe_app_type=ApplicationType.EZSP,
         flash_app_type=None,
-        otbr_addon_info=AddonInfo(
-            available=True,
-            hostname=None,
-            options={"device": TEST_DEVICE},
-            state=AddonState.RUNNING,
-            update_available=False,
-            version="1.0.0",
-        ),
     ):
-        confirm_result = await hass.config_entries.flow.async_configure(
-            init_result["flow_id"], user_input={}
-        )
         pick_thread_result = await hass.config_entries.flow.async_configure(
-            confirm_result["flow_id"],
+            init_result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
         )
 
@@ -467,13 +434,10 @@ async def test_config_flow_firmware_index_download_fails_and_required(
     assert init_result["type"] is FlowResultType.MENU
     assert init_result["step_id"] == "pick_firmware"
 
-    with (
-        mock_firmware_info(
-            hass,
-            # The wrong firmware is installed, so a new install is required
-            probe_app_type=ApplicationType.SPINEL,
-        ) as (_, mock_update_client),
-    ):
+    with mock_firmware_info(
+        # The wrong firmware is installed, so a new install is required
+        probe_app_type=ApplicationType.SPINEL,
+    ) as mock_update_client:
         mock_update_client.async_update_data.side_effect = ClientError()
 
         pick_result = await hass.config_entries.flow.async_configure(
@@ -507,13 +471,10 @@ async def test_config_flow_firmware_download_fails_and_required(
     assert init_result["type"] is FlowResultType.MENU
     assert init_result["step_id"] == "pick_firmware"
 
-    with (
-        mock_firmware_info(
-            hass,
-            # The wrong firmware is installed, so a new install is required
-            probe_app_type=ApplicationType.SPINEL,
-        ) as (_, mock_update_client),
-    ):
+    with mock_firmware_info(
+        # The wrong firmware is installed, so a new install is required
+        probe_app_type=ApplicationType.SPINEL,
+    ) as mock_update_client:
         mock_update_client.async_fetch_firmware.side_effect = ClientError()
 
         pick_result = await hass.config_entries.flow.async_configure(
@@ -585,7 +546,6 @@ async def test_options_flow_zigbee_to_thread_zha_configured(
     "ignore_translations_for_mock_domains",
     ["test_firmware_domain"],
 )
-@pytest.mark.usefixtures("addon_store_info")
 async def test_options_flow_thread_to_zigbee_otbr_configured(
     hass: HomeAssistant,
 ) -> None:
@@ -607,21 +567,23 @@ async def test_options_flow_thread_to_zigbee_otbr_configured(
     # Confirm options flow
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    with mock_firmware_info(
-        hass,
-        probe_app_type=ApplicationType.SPINEL,
-        otbr_addon_info=AddonInfo(
-            available=True,
-            hostname=None,
-            options={"device": TEST_DEVICE},
-            state=AddonState.RUNNING,
-            update_available=False,
-            version="1.0.0",
-        ),
+    # Pretend OTBR is using the stick
+    with patch(
+        "homeassistant.components.homeassistant_hardware.firmware_config_flow.guess_hardware_owners",
+        return_value=[
+            FirmwareInfo(
+                device=TEST_DEVICE,
+                firmware_type=ApplicationType.EZSP,
+                firmware_version="1.2.3.4",
+                source="otbr",
+                owners=[OwningAddon(slug="openthread_border_router")],
+            )
+        ],
     ):
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
         )
-        assert result["type"] == FlowResultType.ABORT
-        assert result["reason"] == "otbr_still_using_stick"
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "otbr_still_using_stick"

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the Home Assistant SkyConnect config flow."""
 
-from unittest.mock import Mock, patch
+from collections.abc import Generator
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
 
@@ -27,6 +28,16 @@ from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from .common import USB_DATA_SKY, USB_DATA_ZBT1
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="supervisor")
+def mock_supervisor_fixture() -> Generator[None]:
+    """Mock Supervisor."""
+    with patch(
+        "homeassistant.components.homeassistant_hardware.firmware_config_flow.is_hassio",
+        return_value=True,
+    ):
+        yield
 
 
 @pytest.mark.parametrize(
@@ -70,16 +81,9 @@ async def test_config_flow_zigbee(
         step_id: str,
         next_step_id: str,
     ) -> ConfigFlowResult:
-        if next_step_id == "start_otbr_addon":
-            next_step_id = "pre_confirm_otbr"
-
-        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
+        return await getattr(self, f"async_step_{next_step_id}")()
 
     with (
-        patch(
-            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._ensure_thread_addon_setup",
-            return_value=None,
-        ),
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._install_firmware_step",
             autospec=True,
@@ -133,6 +137,7 @@ async def test_config_flow_zigbee(
     assert zha_flow["step_id"] == "confirm"
 
 
+@pytest.mark.usefixtures("addon_installed", "supervisor")
 @pytest.mark.parametrize(
     ("usb_data", "model"),
     [
@@ -150,6 +155,7 @@ async def test_config_flow_thread(
     usb_data: UsbServiceInfo,
     model: str,
     hass: HomeAssistant,
+    start_addon: AsyncMock,
 ) -> None:
     """Test the config flow for SkyConnect with Thread."""
     fw_type = ApplicationType.SPINEL
@@ -174,16 +180,9 @@ async def test_config_flow_thread(
         step_id: str,
         next_step_id: str,
     ) -> ConfigFlowResult:
-        if next_step_id == "start_otbr_addon":
-            next_step_id = "pre_confirm_otbr"
-
-        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
+        return await getattr(self, f"async_step_{next_step_id}")()
 
     with (
-        patch(
-            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._ensure_thread_addon_setup",
-            return_value=None,
-        ),
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._install_firmware_step",
             autospec=True,
@@ -200,11 +199,23 @@ async def test_config_flow_thread(
             ),
         ),
     ):
-        confirm_result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
         )
 
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
+        assert result["step_id"] == "start_otbr_addon"
+
+        # Make sure the flow continues when the progress task is done.
+        await hass.async_block_till_done()
+
+        confirm_result = await hass.config_entries.flow.async_configure(
+            result["flow_id"]
+        )
+
+        assert start_addon.call_count == 1
+        assert start_addon.call_args == call("core_openthread_border_router")
         assert confirm_result["type"] is FlowResultType.FORM
         assert confirm_result["step_id"] == ("confirm_otbr")
 
@@ -279,19 +290,12 @@ async def test_options_flow(
         step_id: str,
         next_step_id: str,
     ) -> ConfigFlowResult:
-        if next_step_id == "start_otbr_addon":
-            next_step_id = "pre_confirm_otbr"
-
-        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
+        return await getattr(self, f"async_step_{next_step_id}")()
 
     with (
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.guess_hardware_owners",
             return_value=[],
-        ),
-        patch(
-            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareOptionsFlow._ensure_thread_addon_setup",
-            return_value=None,
         ),
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareOptionsFlow._install_firmware_step",

--- a/tests/components/homeassistant_yellow/test_config_flow.py
+++ b/tests/components/homeassistant_yellow/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Home Assistant Yellow config flow."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
 
@@ -352,19 +352,12 @@ async def test_firmware_options_flow_zigbee(hass: HomeAssistant) -> None:
         step_id: str,
         next_step_id: str,
     ) -> ConfigFlowResult:
-        if next_step_id == "start_otbr_addon":
-            next_step_id = "pre_confirm_otbr"
-
-        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
+        return await getattr(self, f"async_step_{next_step_id}")()
 
     with (
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.guess_hardware_owners",
             return_value=[],
-        ),
-        patch(
-            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareInstallFlow._ensure_thread_addon_setup",
-            return_value=None,
         ),
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareInstallFlow._install_firmware_step",
@@ -403,8 +396,10 @@ async def test_firmware_options_flow_zigbee(hass: HomeAssistant) -> None:
     }
 
 
-@pytest.mark.usefixtures("addon_store_info")
-async def test_firmware_options_flow_thread(hass: HomeAssistant) -> None:
+@pytest.mark.usefixtures("addon_installed")
+async def test_firmware_options_flow_thread(
+    hass: HomeAssistant, start_addon: AsyncMock
+) -> None:
     """Test the firmware options flow for Yellow with Thread."""
     fw_type = ApplicationType.SPINEL
     fw_version = "2.4.4.0"
@@ -448,19 +443,12 @@ async def test_firmware_options_flow_thread(hass: HomeAssistant) -> None:
         step_id: str,
         next_step_id: str,
     ) -> ConfigFlowResult:
-        if next_step_id == "start_otbr_addon":
-            next_step_id = "pre_confirm_otbr"
-
-        return await getattr(self, f"async_step_{next_step_id}")(user_input={})
+        return await getattr(self, f"async_step_{next_step_id}")()
 
     with (
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.guess_hardware_owners",
             return_value=[],
-        ),
-        patch(
-            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareInstallFlow._ensure_thread_addon_setup",
-            return_value=None,
         ),
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareInstallFlow._install_firmware_step",
@@ -478,11 +466,23 @@ async def test_firmware_options_flow_thread(hass: HomeAssistant) -> None:
             ),
         ),
     ):
-        confirm_result = await hass.config_entries.options.async_configure(
+        result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
         )
 
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
+        assert result["step_id"] == "start_otbr_addon"
+
+        # Make sure the flow continues when the progress task is done.
+        await hass.async_block_till_done()
+
+        confirm_result = await hass.config_entries.options.async_configure(
+            result["flow_id"]
+        )
+
+        assert start_addon.call_count == 1
+        assert start_addon.call_args == call("core_openthread_border_router")
         assert confirm_result["type"] is FlowResultType.FORM
         assert confirm_result["step_id"] == ("confirm_otbr")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Move the OTBR add-on install in the Thread hardware flow after firmware install. This will make it easier to move the firmware probing to the firmware install step. It will also in the future potentially allow users that want to use Thread with another container (not the add-on) to install the firmware.
- Solves this comment: https://github.com/home-assistant/core/pull/152451#discussion_r2356091957

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
