### PR TITLE
Fix Thread flow abort on multiple flows

### DIFF
--- a/homeassistant/components/thread/config_flow.py
+++ b/homeassistant/components/thread/config_flow.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components import onboarding
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    DEFAULT_DISCOVERY_UNIQUE_ID,
+    ConfigFlow,
+    ConfigFlowResult,
+)
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
@@ -18,14 +22,18 @@ class ThreadConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_data: None) -> ConfigFlowResult:
         """Set up by import from async_setup."""
-        await self._async_handle_discovery_without_unique_id()
+        await self.async_set_unique_id(
+            DEFAULT_DISCOVERY_UNIQUE_ID, raise_on_progress=False
+        )
         return self.async_create_entry(title="Thread", data={})
 
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
     ) -> ConfigFlowResult:
         """Set up by import from async_setup."""
-        await self._async_handle_discovery_without_unique_id()
+        await self.async_set_unique_id(
+            DEFAULT_DISCOVERY_UNIQUE_ID, raise_on_progress=False
+        )
         return self.async_create_entry(title="Thread", data={})
 
     async def async_step_zeroconf(

--- a/homeassistant/components/thread/manifest.json
+++ b/homeassistant/components/thread/manifest.json
@@ -8,5 +8,6 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "requirements": ["python-otbr-api==2.7.0", "pyroute2==0.7.5"],
+  "single_config_entry": true,
   "zeroconf": ["_meshcop._udp.local."]
 }

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6807,7 +6807,8 @@
       "name": "Thread",
       "integration_type": "service",
       "config_flow": true,
-      "iot_class": "local_polling"
+      "iot_class": "local_polling",
+      "single_config_entry": true
     },
     "tibber": {
       "name": "Tibber",

--- a/tests/components/thread/test_config_flow.py
+++ b/tests/components/thread/test_config_flow.py
@@ -3,6 +3,8 @@
 from ipaddress import ip_address
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components import thread
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -56,14 +58,18 @@ async def test_import(hass: HomeAssistant) -> None:
     assert config_entry.unique_id is None
 
 
-async def test_import_then_zeroconf(hass: HomeAssistant) -> None:
-    """Test the import flow."""
+@pytest.mark.parametrize("source", ["import", "user"])
+async def test_single_instance_allowed_zeroconf(
+    hass: HomeAssistant,
+    source: str,
+) -> None:
+    """Test zeroconf single instance allowed abort reason."""
     with patch(
         "homeassistant.components.thread.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
-            thread.DOMAIN, context={"source": "import"}
+            thread.DOMAIN, context={"source": source}
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -152,8 +158,45 @@ async def test_zeroconf_setup_onboarding(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_then_import(hass: HomeAssistant) -> None:
-    """Test the import flow."""
+@pytest.mark.parametrize(
+    ("first_source", "second_source"), [("import", "user"), ("user", "import")]
+)
+async def test_import_and_user(
+    hass: HomeAssistant,
+    first_source: str,
+    second_source: str,
+) -> None:
+    """Test single instance allowed for user and import."""
+    with patch(
+        "homeassistant.components.thread.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            thread.DOMAIN, context={"source": first_source}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    with patch(
+        "homeassistant.components.thread.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            thread.DOMAIN, context={"source": second_source}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert len(mock_setup_entry.mock_calls) == 0
+
+
+@pytest.mark.parametrize("source", ["import", "user"])
+async def test_zeroconf_then_import_user(
+    hass: HomeAssistant,
+    source: str,
+) -> None:
+    """Test single instance allowed abort reason for import/user flow."""
     result = await hass.config_entries.flow.async_init(
         thread.DOMAIN, context={"source": "zeroconf"}, data=TEST_ZEROCONF_RECORD
     )
@@ -169,9 +212,37 @@ async def test_zeroconf_then_import(hass: HomeAssistant) -> None:
         return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
-            thread.DOMAIN, context={"source": "import"}
+            thread.DOMAIN, context={"source": source}
         )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert len(mock_setup_entry.mock_calls) == 0
+
+
+@pytest.mark.parametrize("source", ["import", "user"])
+async def test_zeroconf_in_progress_then_import_user(
+    hass: HomeAssistant,
+    source: str,
+) -> None:
+    """Test priority (import/user) flow with zeroconf flow in progress."""
+    result = await hass.config_entries.flow.async_init(
+        thread.DOMAIN, context={"source": "zeroconf"}, data=TEST_ZEROCONF_RECORD
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+
+    with patch(
+        "homeassistant.components.thread.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            thread.DOMAIN, context={"source": source}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert mock_setup_entry.call_count == 1
+
+    flows_in_progress = hass.config_entries.flow.async_progress()
+    assert len(flows_in_progress) == 0

--- a/tests/components/thread/test_config_flow.py
+++ b/tests/components/thread/test_config_flow.py
@@ -83,7 +83,7 @@ async def test_single_instance_allowed_zeroconf(
         )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"
     assert len(mock_setup_entry.mock_calls) == 0
 
 
@@ -187,7 +187,7 @@ async def test_import_and_user(
         )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"
     assert len(mock_setup_entry.mock_calls) == 0
 
 
@@ -216,7 +216,7 @@ async def test_zeroconf_then_import_user(
         )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"
     assert len(mock_setup_entry.mock_calls) == 0
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- If there's an existing Thread discovery flow the import or user flow  would abort. We always want import and user flows to take precedence over discovery flows.
- Set `single_config_entry` in manifest to make the single config entry feature clearer. We need to add a guard for that somehow since we can't use the unique id helper in the import and user flows anymore.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zigpy/backlog/issues/36
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
