### PR TITLE
Ensure togrill detects disconnected devices

### DIFF
--- a/tests/components/togrill/conftest.py
+++ b/tests/components/togrill/conftest.py
@@ -57,9 +57,18 @@ def mock_client(enable_bluetooth: None, mock_client_class: Mock) -> Generator[Mo
     client_object.mocked_notify = None
 
     async def _connect(
-        address: str, callback: Callable[[Packet], None] | None = None
+        address: str,
+        callback: Callable[[Packet], None] | None = None,
+        disconnected_callback: Callable[[], None] | None = None,
     ) -> Mock:
         client_object.mocked_notify = callback
+        if disconnected_callback:
+
+            def _disconnected_callback():
+                client_object.is_connected = False
+                disconnected_callback()
+
+            client_object.mocked_disconnected_callback = _disconnected_callback
         return client_object
 
     async def _disconnect() -> None:

--- a/tests/components/togrill/test_sensor.py
+++ b/tests/components/togrill/test_sensor.py
@@ -1,7 +1,8 @@
 """Test sensors for ToGrill integration."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
+from habluetooth import BluetoothServiceInfoBleak
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from togrill_bluetooth.packets import PacketA0Notify, PacketA1Notify
@@ -14,6 +15,16 @@ from . import TOGRILL_SERVICE_INFO, setup_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 from tests.components.bluetooth import inject_bluetooth_service_info
+
+
+def patch_async_ble_device_from_address(
+    return_value: BluetoothServiceInfoBleak | None = None,
+):
+    """Patch async_ble_device_from_address to return a mocked BluetoothServiceInfoBleak."""
+    return patch(
+        "homeassistant.components.bluetooth.async_ble_device_from_address",
+        return_value=return_value,
+    )
 
 
 @pytest.mark.parametrize(
@@ -57,3 +68,51 @@ async def test_setup(
         mock_client.mocked_notify(packet)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_entry.entry_id)
+
+
+async def test_device_disconnected(
+    hass: HomeAssistant,
+    mock_entry: MockConfigEntry,
+    mock_client: Mock,
+) -> None:
+    """Test the switch set."""
+    inject_bluetooth_service_info(hass, TOGRILL_SERVICE_INFO)
+
+    await setup_entry(hass, mock_entry, [Platform.SENSOR])
+
+    entity_id = "sensor.pro_05_battery"
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "0"
+
+    with patch_async_ble_device_from_address():
+        mock_client.mocked_disconnected_callback()
+        await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "unavailable"
+
+
+async def test_device_discovered(
+    hass: HomeAssistant,
+    mock_entry: MockConfigEntry,
+    mock_client: Mock,
+) -> None:
+    """Test the switch set."""
+
+    await setup_entry(hass, mock_entry, [Platform.SENSOR])
+
+    entity_id = "sensor.pro_05_battery"
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "unavailable"
+
+    inject_bluetooth_service_info(hass, TOGRILL_SERVICE_INFO)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ensure ToGrill detects when a device disconnects and re-connects. Previously
only the connection event was detected directly and a pending disconnection
would begin with re-connection before being visible in UI which could take
a long time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
