### PR TITLE
Fix event range in workday calendar

### DIFF
--- a/homeassistant/components/workday/calendar.py
+++ b/homeassistant/components/workday/calendar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 from holidays import HolidayBase
 
@@ -73,8 +73,10 @@ class WorkdayCalendarEntity(BaseWorkdayEntity, CalendarEntity):
     def update_data(self, now: datetime) -> None:
         """Update data."""
         event_list = []
-        for i in range(CALENDAR_DAYS_AHEAD):
-            future_date = now.date() + timedelta(days=i)
+        start_date = date(now.year, 1, 1)
+        end_number_of_days = date(now.year + 1, 12, 31) - start_date
+        for i in range(end_number_of_days.days + 1):
+            future_date = start_date + timedelta(days=i)
             if self.date_is_workday(future_date):
                 event = CalendarEvent(
                     summary=self._name,

--- a/homeassistant/components/workday/calendar.py
+++ b/homeassistant/components/workday/calendar.py
@@ -15,8 +15,6 @@ from . import WorkdayConfigEntry
 from .const import CONF_EXCLUDES, CONF_OFFSET, CONF_WORKDAYS
 from .entity import BaseWorkdayEntity
 
-CALENDAR_DAYS_AHEAD = 365
-
 
 async def async_setup_entry(
     hass: HomeAssistant,


### PR DESCRIPTION
## Breaking change


## Proposed change
As formerly it didn't show dates in the past.
Now it will show for current + next year.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 