### PR TITLE
Skip ignored discovery entries when showing migrate/setup config flow steps for ZHA and Hardware

### DIFF
--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -127,8 +127,12 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
     ) -> ConfigFlowResult:
         """Pick Thread or Zigbee firmware."""
         # Determine if ZHA or Thread are already configured to present migrate options
-        zha_entries = self.hass.config_entries.async_entries(ZHA_DOMAIN)
-        otbr_entries = self.hass.config_entries.async_entries(OTBR_DOMAIN)
+        zha_entries = self.hass.config_entries.async_entries(
+            ZHA_DOMAIN, include_ignore=False
+        )
+        otbr_entries = self.hass.config_entries.async_entries(
+            OTBR_DOMAIN, include_ignore=False
+        )
 
         return self.async_show_menu(
             step_id="pick_firmware",

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -364,7 +364,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
         if user_input is not None or self._radio_mgr.radio_type in RECOMMENDED_RADIOS:
             # ZHA disables the single instance check and will decide at runtime if we
             # are migrating or setting up from scratch
-            if self.hass.config_entries.async_entries(DOMAIN):
+            if self.hass.config_entries.async_entries(DOMAIN, include_ignore=False):
                 return await self.async_step_choose_migration_strategy()
             return await self.async_step_choose_setup_strategy()
 
@@ -386,7 +386,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
         # Allow onboarding for new users to just create a new network automatically
         if (
             not onboarding.async_is_onboarded(self.hass)
-            and not self.hass.config_entries.async_entries(DOMAIN)
+            and not self.hass.config_entries.async_entries(DOMAIN, include_ignore=False)
             and not self._radio_mgr.backups
         ):
             return await self.async_step_setup_strategy_recommended()
@@ -438,7 +438,9 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
         """Erase the old radio's network settings before migration."""
 
         # Like in the options flow, pull the correct settings from the config entry
-        config_entries = self.hass.config_entries.async_entries(DOMAIN)
+        config_entries = self.hass.config_entries.async_entries(
+            DOMAIN, include_ignore=False
+        )
 
         if config_entries:
             assert len(config_entries) == 1
@@ -693,7 +695,9 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
 
         self._set_confirm_only()
 
-        zha_config_entries = self.hass.config_entries.async_entries(DOMAIN)
+        zha_config_entries = self.hass.config_entries.async_entries(
+            DOMAIN, include_ignore=False
+        )
 
         # Without confirmation, discovery can automatically progress into parts of the
         # config flow logic that interacts with hardware.
@@ -862,7 +866,9 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
 
         # ZHA is still single instance only, even though we use discovery to allow for
         # migrating to a new radio
-        zha_config_entries = self.hass.config_entries.async_entries(DOMAIN)
+        zha_config_entries = self.hass.config_entries.async_entries(
+            DOMAIN, include_ignore=False
+        )
         data = await self._get_config_entry_data()
 
         if len(zha_config_entries) == 1:

--- a/tests/components/homeassistant_hardware/test_config_flow.py
+++ b/tests/components/homeassistant_hardware/test_config_flow.py
@@ -26,7 +26,13 @@ from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
 )
-from homeassistant.config_entries import ConfigEntry, ConfigFlowResult, OptionsFlow
+from homeassistant.config_entries import (
+    SOURCE_IGNORE,
+    SOURCE_USER,
+    ConfigEntry,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import HomeAssistantError
@@ -1100,3 +1106,48 @@ async def test_config_flow_thread_migrate_handler(hass: HomeAssistant) -> None:
         assert result["type"] is FlowResultType.SHOW_PROGRESS
         assert result["progress_action"] == "install_firmware"
         assert result["step_id"] == "install_thread_firmware"
+
+
+@pytest.mark.parametrize("zha_source", [SOURCE_USER, SOURCE_IGNORE])
+@pytest.mark.parametrize("otbr_source", [SOURCE_USER, SOURCE_IGNORE])
+async def test_config_flow_pick_firmware_with_ignored_entries(
+    hass: HomeAssistant, zha_source: str, otbr_source: str
+) -> None:
+    """Test that ignored entries are properly excluded from migration menu options."""
+    zha_entry = MockConfigEntry(
+        domain="zha",
+        data={"device": {"path": "/dev/ttyUSB1"}},
+        title="ZHA",
+        source=zha_source,
+    )
+    zha_entry.add_to_hass(hass)
+
+    otbr_entry = MockConfigEntry(
+        domain="otbr",
+        data={"url": "http://192.168.1.100:8081"},
+        title="OTBR",
+        source=otbr_source,
+    )
+    otbr_entry.add_to_hass(hass)
+
+    # Set up the flow
+    init_result = await hass.config_entries.flow.async_init(
+        TEST_DOMAIN, context={"source": "hardware"}
+    )
+
+    assert init_result["type"] is FlowResultType.MENU
+    assert init_result["step_id"] == "pick_firmware"
+
+    # Expected menu options based on whether entries are ignored or not
+    assert init_result["menu_options"] == [
+        (
+            "pick_firmware_zigbee_migrate"
+            if zha_source != SOURCE_IGNORE
+            else "pick_firmware_zigbee"
+        ),
+        (
+            "pick_firmware_thread_migrate"
+            if otbr_source != SOURCE_IGNORE
+            else "pick_firmware_thread"
+        ),
+    ]

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -2364,3 +2364,52 @@ async def test_formation_strategy_restore_manual_backup_overwrite_ieee_ezsp_writ
 
     assert mock_restore_backup.call_count == 1
     assert mock_restore_backup.mock_calls[0].kwargs["overwrite_ieee"] is True
+
+
+@patch(f"bellows.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
+async def test_migrate_setup_options_with_ignored_discovery(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test that ignored discovery info is migrated to options."""
+
+    # Ignored ZHA
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="AAAA:AAAA_1234_test_zigbee radio",
+        data={
+            CONF_DEVICE: {
+                CONF_DEVICE_PATH: "/dev/ttyUSB1",
+                CONF_BAUDRATE: 115200,
+                CONF_FLOW_CONTROL: None,
+            }
+        },
+        source=config_entries.SOURCE_IGNORE,
+    )
+    entry.add_to_hass(hass)
+
+    # Set up one discovery entry
+    discovery_info = UsbServiceInfo(
+        device="/dev/ttyZIGBEE",
+        pid="BBBB",
+        vid="BBBB",
+        serial_number="5678",
+        description="zigbee radio",
+        manufacturer="test manufacturer",
+    )
+    discovery_result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USB}, data=discovery_info
+    )
+    await hass.async_block_till_done()
+
+    # Progress the discovery
+    confirm_result = await hass.config_entries.flow.async_configure(
+        discovery_result["flow_id"], user_input={}
+    )
+    await hass.async_block_till_done()
+
+    # We only show "setup" options, not "migrate"
+    assert confirm_result["step_id"] == "choose_setup_strategy"
+    assert confirm_result["menu_options"] == [
+        "setup_strategy_recommended",
+        "setup_strategy_advanced",
+    ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For the Yellow, for example, an ignored ZHA discovery for the internal radio currently counts as a configured ZHA instance and will result in "migrate" options being shown instead of "setup". For both integrations, we should ignore ignored discovery.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
