### PR TITLE
Ignore gateway device in ViCare integration

### DIFF
--- a/homeassistant/components/vicare/const.py
+++ b/homeassistant/components/vicare/const.py
@@ -19,6 +19,7 @@ PLATFORMS = [
 UNSUPPORTED_DEVICES = [
     "Heatbox1",
     "Heatbox2_SRC",
+    "E3_TCU10_x07",
     "E3_TCU41_x04",
     "E3_FloorHeatingCircuitChannel",
     "E3_FloorHeatingCircuitDistributorBox",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None.
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Added `E3_TCU10_x07` as `UNSUPPORTED_DEVICES`, so that data for this device will not be polled and counted against the API limits.

It seams there a devices exposed through the API, that have no meaningful features to interact with. There are already similiar device strings listed as unsupported, so i can imagine this is just new/another model of the gateway device. 

I use a the following viessmann Hardware devices.
* Vitocal 252A Heatpump
* Vitocharge VX3 with 5kWh battery
* Viessmann Energy Meter E380


The viessmann API `equipment` endpoint returns the following device entry. 
```
 {
  "gatewaySerial": "XXX",
  "id": "gateway",
  "boilerSerial": null,
  "boilerSerialEditor": null,
  "bmuSerial": null,
  "bmuSerialEditor": null,
  "createdAt": "2025-08-24T09:37:57.896Z",
  "editedAt": "2025-09-24T16:25:12.663Z",
  "modelId": "E3_TCU10_x07",
  "status": "Online",
  "deviceType": "tcu",
  "roles": [
    "capability:hems",
    "capability:src",
    "capability:zigbeeCoordinator",
    "type:E3",
    "type:gateway;TCU300"
  ],
  "isBoilerSerialEditable": false,
  "brand": null,
  "translationKey": "E3_TCU10_x07"
}
```

The `features` endpoint returns the following features.
```
{
  "data": [
    {
      "feature": "tcu.features.hems",
      "gatewayId": "XXX",
      "deviceId": "gateway",
      "timestamp": "2025-09-25T13:45:12.145Z",
      "isEnabled": true,
      "isReady": true,
      "apiVersion": 1,
      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/XXX/gateways/XXX/devices/gateway/features/tcu.features.hems",
      "properties": {
        "active": {
          "type": "boolean",
          "value": true
        }
      },
      "commands": {}
    },
    {
      "feature": "tcu.features.wirelessRemoteController",
      "gatewayId": "XXX",
      "deviceId": "gateway",
      "timestamp": "2025-09-25T13:45:12.145Z",
      "isEnabled": true,
      "isReady": true,
      "apiVersion": 1,
      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/XXX/gateways/XXX/devices/gateway/features/tcu.features.wirelessRemoteController",
      "properties": {
        "active": {
          "type": "boolean",
          "value": true
        }
      },
      "commands": {}
    }
  ]
}
```

 
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
