### PR TITLE
Make Snapcast snapshot action async

### DIFF
--- a/homeassistant/components/snapcast/media_player.py
+++ b/homeassistant/components/snapcast/media_player.py
@@ -65,7 +65,7 @@ def register_services() -> None:
     """Register snapcast services."""
     platform = entity_platform.async_get_current_platform()
 
-    platform.async_register_entity_service(SERVICE_SNAPSHOT, None, "snapshot")
+    platform.async_register_entity_service(SERVICE_SNAPSHOT, None, "async_snapshot")
     platform.async_register_entity_service(SERVICE_RESTORE, None, "async_restore")
     platform.async_register_entity_service(
         SERVICE_JOIN, {vol.Required(ATTR_MASTER): cv.entity_id}, "async_join"
@@ -250,7 +250,7 @@ class SnapcastBaseDevice(SnapcastCoordinatorEntity, MediaPlayerEntity):
         await self._device.set_volume(round(volume * 100))
         self.async_write_ha_state()
 
-    def snapshot(self) -> None:
+    async def async_snapshot(self) -> None:
         """Snapshot the group state."""
         self._device.snapshot()
 
@@ -428,12 +428,12 @@ class SnapcastGroupDevice(SnapcastBaseDevice):
 
         await super().async_set_volume_level(volume)
 
-    def snapshot(self) -> None:
+    async def async_snapshot(self) -> None:
         """Snapshot the group state."""
         # Groups are deprecated, create an issue when used
         self._async_create_group_deprecation_issue()
 
-        super().snapshot()
+        await super().async_snapshot()
 
     async def async_restore(self) -> None:
         """Restore the group state."""


### PR DESCRIPTION
## Proposed change
Make the Snapcast `snapshot` action async (like all the others) so it can safely call other async APIs like `_async_create_group_deprecation_issue`.

Close #152913

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #152913
- This PR is related to issue: 
- Link to documentation pull request:  N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
