### PR TITLE
Fix bug where Roborock loading map in cleaning causes a crash

### DIFF
--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -458,7 +458,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
             # If either of these fail, we don't care, and we want to continue.
             await asyncio.gather(*tasks, return_exceptions=True)
 
-        if len(self.maps) > 1:
+        if len(self.maps) > 1 and not self.data.status.in_cleaning:
             # Set the map back to the map the user previously had selected so that it
             # does not change the end user's app.
             # Only needs to happen when we changed maps above.

--- a/tests/components/roborock/test_coordinator.py
+++ b/tests/components/roborock/test_coordinator.py
@@ -1,5 +1,6 @@
 """Test Roborock Coordinator specific logic."""
 
+import asyncio
 import copy
 from datetime import timedelta
 from unittest.mock import patch
@@ -11,13 +12,15 @@ from vacuum_map_parser_base.config.color import SupportedColor
 
 from homeassistant.components.roborock.const import (
     CONF_SHOW_BACKGROUND,
+    DOMAIN,
+    GET_MAPS_SERVICE_NAME,
     V1_CLOUD_IN_CLEANING_INTERVAL,
     V1_CLOUD_NOT_CLEANING_INTERVAL,
     V1_LOCAL_IN_CLEANING_INTERVAL,
     V1_LOCAL_NOT_CLEANING_INTERVAL,
 )
 from homeassistant.components.roborock.coordinator import RoborockDataUpdateCoordinator
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
@@ -29,7 +32,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 @pytest.fixture
 def platforms() -> list[Platform]:
     """Fixture to set platforms used in the test."""
-    return [Platform.SENSOR]
+    return [Platform.SENSOR, Platform.VACUUM]
 
 
 @pytest.mark.parametrize(
@@ -163,3 +166,112 @@ async def test_no_maps(
     ):
         await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
     assert load_map.call_count == 0
+
+
+async def test_two_maps_in_cleaning(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    bypass_api_fixture: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that we gracefully handle having two maps but we are in cleaning."""
+    prop = copy.deepcopy(PROP)
+    prop.status.in_cleaning = True
+    with (
+        patch(
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_prop",
+            return_value=prop,
+        ),
+        patch(
+            "homeassistant.components.roborock.RoborockMqttClientV1.load_multi_map"
+        ) as load_map,
+    ):
+        await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    # We should not try to load any maps as we should just get the information for our
+    # current map and move on.
+    assert load_map.call_count == 0
+    assert (
+        "Vacuum is cleaning, not switching to other maps to fetch rooms" in caplog.text
+    )
+
+
+async def test_failed_load_multi_map(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    bypass_api_fixture: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that we gracefully handle one map failing to load."""
+    with (
+        patch(
+            "homeassistant.components.roborock.RoborockMqttClientV1.load_multi_map",
+            side_effect=[RoborockException(), None, None, None],
+        ) as load_map,
+    ):
+        await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    assert "Failed to change to map 1 when refreshing maps" in caplog.text
+    # We continue to try and load the next map so we we should have multiple load maps.
+    # 2 for both devices, even though one for one of the devices failed.
+    assert load_map.call_count == 4
+    # Just to be safe since we load the maps asynchronously, lets make sure that only
+    # one map out of the four didn't get called.
+    responses = await asyncio.gather(
+        *(
+            hass.services.async_call(
+                DOMAIN,
+                GET_MAPS_SERVICE_NAME,
+                {ATTR_ENTITY_ID: dev},
+                blocking=True,
+                return_response=True,
+            )
+            for dev in ("vacuum.roborock_s7_maxv", "vacuum.roborock_s7_2")
+        )
+    )
+    num_no_rooms = sum(
+        1
+        for res in responses
+        for data in res.values()
+        for m in data["maps"]
+        if not m["rooms"]
+    )
+    assert num_no_rooms == 1
+
+
+async def test_failed_reset_map(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    bypass_api_fixture: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that we gracefully handle not being able to revert back to the original map."""
+    with (
+        patch(
+            "homeassistant.components.roborock.RoborockMqttClientV1.load_multi_map",
+            side_effect=[None, None, None, RoborockException()],
+        ) as load_map,
+    ):
+        await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    assert "Failed to change back to map 0 when refreshing maps" in caplog.text
+    # 2 for both devices, even though one for one of the devices failed.
+    assert load_map.call_count == 4
+    responses = await asyncio.gather(
+        *(
+            hass.services.async_call(
+                DOMAIN,
+                GET_MAPS_SERVICE_NAME,
+                {ATTR_ENTITY_ID: dev},
+                blocking=True,
+                return_response=True,
+            )
+            for dev in ("vacuum.roborock_s7_maxv", "vacuum.roborock_s7_2")
+        )
+    )
+    num_no_rooms = sum(
+        1
+        for res in responses
+        for data in res.values()
+        for m in data["maps"]
+        if not m["rooms"]
+    )
+    # No maps should be missing information, as we just couldn't go back to the original.
+    assert num_no_rooms == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While talking to @rccoleman about the new vacuum protocol in the beta, He made me aware of a bug where the act of loading a map while the vacuum was in cleaning would cause the integration to crash.

This PR does a few things:
1) If the vacuum is in cleaning, we updated the map we can and then return, we don't try to swap maps. This is not ideal, but when the user changes to a different map, it will automatically update the info we don't have. I did not want to do an automatic retry in some amount of time as we are currently dealing with issues with the cloud api leading to rate limiting. I do not want to put unneeded stress on it, especially as it can be in_cleaning for hours. i.e. my vac runs at night and pauses to charge in the middle. That is still in cleaning.
2) We had error catching on the other important steps in this function, but now if we fail to load the map, we catch the error and handle it appropriately.


This would be best to be in beta if possible.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #153359 fixes #153716
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
