### PR TITLE
Portainer add ability to skip SSL verification

### DIFF
--- a/homeassistant/components/portainer/__init__.py
+++ b/homeassistant/components/portainer/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pyportainer import Portainer
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, CONF_HOST, Platform
+from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
@@ -19,11 +19,12 @@ type PortainerConfigEntry = ConfigEntry[PortainerCoordinator]
 async def async_setup_entry(hass: HomeAssistant, entry: PortainerConfigEntry) -> bool:
     """Set up Portainer from a config entry."""
 
-    session = async_create_clientsession(hass)
     client = Portainer(
         api_url=entry.data[CONF_HOST],
         api_key=entry.data[CONF_API_KEY],
-        session=session,
+        session=async_create_clientsession(
+            hass=hass, verify_ssl=entry.data[CONF_VERIFY_SSL]
+        ),
     )
 
     coordinator = PortainerCoordinator(hass, entry, client)

--- a/homeassistant/components/portainer/config_flow.py
+++ b/homeassistant/components/portainer/config_flow.py
@@ -26,7 +26,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_API_KEY): str,
-        vol.Optional(CONF_VERIFY_SSL, default=False): bool,
+        vol.Optional(CONF_VERIFY_SSL, default=True): bool,
     }
 )
 

--- a/homeassistant/components/portainer/config_flow.py
+++ b/homeassistant/components/portainer/config_flow.py
@@ -14,7 +14,7 @@ from pyportainer import (
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_API_KEY, CONF_HOST
+from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -26,6 +26,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_API_KEY): str,
+        vol.Optional(CONF_VERIFY_SSL, default=False): bool,
     }
 )
 
@@ -36,7 +37,7 @@ async def _validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
     client = Portainer(
         api_url=data[CONF_HOST],
         api_key=data[CONF_API_KEY],
-        session=async_get_clientsession(hass),
+        session=async_get_clientsession(hass=hass, verify_ssl=data[CONF_VERIFY_SSL]),
     )
     try:
         await client.get_endpoints()

--- a/homeassistant/components/portainer/strings.json
+++ b/homeassistant/components/portainer/strings.json
@@ -4,11 +4,13 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "api_key": "[%key:common::config_flow::data::api_key%]"
+          "api_key": "[%key:common::config_flow::data::api_key%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
           "host": "The host/URL, including the port, of your Portainer instance",
-          "api_key": "The API key for authenticating with Portainer"
+          "api_key": "The API key for authenticating with Portainer",
+          "verify_ssl": "Whether to verify SSL certificates. Disable only if you have a self-signed certificate"
         },
         "description": "You can create an API key in the Portainer UI. Go to **My account > API keys** and select **Add API key**"
       }

--- a/tests/components/portainer/conftest.py
+++ b/tests/components/portainer/conftest.py
@@ -8,13 +8,14 @@ from pyportainer.models.portainer import Endpoint
 import pytest
 
 from homeassistant.components.portainer.const import DOMAIN
-from homeassistant.const import CONF_API_KEY, CONF_HOST
+from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_VERIFY_SSL
 
 from tests.common import MockConfigEntry, load_json_array_fixture
 
 MOCK_TEST_CONFIG = {
     CONF_HOST: "https://127.0.0.1:9000/",
     CONF_API_KEY: "test_api_key",
+    CONF_VERIFY_SSL: False,
 }
 
 

--- a/tests/components/portainer/conftest.py
+++ b/tests/components/portainer/conftest.py
@@ -15,7 +15,7 @@ from tests.common import MockConfigEntry, load_json_array_fixture
 MOCK_TEST_CONFIG = {
     CONF_HOST: "https://127.0.0.1:9000/",
     CONF_API_KEY: "test_api_key",
-    CONF_VERIFY_SSL: False,
+    CONF_VERIFY_SSL: True,
 }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the ability to verify or skip SSL certificate. Ideal for users who use self-signed certificates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #152949 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
