### PR TITLE
Add validation for ObjectSelector

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1148,7 +1148,7 @@ class NumberSelector(Selector[NumberSelectorConfig]):
         return value
 
 
-class ObjectSelectorField(TypedDict):
+class ObjectSelectorField(TypedDict, total=False):
     """Class to represent an object selector fields dict."""
 
     label: str
@@ -1156,7 +1156,7 @@ class ObjectSelectorField(TypedDict):
     selector: dict[str, Any]
 
 
-class ObjectSelectorConfig(BaseSelectorConfig):
+class ObjectSelectorConfig(BaseSelectorConfig, total=False):
     """Class to represent an object selector config."""
 
     fields: dict[str, ObjectSelectorField]
@@ -1196,7 +1196,7 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
         """Validate the passed selection."""
         if "fields" not in self.config:
             # Return data if no fields are defined
-            return data  # type: ignore[unreachable]
+            return data
 
         if not isinstance(data, (list, dict)):
             raise vol.Invalid("Value should be a dict or a list of dicts")
@@ -1211,6 +1211,10 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
                     raise vol.Invalid(f"Field {field} is required")
                 if field in _config:
                     selector(field_data["selector"])(_config[field])  # type: ignore[operator]
+
+            for key in _config:
+                if key not in self.config["fields"]:
+                    raise vol.Invalid(f"Field {key} is not allowed")
 
         return data
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1210,7 +1210,7 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
                 if field_data.get("required") and field not in _config:
                     raise vol.Invalid(f"Field {field} is required")
                 if field in _config:
-                    selector(field_data["selector"])(_config.get(field))  # type: ignore[operator]
+                    selector(field_data["selector"])(_config[field])  # type: ignore[operator]
 
         return data
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1194,21 +1194,24 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
 
     def __call__(self, data: Any) -> Any:
         """Validate the passed selection."""
-
         if "fields" not in self.config:
-            # Return any object if no fields are defined
+            # Return data if no fields are defined
             return data  # type: ignore[unreachable]
 
         if not isinstance(data, (list, dict)):
             raise vol.Invalid("Value should be a dict or a list of dicts")
-
-        for _d in data:
-            for field, field_data in self.config["fields"].items():
-                if field_data.get("required") and field not in _d:
-                    raise vol.Invalid(f"Field {field} is required")
-
         if isinstance(data, list) and not self.config["multiple"]:
             raise vol.Invalid("Value should not be a list")
+
+        test_data = data if isinstance(data, list) else [data]
+
+        for _config in test_data:
+            for field, field_data in self.config["fields"].items():
+                if field_data.get("required") and field not in _config:
+                    raise vol.Invalid(f"Field {field} is required")
+                if field in _config:
+                    selector(field_data["selector"])(_config.get(field))  # type: ignore[operator]
+
         return data
 
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1153,7 +1153,7 @@ class ObjectSelectorField(TypedDict, total=False):
 
     label: str
     required: bool
-    selector: dict[str, Any]
+    selector: Required[dict[str, Any]]
 
 
 class ObjectSelectorConfig(BaseSelectorConfig, total=False):

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1176,7 +1176,7 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
         {
             vol.Optional("fields"): {
                 str: {
-                    vol.Required("selector"): dict,
+                    vol.Required("selector"): validate_selector,
                     vol.Optional("required"): bool,
                     vol.Optional("label"): str,
                 }

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1194,6 +1194,21 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
 
     def __call__(self, data: Any) -> Any:
         """Validate the passed selection."""
+
+        if "fields" not in self.config:
+            # Return any object if no fields are defined
+            return data  # type: ignore[unreachable]
+
+        if not isinstance(data, (list, dict)):
+            raise vol.Invalid("Value should be a dict or a list of dicts")
+
+        for _d in data:
+            for field, field_data in self.config["fields"].items():
+                if field_data.get("required") and field not in _d:
+                    raise vol.Invalid(f"Field {field} is required")
+
+        if isinstance(data, list) and not self.config["multiple"]:
+            raise vol.Invalid("Value should not be a list")
         return data
 
 

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -653,7 +653,7 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
     [
-        ({}, ("abc123",), ()),
+        ({"multiple": False}, ("abc123", None), ("kalle")),
         (
             {
                 "fields": {
@@ -669,8 +669,14 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
                 "label_field": "name",
                 "description_field": "percentage",
             },
-            ("abc123",),
-            (),
+            (
+                [
+                    {"name": "abc123", "percentage": 3},
+                    {"name": "def987", "percentage": 5},
+                ],
+                [{"name": "abc123"}],
+            ),
+            ("abc123", None, [{"name": "abc123", "percentage": "nope"}]),
         ),
     ],
     [],

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -669,7 +669,7 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
                 "label_field": "name",
                 "description_field": "percentage",
             },
-            (),
+            ("abc123",),
             (),
         ),
     ],

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1,6 +1,7 @@
 """Test selectors."""
 
 from collections.abc import Callable, Iterable
+from contextlib import AbstractContextManager, nullcontext as does_not_raise
 from enum import Enum
 from typing import Any
 
@@ -653,7 +654,38 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
     [
-        ({"multiple": False}, ("abc123", None), ("kalle")),
+        ({}, ("abc123", None, {"key": "value"}), ()),
+        ({"multiple": False}, ("abc123", None, {"key": "value"}), ()),
+        (
+            {
+                "fields": {
+                    "name": {
+                        "required": True,
+                        "selector": {"text": {}},
+                    },
+                    "percentage": {
+                        "selector": {"number": {}},
+                    },
+                },
+                "multiple": False,
+                "label_field": "name",
+                "description_field": "percentage",
+            },
+            (
+                {"name": "abc123", "percentage": 3},
+                {"name": "abc123"},
+            ),
+            (
+                "abc123",
+                None,
+                {"name": "abc123", "percentage": "nope"},
+                [
+                    {"name": "abc123", "percentage": 3},
+                    {"name": "def987", "percentage": 5},
+                ],
+                [{"name": "abc123"}],
+            ),
+        ),
         (
             {
                 "fields": {
@@ -684,6 +716,77 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
 def test_object_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test object selector."""
     _test_selector("object", schema, valid_selections, invalid_selections)
+
+
+@pytest.mark.parametrize(
+    ("schema", "raises"),
+    [
+        ({}, does_not_raise()),
+        ({"multiple": False}, does_not_raise()),
+        (
+            {
+                "fields": {
+                    "name": {
+                        "required": True,
+                        "selector": {"text": {}},
+                    },
+                    "percentage": {
+                        "selector": {"number": {}},
+                    },
+                },
+                "multiple": True,
+                "label_field": "name",
+                "description_field": "percentage",
+            },
+            does_not_raise(),
+        ),
+        (
+            {
+                "fields": {
+                    "name": {
+                        "required": True,
+                        "selector": selector.TextSelector(),
+                    },
+                    "percentage": {
+                        "selector": selector.NumberSelector(),
+                    },
+                },
+                "multiple": True,
+                "label_field": "name",
+                "description_field": "percentage",
+            },
+            pytest.raises(vol.Invalid),
+        ),
+        (
+            {
+                "fields": {
+                    "name": {
+                        "required": True,
+                        "selector": {"not_exist": {}},
+                    },
+                    "percentage": {
+                        "selector": {"number": {}},
+                    },
+                },
+                "multiple": True,
+                "label_field": "name",
+                "description_field": "percentage",
+            },
+            pytest.raises(vol.Invalid),
+        ),
+        ({"multiple": "False"}, pytest.raises(vol.Invalid)),
+    ],
+    [],
+)
+def test_object_selector_validate_schema(
+    schema: dict, raises: AbstractContextManager
+) -> None:
+    """Test object selector schemas."""
+    # Validate selector configuration
+
+    config = {"object": schema}
+    with raises:
+        selector.validate_selector(config)
 
 
 @pytest.mark.parametrize(

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -716,7 +716,6 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
             ),
         ),
     ],
-    [],
 )
 def test_object_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test object selector."""
@@ -781,7 +780,6 @@ def test_object_selector_schema(schema, valid_selections, invalid_selections) ->
         ),
         ({"multiple": "False"}, pytest.raises(vol.Invalid)),
     ],
-    [],
 )
 def test_object_selector_validate_schema(
     schema: dict, raises: AbstractContextManager
@@ -789,9 +787,8 @@ def test_object_selector_validate_schema(
     """Test object selector schemas."""
     # Validate selector configuration
 
-    config = {"object": schema}
     with raises:
-        selector.validate_selector(config)
+        selector.validate_selector({"object": schema})
 
 
 @pytest.mark.parametrize(

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -708,7 +708,12 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
                 ],
                 [{"name": "abc123"}],
             ),
-            ("abc123", None, [{"name": "abc123", "percentage": "nope"}]),
+            (
+                "abc123",
+                None,
+                [{"name": "abc123", "percentage": "nope"}],
+                [{"name": "abc123", "percentage": 3, "not_exist": 5}],
+            ),
         ),
     ],
     [],


### PR DESCRIPTION
## Breaking change


## Proposed change
Prel PR: https://github.com/home-assistant/core/pull/147929

Adds validation to `ObjectSelector`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 