### PR TITLE
Mypy fixes for Plugwise

### DIFF
--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -127,7 +127,7 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return self.device.get(BINARY_SENSORS, {}).get(self.entity_description.key)
+        return self.device.get("binary_sensors", {}).get(self.entity_description.key)
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:

--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -125,9 +125,9 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
         self._attr_unique_id = f"{device_id}-{description.key}"
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return self.device["binary_sensors"][self.entity_description.key]
+        return self.device.get(BINARY_SENSORS, {}).get(self.entity_description.key)
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -131,7 +131,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         Connected to the HVACMode combination of AUTO-HEAT.
         """
 
-        return self.deviceget("thermostat", {}).get("setpoint")
+        return self.device.get("thermostat", {}).get("setpoint")
 
     @property
     def target_temperature_high(self) -> float | None:
@@ -139,7 +139,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
 
         Connected to the HVACMode combination of AUTO-HEAT_COOL.
         """
-        return self.deviceget("thermostat", {}).get("setpoint_high")
+        return self.device.get("thermostat", {}).get("setpoint_high")
 
     @property
     def target_temperature_low(self) -> float | None:
@@ -147,7 +147,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
 
         Connected to the HVACMode combination AUTO-HEAT_COOL.
         """
-        return self.deviceget("thermostat", {}).get("setpoint_low")
+        return self.device.get("thermostat", {}).get("setpoint_low")
 
     @property
     def hvac_mode(self) -> HVACMode:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -98,11 +98,11 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
             self._attr_preset_modes = presets
 
-        self._attr_min_temp = self.device["thermostat"]["lower_bound"]
-        self._attr_max_temp = min(self.device["thermostat"]["upper_bound"], 35.0)
+        self._attr_max_temp = min(self.device.get("thermostat", {}).get("upper_bound", 35.0), 35.0)
+        self._attr_min_temp = self.device.get("thermostat", {}).get("lower_bound", 0.0)
         # Ensure we don't drop below 0.1
         self._attr_target_temperature_step = max(
-            self.device["thermostat"]["resolution"], 0.1
+            self.device.get("thermostat", {}).get("resolution", 0.5), 0.1
         )
 
     def _previous_action_mode(self, coordinator: PlugwiseDataUpdateCoordinator) -> None:
@@ -120,34 +120,34 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
                 self._previous_mode = mode
 
     @property
-    def current_temperature(self) -> float:
+    def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        return self.device["sensors"]["temperature"]
+        return self.device.get("sensors", {}).get("temperature")
 
     @property
-    def target_temperature(self) -> float:
+    def target_temperature(self) -> float | None:
         """Return the temperature we try to reach.
 
         Connected to the HVACMode combination of AUTO-HEAT.
         """
 
-        return self.device["thermostat"]["setpoint"]
+        return self.deviceget("thermostat", {}).get("setpoint")
 
     @property
-    def target_temperature_high(self) -> float:
+    def target_temperature_high(self) -> float | None:
         """Return the temperature we try to reach in case of cooling.
 
         Connected to the HVACMode combination of AUTO-HEAT_COOL.
         """
-        return self.device["thermostat"]["setpoint_high"]
+        return self.deviceget("thermostat", {}).get("setpoint_high")
 
     @property
-    def target_temperature_low(self) -> float:
+    def target_temperature_low(self) -> float | None:
         """Return the heating temperature we try to reach in case of heating.
 
         Connected to the HVACMode combination AUTO-HEAT_COOL.
         """
-        return self.device["thermostat"]["setpoint_low"]
+        return self.deviceget("thermostat", {}).get("setpoint_low")
 
     @property
     def hvac_mode(self) -> HVACMode:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -98,7 +98,9 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
             self._attr_preset_modes = presets
 
-        self._attr_max_temp = min(self.device.get("thermostat", {}).get("upper_bound", 35.0), 35.0)
+        self._attr_max_temp = min(
+            self.device.get("thermostat", {}).get("upper_bound", 35.0), 35.0
+        )
         self._attr_min_temp = self.device.get("thermostat", {}).get("lower_bound", 0.0)
         # Ensure we don't drop below 0.1
         self._attr_target_temperature_step = max(

--- a/homeassistant/components/plugwise/entity.py
+++ b/homeassistant/components/plugwise/entity.py
@@ -69,7 +69,7 @@ class PlugwiseEntity(CoordinatorEntity[PlugwiseDataUpdateCoordinator]):
         """Return if entity is available."""
         return (
             self._dev_id in self.coordinator.data
-            and (self.device.get(AVAILABLE, True) is True)
+            and (self.device.get("available", True) is True)
             and super().available
         )
 

--- a/homeassistant/components/plugwise/entity.py
+++ b/homeassistant/components/plugwise/entity.py
@@ -69,7 +69,7 @@ class PlugwiseEntity(CoordinatorEntity[PlugwiseDataUpdateCoordinator]):
         """Return if entity is available."""
         return (
             self._dev_id in self.coordinator.data
-            and ("available" not in self.device or self.device["available"] is True)
+            and (self.device.get(AVAILABLE, True) is True)
             and super().available
         )
 

--- a/homeassistant/components/plugwise/number.py
+++ b/homeassistant/components/plugwise/number.py
@@ -93,21 +93,22 @@ class PlugwiseNumberEntity(PlugwiseEntity, NumberEntity):
         """Initiate Plugwise Number."""
         super().__init__(coordinator, device_id)
         self._attr_mode = NumberMode.BOX
-        self._attr_native_max_value = self.device[description.key]["upper_bound"]
-        self._attr_native_min_value = self.device[description.key]["lower_bound"]
+        ctrl = self.device.get(description.key, {})
+        self._attr_native_max_value = ctrl.get("upper_bound", 100.0)
+        self._attr_native_min_value = ctrl.get("lower_bound", 0.0)
         self._attr_unique_id = f"{device_id}-{description.key}"
         self.device_id = device_id
         self.entity_description = description
 
-        native_step = self.device[description.key]["resolution"]
+        native_step = ctrl.get("resolution", 0.5)
         if description.key != "temperature_offset":
             native_step = max(native_step, 0.5)
         self._attr_native_step = native_step
 
     @property
-    def native_value(self) -> float:
+    def native_value(self) -> float | None:
         """Return the present setpoint value."""
-        return self.device[self.entity_description.key]["setpoint"]
+        return self.device.get(self.entity_description.key, {}).get("setpoint")
 
     @plugwise_command
     async def async_set_native_value(self, value: float) -> None:

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -100,12 +100,12 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return self.device[self.entity_description.key]
+        return self.device.get(self.entity_description.key)
 
     @property
     def options(self) -> list[str]:
         """Return the available select-options."""
-        return self.device[self.entity_description.options_key]
+        return self.device.get(self.entity_description.options_key, [])
 
     @plugwise_command
     async def async_select_option(self, option: str) -> None:

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -445,6 +445,6 @@ class PlugwiseSensorEntity(PlugwiseEntity, SensorEntity):
         self.entity_description = description
 
     @property
-    def native_value(self) -> int | float:
+    def native_value(self) -> int | float | None
         """Return the value reported by the sensor."""
-        return self.device["sensors"][self.entity_description.key]
+        return self.device.get("sensors", {}).get(self.entity_description.key)

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -445,6 +445,6 @@ class PlugwiseSensorEntity(PlugwiseEntity, SensorEntity):
         self.entity_description = description
 
     @property
-    def native_value(self) -> int | float | None
+    def native_value(self) -> int | float | None:
         """Return the value reported by the sensor."""
         return self.device.get("sensors", {}).get(self.entity_description.key)

--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -97,9 +97,9 @@ class PlugwiseSwitchEntity(PlugwiseEntity, SwitchEntity):
         self.entity_description = description
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return True if entity is on."""
-        return self.device["switches"][self.entity_description.key]
+        return self.device.get("switches", {}).get(self.entity_description.key)
 
     @plugwise_command
     async def async_turn_on(self, **kwargs: Any) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mypy reported some issues for the Plugwise integration, these changes should fix them.

Background were messages like these when testing a previous update:
```
homeassistant/components/plugwise/switch.py:102: error: Returning Any from function declared to return "bool"  [no-any-return]
homeassistant/components/plugwise/select.py:103: error: Returning Any from function declared to return "str | None"  [no-any-return]
homeassistant/components/plugwise/select.py:108: error: Returning Any from function declared to return "list[str]"  [no-any-return]
homeassistant/components/plugwise/number.py:110: error: Returning Any from function declared to return "float"  [no-any-return]
homeassistant/components/plugwise/climate.py:125: error: Returning Any from function declared to return "float"  [no-any-return]
homeassistant/components/plugwise/climate.py:134: error: Returning Any from function declared to return "float"  [no-any-return]
homeassistant/components/plugwise/climate.py:142: error: Returning Any from function declared to return "float"  [no-any-return]
homeassistant/components/plugwise/climate.py:150: error: Returning Any from function declared to return "float"  [no-any-return]
homeassistant/components/plugwise/climate.py:197: error: Returning Any from function declared to return "str | None"  [no-any-return]
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
