### PR TITLE
Add derivative tests exhibiting unit issues

### DIFF
--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -1,14 +1,18 @@
 """Test the Derivative config flow."""
 
+from datetime import timedelta
 from unittest.mock import patch
 
+from freezegun import freeze_time
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.derivative.const import DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import selector
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, get_schema_suggested_value
 
@@ -154,3 +158,86 @@ async def test_options(
     await hass.async_block_till_done()
     state = hass.states.get(f"{platform}.my_derivative")
     assert state.attributes["unit_of_measurement"] == "cat/h"
+
+
+async def test_update_unit(hass: HomeAssistant) -> None:
+    """Test behavior of changing the unit_time option."""
+    # Setup the config entry
+    source_id = "sensor.source"
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My derivative",
+            "round": 1.0,
+            "source": source_id,
+            "unit_time": "min",
+            "time_window": {"seconds": 0.0},
+        },
+        title="My derivative",
+    )
+    derivative_id = "sensor.my_derivative"
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(derivative_id)
+    assert state.state == STATE_UNAVAILABLE
+    assert state.attributes.get("unit_of_measurement") is None
+
+    time = dt_util.utcnow()
+    with freeze_time(time) as freezer:
+        # First state update of the source.
+        # Derivative does not learn the unit yet.
+        hass.states.async_set(source_id, 5, {"unit_of_measurement": "dogs"})
+        await hass.async_block_till_done()
+        state = hass.states.get(derivative_id)
+        assert state.state == "0.0"
+        assert state.attributes.get("unit_of_measurement") is None
+
+        # Second state update of the source.
+        time += timedelta(minutes=1)
+        freezer.move_to(time)
+        hass.states.async_set(source_id, "7", {"unit_of_measurement": "dogs"})
+        await hass.async_block_till_done()
+        state = hass.states.get(derivative_id)
+        assert state.state == "2.0"
+        assert state.attributes.get("unit_of_measurement") == "dogs/min"
+
+        # Update the unit_time from minutes to seconds.
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "source": source_id,
+                "round": 1.0,
+                "unit_time": "s",
+                "time_window": {"seconds": 0.0},
+            },
+        )
+        await hass.async_block_till_done()
+
+        # Check the state after reconfigure. Neither unit or state has changed.
+        state = hass.states.get(derivative_id)
+        assert state.state == "2.0"
+        assert state.attributes.get("unit_of_measurement") == "dogs/min"
+
+        # Third state update of the source.
+        time += timedelta(seconds=1)
+        freezer.move_to(time)
+        hass.states.async_set(source_id, "10", {"unit_of_measurement": "dogs"})
+        await hass.async_block_till_done()
+        state = hass.states.get(derivative_id)
+        assert state.state == "3.0"
+        # While the state is correctly reporting a state of 3 dogs per second, it incorrectly keeps
+        # the unit as dogs/min
+        assert state.attributes.get("unit_of_measurement") == "dogs/min"
+
+        # Fourth state update of the source.
+        time += timedelta(seconds=1)
+        freezer.move_to(time)
+        hass.states.async_set(source_id, "20", {"unit_of_measurement": "dogs"})
+        await hass.async_block_till_done()
+        state = hass.states.get(derivative_id)
+        assert state.state == "10.0"
+        assert state.attributes.get("unit_of_measurement") == "dogs/min"

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -934,3 +934,65 @@ async def test_unavailable_boot(
         assert state is not None
         # Now that the source sensor has two valid datapoints, we can calculate derivative
         assert state.state == "5.00"
+
+
+async def test_source_unit_change(
+    hass: HomeAssistant,
+) -> None:
+    """Test how derivative responds when the source sensor changes unit."""
+    source_id = "sensor.source"
+    config = {
+        "sensor": {
+            "platform": "derivative",
+            "name": "derivative",
+            "source": source_id,
+            "unit_time": "s",
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+    entity_id = "sensor.derivative"
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
+    assert state.attributes.get("unit_of_measurement") is None
+
+    time = dt_util.utcnow()
+    with freeze_time(time) as freezer:
+        # First state update of the source.
+        # Derivative does not learn the UoM yet.
+        hass.states.async_set(source_id, "5", {"unit_of_measurement": "cats"})
+        await hass.async_block_till_done()
+        state = hass.states.get(entity_id)
+        assert state.state == "0.000"
+        assert state.attributes.get("unit_of_measurement") is None
+
+        # Second state update of the source.
+        time += timedelta(seconds=1)
+        freezer.move_to(time)
+        hass.states.async_set(source_id, "7", {"unit_of_measurement": "cats"})
+        await hass.async_block_till_done()
+        state = hass.states.get(entity_id)
+        assert state.state == "2.000"
+        assert state.attributes.get("unit_of_measurement") == "cats/s"
+
+        # Third state update of the source, source unit changes to dogs.
+        # Ignored by derivative which continues reporting cats.
+        time += timedelta(seconds=1)
+        freezer.move_to(time)
+        hass.states.async_set(source_id, "12", {"unit_of_measurement": "dogs"})
+        await hass.async_block_till_done()
+        state = hass.states.get(entity_id)
+        assert state.state == "5.000"
+        assert state.attributes.get("unit_of_measurement") == "cats/s"
+
+        # Fourth state update of the source, still dogs.
+        # Ignored by derivative which continues reporting cats.
+        time += timedelta(seconds=1)
+        freezer.move_to(time)
+        hass.states.async_set(source_id, "20", {"unit_of_measurement": "dogs"})
+        await hass.async_block_till_done()
+        state = hass.states.get(entity_id)
+        assert state.state == "8.000"
+        assert state.attributes.get("unit_of_measurement") == "cats/s"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This change adds two tests exhibiting problems with current derivative handling of units. It is expected these issues will be fixed by #147527.

Test 1 (test_config_flow.py::test_update_unit):
- A sensor is configured, and the unit is later changed in the options flow. The sensor _value_ correctly reflects the updated unit settings, but the `unit_of_measurement` attribute continues reporting the wrong/old value. 

Test 2 (test_sensor.py::test_source_unit_change):
- A sensor is configured, and later the source sensor changes its unit of measurement. The derivative sensor continues reporting the old unit of measurement. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #147527
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
