### PR TITLE
Remove hardware flow thread confirm step after install

### DIFF
--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -641,20 +641,6 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         """Pre-confirm OTBR setup."""
 
         # This step is necessary to prevent `user_input` from being passed through
-        return await self.async_step_confirm_otbr()
-
-    async def async_step_confirm_otbr(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Confirm OTBR setup."""
-        assert self._device is not None
-
-        if user_input is None:
-            return self.async_show_form(
-                step_id="confirm_otbr",
-                description_placeholders=self._get_translation_placeholders(),
-            )
-
         # OTBR discovery is done automatically via hassio
         return self._async_flow_finished()
 

--- a/tests/components/homeassistant_connect_zbt2/test_config_flow.py
+++ b/tests/components/homeassistant_connect_zbt2/test_config_flow.py
@@ -177,19 +177,12 @@ async def test_config_flow_thread(
         # Make sure the flow continues when the progress task is done.
         await hass.async_block_till_done()
 
-        confirm_result = await hass.config_entries.flow.async_configure(
+        create_result = await hass.config_entries.flow.async_configure(
             result["flow_id"]
         )
 
-        assert start_addon.call_count == 1
-        assert start_addon.call_args == call("core_openthread_border_router")
-        assert confirm_result["type"] is FlowResultType.FORM
-        assert confirm_result["step_id"] == "confirm_otbr"
-
-        create_result = await hass.config_entries.flow.async_configure(
-            confirm_result["flow_id"], user_input={}
-        )
-
+    assert start_addon.call_count == 1
+    assert start_addon.call_args == call("core_openthread_border_router")
     assert create_result["type"] is FlowResultType.CREATE_ENTRY
     config_entry = create_result["result"]
     assert config_entry.data == {

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -210,19 +210,12 @@ async def test_config_flow_thread(
         # Make sure the flow continues when the progress task is done.
         await hass.async_block_till_done()
 
-        confirm_result = await hass.config_entries.flow.async_configure(
+        create_result = await hass.config_entries.flow.async_configure(
             result["flow_id"]
         )
 
-        assert start_addon.call_count == 1
-        assert start_addon.call_args == call("core_openthread_border_router")
-        assert confirm_result["type"] is FlowResultType.FORM
-        assert confirm_result["step_id"] == ("confirm_otbr")
-
-        create_result = await hass.config_entries.flow.async_configure(
-            confirm_result["flow_id"], user_input={}
-        )
-
+    assert start_addon.call_count == 1
+    assert start_addon.call_args == call("core_openthread_border_router")
     assert create_result["type"] is FlowResultType.CREATE_ENTRY
     config_entry = create_result["result"]
     assert config_entry.data == {

--- a/tests/components/homeassistant_yellow/test_config_flow.py
+++ b/tests/components/homeassistant_yellow/test_config_flow.py
@@ -477,21 +477,13 @@ async def test_firmware_options_flow_thread(
         # Make sure the flow continues when the progress task is done.
         await hass.async_block_till_done()
 
-        confirm_result = await hass.config_entries.options.async_configure(
+        create_result = await hass.config_entries.options.async_configure(
             result["flow_id"]
         )
 
-        assert start_addon.call_count == 1
-        assert start_addon.call_args == call("core_openthread_border_router")
-        assert confirm_result["type"] is FlowResultType.FORM
-        assert confirm_result["step_id"] == ("confirm_otbr")
-
-        create_result = await hass.config_entries.options.async_configure(
-            confirm_result["flow_id"], user_input={}
-        )
-
+    assert start_addon.call_count == 1
+    assert start_addon.call_args == call("core_openthread_border_router")
     assert create_result["type"] is FlowResultType.CREATE_ENTRY
-
     assert config_entry.data == {
         "firmware": fw_type.value,
         "firmware_version": fw_version,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Remove the confirm step after firmware and add-on install as it's not needed. The frontend will show the device added dialog after the end of the flow, and this is enough.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
