### PR TITLE
Replace patch of entity_registry in test_config_flow for Squeezebox

### DIFF
--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -314,11 +314,15 @@ async def test_form_validate_exception(hass: HomeAssistant) -> None:
 
 
 async def test_form_cannot_connect(hass: HomeAssistant) -> None:
-    """Test we handle cannot connect error."""
+    """Test we handle cannot connect error, then succeed after retry."""
+
+    # Start the flow
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "edit"}
     )
+    assert result["type"] is FlowResultType.FORM
 
+    # First attempt: simulate cannot connect
     with patch(
         "pysqueezebox.Server.async_query",
         return_value=False,
@@ -328,17 +332,47 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
             {
                 CONF_HOST: HOST,
                 CONF_PORT: PORT,
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
+                CONF_USERNAME: "",
+                CONF_PASSWORD: "",
             },
         )
 
+    # We should still be in a form, with an error
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
+    # Second attempt: simulate a successful connection
+    with patch(
+        "pysqueezebox.Server.async_query",
+        return_value={"uuid": UUID},
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
+                CONF_USERNAME: "",
+                CONF_PASSWORD: "",
+                CONF_HTTPS: False,
+            },
+        )
+
+        assert result2["type"] is FlowResultType.CREATE_ENTRY
+        assert result2["title"] == HOST  # the flow uses host as title
+        assert result2["data"] == {
+            CONF_HOST: HOST,
+            CONF_PORT: PORT,
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_HTTPS: False,
+        }
+        assert result2["context"]["unique_id"] == UUID
+
 
 async def test_discovery(hass: HomeAssistant) -> None:
-    """Test handling of discovered server."""
+    """Test handling of discovered server, then completing the flow."""
+
+    # Initial discovery: server responds with a uuid
     with patch(
         "pysqueezebox.Server.async_query",
         return_value={"uuid": UUID},
@@ -348,24 +382,109 @@ async def test_discovery(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
             data={CONF_HOST: HOST, CONF_PORT: PORT, "uuid": UUID},
         )
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "edit"
+
+    # Discovery puts us into the edit step
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "edit"
+
+    # Complete the edit step with user input
+    with patch(
+        "pysqueezebox.Server.async_query",
+        return_value={"uuid": UUID},
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
+                CONF_USERNAME: "",
+                CONF_PASSWORD: "",
+                CONF_HTTPS: False,
+            },
+        )
+
+    # Flow should now complete with a config entry
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == HOST
+    assert result2["data"] == {
+        CONF_HOST: HOST,
+        CONF_PORT: PORT,
+        CONF_USERNAME: "",
+        CONF_PASSWORD: "",
+        CONF_HTTPS: False,
+    }
+    assert result2["context"]["unique_id"] == UUID
 
 
 async def test_discovery_no_uuid(hass: HomeAssistant) -> None:
-    """Test handling of discovered server with unavailable uuid."""
-    with patch("pysqueezebox.Server.async_query", new=patch_async_query_unauthorized):
+    """Test discovery without uuid first fails, then succeeds when uuid is available."""
+
+    # Initial discovery: no uuid returned
+    with patch(
+        "pysqueezebox.Server.async_query",
+        new=patch_async_query_unauthorized,
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
             data={CONF_HOST: HOST, CONF_PORT: PORT, CONF_HTTPS: False},
         )
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "edit"
+
+    # Flow shows the edit form
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "edit"
+
+    # First attempt to complete: still no uuid → error on the form
+    with patch(
+        "pysqueezebox.Server.async_query",
+        new=patch_async_query_unauthorized,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
+                CONF_USERNAME: "",
+                CONF_PASSWORD: "",
+                CONF_HTTPS: False,
+            },
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+    # Second attempt: now the server responds with a uuid
+    with patch(
+        "pysqueezebox.Server.async_query",
+        return_value={"uuid": UUID},
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
+                CONF_USERNAME: "",
+                CONF_PASSWORD: "",
+                CONF_HTTPS: False,
+            },
+        )
+
+    # Flow should now complete successfully
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == HOST
+    assert result3["data"] == {
+        CONF_HOST: HOST,
+        CONF_PORT: PORT,
+        CONF_USERNAME: "",
+        CONF_PASSWORD: "",
+        CONF_HTTPS: False,
+    }
+    assert result3["context"]["unique_id"] == UUID
 
 
 async def test_dhcp_discovery(hass: HomeAssistant) -> None:
-    """Test we can process discovery from dhcp."""
+    """Test we can process discovery from dhcp and complete the flow."""
+
     with (
         patch(
             "pysqueezebox.Server.async_query",
@@ -380,17 +499,48 @@ async def test_dhcp_discovery(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
             data=DhcpServiceInfo(
-                ip="1.1.1.1",
+                ip=HOST,
                 macaddress="aabbccddeeff",
                 hostname="any",
             ),
         )
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "edit"
+
+    # DHCP discovery puts us into the edit step
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "edit"
+
+    # Complete the edit step with user input
+    with patch(
+        "pysqueezebox.Server.async_query",
+        return_value={"uuid": UUID},
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
+                CONF_USERNAME: "",
+                CONF_PASSWORD: "",
+                CONF_HTTPS: False,
+            },
+        )
+
+    # Flow should now complete with a config entry
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == HOST
+    assert result2["data"] == {
+        CONF_HOST: HOST,
+        CONF_PORT: PORT,
+        CONF_USERNAME: "",
+        CONF_PASSWORD: "",
+        CONF_HTTPS: False,
+    }
+    assert result2["context"]["unique_id"] == UUID
 
 
 async def test_dhcp_discovery_no_server_found(hass: HomeAssistant) -> None:
     """Test we can handle dhcp discovery when no server is found."""
+
     with (
         patch(
             "homeassistant.components.squeezebox.config_flow.async_discover",
@@ -402,13 +552,43 @@ async def test_dhcp_discovery_no_server_found(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
             data=DhcpServiceInfo(
-                ip="1.1.1.1",
+                ip=HOST,
                 macaddress="aabbccddeeff",
                 hostname="any",
             ),
         )
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "user"
+
+    # First step: user form with only host
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Provide just the host to move into edit step
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: HOST},
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "edit"
+
+    # Now try to complete the edit step with full schema
+    with patch(
+        "homeassistant.components.squeezebox.config_flow.async_discover",
+        mock_failed_discover,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
+                CONF_USERNAME: "",
+                CONF_PASSWORD: "",
+                CONF_HTTPS: False,
+            },
+        )
+
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["step_id"] == "edit"
+    assert result3["errors"] == {"base": "unknown"}
 
 
 async def test_dhcp_discovery_existing_player(hass: HomeAssistant) -> None:

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -346,7 +346,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         "pysqueezebox.Server.async_query",
         return_value={"uuid": UUID},
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_HOST: HOST,
@@ -357,16 +357,16 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
             },
         )
 
-        assert result2["type"] is FlowResultType.CREATE_ENTRY
-        assert result2["title"] == HOST  # the flow uses host as title
-        assert result2["data"] == {
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == HOST  # the flow uses host as title
+        assert result["data"] == {
             CONF_HOST: HOST,
             CONF_PORT: PORT,
             CONF_USERNAME: "",
             CONF_PASSWORD: "",
             CONF_HTTPS: False,
         }
-        assert result2["context"]["unique_id"] == UUID
+        assert result["context"]["unique_id"] == UUID
 
 
 async def test_discovery(hass: HomeAssistant) -> None:
@@ -439,7 +439,7 @@ async def test_discovery_no_uuid(hass: HomeAssistant) -> None:
         "pysqueezebox.Server.async_query",
         new=patch_async_query_unauthorized,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_HOST: HOST,
@@ -450,16 +450,16 @@ async def test_discovery_no_uuid(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "invalid_auth"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
 
     # Second attempt: now the server responds with a uuid
     with patch(
         "pysqueezebox.Server.async_query",
         return_value={"uuid": UUID},
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
             {
                 CONF_HOST: HOST,
                 CONF_PORT: PORT,
@@ -470,16 +470,16 @@ async def test_discovery_no_uuid(hass: HomeAssistant) -> None:
         )
 
     # Flow should now complete successfully
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == HOST
-    assert result3["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == HOST
+    assert result["data"] == {
         CONF_HOST: HOST,
         CONF_PORT: PORT,
         CONF_USERNAME: "",
         CONF_PASSWORD: "",
         CONF_HTTPS: False,
     }
-    assert result3["context"]["unique_id"] == UUID
+    assert result["context"]["unique_id"] == UUID
 
 
 async def test_dhcp_discovery(hass: HomeAssistant) -> None:
@@ -514,7 +514,7 @@ async def test_dhcp_discovery(hass: HomeAssistant) -> None:
         "pysqueezebox.Server.async_query",
         return_value={"uuid": UUID},
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_HOST: HOST,
@@ -526,16 +526,16 @@ async def test_dhcp_discovery(hass: HomeAssistant) -> None:
         )
 
     # Flow should now complete with a config entry
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == HOST
-    assert result2["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == HOST
+    assert result["data"] == {
         CONF_HOST: HOST,
         CONF_PORT: PORT,
         CONF_USERNAME: "",
         CONF_PASSWORD: "",
         CONF_HTTPS: False,
     }
-    assert result2["context"]["unique_id"] == UUID
+    assert result["context"]["unique_id"] == UUID
 
 
 async def test_dhcp_discovery_no_server_found(hass: HomeAssistant) -> None:
@@ -563,20 +563,20 @@ async def test_dhcp_discovery_no_server_found(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
     # Provide just the host to move into edit step
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_HOST: HOST},
     )
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "edit"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "edit"
 
     # Now try to complete the edit step with full schema
     with patch(
         "homeassistant.components.squeezebox.config_flow.async_discover",
         mock_failed_discover,
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
             {
                 CONF_HOST: HOST,
                 CONF_PORT: PORT,
@@ -586,9 +586,9 @@ async def test_dhcp_discovery_no_server_found(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["step_id"] == "edit"
-    assert result3["errors"] == {"base": "unknown"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "edit"
+    assert result["errors"] == {"base": "unknown"}
 
 
 async def test_dhcp_discovery_existing_player(hass: HomeAssistant) -> None:

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -15,6 +15,8 @@ from homeassistant.components.squeezebox.const import (
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry
@@ -591,19 +593,29 @@ async def test_dhcp_discovery_no_server_found(hass: HomeAssistant) -> None:
     assert result["errors"] == {"base": "unknown"}
 
 
-async def test_dhcp_discovery_existing_player(hass: HomeAssistant) -> None:
+async def test_dhcp_discovery_existing_player(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test that we properly ignore known players during dhcp discover."""
-    with patch(
-        "homeassistant.helpers.entity_registry.EntityRegistry.async_get_entity_id",
-        return_value="test_entity",
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_DHCP},
-            data=DhcpServiceInfo(
-                ip="1.1.1.1",
-                macaddress="aabbccddeeff",
-                hostname="any",
-            ),
-        )
-        assert result["type"] is FlowResultType.ABORT
+
+    # Register a squeezebox media_player entity with the same MAC unique_id
+    entity_registry.async_get_or_create(
+        domain="media_player",
+        platform=DOMAIN,
+        unique_id=format_mac("aabbccddeeff"),
+    )
+
+    # Now fire a DHCP discovery for the same MAC
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_DHCP},
+        data=DhcpServiceInfo(
+            ip="1.1.1.1",
+            macaddress="aabbccddeeff",
+            hostname="any",
+        ),
+    )
+
+    # Because the player is already known, the flow should abort
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION

## Proposed change
Currently in test_dhcp_discovery_existing_player in test_config_flow we patch entity_registry.  This PR instead adds an entity rather than patching.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
