### PR TITLE
Revert "Fix logical error when user has no Roborock maps"

### DIFF
--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -351,9 +351,13 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
     def _set_current_map(self) -> None:
         if (
             self.roborock_device_info.props.status is not None
-            and self.roborock_device_info.props.status.current_map is not None
+            and self.roborock_device_info.props.status.map_status is not None
         ):
-            self.current_map = self.roborock_device_info.props.status.current_map
+            # The map status represents the map flag as flag * 4 + 3 -
+            # so we have to invert that in order to get the map flag that we can use to set the current map.
+            self.current_map = (
+                self.roborock_device_info.props.status.map_status - 3
+            ) // 4
 
     async def set_current_map_rooms(self) -> None:
         """Fetch all of the rooms for the current map and set on RoborockMapInfo."""
@@ -436,7 +440,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
             # If either of these fail, we don't care, and we want to continue.
             await asyncio.gather(*tasks, return_exceptions=True)
 
-        if len(self.maps) > 1:
+        if len(self.maps) != 1:
             # Set the map back to the map the user previously had selected so that it
             # does not change the end user's app.
             # Only needs to happen when we changed maps above.

--- a/tests/components/roborock/test_coordinator.py
+++ b/tests/components/roborock/test_coordinator.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
-from roborock import MultiMapsList
 from roborock.exceptions import RoborockException
 from vacuum_map_parser_base.config.color import SupportedColor
 
@@ -136,30 +135,3 @@ async def test_dynamic_local_scan_interval(
         async_fire_time_changed(hass, dt_util.utcnow() + interval)
 
     assert hass.states.get("sensor.roborock_s7_maxv_battery").state == "20"
-
-
-async def test_no_maps(
-    hass: HomeAssistant,
-    mock_roborock_entry: MockConfigEntry,
-    bypass_api_fixture: None,
-) -> None:
-    """Test that a device with no maps is handled correctly."""
-    prop = copy.deepcopy(PROP)
-    prop.status.map_status = 252
-    with (
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_prop",
-            return_value=prop,
-        ),
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockMqttClientV1.get_multi_maps_list",
-            return_value=MultiMapsList(
-                max_multi_map=1, max_bak_map=1, multi_map_count=0, map_info=[]
-            ),
-        ),
-        patch(
-            "homeassistant.components.roborock.RoborockMqttClientV1.load_multi_map"
-        ) as load_map,
-    ):
-        await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
-    assert load_map.call_count == 0


### PR DESCRIPTION
Reverts home-assistant/core#152752

The test added by the PR fails, probably because it conflicts with the changes introduced by https://github.com/home-assistant/core/pull/152698