### PR TITLE
Add timeout to dnsip (to handle stale connections)

### DIFF
--- a/homeassistant/components/dnsip/sensor.py
+++ b/homeassistant/components/dnsip/sensor.py
@@ -114,7 +114,7 @@ class WanIpSensor(SensorEntity):
 
     async def async_update(self) -> None:
         """Get the current DNS IP address for hostname."""
-        if not self.resolver:
+        if self.resolver._closed:  # noqa: SLF001
             self.create_dns_resolver()
         try:
             async with asyncio.timeout(10):

--- a/homeassistant/components/dnsip/sensor.py
+++ b/homeassistant/components/dnsip/sensor.py
@@ -116,15 +116,14 @@ class WanIpSensor(SensorEntity):
         """Get the current DNS IP address for hostname."""
         if self.resolver._closed:  # noqa: SLF001
             self.create_dns_resolver()
+        response = None
         try:
             async with asyncio.timeout(10):
                 response = await self.resolver.query(self.hostname, self.querytype)
         except TimeoutError:
             await self.resolver.close()
-            response = None
         except DNSError as err:
             _LOGGER.warning("Exception while resolving host: %s", err)
-            response = None
 
         if response:
             sorted_ips = sort_ips(

--- a/homeassistant/components/dnsip/sensor.py
+++ b/homeassistant/components/dnsip/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from ipaddress import IPv4Address, IPv6Address
 import logging
@@ -88,8 +89,8 @@ class WanIpSensor(SensorEntity):
         self._attr_name = "IPv6" if ipv6 else None
         self._attr_unique_id = f"{hostname}_{ipv6}"
         self.hostname = hostname
-        self.resolver = aiodns.DNSResolver(tcp_port=port, udp_port=port)
-        self.resolver.nameservers = [resolver]
+        self.port = port
+        self._resolver = resolver
         self.querytype: Literal["A", "AAAA"] = "AAAA" if ipv6 else "A"
         self._retries = DEFAULT_RETRIES
         self._attr_extra_state_attributes = {
@@ -103,11 +104,24 @@ class WanIpSensor(SensorEntity):
             model=aiodns.__version__,
             name=name,
         )
+        self.resolver: aiodns.DNSResolver
+        self.create_dns_resolver()
+
+    def create_dns_resolver(self) -> None:
+        """Create the DNS resolver."""
+        self.resolver = aiodns.DNSResolver(tcp_port=self.port, udp_port=self.port)
+        self.resolver.nameservers = [self._resolver]
 
     async def async_update(self) -> None:
         """Get the current DNS IP address for hostname."""
+        if not self.resolver:
+            self.create_dns_resolver()
         try:
-            response = await self.resolver.query(self.hostname, self.querytype)
+            async with asyncio.timeout(10):
+                response = await self.resolver.query(self.hostname, self.querytype)
+        except TimeoutError:
+            await self.resolver.close()
+            response = None
         except DNSError as err:
             _LOGGER.warning("Exception while resolving host: %s", err)
             response = None

--- a/tests/components/dnsip/__init__.py
+++ b/tests/components/dnsip/__init__.py
@@ -23,6 +23,7 @@ class RetrieveDNS:
             self.nameservers = nameservers
         self._nameservers = ["1.2.3.4"]
         self.error = error
+        self._closed = False
 
     async def query(self, hostname, qtype) -> list[QueryResult]:
         """Return information."""
@@ -50,3 +51,4 @@ class RetrieveDNS:
 
     async def close(self) -> None:
         """Close the resolver."""
+        self._closed = True

--- a/tests/components/dnsip/__init__.py
+++ b/tests/components/dnsip/__init__.py
@@ -47,3 +47,6 @@ class RetrieveDNS:
     @nameservers.setter
     def nameservers(self, value: list[str]) -> None:
         self._nameservers = value
+
+    async def close(self) -> None:
+        """Close the resolver."""

--- a/tests/components/dnsip/test_sensor.py
+++ b/tests/components/dnsip/test_sensor.py
@@ -171,3 +171,70 @@ async def test_sensor_no_response(
 
     state = hass.states.get("sensor.home_assistant_io")
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_sensor_timeout(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test the DNS IP sensor with timeout."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        data={
+            CONF_HOSTNAME: "home-assistant.io",
+            CONF_NAME: "home-assistant.io",
+            CONF_IPV4: True,
+            CONF_IPV6: False,
+        },
+        options={
+            CONF_RESOLVER: "208.67.222.222",
+            CONF_RESOLVER_IPV6: "2620:119:53::53",
+            CONF_PORT: 53,
+            CONF_PORT_IPV6: 53,
+        },
+        entry_id="1",
+        unique_id="home-assistant.io",
+    )
+    entry.add_to_hass(hass)
+
+    dns_mock = RetrieveDNS()
+    with patch(
+        "homeassistant.components.dnsip.sensor.aiodns.DNSResolver",
+        return_value=dns_mock,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.home_assistant_io")
+
+    assert state.state == "1.1.1.1"
+
+    with (
+        patch(
+            "homeassistant.components.dnsip.sensor.aiodns.DNSResolver",
+            return_value=dns_mock,
+        ),
+        patch(
+            "homeassistant.components.dnsip.sensor.asyncio.timeout",
+            side_effect=TimeoutError(),
+        ),
+    ):
+        freezer.tick(timedelta(seconds=SCAN_INTERVAL.seconds))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        # Allows 2 retries before going unavailable
+        state = hass.states.get("sensor.home_assistant_io")
+        assert state.state == "1.1.1.1"
+        assert state.attributes["ip_addresses"] == ["1.1.1.1", "1.2.3.4"]
+
+        freezer.tick(timedelta(seconds=SCAN_INTERVAL.seconds))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        freezer.tick(timedelta(seconds=SCAN_INTERVAL.seconds))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.home_assistant_io")
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Breaking change


## Proposed change
Implement a 10 second timeout for refreshing the resolver in `dnsip`.
Should fix the problem with stale connections that hangs infinitive.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #151609
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 