### PR TITLE
Ignore discovery for existing ZHA entries

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -23,6 +23,7 @@ from homeassistant.components.homeassistant_hardware import silabs_multiprotocol
 from homeassistant.components.homeassistant_yellow import hardware as yellow_hardware
 from homeassistant.config_entries import (
     SOURCE_IGNORE,
+    SOURCE_ZEROCONF,
     ConfigEntry,
     ConfigEntryBaseFlow,
     ConfigEntryState,
@@ -183,27 +184,17 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
         self._hass = hass
         self._radio_mgr.hass = hass
 
-    async def _get_config_entry_data(self) -> dict:
+    def _get_config_entry_data(self) -> dict[str, Any]:
         """Extract ZHA config entry data from the radio manager."""
         assert self._radio_mgr.radio_type is not None
         assert self._radio_mgr.device_path is not None
         assert self._radio_mgr.device_settings is not None
 
-        try:
-            device_path = await self.hass.async_add_executor_job(
-                usb.get_serial_by_id, self._radio_mgr.device_path
-            )
-        except OSError as error:
-            raise AbortFlow(
-                reason="cannot_resolve_path",
-                description_placeholders={"path": self._radio_mgr.device_path},
-            ) from error
-
         return {
             CONF_DEVICE: DEVICE_SCHEMA(
                 {
                     **self._radio_mgr.device_settings,
-                    CONF_DEVICE_PATH: device_path,
+                    CONF_DEVICE_PATH: self._radio_mgr.device_path,
                 }
             ),
             CONF_RADIO_TYPE: self._radio_mgr.radio_type.name,
@@ -705,15 +696,32 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
 
         if self._radio_mgr.device_path is not None:
             # Ensure the radio manager device path is unique and will match ZHA's
-            self._radio_mgr.device_path = await self.hass.async_add_executor_job(
-                usb.get_serial_by_id, self._radio_mgr.device_path
-            )
+            try:
+                self._radio_mgr.device_path = await self.hass.async_add_executor_job(
+                    usb.get_serial_by_id, self._radio_mgr.device_path
+                )
+            except OSError as error:
+                raise AbortFlow(
+                    reason="cannot_resolve_path",
+                    description_placeholders={"path": self._radio_mgr.device_path},
+                ) from error
+
+            # mDNS discovery can advertise the same adapter on multiple IPs or via a
+            # hostname, which should be considered a duplicate
+            current_device_paths = {self._radio_mgr.device_path}
+
+            if self.source == SOURCE_ZEROCONF:
+                discovery_info = self.init_data
+                current_device_paths |= {
+                    f"socket://{ip}:{discovery_info.port}"
+                    for ip in discovery_info.ip_addresses
+                }
 
             for entry in zha_config_entries:
-                if (
-                    entry.data.get(CONF_DEVICE, {}).get(CONF_DEVICE_PATH)
-                    == self._radio_mgr.device_path
-                ):
+                path = entry.data.get(CONF_DEVICE, {}).get(CONF_DEVICE_PATH)
+
+                # Abort discovery if the device path is already configured
+                if path is not None and path in current_device_paths:
                     return self.async_abort(reason="single_instance_allowed")
 
         # Without confirmation, discovery can automatically progress into parts of the
@@ -886,7 +894,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
         zha_config_entries = self.hass.config_entries.async_entries(
             DOMAIN, include_ignore=False
         )
-        data = await self._get_config_entry_data()
+        data = self._get_config_entry_data()
 
         if len(zha_config_entries) == 1:
             return self.async_update_reload_and_abort(
@@ -989,7 +997,7 @@ class ZhaOptionsFlowHandler(BaseZhaFlow, OptionsFlow):
         # Avoid creating both `.options` and `.data` by directly writing `data` here
         self.hass.config_entries.async_update_entry(
             entry=self.config_entry,
-            data=await self._get_config_entry_data(),
+            data=self._get_config_entry_data(),
             options=self.config_entry.options,
         )
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -703,6 +703,19 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
             DOMAIN, include_ignore=False
         )
 
+        if self._radio_mgr.device_path is not None:
+            # Ensure the radio manager device path is unique and will match ZHA's
+            self._radio_mgr.device_path = await self.hass.async_add_executor_job(
+                usb.get_serial_by_id, self._radio_mgr.device_path
+            )
+
+            for entry in zha_config_entries:
+                if (
+                    entry.data.get(CONF_DEVICE, {}).get(CONF_DEVICE_PATH)
+                    == self._radio_mgr.device_path
+                ):
+                    return self.async_abort(reason="single_instance_allowed")
+
         # Without confirmation, discovery can automatically progress into parts of the
         # config flow logic that interacts with hardware.
         if user_input is not None or (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
ZHA has removed the single instance check for discovery and thus exposed an issue where we do not set a usable `unique_id` for the integration that can be matched up to USB discovery entries. To avoid this issue, we scan existing ZHA config entries and abort discovery if it is for an existing device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #152953
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
