### PR TITLE
Add IMAP fetch message part feature

### DIFF
--- a/homeassistant/components/imap/__init__.py
+++ b/homeassistant/components/imap/__init__.py
@@ -208,7 +208,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def async_fetch(call: ServiceCall) -> ServiceResponse:
         """Process fetch email service and return content."""
-
         entry_id: str = call.data[CONF_ENTRY]
         uid: str = call.data[CONF_UID]
         _LOGGER.debug(
@@ -226,6 +225,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 translation_placeholders={"error": str(exc)},
             ) from exc
         raise_on_error(response, "fetch_failed")
+        # Index 1 of of the response lines contains the bytearray with the message data
         message = ImapMessage(response.lines[1])
         await client.close()
         return {
@@ -282,6 +282,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 translation_placeholders={"error": str(exc)},
             ) from exc
         raise_on_error(response, "fetch_failed")
+        # Index 1 of of the response lines contains the bytearray with the message data
         message = ImapMessage(response.lines[1])
         await client.close()
         part_data = get_message_part(message.email_message, part_key)

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -212,15 +212,13 @@ class ImapMessage:
 @callback
 def get_parts(message: Message, prefix: str | None = None) -> dict[str, Any]:
     """Return information about the parts of a multipart message."""
-    index = 0
     parts: dict[str, Any] = {}
     if not message.is_multipart():
         return {}
-    for part in message.get_payload():
+    for index, part in enumerate(message.get_payload(), 0):
         if TYPE_CHECKING:
             assert isinstance(part, Message)
         key = f"{prefix},{index}" if prefix else f"{index}"
-        index += 1
         if part.is_multipart():
             parts |= get_parts(part, key)
             continue

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
     CONTENT_TYPE_TEXT_PLAIN,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
     ConfigEntryError,
@@ -209,6 +209,30 @@ class ImapMessage:
         return str(self.email_message.get_payload())
 
 
+@callback
+def get_parts(message: Message, prefix: str | None = None) -> dict[str, Any]:
+    """Return information about the parts of a multipart message."""
+    index = 0
+    parts: dict[str, Any] = {}
+    if not message.is_multipart():
+        return {}
+    for part in message.get_payload():
+        if TYPE_CHECKING:
+            assert isinstance(part, Message)
+        key = f"{prefix},{index}" if prefix else f"{index}"
+        index += 1
+        if part.is_multipart():
+            parts |= get_parts(part, key)
+            continue
+        parts[key] = {"content_type": part.get_content_type()}
+        if filename := part.get_filename():
+            parts[key]["filename"] = filename
+        if content_transfer_encoding := part.get("Content-Transfer-Encoding"):
+            parts[key]["content_transfer_encoding"] = content_transfer_encoding
+
+    return parts
+
+
 class ImapDataUpdateCoordinator(DataUpdateCoordinator[int | None]):
     """Base class for imap client."""
 
@@ -275,6 +299,7 @@ class ImapDataUpdateCoordinator(DataUpdateCoordinator[int | None]):
                 "sender": message.sender,
                 "subject": message.subject,
                 "uid": last_message_uid,
+                "parts": get_parts(message.email_message),
             }
             data.update({key: getattr(message, key) for key in self._event_data_keys})
             if self.custom_event_template is not None:

--- a/homeassistant/components/imap/icons.json
+++ b/homeassistant/components/imap/icons.json
@@ -21,6 +21,9 @@
     },
     "fetch": {
       "service": "mdi:email-sync-outline"
+    },
+    "fetch_part": {
+      "service": "mdi:email-sync-outline"
     }
   }
 }

--- a/homeassistant/components/imap/services.yaml
+++ b/homeassistant/components/imap/services.yaml
@@ -57,8 +57,21 @@ fetch:
       selector:
         text:
 
+fetch_part:
+  fields:
+    entry:
+      required: true
+      selector:
+        config_entry:
+          integration: "imap"
+    uid:
+      required: true
+      example: "12"
+      selector:
+        text:
+
     part:
-      required: false
+      required: true
       example: "0,1"
       selector:
         text:

--- a/homeassistant/components/imap/services.yaml
+++ b/homeassistant/components/imap/services.yaml
@@ -56,3 +56,9 @@ fetch:
       example: "12"
       selector:
         text:
+
+    part:
+      required: false
+      example: "0,1"
+      selector:
+        text:

--- a/homeassistant/components/imap/strings.json
+++ b/homeassistant/components/imap/strings.json
@@ -84,6 +84,9 @@
     "imap_server_fail": {
       "message": "The IMAP server failed to connect: {error}."
     },
+    "invalid_part_index": {
+      "message": "Invalid part index."
+    },
     "seen_failed": {
       "message": "Marking message as seen failed with \"{error}\"."
     }
@@ -145,6 +148,10 @@
         "uid": {
           "name": "UID",
           "description": "The email identifier (UID)."
+        },
+        "part": {
+          "name": "Part",
+          "description": "The message part index."
         }
       }
     },

--- a/homeassistant/components/imap/strings.json
+++ b/homeassistant/components/imap/strings.json
@@ -148,6 +148,20 @@
         "uid": {
           "name": "UID",
           "description": "The email identifier (UID)."
+        }
+      }
+    },
+    "fetch_part": {
+      "name": "Fetch message part",
+      "description": "Fetches a message part or attachment from an email message.",
+      "fields": {
+        "entry": {
+          "name": "[%key:component::imap::services::fetch::fields::entry::name%]",
+          "description": "[%key:component::imap::services::fetch::fields::entry::description%]"
+        },
+        "uid": {
+          "name": "[%key:component::imap::services::fetch::fields::uid::name%]",
+          "description": "[%key:component::imap::services::fetch::fields::uid::description%]"
         },
         "part": {
           "name": "Part",

--- a/tests/components/imap/const.py
+++ b/tests/components/imap/const.py
@@ -27,6 +27,9 @@ TEST_MESSAGE_HEADERS2 = (
 TEST_MULTIPART_HEADER = (
     b'Content-Type: multipart/related;\r\n\tboundary="Mark=_100584970350292485166"'
 )
+TEST_MULTIPART_ATTACHMENT_HEADER = (
+    b'Content-Type: multipart/mixed; boundary="------------qIuh0xG6dsImymfJo6f2M4Zv"'
+)
 
 TEST_MESSAGE_HEADERS3 = b""
 
@@ -34,6 +37,13 @@ TEST_MESSAGE = TEST_MESSAGE_HEADERS1 + DATE_HEADER1 + TEST_MESSAGE_HEADERS2
 
 TEST_MESSAGE_MULTIPART = (
     TEST_MESSAGE_HEADERS1 + DATE_HEADER1 + TEST_MESSAGE_HEADERS2 + TEST_MULTIPART_HEADER
+)
+
+TEST_MESSAGE_MULTIPART_ATTACHMENT = (
+    TEST_MESSAGE_HEADERS1
+    + DATE_HEADER1
+    + TEST_MESSAGE_HEADERS2
+    + TEST_MULTIPART_ATTACHMENT_HEADER
 )
 
 TEST_MESSAGE_NO_SUBJECT_TO_FROM = (
@@ -139,6 +149,45 @@ TEST_CONTENT_MULTIPART_BASE64_INVALID = (
     + TEST_CONTENT_HTML_BASE64
     + b"\r\n--Mark=_100584970350292485166--\r\n"
 )
+
+TEST_CONTENT_MULTIPART_WITH_ATTACHMENT = b"""
+\nThis is a multi-part message in MIME format.
+--------------qIuh0xG6dsImymfJo6f2M4Zv
+Content-Type: multipart/alternative;
+ boundary="------------N4zNjp2QWnOfrYQhtLL02Bk1"
+
+--------------N4zNjp2QWnOfrYQhtLL02Bk1
+Content-Type: text/plain; charset=UTF-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+*Multi* part Test body
+
+--------------N4zNjp2QWnOfrYQhtLL02Bk1
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE html>
+<html>
+  <head>
+
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  </head>
+  <body>
+    <p><b>Multi</b> part Test body</p>
+  </body>
+</html>
+
+--------------N4zNjp2QWnOfrYQhtLL02Bk1--
+--------------qIuh0xG6dsImymfJo6f2M4Zv
+Content-Type: text/plain; charset=UTF-8; name="Text attachment content.txt"
+Content-Disposition: attachment; filename="Text attachment content.txt"
+Content-Transfer-Encoding: base64
+
+VGV4dCBhdHRhY2htZW50IGNvbnRlbnQ=
+
+--------------qIuh0xG6dsImymfJo6f2M4Zv--
+"""
+
 
 EMPTY_SEARCH_RESPONSE = ("OK", [b"", b"Search completed (0.0001 + 0.000 secs)."])
 EMPTY_SEARCH_RESPONSE_ALT = ("OK", [b"Search completed (0.0001 + 0.000 secs)."])
@@ -299,6 +348,24 @@ TEST_FETCH_RESPONSE_MULTIPART_BASE64 = (
         )
         + b"}",
         bytearray(TEST_MESSAGE_MULTIPART + TEST_CONTENT_MULTIPART_BASE64),
+        b")",
+        b"Fetch completed (0.0001 + 0.000 secs).",
+    ],
+)
+TEST_FETCH_RESPONSE_MULTIPART_WITH_ATTACHMENT = (
+    "OK",
+    [
+        b"1 FETCH (BODY[] {"
+        + str(
+            len(
+                TEST_MESSAGE_MULTIPART_ATTACHMENT
+                + TEST_CONTENT_MULTIPART_WITH_ATTACHMENT
+            )
+        ).encode("utf-8")
+        + b"}",
+        bytearray(
+            TEST_MESSAGE_MULTIPART_ATTACHMENT + TEST_CONTENT_MULTIPART_WITH_ATTACHMENT
+        ),
         b")",
         b"Fetch completed (0.0001 + 0.000 secs).",
     ],

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -1,6 +1,7 @@
 """Test the imap entry initialization."""
 
 import asyncio
+from base64 import b64decode
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -31,6 +32,7 @@ from .const import (
     TEST_FETCH_RESPONSE_MULTIPART_BASE64,
     TEST_FETCH_RESPONSE_MULTIPART_BASE64_INVALID,
     TEST_FETCH_RESPONSE_MULTIPART_EMPTY_PLAIN,
+    TEST_FETCH_RESPONSE_MULTIPART_WITH_ATTACHMENT,
     TEST_FETCH_RESPONSE_NO_SUBJECT_TO_FROM,
     TEST_FETCH_RESPONSE_TEXT_BARE,
     TEST_FETCH_RESPONSE_TEXT_OTHER,
@@ -107,20 +109,72 @@ async def test_entry_startup_fails(
 
 @pytest.mark.parametrize("imap_search", [TEST_SEARCH_RESPONSE])
 @pytest.mark.parametrize(
-    ("imap_fetch", "valid_date"),
+    ("imap_fetch", "valid_date", "parts"),
     [
-        (TEST_FETCH_RESPONSE_TEXT_BARE, True),
-        (TEST_FETCH_RESPONSE_TEXT_PLAIN, True),
-        (TEST_FETCH_RESPONSE_TEXT_PLAIN_ALT, True),
-        (TEST_FETCH_RESPONSE_INVALID_DATE1, False),
-        (TEST_FETCH_RESPONSE_INVALID_DATE2, False),
-        (TEST_FETCH_RESPONSE_INVALID_DATE3, False),
-        (TEST_FETCH_RESPONSE_TEXT_OTHER, True),
-        (TEST_FETCH_RESPONSE_HTML, True),
-        (TEST_FETCH_RESPONSE_MULTIPART, True),
-        (TEST_FETCH_RESPONSE_MULTIPART_EMPTY_PLAIN, True),
-        (TEST_FETCH_RESPONSE_MULTIPART_BASE64, True),
-        (TEST_FETCH_RESPONSE_BINARY, True),
+        (TEST_FETCH_RESPONSE_TEXT_BARE, True, {}),
+        (TEST_FETCH_RESPONSE_TEXT_PLAIN, True, {}),
+        (TEST_FETCH_RESPONSE_TEXT_PLAIN_ALT, True, {}),
+        (TEST_FETCH_RESPONSE_INVALID_DATE1, False, {}),
+        (TEST_FETCH_RESPONSE_INVALID_DATE2, False, {}),
+        (TEST_FETCH_RESPONSE_INVALID_DATE3, False, {}),
+        (TEST_FETCH_RESPONSE_TEXT_OTHER, True, {}),
+        (TEST_FETCH_RESPONSE_HTML, True, {}),
+        (
+            TEST_FETCH_RESPONSE_MULTIPART,
+            True,
+            {
+                "0": {
+                    "content_type": "text/plain",
+                    "content_transfer_encoding": "7bit",
+                },
+                "1": {"content_type": "text/html", "content_transfer_encoding": "7bit"},
+            },
+        ),
+        (
+            TEST_FETCH_RESPONSE_MULTIPART_EMPTY_PLAIN,
+            True,
+            {
+                "0": {
+                    "content_type": "text/plain",
+                    "content_transfer_encoding": "7bit",
+                },
+                "1": {"content_type": "text/html", "content_transfer_encoding": "7bit"},
+            },
+        ),
+        (
+            TEST_FETCH_RESPONSE_MULTIPART_BASE64,
+            True,
+            {
+                "0": {
+                    "content_type": "text/plain",
+                    "content_transfer_encoding": "base64",
+                },
+                "1": {
+                    "content_type": "text/html",
+                    "content_transfer_encoding": "base64",
+                },
+            },
+        ),
+        (
+            TEST_FETCH_RESPONSE_MULTIPART_WITH_ATTACHMENT,
+            True,
+            {
+                "0,0": {
+                    "content_type": "text/plain",
+                    "content_transfer_encoding": "7bit",
+                },
+                "0,1": {
+                    "content_type": "text/html",
+                    "content_transfer_encoding": "7bit",
+                },
+                "1": {
+                    "content_type": "text/plain",
+                    "filename": "Text attachment content.txt",
+                    "content_transfer_encoding": "base64",
+                },
+            },
+        ),
+        (TEST_FETCH_RESPONSE_BINARY, True, {}),
     ],
     ids=[
         "bare",
@@ -134,13 +188,18 @@ async def test_entry_startup_fails(
         "multipart",
         "multipart_empty_plain",
         "multipart_base64",
+        "multipart_attachment",
         "binary",
     ],
 )
 @pytest.mark.parametrize("imap_has_capability", [True, False], ids=["push", "poll"])
 @pytest.mark.parametrize("charset", ["utf-8", "us-ascii"], ids=["utf-8", "us-ascii"])
 async def test_receiving_message_successfully(
-    hass: HomeAssistant, mock_imap_protocol: MagicMock, valid_date: bool, charset: str
+    hass: HomeAssistant,
+    mock_imap_protocol: MagicMock,
+    valid_date: bool,
+    charset: str,
+    parts: dict[str, Any],
 ) -> None:
     """Test receiving a message successfully."""
     event_called = async_capture_events(hass, "imap_content")
@@ -170,6 +229,7 @@ async def test_receiving_message_successfully(
     assert data["sender"] == "john.doe@example.com"
     assert data["subject"] == "Test subject"
     assert data["uid"] == "1"
+    assert data["parts"] == parts
     assert "Test body" in data["text"]
     assert (valid_date and isinstance(data["date"], datetime)) or (
         not valid_date and data["date"] is None
@@ -826,11 +886,33 @@ async def test_enforce_polling(
 
 
 @pytest.mark.parametrize(
-    ("imap_search", "imap_fetch"),
-    [(TEST_SEARCH_RESPONSE, TEST_FETCH_RESPONSE_TEXT_PLAIN)],
+    ("imap_search", "imap_fetch", "message_parts"),
+    [
+        (
+            TEST_SEARCH_RESPONSE,
+            TEST_FETCH_RESPONSE_MULTIPART_WITH_ATTACHMENT,
+            {
+                "0,0": {
+                    "content_type": "text/plain",
+                    "content_transfer_encoding": "7bit",
+                },
+                "0,1": {
+                    "content_type": "text/html",
+                    "content_transfer_encoding": "7bit",
+                },
+                "1": {
+                    "content_type": "text/plain",
+                    "filename": "Text attachment content.txt",
+                    "content_transfer_encoding": "base64",
+                },
+            },
+        )
+    ],
 )
 @pytest.mark.parametrize("imap_has_capability", [True, False], ids=["push", "poll"])
-async def test_services(hass: HomeAssistant, mock_imap_protocol: MagicMock) -> None:
+async def test_services(
+    hass: HomeAssistant, mock_imap_protocol: MagicMock, message_parts: dict[str, Any]
+) -> None:
     """Test receiving a message successfully."""
     event_called = async_capture_events(hass, "imap_content")
 
@@ -859,6 +941,7 @@ async def test_services(hass: HomeAssistant, mock_imap_protocol: MagicMock) -> N
     assert data["subject"] == "Test subject"
     assert data["uid"] == "1"
     assert data["entry_id"] == config_entry.entry_id
+    assert data["parts"] == message_parts
 
     # Test seen service
     data = {"entry": config_entry.entry_id, "uid": "1"}
@@ -889,16 +972,42 @@ async def test_services(hass: HomeAssistant, mock_imap_protocol: MagicMock) -> N
     mock_imap_protocol.store.assert_called_with("1", "+FLAGS (\\Deleted)")
     mock_imap_protocol.protocol.expunge.assert_called_once()
 
-    # Test fetch service
+    # Test fetch service with text response
+    mock_imap_protocol.reset_mock()
     data = {"entry": config_entry.entry_id, "uid": "1"}
     response = await hass.services.async_call(
         DOMAIN, "fetch", data, blocking=True, return_response=True
     )
     mock_imap_protocol.fetch.assert_called_with("1", "BODY.PEEK[]")
-    assert response["text"] == "Test body\r\n"
+    assert response["text"] == "*Multi* part Test body\n"
     assert response["sender"] == "john.doe@example.com"
     assert response["subject"] == "Test subject"
     assert response["uid"] == "1"
+    assert response["parts"] == message_parts
+
+    # Test fetch service with attachment response
+    mock_imap_protocol.reset_mock()
+    data = {"entry": config_entry.entry_id, "uid": "1", "part": "1"}
+    response = await hass.services.async_call(
+        DOMAIN, "fetch", data, blocking=True, return_response=True
+    )
+    mock_imap_protocol.fetch.assert_called_with("1", "BODY.PEEK[]")
+    assert response["part_data"] == "VGV4dCBhdHRhY2htZW50IGNvbnRlbnQ=\n"
+    assert response["content_type"] == "text/plain"
+    assert response["content_transfer_encoding"] == "base64"
+    assert response["filename"] == "Text attachment content.txt"
+    assert response["part"] == "1"
+    assert response["uid"] == "1"
+    assert b64decode(response["part_data"]) == b"Text attachment content"
+
+    # Test fetch service with invalid part index
+    for part in ("A", "2", "0"):
+        data = {"entry": config_entry.entry_id, "uid": "1", "part": part}
+        with pytest.raises(ServiceValidationError) as exc:
+            await hass.services.async_call(
+                DOMAIN, "fetch", data, blocking=True, return_response=True
+            )
+        assert exc.value.translation_key == "invalid_part_index"
 
     # Test with invalid entry_id
     data = {"entry": "invalid", "uid": "1"}

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -985,11 +985,11 @@ async def test_services(
     assert response["uid"] == "1"
     assert response["parts"] == message_parts
 
-    # Test fetch service with attachment response
+    # Test fetch part service with attachment response
     mock_imap_protocol.reset_mock()
     data = {"entry": config_entry.entry_id, "uid": "1", "part": "1"}
     response = await hass.services.async_call(
-        DOMAIN, "fetch", data, blocking=True, return_response=True
+        DOMAIN, "fetch_part", data, blocking=True, return_response=True
     )
     mock_imap_protocol.fetch.assert_called_with("1", "BODY.PEEK[]")
     assert response["part_data"] == "VGV4dCBhdHRhY2htZW50IGNvbnRlbnQ=\n"
@@ -1000,12 +1000,12 @@ async def test_services(
     assert response["uid"] == "1"
     assert b64decode(response["part_data"]) == b"Text attachment content"
 
-    # Test fetch service with invalid part index
+    # Test fetch part service with invalid part index
     for part in ("A", "2", "0"):
         data = {"entry": config_entry.entry_id, "uid": "1", "part": part}
         with pytest.raises(ServiceValidationError) as exc:
             await hass.services.async_call(
-                DOMAIN, "fetch", data, blocking=True, return_response=True
+                DOMAIN, "fetch_part", data, blocking=True, return_response=True
             )
         assert exc.value.translation_key == "invalid_part_index"
 
@@ -1052,12 +1052,14 @@ async def test_services(
         ),
         "delete": ({"entry": config_entry.entry_id, "uid": "1"}, False),
         "fetch": ({"entry": config_entry.entry_id, "uid": "1"}, True),
+        "fetch_part": ({"entry": config_entry.entry_id, "uid": "1", "part": "1"}, True),
     }
     patch_error_translation_key = {
         "seen": ("store", "seen_failed"),
         "move": ("copy", "copy_failed"),
         "delete": ("store", "delete_failed"),
         "fetch": ("fetch", "fetch_failed"),
+        "fetch_part": ("fetch", "fetch_failed"),
     }
     for service, (data, response) in service_calls_response.items():
         with (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add IMAP fetch message part feature by adding a new `fetch_part` action with the `part` option to allow to retrieve a specific message part. The event data will include the available message parts via the `parts` key.
The `fetch` action will also return this `parts` key via the action return variable.

Works out a solution for feature request: https://github.com/orgs/home-assistant/discussions/819

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40983
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
