### PR TITLE
Move first probe firmware to firmware progress in hardware flow

### DIFF
--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -88,7 +88,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         self.addon_install_task: asyncio.Task | None = None
         self.addon_start_task: asyncio.Task | None = None
         self.addon_uninstall_task: asyncio.Task | None = None
-        self.firmware_install_task: asyncio.Task | None = None
+        self.firmware_install_task: asyncio.Task[None] | None = None
         self.installing_firmware_name: str | None = None
 
     def _get_translation_placeholders(self) -> dict[str, str]:
@@ -184,91 +184,17 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         step_id: str,
         next_step_id: str,
     ) -> ConfigFlowResult:
-        assert self._device is not None
-
+        """Show progress dialog for installing firmware."""
         if not self.firmware_install_task:
-            # Keep track of the firmware we're working with, for error messages
-            self.installing_firmware_name = firmware_name
-
-            # Installing new firmware is only truly required if the wrong type is
-            # installed: upgrading to the latest release of the current firmware type
-            # isn't strictly necessary for functionality.
-            firmware_install_required = self._probed_firmware_info is None or (
-                self._probed_firmware_info.firmware_type
-                != expected_installed_firmware_type
-            )
-
-            session = async_get_clientsession(self.hass)
-            client = FirmwareUpdateClient(fw_update_url, session)
-
-            try:
-                manifest = await client.async_update_data()
-                fw_manifest = next(
-                    fw for fw in manifest.firmwares if fw.filename.startswith(fw_type)
-                )
-            except (StopIteration, TimeoutError, ClientError, ManifestMissing):
-                _LOGGER.warning(
-                    "Failed to fetch firmware update manifest", exc_info=True
-                )
-
-                # Not having internet access should not prevent setup
-                if not firmware_install_required:
-                    _LOGGER.debug(
-                        "Skipping firmware upgrade due to index download failure"
-                    )
-                    return self.async_show_progress_done(next_step_id=next_step_id)
-
-                return self.async_show_progress_done(
-                    next_step_id="firmware_download_failed"
-                )
-
-            if not firmware_install_required:
-                assert self._probed_firmware_info is not None
-
-                # Make sure we do not downgrade the firmware
-                fw_metadata = NabuCasaMetadata.from_json(fw_manifest.metadata)
-                fw_version = fw_metadata.get_public_version()
-                probed_fw_version = Version(self._probed_firmware_info.firmware_version)
-
-                if probed_fw_version >= fw_version:
-                    _LOGGER.debug(
-                        "Not downgrading firmware, installed %s is newer than available %s",
-                        probed_fw_version,
-                        fw_version,
-                    )
-                    return self.async_show_progress_done(next_step_id=next_step_id)
-
-            try:
-                fw_data = await client.async_fetch_firmware(fw_manifest)
-            except (TimeoutError, ClientError, ValueError):
-                _LOGGER.warning("Failed to fetch firmware update", exc_info=True)
-
-                # If we cannot download new firmware, we shouldn't block setup
-                if not firmware_install_required:
-                    _LOGGER.debug(
-                        "Skipping firmware upgrade due to image download failure"
-                    )
-                    return self.async_show_progress_done(next_step_id=next_step_id)
-
-                # Otherwise, fail
-                return self.async_show_progress_done(
-                    next_step_id="firmware_download_failed"
-                )
-
             self.firmware_install_task = self.hass.async_create_task(
-                async_flash_silabs_firmware(
-                    hass=self.hass,
-                    device=self._device,
-                    fw_data=fw_data,
-                    expected_installed_firmware_type=expected_installed_firmware_type,
-                    bootloader_reset_type=None,
-                    progress_callback=lambda offset, total: self.async_update_progress(
-                        offset / total
-                    ),
+                self._install_firmware(
+                    fw_update_url,
+                    fw_type,
+                    firmware_name,
+                    expected_installed_firmware_type,
                 ),
-                f"Flash {firmware_name} firmware",
+                f"Install {firmware_name} firmware",
             )
-
         if not self.firmware_install_task.done():
             return self.async_show_progress(
                 step_id=step_id,
@@ -282,11 +208,101 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
 
         try:
             await self.firmware_install_task
+        except AbortFlow as err:
+            return self.async_show_progress_done(
+                next_step_id=err.reason,
+            )
         except HomeAssistantError:
             _LOGGER.exception("Failed to flash firmware")
             return self.async_show_progress_done(next_step_id="firmware_install_failed")
+        finally:
+            self.firmware_install_task = None
 
         return self.async_show_progress_done(next_step_id=next_step_id)
+
+    async def _install_firmware(
+        self,
+        fw_update_url: str,
+        fw_type: str,
+        firmware_name: str,
+        expected_installed_firmware_type: ApplicationType,
+    ) -> None:
+        """Install firmware."""
+        if not await self._probe_firmware_info():
+            raise AbortFlow(
+                reason="unsupported_firmware",
+                description_placeholders=self._get_translation_placeholders(),
+            )
+
+        assert self._device is not None
+
+        # Keep track of the firmware we're working with, for error messages
+        self.installing_firmware_name = firmware_name
+
+        # Installing new firmware is only truly required if the wrong type is
+        # installed: upgrading to the latest release of the current firmware type
+        # isn't strictly necessary for functionality.
+        firmware_install_required = self._probed_firmware_info is None or (
+            self._probed_firmware_info.firmware_type != expected_installed_firmware_type
+        )
+
+        session = async_get_clientsession(self.hass)
+        client = FirmwareUpdateClient(fw_update_url, session)
+
+        try:
+            manifest = await client.async_update_data()
+            fw_manifest = next(
+                fw for fw in manifest.firmwares if fw.filename.startswith(fw_type)
+            )
+        except (StopIteration, TimeoutError, ClientError, ManifestMissing) as err:
+            _LOGGER.warning("Failed to fetch firmware update manifest", exc_info=True)
+
+            # Not having internet access should not prevent setup
+            if not firmware_install_required:
+                _LOGGER.debug("Skipping firmware upgrade due to index download failure")
+                return
+
+            raise AbortFlow(reason="firmware_download_failed") from err
+
+        if not firmware_install_required:
+            assert self._probed_firmware_info is not None
+
+            # Make sure we do not downgrade the firmware
+            fw_metadata = NabuCasaMetadata.from_json(fw_manifest.metadata)
+            fw_version = fw_metadata.get_public_version()
+            probed_fw_version = Version(self._probed_firmware_info.firmware_version)
+
+            if probed_fw_version >= fw_version:
+                _LOGGER.debug(
+                    "Not downgrading firmware, installed %s is newer than available %s",
+                    probed_fw_version,
+                    fw_version,
+                )
+                return
+
+        try:
+            fw_data = await client.async_fetch_firmware(fw_manifest)
+        except (TimeoutError, ClientError, ValueError) as err:
+            _LOGGER.warning("Failed to fetch firmware update", exc_info=True)
+
+            # If we cannot download new firmware, we shouldn't block setup
+            if not firmware_install_required:
+                _LOGGER.debug("Skipping firmware upgrade due to image download failure")
+                return
+
+            # Otherwise, fail
+            raise AbortFlow(reason="firmware_download_failed") from err
+
+        await async_flash_silabs_firmware(
+            hass=self.hass,
+            device=self._device,
+            fw_data=fw_data,
+            expected_installed_firmware_type=expected_installed_firmware_type,
+            bootloader_reset_type=None,
+            progress_callback=lambda offset, total: self.async_update_progress(
+                offset / total
+            ),
+        )
 
     async def _configure_and_start_otbr_addon(self) -> None:
         """Configure and start the OTBR addon."""
@@ -353,6 +369,15 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
             },
         )
 
+    async def async_step_unsupported_firmware(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Abort when unsupported firmware is detected."""
+        return self.async_abort(
+            reason="unsupported_firmware",
+            description_placeholders=self._get_translation_placeholders(),
+        )
+
     async def async_step_zigbee_installation_type(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -406,12 +431,6 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
 
     async def _async_continue_picked_firmware(self) -> ConfigFlowResult:
         """Continue to the picked firmware step."""
-        if not await self._probe_firmware_info():
-            return self.async_abort(
-                reason="unsupported_firmware",
-                description_placeholders=self._get_translation_placeholders(),
-            )
-
         if self._picked_firmware_type == PickedFirmwareType.ZIGBEE:
             return await self.async_step_install_zigbee_firmware()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Move the firmware probing before firmware install to inside the progress task, to show a progress spinner also during the firmware probing which takes some time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
