### PR TITLE
Add new settings option to kostal plenticore

### DIFF
--- a/homeassistant/components/kostal_plenticore/diagnostics.py
+++ b/homeassistant/components/kostal_plenticore/diagnostics.py
@@ -8,10 +8,9 @@ from homeassistant.components.diagnostics import REDACTED, async_redact_data
 from homeassistant.const import ATTR_IDENTIFIERS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_SERVICE_CODE
 from .coordinator import PlenticoreConfigEntry
 
-TO_REDACT = {CONF_PASSWORD, CONF_SERVICE_CODE}
+TO_REDACT = {CONF_PASSWORD}
 
 
 async def async_get_config_entry_diagnostics(
@@ -48,12 +47,7 @@ async def async_get_config_entry_diagnostics(
 
     configuration_settings = await plenticore.client.get_setting_values(
         "devices:local",
-        (
-            "EnergySensor:SensorPosition",
-            "EnergySensor:InstalledSensor",
-            "Battery:Type",
-            *(f"Properties:String{idx}Features" for idx in range(string_count)),
-        ),
+        (*(f"Properties:String{idx}Features" for idx in range(string_count)),),
     )
 
     data["configuration"] = {

--- a/homeassistant/components/kostal_plenticore/diagnostics.py
+++ b/homeassistant/components/kostal_plenticore/diagnostics.py
@@ -47,11 +47,13 @@ async def async_get_config_entry_diagnostics(
 
     configuration_settings = await plenticore.client.get_setting_values(
         "devices:local",
-        (*(f"Properties:String{idx}Features" for idx in range(string_count)),),
+        (
+            "Properties:StringCnt",
+            *(f"Properties:String{idx}Features" for idx in range(string_count)),
+        ),
     )
 
     data["configuration"] = {
-        "string_count": string_count,
         **configuration_settings,
     }
 

--- a/homeassistant/components/kostal_plenticore/select.py
+++ b/homeassistant/components/kostal_plenticore/select.py
@@ -25,6 +25,20 @@ class PlenticoreSelectEntityDescription(SelectEntityDescription):
     module_id: str
 
 
+SELECT_SETTINGS_DATA = [
+    PlenticoreSelectEntityDescription(
+        module_id="devices:local",
+        key="battery_charge",
+        name="Battery Charging / Usage mode",
+        options=[
+            "None",
+            "Battery:SmartBatteryControl:Enable",
+            "Battery:TimeControl:Enable",
+        ],
+    )
+]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: PlenticoreConfigEntry,
@@ -39,78 +53,27 @@ async def async_setup_entry(
     )
 
     entities = []
-
-    # Add option for battery mode selection
-    if (
-        device_local_data_ids := available_settings_data.get("devices:local")
-    ) is not None:
-        options = ["None"]
-
-        if any(
-            setting.id == "Battery:SmartBatteryControl:Enable"
-            for setting in device_local_data_ids
-        ):
-            options.append("Battery:SmartBatteryControl:Enable")
-
-        if any(
-            setting.id == "Battery:TimeControl:Enable"
-            for setting in device_local_data_ids
-        ):
-            options.append("Battery:TimeControl:Enable")
-
-        battery_mode_settings = await plenticore.client.get_setting_values(
-            "devices:local",
-            (
-                "Battery:Type",
-                "EnergySensor:SensorPosition",
-                "EnergySensor:InstalledSensor",
-            ),
+    for description in SELECT_SETTINGS_DATA:
+        assert description.options is not None
+        if description.module_id not in available_settings_data:
+            continue
+        needed_data_ids = {
+            data_id for data_id in description.options if data_id != "None"
+        }
+        available_data_ids = {
+            setting.id for setting in available_settings_data[description.module_id]
+        }
+        if not needed_data_ids <= available_data_ids:
+            continue
+        entities.append(
+            PlenticoreDataSelect(
+                select_data_update_coordinator,
+                description,
+                entry_id=entry.entry_id,
+                platform_name=entry.title,
+                device_info=plenticore.device_info,
+            )
         )
-
-        try:
-            sensor_position = int(
-                battery_mode_settings["devices:local"]["EnergySensor:SensorPosition"]
-            )
-            battery_type = int(battery_mode_settings["devices:local"]["Battery:Type"])
-            installed_sensor = int(
-                battery_mode_settings["devices:local"]["EnergySensor:InstalledSensor"]
-            )
-        except ValueError:
-            _LOGGER.warning(
-                "Failed to retrieve battery mode settings: %s", battery_mode_settings
-            )
-        else:
-            if sensor_position == 2 and battery_type > 0 and installed_sensor > 0:
-                # This option is only available if
-                # - energy sensor is installed
-                # - energy sensor is positioned at the grid connection
-                # - a battery is installed
-                # It is added to this selection because it is mutually exclusive to the other modes
-                # and only one of these modes can be active at a time.
-                options.append("EnergyMgmt:AcStorage")
-            else:
-                _LOGGER.debug(
-                    "Skipping excess energy switch, not supported (Sensor position: %d, Battery type: %d, Installed sensor: %d)",
-                    sensor_position,
-                    battery_type,
-                    installed_sensor,
-                )
-
-        if len(options) > 1:
-            entities.append(
-                PlenticoreDataSelect(
-                    select_data_update_coordinator,
-                    PlenticoreSelectEntityDescription(
-                        module_id="devices:local",
-                        key="battery_charge",
-                        name="Battery Charging / Usage mode",
-                        options=options,
-                    ),
-                    entry_id=entry.entry_id,
-                    platform_name=entry.title,
-                    device_info=plenticore.device_info,
-                )
-            )
 
     async_add_entities(entities)
 

--- a/homeassistant/components/kostal_plenticore/switch.py
+++ b/homeassistant/components/kostal_plenticore/switch.py
@@ -58,19 +58,6 @@ SWITCH_SETTINGS_DATA = [
     ),
 ]
 
-EXCESS_AC_ENERGY_SETTINGS_DATA = PlenticoreSwitchEntityDescription(
-    module_id="devices:local",
-    key="EnergyMgmt:AcStorage",
-    name="Store Excess Energy from Local Generation",
-    is_on="1",
-    on_value="1",
-    on_label="On",
-    off_value="0",
-    off_label="Off",
-    installer_required=True,
-    entity_registry_enabled_default=False,
-)
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -116,51 +103,6 @@ async def async_setup_entry(
                 plenticore.device_info,
             )
         )
-
-    # add excess AC energy switch if supported
-    excess_energy_settings = await plenticore.client.get_setting_values(
-        "devices:local",
-        (
-            "EnergySensor:SensorPosition",
-            "Battery:Type",
-            "EnergySensor:InstalledSensor",
-        ),
-    )
-
-    try:
-        sensor_position = int(
-            excess_energy_settings["devices:local"]["EnergySensor:SensorPosition"]
-        )
-        battery_type = int(excess_energy_settings["devices:local"]["Battery:Type"])
-        installed_sensor = int(
-            excess_energy_settings["devices:local"]["EnergySensor:InstalledSensor"]
-        )
-    except ValueError:
-        _LOGGER.warning(
-            "Failed to retrieve excess energy settings: %s", excess_energy_settings
-        )
-    else:
-        if sensor_position == 2 and battery_type > 0 and installed_sensor > 0:
-            # this settings is only available if
-            # - energy sensor is installed
-            # - energy sensor is positioned at the grid connection
-            # - a battery is installed
-            entities.append(
-                PlenticoreDataSwitch(
-                    settings_data_update_coordinator,
-                    EXCESS_AC_ENERGY_SETTINGS_DATA,
-                    entry.entry_id,
-                    entry.title,
-                    plenticore.device_info,
-                )
-            )
-        else:
-            _LOGGER.debug(
-                "Skipping excess energy switch, not supported (Sensor position: %d, Battery type: %d, Installed sensor: %d)",
-                sensor_position,
-                battery_type,
-                installed_sensor,
-            )
 
     # add shadow management switches for strings which support it
     string_count_setting = await plenticore.client.get_setting_values(

--- a/homeassistant/components/kostal_plenticore/switch.py
+++ b/homeassistant/components/kostal_plenticore/switch.py
@@ -335,7 +335,7 @@ class PlenticoreShadowMgmtSwitch(
         device_info: DeviceInfo,
     ) -> None:
         """Create a new Switch Entity for Plenticore shadow management."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, context=(self.MODULE_ID, self.SHADOW_DATA_ID))
 
         self._mask: Final = 1 << dc_string
 
@@ -361,18 +361,6 @@ class PlenticoreShadowMgmtSwitch(
             and self.MODULE_ID in self.coordinator.data
             and self.SHADOW_DATA_ID in self.coordinator.data[self.MODULE_ID]
         )
-
-    async def async_added_to_hass(self) -> None:
-        """Register this entity on the Update Coordinator."""
-        await super().async_added_to_hass()
-        self.async_on_remove(
-            self.coordinator.start_fetch_data(self.MODULE_ID, self.SHADOW_DATA_ID)
-        )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Unregister this entity from the Update Coordinator."""
-        self.coordinator.stop_fetch_data(self.MODULE_ID, self.SHADOW_DATA_ID)
-        await super().async_will_remove_from_hass()
 
     def _get_shadow_mgmt_value(self) -> int:
         """Return the current shadow management value for all strings as integer."""

--- a/homeassistant/components/kostal_plenticore/switch.py
+++ b/homeassistant/components/kostal_plenticore/switch.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, Final
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -66,7 +67,7 @@ async def async_setup_entry(
     """Add kostal plenticore Switch."""
     plenticore = entry.runtime_data
 
-    entities = []
+    entities: list[Entity] = []
 
     available_settings_data = await plenticore.client.get_settings()
     settings_data_update_coordinator = SettingDataUpdateCoordinator(
@@ -102,6 +103,41 @@ async def async_setup_entry(
                 plenticore.device_info,
             )
         )
+
+    # add shadow management switches for strings which support it
+    dc_strings = (0, 1, 2)
+    dc_string_feature_ids = tuple(
+        PlenticoreShadowMgmtSwitch.DC_STRING_FEATURE_DATA_ID % dc_string
+        for dc_string in dc_strings
+    )
+
+    dc_string_features = await plenticore.client.get_setting_values(
+        PlenticoreShadowMgmtSwitch.MODULE_ID,
+        dc_string_feature_ids,
+    )
+
+    for dc_string, dc_string_feature_id in zip(
+        dc_strings, dc_string_feature_ids, strict=True
+    ):
+        try:
+            dc_string_feature = int(
+                dc_string_features[PlenticoreShadowMgmtSwitch.MODULE_ID][
+                    dc_string_feature_id
+                ]
+            )
+        except ValueError:
+            dc_string_feature = 0
+
+        if dc_string_feature == PlenticoreShadowMgmtSwitch.SHADOW_MANAGEMENT_SUPPORT:
+            entities.append(
+                PlenticoreShadowMgmtSwitch(
+                    settings_data_update_coordinator,
+                    dc_string,
+                    entry.entry_id,
+                    entry.title,
+                    plenticore.device_info,
+                )
+            )
 
     async_add_entities(entities)
 
@@ -189,3 +225,109 @@ class PlenticoreDataSwitch(
                 f"{self.platform_name} {self._name} {self.off_label}"
             )
         return bool(self.coordinator.data[self.module_id][self.data_id] == self._is_on)
+
+
+class PlenticoreShadowMgmtSwitch(
+    CoordinatorEntity[SettingDataUpdateCoordinator], SwitchEntity
+):
+    """Representation of a Plenticore Switch for shadow management.
+
+    The shadow management switch can be controlled for each DC string separately. The DC string is
+    coded as bit in a single settings value, bit 0 for DC string 1, bit 1 for DC string 2, etc.
+
+    Not all DC strings are available for shadown management, for example if one of them is used
+    for a battery.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+    entity_description: SwitchEntityDescription
+
+    MODULE_ID: Final = "devices:local"
+
+    SHADOW_DATA_ID: Final = "Generator:ShadowMgmt:Enable"
+    """Settings id for the bit coded shadow management."""
+
+    DC_STRING_FEATURE_DATA_ID: Final = "Properties:String%dFeatures"
+    """Settings id pattern for the DC string features."""
+
+    SHADOW_MANAGEMENT_SUPPORT: Final = 1
+    """Feature value for shadow management support in the DC string features."""
+
+    def __init__(
+        self,
+        coordinator: SettingDataUpdateCoordinator,
+        dc_string: int,
+        entry_id: str,
+        platform_name: str,
+        device_info: DeviceInfo,
+    ) -> None:
+        """Create a new Switch Entity for Plenticore shadow management."""
+        super().__init__(coordinator)
+
+        self._mask: Final = 1 << dc_string
+
+        self.entity_description = SwitchEntityDescription(
+            key=f"ShadowMgmt{dc_string}",
+            name=f"Shadow Management DC string {dc_string + 1}",
+        )
+
+        self.platform_name = platform_name
+        self._attr_name = f"{platform_name} {self.entity_description.name}"
+        self._attr_unique_id = (
+            f"{entry_id}_{self.MODULE_ID}_{self.SHADOW_DATA_ID}_{dc_string}"
+        )
+        self._attr_device_info = device_info
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            super().available
+            and self.coordinator.data is not None
+            and self.MODULE_ID in self.coordinator.data
+            and self.SHADOW_DATA_ID in self.coordinator.data[self.MODULE_ID]
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Register this entity on the Update Coordinator."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.start_fetch_data(self.MODULE_ID, self.SHADOW_DATA_ID)
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister this entity from the Update Coordinator."""
+        self.coordinator.stop_fetch_data(self.MODULE_ID, self.SHADOW_DATA_ID)
+        await super().async_will_remove_from_hass()
+
+    def _get_shadow_mgmt_value(self) -> int:
+        """Return the current shadow management value for all strings as integer."""
+        try:
+            return int(self.coordinator.data[self.MODULE_ID][self.SHADOW_DATA_ID])
+        except ValueError:
+            return 0
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn shadow management on."""
+        shadow_mgmt_value = self._get_shadow_mgmt_value()
+        shadow_mgmt_value |= self._mask
+
+        if await self.coordinator.async_write_data(
+            self.MODULE_ID, {self.SHADOW_DATA_ID: str(shadow_mgmt_value)}
+        ):
+            await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn shadow management off."""
+        shadow_mgmt_value = self._get_shadow_mgmt_value()
+        shadow_mgmt_value &= ~self._mask
+
+        if await self.coordinator.async_write_data(
+            self.MODULE_ID, {self.SHADOW_DATA_ID: str(shadow_mgmt_value)}
+        ):
+            await self.coordinator.async_request_refresh()
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if shadow management is on."""
+        return (self._get_shadow_mgmt_value() & self._mask) != 0

--- a/homeassistant/components/kostal_plenticore/switch.py
+++ b/homeassistant/components/kostal_plenticore/switch.py
@@ -136,7 +136,9 @@ async def async_setup_entry(
                 excess_energy_settings["devices:local"]["EnergySensor:InstalledSensor"]
             )
         except (KeyError, ValueError):
-            pass
+            _LOGGER.warning(
+                "Failed to retrieve excess energy settings: %s", excess_energy_settings
+            )
         else:
             if sensor_position == 2 and battery_type > 0 and installed_sensor > 0:
                 # this settings is only available if
@@ -152,6 +154,13 @@ async def async_setup_entry(
                         plenticore.device_info,
                         enabled_default=False,
                     )
+                )
+            else:
+                _LOGGER.debug(
+                    "Skipping excess energy switch, not supported (Sensor position: %d, Battery type: %d, Installed sensor: %d)",
+                    sensor_position,
+                    battery_type,
+                    installed_sensor,
                 )
 
     # add shadow management switches for strings which support it
@@ -187,6 +196,12 @@ async def async_setup_entry(
                     entry.title,
                     plenticore.device_info,
                 )
+            )
+        else:
+            _LOGGER.debug(
+                "Skipping shadow management for DC string %d, not supported (Feature: %d)",
+                dc_string + 1,
+                dc_string_feature,
             )
 
     async_add_entities(entities)

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
+import copy
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from pykoplenti import MeData, VersionData
+from pykoplenti import ApiClient, ExtendedApiClient, MeData, SettingsData, VersionData
 import pytest
 
 from homeassistant.components.kostal_plenticore.coordinator import Plenticore
@@ -13,6 +14,59 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from tests.common import MockConfigEntry
+
+DEFAULT_SETTING_VALUES = {
+    "devices:local": {
+        "Properties:StringCnt": "2",
+        "EnergySensor:SensorPosition": "1",
+        "EnergySensor:InstalledSensor": "1",
+        "Battery:Type": "0",
+        "Properties:String0Features": "1",
+        "Properties:String1Features": "1",
+        "Properties:SerialNo": "42",
+        "Branding:ProductName1": "PLENTICORE",
+        "Branding:ProductName2": "plus 10",
+        "Properties:VersionIOC": "01.45",
+        "Properties:VersionMC": " 01.46",
+        "Battery:MinSoc": "5",
+        "Battery:MinHomeComsumption": "50",
+    },
+    "scb:network": {"Hostname": "scb"},
+}
+
+DEFAULT_SETTINGS = {
+    "devices:local": [
+        SettingsData(
+            min="5",
+            max="100",
+            default=None,
+            access="readwrite",
+            unit="%",
+            id="Battery:MinSoc",
+            type="byte",
+        ),
+        SettingsData(
+            min="50",
+            max="38000",
+            default=None,
+            access="readwrite",
+            unit="W",
+            id="Battery:MinHomeComsumption",
+            type="byte",
+        ),
+    ],
+    "scb:network": [
+        SettingsData(
+            min="1",
+            max="63",
+            default=None,
+            access="readwrite",
+            unit=None,
+            id="Hostname",
+            type="string",
+        )
+    ],
+}
 
 
 @pytest.fixture
@@ -86,6 +140,73 @@ def mock_plenticore() -> Generator[Plenticore]:
         plenticore.client.get_setting_values = AsyncMock()
 
         yield plenticore
+
+
+@pytest.fixture
+def mock_plenticore_client() -> Generator[ExtendedApiClient]:
+    """Return a patched ExtendedApiClient."""
+    with patch(
+        "homeassistant.components.kostal_plenticore.coordinator.ExtendedApiClient",
+        autospec=True,
+    ) as plenticore_client_class:
+        yield plenticore_client_class.return_value
+
+
+@pytest.fixture
+def mock_get_settings(
+    mock_plenticore_client: ApiClient,
+) -> dict[str, list[SettingsData]]:
+    """Add setting data to mock_plenticore_client.
+
+    Returns a dictionary with setting data which can be mutated by test cases.
+    """
+    settings = copy.deepcopy(DEFAULT_SETTINGS)
+    mock_plenticore_client.get_settings.return_value = settings
+    return settings
+
+
+@pytest.fixture
+def mock_get_setting_values(
+    mock_plenticore_client: ApiClient,
+) -> dict[str, dict[str, str]]:
+    """Add setting values to mock_plenticore_client.
+
+    Returns a dictionary with setting values which can be mutated by test cases.
+    """
+    # Add default settings values - this values are always retrieved by the integration on startup
+    setting_values = copy.deepcopy(DEFAULT_SETTING_VALUES)
+
+    def default_settings_data(*args):
+        # the get_setting_values method can be called with different argument types and numbers
+        match args:
+            case (str() as module_id, str() as data_id):
+                request = {module_id: [data_id]}
+            case (str() as module_id, Iterable() as data_ids):
+                request = {module_id: data_ids}
+            case ({},):
+                request = args[0]
+            case _:
+                raise NotImplementedError
+
+        result = {}
+        for module_id, data_ids in request.items():
+            if (values := setting_values.get(module_id)) is not None:
+                result[module_id] = {}
+                for data_id in data_ids:
+                    if data_id in values:
+                        result[module_id][data_id] = values[data_id]
+                    else:
+                        raise ValueError(
+                            f"Missing data_id {data_id} in module {module_id}"
+                        )
+            else:
+                raise ValueError(f"Missing module_id {module_id}")
+
+        return result
+
+    mock_plenticore_client.get_setting_values.side_effect = default_settings_data
+
+    return setting_values
 
 
 @pytest.fixture

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -83,6 +83,7 @@ def mock_plenticore() -> Generator[Plenticore]:
 
         plenticore.client.get_process_data = AsyncMock()
         plenticore.client.get_settings = AsyncMock()
+        plenticore.client.get_setting_values = AsyncMock()
 
         yield plenticore
 

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Generator, Iterable
 import copy
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
-from pykoplenti import ApiClient, ExtendedApiClient, MeData, SettingsData, VersionData
+from pykoplenti import ExtendedApiClient, MeData, SettingsData, VersionData
 import pytest
 
-from homeassistant.components.kostal_plenticore.coordinator import Plenticore
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 
 from tests.common import MockConfigEntry
 
@@ -27,7 +25,7 @@ DEFAULT_SETTING_VALUES = {
         "Branding:ProductName1": "PLENTICORE",
         "Branding:ProductName2": "plus 10",
         "Properties:VersionIOC": "01.45",
-        "Properties:VersionMC": " 01.46",
+        "Properties:VersionMC": "01.46",
         "Battery:MinSoc": "5",
         "Battery:MinHomeComsumption": "50",
     },
@@ -96,37 +94,67 @@ def mock_installer_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_plenticore() -> Generator[Plenticore]:
-    """Set up a Plenticore mock with some default values."""
+def mock_get_settings() -> dict[str, list[SettingsData]]:
+    """Add setting data to mock_plenticore_client.
+
+    Returns a dictionary with setting data which can be mutated by test cases.
+    """
+    return copy.deepcopy(DEFAULT_SETTINGS)
+
+
+@pytest.fixture
+def mock_get_setting_values() -> dict[str, dict[str, str]]:
+    """Add setting values to mock_plenticore_client.
+
+    Returns a dictionary with setting values which can be mutated by test cases.
+    """
+    # Add default settings values - this values are always retrieved by the integration on startup
+    return copy.deepcopy(DEFAULT_SETTING_VALUES)
+
+
+@pytest.fixture
+def mock_plenticore_client(
+    mock_get_settings: dict[str, list[SettingsData]],
+    mock_get_setting_values: dict[str, dict[str, str]],
+) -> Generator[ExtendedApiClient]:
+    """Return a patched ExtendedApiClient."""
     with patch(
-        "homeassistant.components.kostal_plenticore.Plenticore", autospec=True
-    ) as mock_api_class:
-        # setup
-        plenticore = mock_api_class.return_value
-        plenticore.async_setup = AsyncMock()
-        plenticore.async_setup.return_value = True
+        "homeassistant.components.kostal_plenticore.coordinator.ExtendedApiClient",
+        autospec=True,
+    ) as plenticore_client_class:
 
-        plenticore.device_info = DeviceInfo(
-            configuration_url="http://192.168.1.2",
-            identifiers={("kostal_plenticore", "12345")},
-            manufacturer="Kostal",
-            model="PLENTICORE plus 10",
-            name="scb",
-            sw_version="IOC: 01.45 MC: 01.46",
-        )
+        def default_settings_data(*args):
+            # the get_setting_values method can be called with different argument types and numbers
+            match args:
+                case (str() as module_id, str() as data_id):
+                    request = {module_id: [data_id]}
+                case (str() as module_id, Iterable() as data_ids):
+                    request = {module_id: data_ids}
+                case ({},):
+                    request = args[0]
+                case _:
+                    raise NotImplementedError
 
-        plenticore.client = MagicMock()
+            result = {}
+            for module_id, data_ids in request.items():
+                if (values := mock_get_setting_values.get(module_id)) is not None:
+                    result[module_id] = {}
+                    for data_id in data_ids:
+                        if data_id in values:
+                            result[module_id][data_id] = values[data_id]
+                        else:
+                            raise ValueError(
+                                f"Missing data_id {data_id} in module {module_id}"
+                            )
+                else:
+                    raise ValueError(f"Missing module_id {module_id}")
 
-        plenticore.client.get_version = AsyncMock()
-        plenticore.client.get_version.return_value = VersionData(
-            api_version="0.2.0",
-            hostname="scb",
-            name="PUCK RESTful API",
-            sw_version="01.16.05025",
-        )
+            return result
 
-        plenticore.client.get_me = AsyncMock()
-        plenticore.client.get_me.return_value = MeData(
+        client = plenticore_client_class.return_value
+        client.get_setting_values.side_effect = default_settings_data
+        client.get_settings.return_value = mock_get_settings
+        client.get_me.return_value = MeData(
             locked=False,
             active=True,
             authenticated=True,
@@ -134,79 +162,14 @@ def mock_plenticore() -> Generator[Plenticore]:
             anonymous=False,
             role="USER",
         )
+        client.get_version.return_value = VersionData(
+            api_version="0.2.0",
+            hostname="scb",
+            name="PUCK RESTful API",
+            sw_version="01.16.05025",
+        )
 
-        plenticore.client.get_process_data = AsyncMock(return_value={})
-        plenticore.client.get_settings = AsyncMock(return_value={})
-        plenticore.client.get_setting_values = AsyncMock(return_value={})
-
-        yield plenticore
-
-
-@pytest.fixture
-def mock_plenticore_client() -> Generator[ExtendedApiClient]:
-    """Return a patched ExtendedApiClient."""
-    with patch(
-        "homeassistant.components.kostal_plenticore.coordinator.ExtendedApiClient",
-        autospec=True,
-    ) as plenticore_client_class:
-        yield plenticore_client_class.return_value
-
-
-@pytest.fixture
-def mock_get_settings(
-    mock_plenticore_client: ApiClient,
-) -> dict[str, list[SettingsData]]:
-    """Add setting data to mock_plenticore_client.
-
-    Returns a dictionary with setting data which can be mutated by test cases.
-    """
-    settings = copy.deepcopy(DEFAULT_SETTINGS)
-    mock_plenticore_client.get_settings.return_value = settings
-    return settings
-
-
-@pytest.fixture
-def mock_get_setting_values(
-    mock_plenticore_client: ApiClient,
-) -> dict[str, dict[str, str]]:
-    """Add setting values to mock_plenticore_client.
-
-    Returns a dictionary with setting values which can be mutated by test cases.
-    """
-    # Add default settings values - this values are always retrieved by the integration on startup
-    setting_values = copy.deepcopy(DEFAULT_SETTING_VALUES)
-
-    def default_settings_data(*args):
-        # the get_setting_values method can be called with different argument types and numbers
-        match args:
-            case (str() as module_id, str() as data_id):
-                request = {module_id: [data_id]}
-            case (str() as module_id, Iterable() as data_ids):
-                request = {module_id: data_ids}
-            case ({},):
-                request = args[0]
-            case _:
-                raise NotImplementedError
-
-        result = {}
-        for module_id, data_ids in request.items():
-            if (values := setting_values.get(module_id)) is not None:
-                result[module_id] = {}
-                for data_id in data_ids:
-                    if data_id in values:
-                        result[module_id][data_id] = values[data_id]
-                    else:
-                        raise ValueError(
-                            f"Missing data_id {data_id} in module {module_id}"
-                        )
-            else:
-                raise ValueError(f"Missing module_id {module_id}")
-
-        return result
-
-    mock_plenticore_client.get_setting_values.side_effect = default_settings_data
-
-    return setting_values
+        yield client
 
 
 @pytest.fixture

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -135,9 +135,9 @@ def mock_plenticore() -> Generator[Plenticore]:
             role="USER",
         )
 
-        plenticore.client.get_process_data = AsyncMock()
-        plenticore.client.get_settings = AsyncMock()
-        plenticore.client.get_setting_values = AsyncMock()
+        plenticore.client.get_process_data = AsyncMock(return_value={})
+        plenticore.client.get_settings = AsyncMock(return_value={})
+        plenticore.client.get_setting_values = AsyncMock(return_value={})
 
         yield plenticore
 

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -16,9 +16,6 @@ from tests.common import MockConfigEntry
 DEFAULT_SETTING_VALUES = {
     "devices:local": {
         "Properties:StringCnt": "2",
-        "EnergySensor:SensorPosition": "1",
-        "EnergySensor:InstalledSensor": "1",
-        "Battery:Type": "0",
         "Properties:String0Features": "1",
         "Properties:String1Features": "1",
         "Properties:SerialNo": "42",

--- a/tests/components/kostal_plenticore/test_diagnostics.py
+++ b/tests/components/kostal_plenticore/test_diagnostics.py
@@ -1,9 +1,8 @@
 """Test Kostal Plenticore diagnostics."""
 
-from pykoplenti import SettingsData
+from unittest.mock import Mock
 
 from homeassistant.components.diagnostics import REDACTED
-from homeassistant.components.kostal_plenticore.coordinator import Plenticore
 from homeassistant.core import HomeAssistant
 
 from tests.common import ANY, MockConfigEntry
@@ -14,42 +13,15 @@ from tests.typing import ClientSessionGenerator
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    mock_plenticore: Plenticore,
+    mock_plenticore_client: Mock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test config entry diagnostics."""
 
-    # set some test process and settings data for the diagnostics output
-    mock_plenticore.client.get_process_data.return_value = {
+    # set some test process data for the diagnostics output
+    mock_plenticore_client.get_process_data.return_value = {
         "devices:local": ["HomeGrid_P", "HomePv_P"]
     }
-
-    mock_plenticore.client.get_settings.return_value = {
-        "devices:local": [
-            SettingsData(
-                min="5",
-                max="100",
-                default=None,
-                access="readwrite",
-                unit="%",
-                id="Battery:MinSoc",
-                type="byte",
-            )
-        ]
-    }
-
-    mock_plenticore.client.get_setting_values.side_effect = [
-        {"devices:local": {"Properties:StringCnt": "2"}},
-        {
-            "devices:local": {
-                "EnergySensor:SensorPosition": "2",
-                "EnergySensor:InstalledSensor": "1",
-                "Battery:Type": "1",
-                "Properties:String0Features": "1",
-                "Properties:String1Features": "1",
-            }
-        },
-    ]
 
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration
@@ -78,15 +50,19 @@ async def test_entry_diagnostics(
             "available_process_data": {"devices:local": ["HomeGrid_P", "HomePv_P"]},
             "available_settings_data": {
                 "devices:local": [
-                    "min='5' max='100' default=None access='readwrite' unit='%' id='Battery:MinSoc' type='byte'"
-                ]
+                    "min='5' max='100' default=None access='readwrite' unit='%' id='Battery:MinSoc' type='byte'",
+                    "min='50' max='38000' default=None access='readwrite' unit='W' id='Battery:MinHomeComsumption' type='byte'",
+                ],
+                "scb:network": [
+                    "min='1' max='63' default=None access='readwrite' unit=None id='Hostname' type='string'"
+                ],
             },
         },
         "configuration": {
             "devices:local": {
-                "EnergySensor:SensorPosition": "2",
+                "EnergySensor:SensorPosition": "1",
                 "EnergySensor:InstalledSensor": "1",
-                "Battery:Type": "1",
+                "Battery:Type": "0",
                 "Properties:String0Features": "1",
                 "Properties:String1Features": "1",
             },

--- a/tests/components/kostal_plenticore/test_diagnostics.py
+++ b/tests/components/kostal_plenticore/test_diagnostics.py
@@ -60,9 +60,6 @@ async def test_entry_diagnostics(
         },
         "configuration": {
             "devices:local": {
-                "EnergySensor:SensorPosition": "1",
-                "EnergySensor:InstalledSensor": "1",
-                "Battery:Type": "0",
                 "Properties:String0Features": "1",
                 "Properties:String1Features": "1",
             },

--- a/tests/components/kostal_plenticore/test_diagnostics.py
+++ b/tests/components/kostal_plenticore/test_diagnostics.py
@@ -60,10 +60,10 @@ async def test_entry_diagnostics(
         },
         "configuration": {
             "devices:local": {
+                "Properties:StringCnt": "2",
                 "Properties:String0Features": "1",
                 "Properties:String1Features": "1",
             },
-            "string_count": 2,
         },
         "device": {
             "configuration_url": "http://192.168.1.2",
@@ -73,4 +73,29 @@ async def test_entry_diagnostics(
             "name": "scb",
             "sw_version": "IOC: 01.45 MC: 01.46",
         },
+    }
+
+
+async def test_entry_diagnostics_invalid_string_count(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_plenticore_client: Mock,
+    mock_get_setting_values: Mock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test config entry diagnostics if string count is invalid."""
+
+    # set some test process data for the diagnostics output
+    mock_plenticore_client.get_process_data.return_value = {
+        "devices:local": ["HomeGrid_P", "HomePv_P"]
+    }
+
+    mock_get_setting_values["devices:local"]["Properties:StringCnt"] = "invalid"
+
+    diagnostic_data = await get_diagnostics_for_config_entry(
+        hass, hass_client, init_integration
+    )
+
+    assert diagnostic_data["configuration"] == {
+        "devices:local": {"Properties:StringCnt": "invalid"}
     }

--- a/tests/components/kostal_plenticore/test_diagnostics.py
+++ b/tests/components/kostal_plenticore/test_diagnostics.py
@@ -38,6 +38,19 @@ async def test_entry_diagnostics(
         ]
     }
 
+    mock_plenticore.client.get_setting_values.side_effect = [
+        {"devices:local": {"Properties:StringCnt": "2"}},
+        {
+            "devices:local": {
+                "EnergySensor:SensorPosition": "2",
+                "EnergySensor:InstalledSensor": "1",
+                "Battery:Type": "1",
+                "Properties:String0Features": "1",
+                "Properties:String1Features": "1",
+            }
+        },
+    ]
+
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration
     ) == {
@@ -68,6 +81,16 @@ async def test_entry_diagnostics(
                     "min='5' max='100' default=None access='readwrite' unit='%' id='Battery:MinSoc' type='byte'"
                 ]
             },
+        },
+        "configuration": {
+            "devices:local": {
+                "EnergySensor:SensorPosition": "2",
+                "EnergySensor:InstalledSensor": "1",
+                "Battery:Type": "1",
+                "Properties:String0Features": "1",
+                "Properties:String1Features": "1",
+            },
+            "string_count": 2,
         },
         "device": {
             "configuration_url": "http://192.168.1.2",

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -19,14 +19,16 @@ from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
+pytestmark = [
+    pytest.mark.usefixtures("mock_plenticore_client"),
+]
+
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_setup_all_entries(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
-    mock_get_settings: dict[str, list[SettingsData]],
-    mock_get_setting_values: dict[str, dict[str, str]],
 ) -> None:
     """Test if all available entries are setup."""
 
@@ -47,7 +49,6 @@ async def test_setup_no_entries(
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_get_settings: dict[str, list[SettingsData]],
-    mock_get_setting_values: dict[str, dict[str, str]],
 ) -> None:
     """Test that no entries are setup if Plenticore does not provide data."""
 
@@ -82,7 +83,6 @@ async def test_setup_no_entries(
 async def test_number_has_value(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_get_settings: dict[str, list[SettingsData]],
     mock_get_setting_values: dict[str, dict[str, str]],
 ) -> None:
     """Test if number has a value if data is provided on update."""
@@ -107,7 +107,6 @@ async def test_number_has_value(
 async def test_number_is_unavailable(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_get_settings: dict[str, list[SettingsData]],
     mock_get_setting_values: dict[str, dict[str, str]],
 ) -> None:
     """Test if number is unavailable if no data is provided on update."""
@@ -131,7 +130,6 @@ async def test_set_value(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
-    mock_get_settings: dict[str, list[SettingsData]],
     mock_get_setting_values: dict[str, dict[str, str]],
 ) -> None:
     """Test if a new value could be set."""

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -47,11 +47,27 @@ async def test_setup_no_entries(
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_get_settings: dict[str, list[SettingsData]],
+    mock_get_setting_values: dict[str, dict[str, str]],
 ) -> None:
     """Test that no entries are setup if Plenticore does not provide data."""
 
     # remove all settings except hostname which is used during setup
-    mock_get_settings["devices:local"].clear()
+    mock_get_settings.clear()
+    mock_get_settings.update(
+        {
+            "scb:network": [
+                SettingsData(
+                    min="1",
+                    max="63",
+                    default=None,
+                    access="readwrite",
+                    unit=None,
+                    id="Hostname",
+                    type="string",
+                )
+            ]
+        }
+    )
 
     mock_config_entry.add_to_hass(hass)
 

--- a/tests/components/kostal_plenticore/test_select.py
+++ b/tests/components/kostal_plenticore/test_select.py
@@ -2,7 +2,6 @@
 
 from pykoplenti import SettingsData
 
-from homeassistant.components.kostal_plenticore.coordinator import Plenticore
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -11,14 +10,14 @@ from tests.common import MockConfigEntry
 
 async def test_select_battery_charging_usage_available(
     hass: HomeAssistant,
-    mock_plenticore: Plenticore,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
+    mock_get_settings: dict[str, list[SettingsData]],
 ) -> None:
     """Test that the battery charging usage select entity is added if the settings are available."""
 
-    mock_plenticore.client.get_settings.return_value = {
-        "devices:local": [
+    mock_get_settings["devices:local"].extend(
+        [
             SettingsData(
                 min=None,
                 max=None,
@@ -38,7 +37,7 @@ async def test_select_battery_charging_usage_available(
                 type="string",
             ),
         ]
-    }
+    )
 
     mock_config_entry.add_to_hass(hass)
 
@@ -47,12 +46,75 @@ async def test_select_battery_charging_usage_available(
 
     assert entity_registry.async_is_registered("select.battery_charging_usage_mode")
 
+    entity = entity_registry.async_get("select.battery_charging_usage_mode")
+    assert entity.capabilities.get("options") == [
+        "None",
+        "Battery:SmartBatteryControl:Enable",
+        "Battery:TimeControl:Enable",
+    ]
+
+
+async def test_select_battery_charging_usage_excess_energy_available(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    mock_get_settings: dict[str, list[SettingsData]],
+    mock_get_setting_values: dict[str, dict[str, str]],
+) -> None:
+    """Test that the battery charging usage select entity contains the option for excess AC energy."""
+
+    mock_get_settings["devices:local"].extend(
+        [
+            SettingsData(
+                min=None,
+                max=None,
+                default=None,
+                access="readwrite",
+                unit=None,
+                id="Battery:SmartBatteryControl:Enable",
+                type="string",
+            ),
+            SettingsData(
+                min=None,
+                max=None,
+                default=None,
+                access="readwrite",
+                unit=None,
+                id="Battery:TimeControl:Enable",
+                type="string",
+            ),
+        ]
+    )
+
+    mock_get_setting_values["devices:local"].update(
+        {
+            "Battery:Type": "1",
+            "EnergySensor:SensorPosition": "2",
+            "EnergySensor:InstalledSensor": "1",
+        }
+    )
+
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_is_registered("select.battery_charging_usage_mode")
+
+    entity = entity_registry.async_get("select.battery_charging_usage_mode")
+    assert entity.capabilities.get("options") == [
+        "None",
+        "Battery:SmartBatteryControl:Enable",
+        "Battery:TimeControl:Enable",
+        "EnergyMgmt:AcStorage",
+    ]
+
 
 async def test_select_battery_charging_usage_not_available(
     hass: HomeAssistant,
-    mock_plenticore: Plenticore,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
+    mock_get_settings: dict[str, list[SettingsData]],
 ) -> None:
     """Test that the battery charging usage select entity is not added if the settings are unavailable."""
 

--- a/tests/components/kostal_plenticore/test_select.py
+++ b/tests/components/kostal_plenticore/test_select.py
@@ -13,6 +13,7 @@ async def test_select_battery_charging_usage_available(
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     mock_get_settings: dict[str, list[SettingsData]],
+    mock_get_setting_values: dict[str, dict[str, str]],
 ) -> None:
     """Test that the battery charging usage select entity is added if the settings are available."""
 
@@ -115,6 +116,7 @@ async def test_select_battery_charging_usage_not_available(
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     mock_get_settings: dict[str, list[SettingsData]],
+    mock_get_setting_values: dict[str, dict[str, str]],
 ) -> None:
     """Test that the battery charging usage select entity is not added if the settings are unavailable."""
 

--- a/tests/components/kostal_plenticore/test_select.py
+++ b/tests/components/kostal_plenticore/test_select.py
@@ -1,11 +1,16 @@
 """Test the Kostal Plenticore Solar Inverter select platform."""
 
 from pykoplenti import SettingsData
+import pytest
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
+
+pytestmark = [
+    pytest.mark.usefixtures("mock_plenticore_client"),
+]
 
 
 async def test_select_battery_charging_usage_available(
@@ -13,7 +18,6 @@ async def test_select_battery_charging_usage_available(
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     mock_get_settings: dict[str, list[SettingsData]],
-    mock_get_setting_values: dict[str, dict[str, str]],
 ) -> None:
     """Test that the battery charging usage select entity is added if the settings are available."""
 
@@ -115,8 +119,6 @@ async def test_select_battery_charging_usage_not_available(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
-    mock_get_settings: dict[str, list[SettingsData]],
-    mock_get_setting_values: dict[str, dict[str, str]],
 ) -> None:
     """Test that the battery charging usage select entity is not added if the settings are unavailable."""
 

--- a/tests/components/kostal_plenticore/test_select.py
+++ b/tests/components/kostal_plenticore/test_select.py
@@ -91,14 +91,6 @@ async def test_select_battery_charging_usage_excess_energy_available(
         ]
     )
 
-    mock_get_setting_values["devices:local"].update(
-        {
-            "Battery:Type": "1",
-            "EnergySensor:SensorPosition": "2",
-            "EnergySensor:InstalledSensor": "1",
-        }
-    )
-
     mock_config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -111,7 +103,6 @@ async def test_select_battery_charging_usage_excess_energy_available(
         "None",
         "Battery:SmartBatteryControl:Enable",
         "Battery:TimeControl:Enable",
-        "EnergyMgmt:AcStorage",
     ]
 
 

--- a/tests/components/kostal_plenticore/test_switch.py
+++ b/tests/components/kostal_plenticore/test_switch.py
@@ -20,11 +20,14 @@ from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
+pytestmark = [
+    pytest.mark.usefixtures("mock_plenticore_client"),
+]
+
 
 async def test_installer_setting_not_available(
     hass: HomeAssistant,
     mock_get_settings: dict[str, list[SettingsData]],
-    mock_get_setting_values: dict[str, dict[str, str]],
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -56,7 +59,6 @@ async def test_installer_setting_not_available(
 async def test_installer_setting_available(
     hass: HomeAssistant,
     mock_get_settings: dict[str, list[SettingsData]],
-    mock_get_setting_values: dict[str, dict[str, str]],
     mock_installer_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -87,7 +89,6 @@ async def test_installer_setting_available(
 
 async def test_invalid_string_count_value(
     hass: HomeAssistant,
-    mock_get_settings: dict[str, list[SettingsData]],
     mock_get_setting_values: dict[str, dict[str, str]],
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
@@ -120,10 +121,8 @@ async def test_invalid_string_count_value(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_shadow_management_switch_state(
     hass: HomeAssistant,
-    mock_get_settings: dict[str, list[SettingsData]],
     mock_get_setting_values: dict[str, dict[str, str]],
     mock_config_entry: MockConfigEntry,
-    entity_registry: er.EntityRegistry,
     shadow_mgmt: str,
     string: tuple[str, str],
 ) -> None:
@@ -163,11 +162,9 @@ async def test_shadow_management_switch_state(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_shadow_management_switch_action(
     hass: HomeAssistant,
-    mock_get_settings: dict[str, list[SettingsData]],
     mock_get_setting_values: dict[str, dict[str, str]],
     mock_plenticore_client: Mock,
     mock_config_entry: MockConfigEntry,
-    entity_registry: er.EntityRegistry,
     initial_shadow_mgmt: str,
     dc_string: int,
     service: str,

--- a/tests/components/kostal_plenticore/test_switch.py
+++ b/tests/components/kostal_plenticore/test_switch.py
@@ -1,15 +1,12 @@
 """Test the Kostal Plenticore Solar Inverter switch platform."""
 
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import Mock
 
-from pykoplenti import ApiClient, SettingsData
+from pykoplenti import SettingsData
 import pytest
 
-from homeassistant.components.switch import (
-    DOMAIN as SWITCH_DOMAIN,
-    SwitchEntityDescription,
-)
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -111,12 +108,6 @@ async def test_invalid_string_count_value(
     ] == []
 
 
-def _enabled_switch_entity_instance(*args, **kwargs):
-    """Return a SwitchEntityDescription which is enabled by default."""
-    kwargs["entity_registry_enabled_default"] = True
-    return SwitchEntityDescription(*args, **kwargs)
-
-
 @pytest.mark.parametrize(
     ("shadow_mgmt", "string"),
     [
@@ -126,6 +117,7 @@ def _enabled_switch_entity_instance(*args, **kwargs):
         ("3", (STATE_ON, STATE_ON)),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_shadow_management_switch_state(
     hass: HomeAssistant,
     mock_get_settings: dict[str, list[SettingsData]],
@@ -136,28 +128,23 @@ async def test_shadow_management_switch_state(
     string: tuple[str, str],
 ) -> None:
     """Test that the state of the shadow management switch is correct."""
+    mock_get_setting_values["devices:local"].update(
+        {"Properties:StringCnt": "2", "Generator:ShadowMgmt:Enable": shadow_mgmt}
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-    with patch(
-        "homeassistant.components.kostal_plenticore.switch.SwitchEntityDescription",
-        side_effect=_enabled_switch_entity_instance,
-    ):
-        mock_get_setting_values["devices:local"].update(
-            {"Properties:StringCnt": "2", "Generator:ShadowMgmt:Enable": shadow_mgmt}
-        )
-        mock_config_entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=300))
+    await hass.async_block_till_done(wait_background_tasks=True)
 
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=300))
-        await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get("switch.scb_shadow_management_dc_string_1")
+    assert state is not None
+    assert state.state == string[0]
 
-        state = hass.states.get("switch.scb_shadow_management_dc_string_1")
-        assert state is not None
-        assert state.state == string[0]
-
-        state = hass.states.get("switch.scb_shadow_management_dc_string_2")
-        assert state is not None
-        assert state.state == string[1]
+    state = hass.states.get("switch.scb_shadow_management_dc_string_2")
+    assert state is not None
+    assert state.state == string[1]
 
 
 @pytest.mark.parametrize(
@@ -173,11 +160,12 @@ async def test_shadow_management_switch_state(
         ("3", 2, SERVICE_TURN_OFF, "1"),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_shadow_management_switch_action(
     hass: HomeAssistant,
     mock_get_settings: dict[str, list[SettingsData]],
     mock_get_setting_values: dict[str, dict[str, str]],
-    mock_plenticore_client: ApiClient,
+    mock_plenticore_client: Mock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     initial_shadow_mgmt: str,
@@ -186,33 +174,26 @@ async def test_shadow_management_switch_action(
     shadow_mgmt: str,
 ) -> None:
     """Test that the shadow management can be switch on/off."""
+    mock_get_setting_values["devices:local"].update(
+        {
+            "Properties:StringCnt": "2",
+            "Generator:ShadowMgmt:Enable": initial_shadow_mgmt,
+        }
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-    with patch(
-        "homeassistant.components.kostal_plenticore.switch.SwitchEntityDescription",
-        side_effect=_enabled_switch_entity_instance,
-    ):
-        mock_get_setting_values["devices:local"].update(
-            {
-                "Properties:StringCnt": "2",
-                "Generator:ShadowMgmt:Enable": initial_shadow_mgmt,
-            }
-        )
-        mock_config_entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=300))
+    await hass.async_block_till_done(wait_background_tasks=True)
 
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=300))
-        await hass.async_block_till_done(wait_background_tasks=True)
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service,
+        target={ATTR_ENTITY_ID: f"switch.scb_shadow_management_dc_string_{dc_string}"},
+        blocking=True,
+    )
 
-        await hass.services.async_call(
-            SWITCH_DOMAIN,
-            service,
-            target={
-                ATTR_ENTITY_ID: f"switch.scb_shadow_management_dc_string_{dc_string}"
-            },
-            blocking=True,
-        )
-
-        mock_plenticore_client.set_setting_values.assert_called_with(
-            "devices:local", {"Generator:ShadowMgmt:Enable": shadow_mgmt}
-        )
+    mock_plenticore_client.set_setting_values.assert_called_with(
+        "devices:local", {"Generator:ShadowMgmt:Enable": shadow_mgmt}
+    )

--- a/tests/components/kostal_plenticore/test_switch.py
+++ b/tests/components/kostal_plenticore/test_switch.py
@@ -2,7 +2,6 @@
 
 from pykoplenti import SettingsData
 
-from homeassistant.components.kostal_plenticore.coordinator import Plenticore
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -11,25 +10,27 @@ from tests.common import MockConfigEntry
 
 async def test_installer_setting_not_available(
     hass: HomeAssistant,
-    mock_plenticore: Plenticore,
+    mock_get_settings: dict[str, list[SettingsData]],
+    mock_get_setting_values: dict[str, dict[str, str]],
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test that the manual charge setting is not available when not using the installer login."""
-
-    mock_plenticore.client.get_settings.return_value = {
-        "devices:local": [
-            SettingsData(
-                min=None,
-                max=None,
-                default=None,
-                access="readwrite",
-                unit=None,
-                id="Battery:ManualCharge",
-                type="bool",
-            )
-        ]
-    }
+    mock_get_settings.update(
+        {
+            "devices:local": [
+                SettingsData(
+                    min=None,
+                    max=None,
+                    default=None,
+                    access="readwrite",
+                    unit=None,
+                    id="Battery:ManualCharge",
+                    type="bool",
+                )
+            ]
+        }
+    )
 
     mock_config_entry.add_to_hass(hass)
 
@@ -41,25 +42,27 @@ async def test_installer_setting_not_available(
 
 async def test_installer_setting_available(
     hass: HomeAssistant,
-    mock_plenticore: Plenticore,
+    mock_get_settings: dict[str, list[SettingsData]],
+    mock_get_setting_values: dict[str, dict[str, str]],
     mock_installer_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test that the manual charge setting is available when using the installer login."""
-
-    mock_plenticore.client.get_settings.return_value = {
-        "devices:local": [
-            SettingsData(
-                min=None,
-                max=None,
-                default=None,
-                access="readwrite",
-                unit=None,
-                id="Battery:ManualCharge",
-                type="bool",
-            )
-        ]
-    }
+    mock_get_settings.update(
+        {
+            "devices:local": [
+                SettingsData(
+                    min=None,
+                    max=None,
+                    default=None,
+                    access="readwrite",
+                    unit=None,
+                    id="Battery:ManualCharge",
+                    type="bool",
+                )
+            ]
+        }
+    )
 
     mock_installer_config_entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new configuration entities for the Kostal Plenticore integration, which enables or disables shadow management for supported DC strings (see also #141746).

Since shadow management uses the same settings ID for multiple DC strings, the update coordinator was slightly extended to prevent polling the same settings ID multiple times.

For compatibility reasons, the new configuration is disabled by default.

Additionally, tests have been added for the new entities. Since they require a different setup, the fixtures have been adapted and consolidated to avoid code duplication.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #141746 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41519
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
