### PR TITLE
Add remove item intent for todo component

### DIFF
--- a/homeassistant/components/todo/intent.py
+++ b/homeassistant/components/todo/intent.py
@@ -12,24 +12,28 @@ from .const import DATA_COMPONENT, DOMAIN
 
 INTENT_LIST_ADD_ITEM = "HassListAddItem"
 INTENT_LIST_COMPLETE_ITEM = "HassListCompleteItem"
+INTENT_LIST_REMOVE_ITEM = "HassListRemoveItem"
 
 
 async def async_setup_intents(hass: HomeAssistant) -> None:
-    """Set up the todo intents."""
-    intent.async_register(hass, ListAddItemIntent())
-    intent.async_register(hass, ListCompleteItemIntent())
+    """Set up the todo intent handlers."""
+    intent.async_register(hass, ListAddItemIntentHandler())
+    intent.async_register(hass, ListCompleteItemIntentHandler())
+    intent.async_register(hass, ListRemoveItemIntentHandler())
 
 
-class ListAddItemIntent(intent.IntentHandler):
-    """Handle ListAddItem intents."""
+class ListBaseIntentHandler(intent.IntentHandler):
+    """Base class for toto intent handlers."""
 
-    intent_type = INTENT_LIST_ADD_ITEM
-    description = "Add item to a todo list"
     slot_schema = {
         vol.Required("item"): intent.non_empty_string,
         vol.Required("name"): intent.non_empty_string,
     }
     platforms = {DOMAIN}
+
+    async def _async_do_handle(self, target_list: TodoListEntity, item: str) -> None:
+        """Execute action specific to this intent handler."""
+        raise NotImplementedError
 
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
@@ -59,62 +63,46 @@ class ListAddItemIntent(intent.IntentHandler):
                 f"No to-do list: {list_name}", "list_not_found"
             )
 
-        # Add to list
-        await target_list.async_create_todo_item(
-            TodoItem(summary=item, status=TodoItemStatus.NEEDS_ACTION)
-        )
+        # Execute specific action
+        await self._async_do_handle(target_list, item)
 
+        # Build intent response
         response: intent.IntentResponse = intent_obj.create_response()
         response.async_set_results(
             [
                 intent.IntentResponseTarget(
                     type=intent.IntentResponseTargetType.ENTITY,
                     name=list_name,
-                    id=match_result.states[0].entity_id,
+                    id=target_list.entity_id,
                 )
             ]
         )
         return response
 
 
-class ListCompleteItemIntent(intent.IntentHandler):
+class ListAddItemIntentHandler(ListBaseIntentHandler):
+    """Handle ListAddItem intents."""
+
+    intent_type = INTENT_LIST_ADD_ITEM
+    description = "Add item to a todo list"
+
+    async def _async_do_handle(self, target_list: TodoListEntity, item: str) -> None:
+        """Execute action specific to this intent handler."""
+
+        # Add to list
+        await target_list.async_create_todo_item(
+            TodoItem(summary=item, status=TodoItemStatus.NEEDS_ACTION)
+        )
+
+
+class ListCompleteItemIntentHandler(ListBaseIntentHandler):
     """Handle ListCompleteItem intents."""
 
     intent_type = INTENT_LIST_COMPLETE_ITEM
     description = "Complete item on a todo list"
-    slot_schema = {
-        vol.Required("item"): intent.non_empty_string,
-        vol.Required("name"): intent.non_empty_string,
-    }
-    platforms = {DOMAIN}
 
-    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
-        """Handle the intent."""
-        hass = intent_obj.hass
-
-        slots = self.async_validate_slots(intent_obj.slots)
-        item = slots["item"]["value"]
-        list_name = slots["name"]["value"]
-
-        target_list: TodoListEntity | None = None
-
-        # Find matching list
-        match_constraints = intent.MatchTargetsConstraints(
-            name=list_name, domains=[DOMAIN], assistant=intent_obj.assistant
-        )
-        match_result = intent.async_match_targets(hass, match_constraints)
-        if not match_result.is_match:
-            raise intent.MatchFailedError(
-                result=match_result, constraints=match_constraints
-            )
-
-        target_list = hass.data[DATA_COMPONENT].get_entity(
-            match_result.states[0].entity_id
-        )
-        if target_list is None:
-            raise intent.IntentHandleError(
-                f"No to-do list: {list_name}", "list_not_found"
-            )
+    async def _async_do_handle(self, target_list: TodoListEntity, item: str) -> None:
+        """Execute action specific to this intent handler."""
 
         # Find item in list
         matching_item = None
@@ -139,14 +127,26 @@ class ListCompleteItemIntent(intent.IntentHandler):
             )
         )
 
-        response: intent.IntentResponse = intent_obj.create_response()
-        response.async_set_results(
-            [
-                intent.IntentResponseTarget(
-                    type=intent.IntentResponseTargetType.ENTITY,
-                    name=list_name,
-                    id=match_result.states[0].entity_id,
-                )
-            ]
-        )
-        return response
+
+class ListRemoveItemIntentHandler(ListBaseIntentHandler):
+    """Handle LisRemoveItemIntent intents."""
+
+    intent_type = INTENT_LIST_REMOVE_ITEM
+    description = "Remove one or more items from a todo list"
+
+    async def _async_do_handle(self, target_list: TodoListEntity, item: str) -> None:
+        """Execute action specific to this intent handler."""
+
+        # Find items in list
+        matching_item_uids = [
+            todo_item.uid
+            for todo_item in target_list.todo_items or ()
+            if item in (todo_item.uid, todo_item.summary) and todo_item.uid is not None
+        ]
+        if not matching_item_uids:
+            raise intent.IntentHandleError(
+                f"Item '{item}' not found on list", "item_not_found"
+            )
+
+        # Remove items
+        await target_list.async_delete_todo_items(matching_item_uids)

--- a/homeassistant/components/todo/intent.py
+++ b/homeassistant/components/todo/intent.py
@@ -137,16 +137,16 @@ class ListRemoveItemIntentHandler(ListBaseIntentHandler):
     async def _async_do_handle(self, target_list: TodoListEntity, item: str) -> None:
         """Execute action specific to this intent handler."""
 
-        # Find items in list
-        matching_item_uids = [
-            todo_item.uid
-            for todo_item in target_list.todo_items or ()
-            if item in (todo_item.uid, todo_item.summary) and todo_item.uid is not None
-        ]
-        if not matching_item_uids:
+        # Find item in list
+        matching_item = None
+        for todo_item in target_list.todo_items or ():
+            if item in (todo_item.uid, todo_item.summary):
+                matching_item = todo_item
+                break
+        if not matching_item or not matching_item.uid:
             raise intent.IntentHandleError(
                 f"Item '{item}' not found on list", "item_not_found"
             )
 
         # Remove items
-        await target_list.async_delete_todo_items(matching_item_uids)
+        await target_list.async_delete_todo_items(uids=[matching_item.uid])

--- a/tests/components/conversation/test_default_agent_intents.py
+++ b/tests/components/conversation/test_default_agent_intents.py
@@ -439,7 +439,7 @@ async def test_todo_add_item_fr(
     with (
         patch.object(hass.config, "language", "fr"),
         patch(
-            "homeassistant.components.todo.intent.ListAddItemIntent.async_handle",
+            "homeassistant.components.todo.intent.ListAddItemIntentHandler.async_handle",
             return_value=intent.IntentResponse(hass.config.language),
         ) as mock_handle,
     ):

--- a/tests/components/todo/test_intent.py
+++ b/tests/components/todo/test_intent.py
@@ -290,3 +290,78 @@ async def test_complete_item_intent_ha_errors(
             {ATTR_ITEM: {"value": "wine"}, ATTR_NAME: {"value": "List 1"}},
             assistant=conversation.DOMAIN,
         )
+
+
+async def test_remove_item_intent(
+    hass: HomeAssistant,
+) -> None:
+    """Test the remove item intent."""
+    entity1 = MockTodoListEntity(
+        [
+            TodoItem(summary="beer", uid="1", status=TodoItemStatus.NEEDS_ACTION),
+            TodoItem(summary="wine", uid="2", status=TodoItemStatus.NEEDS_ACTION),
+            TodoItem(summary="beer", uid="3", status=TodoItemStatus.COMPLETED),
+        ]
+    )
+    entity1._attr_name = "List 1"
+    entity1.entity_id = "todo.list_1"
+
+    # Add entities to hass
+    config_entry = await create_mock_platform(hass, [entity1])
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert len(entity1.items) == 3
+
+    # Remove item
+    async_mock_service(hass, DOMAIN, todo_intent.INTENT_LIST_REMOVE_ITEM)
+    response = await intent.async_handle(
+        hass,
+        DOMAIN,
+        todo_intent.INTENT_LIST_REMOVE_ITEM,
+        {ATTR_ITEM: {"value": "beer"}, ATTR_NAME: {"value": "list 1"}},
+        assistant=conversation.DOMAIN,
+    )
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+
+    assert len(entity1.items) == 1
+    assert entity1.items[0].uid == "2"
+
+
+async def test_remove_item_intent_errors(
+    hass: HomeAssistant,
+    test_entity: TodoListEntity,
+) -> None:
+    """Test errors with the remove item intent."""
+    entity1 = MockTodoListEntity(
+        [
+            TodoItem(summary="beer", uid="1", status=TodoItemStatus.COMPLETED),
+        ]
+    )
+    entity1._attr_name = "List 1"
+    entity1.entity_id = "todo.list_1"
+
+    # Add entities to hass
+    await create_mock_platform(hass, [entity1])
+
+    # Try to remove item in list that does not exist
+    with pytest.raises(intent.MatchFailedError):
+        await intent.async_handle(
+            hass,
+            "test",
+            todo_intent.INTENT_LIST_REMOVE_ITEM,
+            {
+                ATTR_ITEM: {"value": "wine"},
+                ATTR_NAME: {"value": "This list does not exist"},
+            },
+            assistant=conversation.DOMAIN,
+        )
+
+    # Try to remove item that does not exist
+    with pytest.raises(intent.IntentHandleError):
+        await intent.async_handle(
+            hass,
+            "test",
+            todo_intent.INTENT_LIST_REMOVE_ITEM,
+            {ATTR_ITEM: {"value": "bread"}, ATTR_NAME: {"value": "list 1"}},
+            assistant=conversation.DOMAIN,
+        )

--- a/tests/components/todo/test_intent.py
+++ b/tests/components/todo/test_intent.py
@@ -323,8 +323,10 @@ async def test_remove_item_intent(
     )
     assert response.response_type == intent.IntentResponseType.ACTION_DONE
 
-    assert len(entity1.items) == 1
+    # only the first matching item has been removed
+    assert len(entity1.items) == 2
     assert entity1.items[0].uid == "2"
+    assert entity1.items[1].uid == "3"
 
 
 async def test_remove_item_intent_errors(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add `HassListRemoveItem` intent to be able to remove items from a todo list from Assist.

This has been tested locally by adding a custom_sentences

```yaml
language: fr
intents:
  HassListRemoveItem:
    data:
      - sentences:
          - <supprime> <item> <dans> [la liste <de>] {name}
        response: item_deleted
        requires_context:
          domain: todo
        expansion_rules:
          item: "{shopping_list_item:item}"
responses:
  intents:
    HassListRemoveItem:
      item_deleted: "{{ slots.item }} supprimé"
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Contrary to `HassListCompleteItem`, this intent will attempt to remove ALL matching items, this can be changed if needed. I was thinking about searching in "NEEDS_ACTION" items first, and then in "COMPLETED" items if none found... But it is simpler to just remove everything.

I will be able to submit new intents to "OHF-Voice/intents" for English and French (wip for "complete" here https://github.com/OHF-Voice/intents/pull/3488)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] [**no generated code**] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
