### PR TITLE
Add [smart radiator thermostat] support to Switchbot Cloud

### DIFF
--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -37,6 +37,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.VACUUM,
+    Platform.WATER_HEATER,
 ]
 
 
@@ -59,6 +60,9 @@ class SwitchbotDevices:
     fans: list[tuple[Device, SwitchBotCoordinator]] = field(default_factory=list)
     lights: list[tuple[Device, SwitchBotCoordinator]] = field(default_factory=list)
     humidifiers: list[tuple[Device, SwitchBotCoordinator]] = field(default_factory=list)
+    water_heaters: list[tuple[Device, SwitchBotCoordinator]] = field(
+        default_factory=list
+    )
 
 
 @dataclass
@@ -275,6 +279,12 @@ async def make_device_data(
             hass, entry, api, device, coordinators_by_id
         )
         devices_data.binary_sensors.append((device, coordinator))
+        devices_data.sensors.append((device, coordinator))
+    if isinstance(device, Device) and device.device_type == "Smart Radiator Thermostat":
+        coordinator = await coordinator_for_device(
+            hass, entry, api, device, coordinators_by_id
+        )
+        devices_data.water_heaters.append((device, coordinator))
         devices_data.sensors.append((device, coordinator))
 
 

--- a/homeassistant/components/switchbot_cloud/sensor.py
+++ b/homeassistant/components/switchbot_cloud/sensor.py
@@ -193,6 +193,7 @@ SENSOR_DESCRIPTIONS_BY_DEVICE_TYPES = {
         HUMIDITY_DESCRIPTION,
         BATTERY_DESCRIPTION,
     ),
+    "Smart Radiator Thermostat": (BATTERY_DESCRIPTION,),
 }
 
 

--- a/homeassistant/components/switchbot_cloud/water_heater.py
+++ b/homeassistant/components/switchbot_cloud/water_heater.py
@@ -68,7 +68,6 @@ class SwitchBotSmartRadiatorThermostat(SwitchBotCloudEntity, WaterHeaterEntity):
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Async set operation mode."""
-        await self.coordinator.async_request_refresh()
         parameters = self.__mode_map_value(operation_mode)
         await self.send_api_command(
             command=SmartRadiatorThermostatCommands.SET_MODE,

--- a/homeassistant/components/switchbot_cloud/water_heater.py
+++ b/homeassistant/components/switchbot_cloud/water_heater.py
@@ -1,0 +1,109 @@
+"""Support for the Switchbot Smart Radiator Thermostat."""
+
+import asyncio
+from typing import Any
+
+from switchbot_api import SmartRadiatorThermostatCommands, SmartRadiatorThermostatMode
+
+from homeassistant.components.water_heater import (
+    WaterHeaterEntity,
+    WaterHeaterEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import SwitchbotCloudData
+from .const import AFTER_COMMAND_REFRESH, DOMAIN
+from .entity import SwitchBotCloudEntity
+
+operation_list = [i.name for i in SmartRadiatorThermostatMode.get_all_modes()]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up SwitchBot Cloud entry."""
+    data: SwitchbotCloudData = hass.data[DOMAIN][config.entry_id]
+    async_add_entities(
+        SwitchBotSmartRadiatorThermostat(data.api, device, coordinator)
+        for device, coordinator in data.devices.water_heaters
+    )
+
+
+class SwitchBotSmartRadiatorThermostat(SwitchBotCloudEntity, WaterHeaterEntity):
+    """Representation of a SwitchBot Smart Radiator Thermostat."""
+
+    _attr_name = None
+    _attr_supported_features = (
+        WaterHeaterEntityFeature.TARGET_TEMPERATURE
+        | WaterHeaterEntityFeature.ON_OFF
+        | WaterHeaterEntityFeature.OPERATION_MODE
+    )
+    _attr_max_temp = 35
+    _attr_min_temp = 4
+    _attr_target_temperature = 21
+    _attr_target_temperature_low = 19
+    _attr_target_temperature_high = 23
+    _attr_target_temperature_step = 0.5
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_operation_list = [i.name for i in SmartRadiatorThermostatMode.get_all_modes()]
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Async set temperature."""
+        target_temperature = kwargs["temperature"]
+        if self._attr_current_operation == SmartRadiatorThermostatMode.MANUAL.name:
+            await self.send_api_command(
+                command=SmartRadiatorThermostatCommands.SET_MANUAL_MODE_TEMPERATURE,
+                parameters=str(target_temperature),
+            )
+            await asyncio.sleep(AFTER_COMMAND_REFRESH)
+            await self.coordinator.async_request_refresh()
+            self._attr_target_temperature = target_temperature
+            self._attr_target_temperature_low = target_temperature - 2
+            self._attr_target_temperature_high = target_temperature + 2
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Async set operation mode."""
+        await self.coordinator.async_request_refresh()
+        parameters = self.__mode_map_value(operation_mode)
+        await self.send_api_command(
+            command=SmartRadiatorThermostatCommands.SET_MODE,
+            parameters=str(parameters),
+        )
+        await asyncio.sleep(AFTER_COMMAND_REFRESH)
+        await self.coordinator.async_request_refresh()
+
+    def _set_attributes(self) -> None:
+        """Set attributes from coordinator data."""
+        if self.coordinator.data is None:
+            return
+        mode: int = self.coordinator.data["mode"]
+        temperature: str = self.coordinator.data["temperature"]
+        self._attr_current_temperature = int(temperature)
+        self._attr_current_operation = str(self.__value_map_mode(mode))
+
+        if self._attr_current_operation == SmartRadiatorThermostatMode.MANUAL.name:
+            self._attr_supported_features = (
+                WaterHeaterEntityFeature.TARGET_TEMPERATURE
+                | WaterHeaterEntityFeature.OPERATION_MODE
+            )
+        else:
+            self._attr_supported_features = WaterHeaterEntityFeature.OPERATION_MODE
+
+    def __value_map_mode(self, value: int) -> Any:
+        """Value map SmartRadiatorThermostatMode mode."""
+        for i in SmartRadiatorThermostatMode.get_all_modes():
+            if i.value == value:
+                return i.name
+        raise NotImplementedError(f"{value} Not Supported")
+
+    def __mode_map_value(self, mode: str) -> Any:
+        """SmartRadiatorThermostatMode mode map value."""
+        for i in SmartRadiatorThermostatMode.get_all_modes():
+            if i.name == mode:
+                return i.value
+        raise NotImplementedError(f"{mode} Not Supported")

--- a/tests/components/switchbot_cloud/test_water_heater.py
+++ b/tests/components/switchbot_cloud/test_water_heater.py
@@ -1,0 +1,135 @@
+"""Test code Support for water heater entity."""
+
+from unittest.mock import patch
+
+from switchbot_api import (
+    Device,
+    SmartRadiatorThermostatCommands,
+    SmartRadiatorThermostatMode,
+)
+
+from homeassistant.components.switchbot_cloud import SwitchBotAPI
+from homeassistant.components.water_heater import (
+    ATTR_OPERATION_MODE,
+    DOMAIN as WATER_HEATER_DOMAIN,
+    SERVICE_SET_OPERATION_MODE,
+    SERVICE_SET_TEMPERATURE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+from . import configure_integration
+
+
+async def test_coordinator_data_is_none(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test coordinator data is none."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="water_heater-id-1",
+            deviceName="water_heater-1",
+            deviceType="Smart Radiator Thermostat",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        None,
+    ]
+    await configure_integration(hass)
+    entity_id = "water_heater.water_heater_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_set_temperature(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test set temperature."""
+
+    mock_list_devices.side_effect = [
+        [
+            Device(
+                version="V1.0",
+                deviceId="water-heater-id-1",
+                deviceName="water_heater-1",
+                deviceType="Smart Radiator Thermostat",
+                hubDeviceId="test-hub-id",
+            ),
+        ]
+    ]
+    mock_get_status.side_effect = [
+        {
+            "version": "V0.6",
+            "temperature": 21,
+            "battery": 90,
+            "mode": 1,
+            "deviceId": "B0E9FEA2547C",
+            "deviceType": "Smart Radiator Thermostat",
+            "hubDeviceId": "000000000000",
+        },
+    ]
+
+    await configure_integration(hass)
+    entity_id = "water_heater.water_heater_1"
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            WATER_HEATER_DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            {ATTR_ENTITY_ID: entity_id, "temperature": 21},
+        )
+        mock_send_command.assert_called_once_with(
+            "water-heater-id-1",
+            SmartRadiatorThermostatCommands.SET_MANUAL_MODE_TEMPERATURE,
+            "command",
+            "21.0",
+        )
+
+
+async def test_set_mode(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test set mode."""
+
+    mock_list_devices.side_effect = [
+        [
+            Device(
+                version="V1.0",
+                deviceId="water-heater-id-1",
+                deviceName="water_heater-1",
+                deviceType="Smart Radiator Thermostat",
+                hubDeviceId="test-hub-id",
+            ),
+        ]
+    ]
+    mock_get_status.side_effect = [
+        {
+            "version": "V0.6",
+            "temperature": 21,
+            "battery": 90,
+            "mode": 2,
+            "deviceId": "B0E9FEA2547C",
+            "deviceType": "Smart Radiator Thermostat",
+            "hubDeviceId": "000000000000",
+        },
+    ]
+
+    await configure_integration(hass)
+    entity_id = "water_heater.water_heater_1"
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            WATER_HEATER_DOMAIN,
+            SERVICE_SET_OPERATION_MODE,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_OPERATION_MODE: SmartRadiatorThermostatMode.OFF.name,
+            },
+        )
+        mock_send_command.assert_called_once_with(
+            "water-heater-id-1",
+            SmartRadiatorThermostatCommands.SET_MODE,
+            "command",
+            str(SmartRadiatorThermostatMode.OFF.value),
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add new supported device[smart radiator thermostat] as water heater entity
1. set temperature
    a. max temperature = 35 
    b. min temperature = 4
    c. if you set temperature to 4,  the mode will become OFF
    d. the temperature can only be set in MANUAL mode
2. set mode
    SCHEDULE = 0
    MANUAL = 1
    OFF = 2
    ENERGY_SAVING = 3
    COMFORT = 4
    FAST_HEATING = 5



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41053
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
