### PR TITLE
Use SI constants in CO unit converter

### DIFF
--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -180,7 +180,7 @@ class BaseUnitConverter:
 
 
 class CarbonMonoxideConcentrationConverter(BaseUnitConverter):
-    """Convert carbon monoxide mass ratio to mass per volume.
+    """Convert carbon monoxide ratio to mass per volume.
 
     Using SATP (Standard Ambient Temperature and Pressure) conditions.
     """

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -180,9 +180,9 @@ class BaseUnitConverter:
 
 
 class CarbonMonoxideConcentrationConverter(BaseUnitConverter):
-    """Convert carbon monoxide ratio to mass per volume.
+    """Convert carbon monoxide mass ratio to mass per volume.
 
-    Using Standard Ambient Temperature and Pressure (SATP) conditions.
+    Using SATP (Standard Ambient Temperature and Pressure) conditions.
     """
 
     UNIT_CLASS = "carbon_monoxide"

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -91,6 +91,17 @@ _GALLON_TO_CUBIC_METER = 231 * pow(_IN_TO_M, 3)  # US gallon is 231 cubic inches
 _FLUID_OUNCE_TO_CUBIC_METER = _GALLON_TO_CUBIC_METER / 128  # 128 fl. oz. in a US gallon
 _CUBIC_FOOT_TO_CUBIC_METER = pow(_FOOT_TO_M, 3)
 
+# Gas concentration conversion constants
+_IDEAL_GAS_CONSTANT = 8.31446261815324  # m3⋅Pa⋅K−1⋅mol−1
+# Standard Ambient Temperature and Pressure constants
+_SATP_TEMPERATURE = 298.15  # K (25 °C)
+_SATP_PRESSURE = 101325  # Pa (1 atm)
+_SATP_IDEAL_GAS_MOLAR_VOLUME = (  # m3⋅mol-1
+    _IDEAL_GAS_CONSTANT * _SATP_TEMPERATURE / _SATP_PRESSURE
+)
+# Molar masses in g/mol
+_CARBON_MONOXIDE_MOLAR_MASS = 28.01
+
 
 class BaseUnitConverter:
     """Define the format of a conversion utility."""
@@ -173,10 +184,10 @@ class CarbonMonoxideConcentrationConverter(BaseUnitConverter):
 
     UNIT_CLASS = "carbon_monoxide"
     _UNIT_CONVERSION: dict[str | None, float] = {
-        CONCENTRATION_PARTS_PER_MILLION: 1,
-        # concentration (mg/m3) = 0.0409 x concentration (ppm) x molar mass
-        # Carbon monoxide molar mass: 28.01 g/mol
-        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: 0.0409 * 28.01,
+        CONCENTRATION_PARTS_PER_MILLION: 1e6,
+        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: _CARBON_MONOXIDE_MOLAR_MASS
+        * 1e3
+        / _SATP_IDEAL_GAS_MOLAR_VOLUME,
     }
     VALID_UNITS = {
         CONCENTRATION_PARTS_PER_MILLION,

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -93,13 +93,13 @@ _CUBIC_FOOT_TO_CUBIC_METER = pow(_FOOT_TO_M, 3)
 
 # Gas concentration conversion constants
 _IDEAL_GAS_CONSTANT = 8.31446261815324  # m3⋅Pa⋅K⁻¹⋅mol⁻¹
-# Standard Ambient Temperature and Pressure constants
-_SATP_TEMPERATURE = 298.15  # K (25 °C)
-_SATP_PRESSURE = 101325  # Pa (1 atm)
-_SATP_IDEAL_GAS_MOLAR_VOLUME = (  # m3⋅mol⁻¹
-    _IDEAL_GAS_CONSTANT * _SATP_TEMPERATURE / _SATP_PRESSURE
+# Ambient constants based on European Commission recommendations (20 °C and 1013mb)
+_AMBIENT_TEMPERATURE = 293.15  # K (20 °C)
+_AMBIENT_PRESSURE = 101325  # Pa (1 atm)
+_AMBIENT_IDEAL_GAS_MOLAR_VOLUME = (  # m3⋅mol⁻¹
+    _IDEAL_GAS_CONSTANT * _AMBIENT_TEMPERATURE / _AMBIENT_PRESSURE
 )
-# Molar masses in g/mol
+# Molar masses in g⋅mol⁻¹
 _CARBON_MONOXIDE_MOLAR_MASS = 28.01
 
 
@@ -189,7 +189,7 @@ class CarbonMonoxideConcentrationConverter(BaseUnitConverter):
     _UNIT_CONVERSION: dict[str | None, float] = {
         CONCENTRATION_PARTS_PER_MILLION: 1e6,
         CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: (
-            _CARBON_MONOXIDE_MOLAR_MASS / _SATP_IDEAL_GAS_MOLAR_VOLUME * 1e3
+            _CARBON_MONOXIDE_MOLAR_MASS / _AMBIENT_IDEAL_GAS_MOLAR_VOLUME * 1e3
         ),
     }
     VALID_UNITS = {

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -182,7 +182,7 @@ class BaseUnitConverter:
 class CarbonMonoxideConcentrationConverter(BaseUnitConverter):
     """Convert carbon monoxide ratio to mass per volume.
 
-    Using SATP (Standard Ambient Temperature and Pressure) conditions.
+    Using ambient temperature of 20°C and pressure of 1 ATM.
     """
 
     UNIT_CLASS = "carbon_monoxide"

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -92,11 +92,11 @@ _FLUID_OUNCE_TO_CUBIC_METER = _GALLON_TO_CUBIC_METER / 128  # 128 fl. oz. in a U
 _CUBIC_FOOT_TO_CUBIC_METER = pow(_FOOT_TO_M, 3)
 
 # Gas concentration conversion constants
-_IDEAL_GAS_CONSTANT = 8.31446261815324  # m3⋅Pa⋅K−1⋅mol−1
+_IDEAL_GAS_CONSTANT = 8.31446261815324  # m3⋅Pa⋅K⁻¹⋅mol⁻¹
 # Standard Ambient Temperature and Pressure constants
 _SATP_TEMPERATURE = 298.15  # K (25 °C)
 _SATP_PRESSURE = 101325  # Pa (1 atm)
-_SATP_IDEAL_GAS_MOLAR_VOLUME = (  # m3⋅mol-1
+_SATP_IDEAL_GAS_MOLAR_VOLUME = (  # m3⋅mol⁻¹
     _IDEAL_GAS_CONSTANT * _SATP_TEMPERATURE / _SATP_PRESSURE
 )
 # Molar masses in g/mol

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -180,14 +180,17 @@ class BaseUnitConverter:
 
 
 class CarbonMonoxideConcentrationConverter(BaseUnitConverter):
-    """Convert carbon monoxide ratio to mass per volume."""
+    """Convert carbon monoxide ratio to mass per volume.
+
+    Using Standard Ambient Temperature and Pressure (SATP) conditions.
+    """
 
     UNIT_CLASS = "carbon_monoxide"
     _UNIT_CONVERSION: dict[str | None, float] = {
         CONCENTRATION_PARTS_PER_MILLION: 1e6,
-        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: _CARBON_MONOXIDE_MOLAR_MASS
-        * 1e3
-        / _SATP_IDEAL_GAS_MOLAR_VOLUME,
+        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: (
+            _CARBON_MONOXIDE_MOLAR_MASS / _SATP_IDEAL_GAS_MOLAR_VOLUME * 1e3
+        ),
     }
     VALID_UNITS = {
         CONCENTRATION_PARTS_PER_MILLION,

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -3626,7 +3626,7 @@ async def test_compile_hourly_statistics_changing_units_3(
             13.050847,
             -10,
             30,
-            1.145609,
+            1.16441,
         ),
         (
             "carbon_monoxide",
@@ -3636,7 +3636,7 @@ async def test_compile_hourly_statistics_changing_units_3(
             13.050847,
             -10,
             30,
-            1 / 1.145609,
+            1 / 1.16441,
         ),
         (None, "%", None, "unitless", 13.050847, -10, 30, 0.01),
         (None, "W", "kW", "power", 13.050847, -10, 30, 0.001),

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -119,7 +119,7 @@ _GET_UNIT_RATIO: dict[type[BaseUnitConverter], tuple[str | None, str | None, flo
     CarbonMonoxideConcentrationConverter: (
         CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
         CONCENTRATION_PARTS_PER_MILLION,
-        1.145609,
+        1.144882,
     ),
     ConductivityConverter: (
         UnitOfConductivity.MICROSIEMENS_PER_CM,
@@ -291,13 +291,13 @@ _CONVERTED_VALUE: dict[
         (
             1,
             CONCENTRATION_PARTS_PER_MILLION,
-            1.145609,
+            1.144882,
             CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
         ),
         (
             120,
             CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-            104.74778,
+            104.81429,
             CONCENTRATION_PARTS_PER_MILLION,
         ),
     ],

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -119,7 +119,7 @@ _GET_UNIT_RATIO: dict[type[BaseUnitConverter], tuple[str | None, str | None, flo
     CarbonMonoxideConcentrationConverter: (
         CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
         CONCENTRATION_PARTS_PER_MILLION,
-        1.144882,
+        1.16441,
     ),
     ConductivityConverter: (
         UnitOfConductivity.MICROSIEMENS_PER_CM,
@@ -291,13 +291,13 @@ _CONVERTED_VALUE: dict[
         (
             1,
             CONCENTRATION_PARTS_PER_MILLION,
-            1.144882,
+            1.16441,
             CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
         ),
         (
             120,
             CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-            104.81429,
+            103.05655,
             CONCENTRATION_PARTS_PER_MILLION,
         ),
     ],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It took me a while to understand where the undocumented ratio `0.0409` was coming from, and it turns out to be the inverse of a rough approximation of the SATP molar volume `24.45`

SATP assumes an ambient temperature of 25°C and pressure of 1 ATM.

However the recommendation in the EU is to use 20°C and 1ATM, so adjusting to that instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
