### PR TITLE
Allow to callback for MQTT subscription status

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -40,6 +40,7 @@ from homeassistant.util.async_ import create_eager_task
 from . import debug_info, discovery
 from .client import (
     MQTT,
+    async_await_subscription,
     async_publish,
     async_subscribe,
     async_subscribe_internal,
@@ -159,6 +160,7 @@ __all__ = [
     "PublishPayloadType",
     "ReceiveMessage",
     "SetupPhases",
+    "async_await_subscription",
     "async_check_config_schema",
     "async_create_certificate_temp_files",
     "async_forward_entry_setup_and_setup_discovery",

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -40,7 +40,7 @@ from homeassistant.util.async_ import create_eager_task
 from . import debug_info, discovery
 from .client import (
     MQTT,
-    async_await_subscription,
+    async_on_subscribe_done,
     async_publish,
     async_subscribe,
     async_subscribe_internal,
@@ -160,11 +160,11 @@ __all__ = [
     "PublishPayloadType",
     "ReceiveMessage",
     "SetupPhases",
-    "async_await_subscription",
     "async_check_config_schema",
     "async_create_certificate_temp_files",
     "async_forward_entry_setup_and_setup_discovery",
     "async_migrate_entry",
+    "async_on_subscribe_done",
     "async_prepare_subscribe_topics",
     "async_publish",
     "async_remove_config_entry_device",

--- a/homeassistant/components/mqtt/const.py
+++ b/homeassistant/components/mqtt/const.py
@@ -373,6 +373,7 @@ DOMAIN = "mqtt"
 LOGGER = logging.getLogger(__package__)
 
 MQTT_CONNECTION_STATE = "mqtt_connection_state"
+MQTT_PROCESSED_SUBSCRIPTIONS = "mqtt_processed_subscriptions"
 
 PAYLOAD_EMPTY_JSON = "{}"
 PAYLOAD_NONE = "None"

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -1456,6 +1456,12 @@
     "mqtt_not_setup_cannot_subscribe": {
       "message": "Cannot subscribe to topic \"{topic}\", make sure MQTT is set up correctly."
     },
+    "mqtt_not_setup_cannot_wait_for_subscribe": {
+      "message": "Cannot wait for subscription to topic \"{topic}\" and QoS {qos}, make sure MQTT is set up correctly."
+    },
+    "mqtt_not_setup_cannot_find_subscription": {
+      "message": "Cannot find subscription to topic \"{topic}\" and QoS {qos}, make sure the subscription is successful."
+    },
     "mqtt_not_setup_cannot_publish": {
       "message": "Cannot publish to topic \"{topic}\", make sure MQTT is set up correctly."
     },

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -1456,12 +1456,6 @@
     "mqtt_not_setup_cannot_subscribe": {
       "message": "Cannot subscribe to topic \"{topic}\", make sure MQTT is set up correctly."
     },
-    "mqtt_not_setup_cannot_wait_for_subscribe": {
-      "message": "Cannot wait for subscription to topic \"{topic}\" and QoS {qos}, make sure MQTT is set up correctly."
-    },
-    "mqtt_not_setup_cannot_find_subscription": {
-      "message": "Cannot find subscription to topic \"{topic}\" and QoS {qos}, make sure the subscription is successful."
-    },
     "mqtt_not_setup_cannot_publish": {
       "message": "Cannot publish to topic \"{topic}\", make sure MQTT is set up correctly."
     },

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -282,6 +282,143 @@ async def test_subscribe_topic(
         unsub()
 
 
+async def test_await_subscription(
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    recorded_calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
+) -> None:
+    """Test the subscription of a topic."""
+    mock_mqtt = await mqtt_mock_entry()
+    # Fail when no subscription is queued
+    with pytest.raises(HomeAssistantError) as exc:
+        await mqtt.async_await_subscription(hass, "test-topic")
+    assert exc.value.args[0] == (
+        "Cannot find subscription to topic 'test-topic' "
+        "and QoS 0, make sure the subscription is successful"
+    )
+    assert exc.value.translation_key == "mqtt_not_setup_cannot_find_subscription"
+    assert exc.value.translation_placeholders == {"topic": "test-topic", "qos": "0"}
+
+    # Test awaiting pending subscription
+    with (
+        patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.5),
+        patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.5),
+    ):
+        unsub_no_wait = await mqtt.async_subscribe(hass, "test-topic", record_calls)
+        # assert ("test-topic", 0) not in help_all_subscribe_calls(mqtt_client_mock)
+        await mqtt.async_await_subscription(hass, "test-topic")
+        assert ("test-topic", 0) in help_all_subscribe_calls(mqtt_client_mock)
+
+    async_fire_mqtt_message(hass, "test-topic", "test-payload")
+
+    await hass.async_block_till_done()
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "test-topic"
+    assert recorded_calls[0].payload == "test-payload"
+    recorded_calls.clear()
+
+    unsub_no_wait()
+    await hass.async_block_till_done()
+
+    # Test existing subscription, should return immediately
+    unsub = await mqtt.async_subscribe(hass, "test-topic", record_calls, wait=True)
+    await mqtt.async_await_subscription(hass, "test-topic")
+
+    async_fire_mqtt_message(hass, "test-topic", "test-payload")
+
+    await hass.async_block_till_done()
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "test-topic"
+    assert recorded_calls[0].payload == "test-payload"
+
+    assert mock_mqtt.is_active_subscription("test-topic")
+
+    unsub()
+    assert not mock_mqtt.is_active_subscription("test-topic")
+
+    recorded_calls.clear()
+
+
+async def test_subscribe_topic_and_wait(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    recorded_calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
+) -> None:
+    """Test the subscription of a topic."""
+    await mqtt_mock_entry()
+    unsub_no_wait = await mqtt.async_subscribe(hass, "other-test-topic/#", record_calls)
+    unsub_wait = await mqtt.async_subscribe(hass, "test-topic", record_calls, wait=True)
+
+    async_fire_mqtt_message(hass, "test-topic", "test-payload")
+    async_fire_mqtt_message(hass, "other-test-topic/test", "other-test-payload")
+
+    await hass.async_block_till_done()
+    assert len(recorded_calls) == 2
+    assert recorded_calls[0].topic == "test-topic"
+    assert recorded_calls[0].payload == "test-payload"
+    assert recorded_calls[1].topic == "other-test-topic/test"
+    assert recorded_calls[1].payload == "other-test-payload"
+
+    unsub_no_wait()
+    unsub_wait()
+
+    async_fire_mqtt_message(hass, "test-topic", "test-payload")
+
+    await hass.async_block_till_done()
+    assert len(recorded_calls) == 2
+
+    # Cannot unsubscribe twice
+    with pytest.raises(HomeAssistantError):
+        unsub_no_wait()
+
+    with pytest.raises(HomeAssistantError):
+        unsub_wait()
+
+
+async def test_subscribe_topic_and_wait_timeout(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    recorded_calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
+) -> None:
+    """Test the subscription of a topic."""
+    await mqtt_mock_entry()
+    with (
+        patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.5),
+        patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.5),
+        patch("homeassistant.components.mqtt.client.SUBSCRIBE_TIMEOUT", 0),
+        pytest.raises(HomeAssistantError) as exc,
+    ):
+        await mqtt.async_subscribe(hass, "test-topic", record_calls, wait=True)
+
+    assert exc.value.translation_domain == mqtt.DOMAIN
+    assert exc.value.translation_key == "subscribe_timeout"
+
+
+async def test_await_subscription_and_wait_timeout(
+    hass: HomeAssistant,
+    mock_debouncer: asyncio.Event,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    record_calls: MessageCallbackType,
+) -> None:
+    """Test the subscription of a topic."""
+    await mqtt_mock_entry()
+    await mqtt.async_subscribe(hass, "test-topic", record_calls)
+    with (
+        patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.5),
+        patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.5),
+        patch("homeassistant.components.mqtt.client.SUBSCRIBE_TIMEOUT", 0.0),
+        pytest.raises(HomeAssistantError) as exc,
+    ):
+        await mqtt.async_await_subscription(hass, "test-topic", 0)
+
+    assert exc.value.translation_domain == mqtt.DOMAIN
+    assert exc.value.translation_key == "subscribe_timeout"
+
+
 @pytest.mark.usefixtures("mqtt_mock_entry")
 async def test_subscribe_topic_not_initialize(
     hass: HomeAssistant, record_calls: MessageCallbackType
@@ -291,6 +428,15 @@ async def test_subscribe_topic_not_initialize(
         HomeAssistantError, match=r".*make sure MQTT is set up correctly"
     ):
         await mqtt.async_subscribe(hass, "test-topic", record_calls)
+
+
+@pytest.mark.usefixtures("mqtt_mock_entry")
+async def test_await_subscription_not_initialize(hass: HomeAssistant) -> None:
+    """Test the subscription of a topic when MQTT was not initialized."""
+    with pytest.raises(
+        HomeAssistantError, match=r".*make sure MQTT is set up correctly"
+    ):
+        await mqtt.async_await_subscription(hass, "test-topic")
 
 
 async def test_subscribe_mqtt_config_entry_disabled(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Integrations that want to be able to poll the state via MQTT when the integration starts, like Tasmota, need to be sure an MQTT subscription has been processed, before it can publish a ready state.

This PR allows allows to set a callback function when calling `async_subscribe` that is called when the subscription is done at the broker.

A second helper `async_on_subscribe_done` will allow to monitor subscriptions via a callback function. This helper will keep listening till the return callback handler is called.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2807
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
