### PR TITLE
Fix for Hue Integration motion aware areas

### DIFF
--- a/homeassistant/components/hue/v2/binary_sensor.py
+++ b/homeassistant/components/hue/v2/binary_sensor.py
@@ -150,7 +150,11 @@ class HueMotionSensor(HueBaseEntity, BinarySensorEntity):
         if not self.resource.enabled:
             # Force None (unknown) if the sensor is set to disabled in Hue
             return None
-        return self.resource.motion.value
+        if not (motion_feature := self.resource.motion):
+            return None
+        if motion_feature.motion_report is not None:
+            return motion_feature.motion_report.motion
+        return motion_feature.motion
 
 
 # pylint: disable-next=hass-enforce-class-module

--- a/homeassistant/components/hue/v2/binary_sensor.py
+++ b/homeassistant/components/hue/v2/binary_sensor.py
@@ -13,7 +13,6 @@ from aiohue.v2.controllers.events import EventType
 from aiohue.v2.controllers.sensors import (
     CameraMotionController,
     ContactController,
-    ConvenienceAreaMotionController,
     GroupedMotionController,
     MotionController,
     SecurityAreaMotionController,
@@ -21,7 +20,6 @@ from aiohue.v2.controllers.sensors import (
 )
 from aiohue.v2.models.camera_motion import CameraMotion
 from aiohue.v2.models.contact import Contact, ContactState
-from aiohue.v2.models.convenience_area_motion import ConvenienceAreaMotion
 from aiohue.v2.models.entertainment_configuration import EntertainmentStatus
 from aiohue.v2.models.grouped_motion import GroupedMotion
 from aiohue.v2.models.motion import Motion
@@ -51,7 +49,6 @@ type SensorType = (
     | Tamper
     | GroupedMotion
     | SecurityAreaMotion
-    | ConvenienceAreaMotion
 )
 type ControllerType = (
     CameraMotionController
@@ -61,7 +58,6 @@ type ControllerType = (
     | TamperController
     | GroupedMotionController
     | SecurityAreaMotionController
-    | ConvenienceAreaMotionController
 )
 
 
@@ -128,7 +124,6 @@ async def async_setup_entry(
     register_items(api.sensors.tamper, HueTamperSensor)
     register_items(api.sensors.grouped_motion, HueGroupedMotionSensor)
     register_items(api.sensors.security_area_motion, HueMotionAwareSensor)
-    register_items(api.sensors.convenience_area_motion, HueConvenienceAreaMotionSensor)
 
 
 # pylint: disable-next=hass-enforce-class-module
@@ -158,36 +153,7 @@ class HueMotionSensor(HueBaseEntity, BinarySensorEntity):
 
 
 # pylint: disable-next=hass-enforce-class-module
-class HueAreaMotionSensor(HueBaseEntity, BinarySensorEntity):
-    """Representation of a Hue area-based motion sensor."""
-
-    controller: (
-        GroupedMotionController
-        | SecurityAreaMotionController
-        | ConvenienceAreaMotionController
-    )
-    resource: GroupedMotion | SecurityAreaMotion | ConvenienceAreaMotion
-
-    entity_description = BinarySensorEntityDescription(
-        key="motion_sensor",
-        device_class=BinarySensorDeviceClass.MOTION,
-        has_entity_name=True,
-    )
-
-    @property
-    def is_on(self) -> bool | None:
-        """Return true if the binary sensor is on."""
-        if getattr(self.resource, "enabled", True) is False:
-            return False
-        if not (motion_feature := self.resource.motion):
-            return None
-        if motion_feature.motion_report is not None:
-            return motion_feature.motion_report.motion
-        return motion_feature.motion
-
-
-# pylint: disable-next=hass-enforce-class-module
-class HueGroupedMotionSensor(HueAreaMotionSensor):
+class HueGroupedMotionSensor(HueMotionSensor):
     """Representation of a Hue Grouped Motion sensor."""
 
     controller: GroupedMotionController
@@ -210,11 +176,18 @@ class HueGroupedMotionSensor(HueAreaMotionSensor):
 
 
 # pylint: disable-next=hass-enforce-class-module
-class HueMotionAreaConfigurationSensor(HueAreaMotionSensor):
-    """Base class for motion sensors linked to a motion area configuration."""
+class HueMotionAwareSensor(HueMotionSensor):
+    """Representation of a Motion sensor based on Hue Motion Aware.
 
-    controller: SecurityAreaMotionController | ConvenienceAreaMotionController
-    resource: SecurityAreaMotion | ConvenienceAreaMotion
+    Note that we only create sensors for the SecurityAreaMotion resource
+    and not for the ConvenienceAreaMotion resource, because the latter
+    does not have a state when it's not directly controlling lights.
+    The SecurityAreaMotion resource is always available with a state, allowing
+    Home Assistant users to actually use it as a motion sensor in their HA automations.
+    """
+
+    controller: SecurityAreaMotionController
+    resource: SecurityAreaMotion
 
     entity_description = BinarySensorEntityDescription(
         key="motion_sensor",
@@ -222,14 +195,20 @@ class HueMotionAreaConfigurationSensor(HueAreaMotionSensor):
         has_entity_name=False,
     )
 
+    @property
+    def name(self) -> str:
+        """Return sensor name."""
+        return self.controller.get_motion_area_configuration(self.resource.id).name
+
     def __init__(
         self,
         bridge: HueBridge,
-        controller: SecurityAreaMotionController | ConvenienceAreaMotionController,
-        resource: SecurityAreaMotion | ConvenienceAreaMotion,
+        controller: SecurityAreaMotionController,
+        resource: SecurityAreaMotion,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(bridge, controller, resource)
+        # link the MotionAware sensor to the group the sensor is associated with
         self._motion_area_configuration = self.controller.get_motion_area_configuration(
             resource.id
         )
@@ -242,37 +221,12 @@ class HueMotionAreaConfigurationSensor(HueAreaMotionSensor):
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
         await super().async_added_to_hass()
+        # subscribe to updates of the MotionAreaConfiguration to update the name
         self.async_on_remove(
             self.bridge.api.config.subscribe(
                 self._handle_event, self._motion_area_configuration.id
             )
         )
-
-
-# pylint: disable-next=hass-enforce-class-module
-class HueMotionAwareSensor(HueMotionAreaConfigurationSensor):
-    """Representation of a Motion sensor based on Hue Motion Aware."""
-
-    controller: SecurityAreaMotionController
-    resource: SecurityAreaMotion
-
-    @property
-    def name(self) -> str:
-        """Return sensor name."""
-        return self._motion_area_configuration.name
-
-
-# pylint: disable-next=hass-enforce-class-module
-class HueConvenienceAreaMotionSensor(HueMotionAreaConfigurationSensor):
-    """Representation of a Hue Convenience Area Motion sensor."""
-
-    controller: ConvenienceAreaMotionController
-    resource: ConvenienceAreaMotion
-
-    @property
-    def name(self) -> str:
-        """Return sensor name."""
-        return f"{self._motion_area_configuration.name} Convenience Motion"
 
 
 # pylint: disable-next=hass-enforce-class-module

--- a/tests/components/hue/test_binary_sensor.py
+++ b/tests/components/hue/test_binary_sensor.py
@@ -94,13 +94,6 @@ async def test_binary_sensors(
     assert sensor.name == "Motion Aware Sensor 1"
     assert sensor.attributes["device_class"] == "motion"
 
-    # test convenience area motion sensor
-    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
-    assert sensor is not None
-    assert sensor.state == "off"
-    assert sensor.name == "Motion Aware Sensor 1 Convenience Motion"
-    assert sensor.attributes["device_class"] == "motion"
-
 
 async def test_binary_sensor_add_update(
     hass: HomeAssistant, mock_bridge_v2: Mock
@@ -158,7 +151,7 @@ async def test_grouped_motion_sensor(
     sensor = hass.states.get("binary_sensor.sensor_group_motion")
     assert sensor.state == "on"
 
-    # test disabled grouped motion sensor keeps last known state
+    # test disabled grouped motion sensor == state unknown
     disabled_sensor = {
         "id": "2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e",
         "type": "grouped_motion",
@@ -167,7 +160,7 @@ async def test_grouped_motion_sensor(
     mock_bridge_v2.api.emit_event("update", disabled_sensor)
     await hass.async_block_till_done()
     sensor = hass.states.get("binary_sensor.sensor_group_motion")
-    assert sensor.state == "off"
+    assert sensor.state == "unknown"
 
 
 async def test_motion_aware_sensor(
@@ -211,42 +204,3 @@ async def test_motion_aware_sensor(
     sensor = hass.states.get("binary_sensor.motion_aware_sensor_1")
     assert sensor is not None
     assert sensor.name == "Updated Motion Area"
-
-
-async def test_convenience_area_motion_sensor(
-    hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
-) -> None:
-    """Test HueConvenienceAreaMotionSensor functionality."""
-
-    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
-    await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
-
-    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
-    assert sensor is not None
-    assert sensor.state == "off"
-    assert sensor.attributes["device_class"] == "motion"
-
-    updated_sensor = {
-        "id": "4f317b69-9da0-4b4f-84f2-7ca07b9fe345",
-        "type": "convenience_area_motion",
-        "motion": {
-            "motion": True,
-            "motion_valid": True,
-            "motion_report": {"changed": "2023-09-23T08:13:42.394Z", "motion": True},
-        },
-    }
-    mock_bridge_v2.api.emit_event("update", updated_sensor)
-    await hass.async_block_till_done()
-    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
-    assert sensor.state == "on"
-
-    updated_config = {
-        "id": "5e6f7a8b-9c1d-4e2f-b3a4-5c6d7e8f9a0b",
-        "type": "motion_area_configuration",
-        "name": "Updated Motion Area",
-    }
-    mock_bridge_v2.api.emit_event("update", updated_config)
-    await hass.async_block_till_done()
-    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
-    assert sensor is not None
-    assert sensor.name == "Updated Motion Area Convenience Motion"

--- a/tests/components/hue/test_binary_sensor.py
+++ b/tests/components/hue/test_binary_sensor.py
@@ -123,7 +123,6 @@ async def test_binary_sensor_add_update(
     test_entity = hass.states.get(test_entity_id)
     assert test_entity is not None
     assert test_entity.state == "on"
-    
     # NEW: prefer motion_report.motion when present (should turn on even if plain motion is False)
     updated_sensor = {
         **FAKE_BINARY_SENSOR,

--- a/tests/components/hue/test_binary_sensor.py
+++ b/tests/components/hue/test_binary_sensor.py
@@ -94,6 +94,13 @@ async def test_binary_sensors(
     assert sensor.name == "Motion Aware Sensor 1"
     assert sensor.attributes["device_class"] == "motion"
 
+    # test convenience area motion sensor
+    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
+    assert sensor is not None
+    assert sensor.state == "off"
+    assert sensor.name == "Motion Aware Sensor 1 Convenience Motion"
+    assert sensor.attributes["device_class"] == "motion"
+
 
 async def test_binary_sensor_add_update(
     hass: HomeAssistant, mock_bridge_v2: Mock
@@ -151,7 +158,7 @@ async def test_grouped_motion_sensor(
     sensor = hass.states.get("binary_sensor.sensor_group_motion")
     assert sensor.state == "on"
 
-    # test disabled grouped motion sensor == state unknown
+    # test disabled grouped motion sensor keeps last known state
     disabled_sensor = {
         "id": "2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e",
         "type": "grouped_motion",
@@ -160,7 +167,7 @@ async def test_grouped_motion_sensor(
     mock_bridge_v2.api.emit_event("update", disabled_sensor)
     await hass.async_block_till_done()
     sensor = hass.states.get("binary_sensor.sensor_group_motion")
-    assert sensor.state == "unknown"
+    assert sensor.state == "off"
 
 
 async def test_motion_aware_sensor(
@@ -204,3 +211,42 @@ async def test_motion_aware_sensor(
     sensor = hass.states.get("binary_sensor.motion_aware_sensor_1")
     assert sensor is not None
     assert sensor.name == "Updated Motion Area"
+
+
+async def test_convenience_area_motion_sensor(
+    hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
+) -> None:
+    """Test HueConvenienceAreaMotionSensor functionality."""
+
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
+
+    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
+    assert sensor is not None
+    assert sensor.state == "off"
+    assert sensor.attributes["device_class"] == "motion"
+
+    updated_sensor = {
+        "id": "4f317b69-9da0-4b4f-84f2-7ca07b9fe345",
+        "type": "convenience_area_motion",
+        "motion": {
+            "motion": True,
+            "motion_valid": True,
+            "motion_report": {"changed": "2023-09-23T08:13:42.394Z", "motion": True},
+        },
+    }
+    mock_bridge_v2.api.emit_event("update", updated_sensor)
+    await hass.async_block_till_done()
+    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
+    assert sensor.state == "on"
+
+    updated_config = {
+        "id": "5e6f7a8b-9c1d-4e2f-b3a4-5c6d7e8f9a0b",
+        "type": "motion_area_configuration",
+        "name": "Updated Motion Area",
+    }
+    mock_bridge_v2.api.emit_event("update", updated_config)
+    await hass.async_block_till_done()
+    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
+    assert sensor is not None
+    assert sensor.name == "Updated Motion Area Convenience Motion"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
N/A — This PR is a non-breaking bugfix for the Hue integration. No user configuration changes or migrations are required.

## Proposed change
Hue recently introduced Motion Aware “motion areas” via the Hue V2 API. Home Assistant currently discovers these resources but the resulting entities remain `unknown`/`unavailable`.

This PR wires up proper support for Hue V2 **area motion** resources so the entities initialize correctly and update in real time:

- Adds handling for:
  - `convenience_area_motion` (comfort motion areas)
  - `security_area_motion` (Hue Secure motion areas)
  - `grouped_motion` (aggregated/group motion)
- Derives binary sensor state from **`motion.motion_report.motion`** (boolean) instead of treating these like classic presence sensors.
- Initializes state from the initial snapshot and subscribes to Hue V2 **eventstream** updates so state flips reliably `off`↔`on`.
- Ensures entity availability is not gated by the wrong flag (prevents perpetual `unknown`/`unavailable`).
- Keeps entity names in sync with the owning **`motion_area_configuration`**.
- Adds/updates tests covering convenience/security/grouped motion entities and their update paths.

User impact: Motion Aware area entities now behave like normal binary motion sensors in Home Assistant (visible, available, and responsive to motion).

## Type of change
<!--
  NOTE: Please, check only 1 box!
-->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
-->
- This PR fixes or closes issue: fixes #152937 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

### Test plan (manual)
1. Enable debug for `homeassistant.components.hue` and `aiohue`.
2. Reload the Hue integration; confirm entities for convenience/security/grouped area motion are created and **available**.
3. Trigger motion in a Motion Aware area and observe the entity state transition `off` → `on` → `off`.
4. Rename a Motion Aware area in the Hue app and reload the Hue integration; confirm the entity name updates accordingly.

### Notes for reviewers
- State comes from `motion.motion_report.motion` per Hue V2 API. Classic presence fields are not applicable to area motion resources.
- Event updates are consumed from the Hue V2 eventstream; polling is not required.

## Checklist
<!--
  Fill out what applies. It's okay to update after opening the PR.
-->
- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.
  Reviewing another PR helps move things faster for everyone.
-->
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr