### PR TITLE
Use attribute names for match class

### DIFF
--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -341,12 +341,12 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
     def process_update(self, message: status.Known) -> None:
         """Process update."""
         match message:
-            case status.Power(status.Power.Param.ON):
+            case status.Power(param=status.Power.Param.ON):
                 self._attr_state = MediaPlayerState.ON
-            case status.Power(status.Power.Param.STANDBY):
+            case status.Power(param=status.Power.Param.STANDBY):
                 self._attr_state = MediaPlayerState.OFF
 
-            case status.Volume(volume):
+            case status.Volume(param=volume):
                 if not self._supports_volume:
                     self._attr_supported_features |= SUPPORTED_FEATURES_VOLUME
                     self._supports_volume = True
@@ -356,10 +356,10 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
                 )
                 self._attr_volume_level = min(1, volume_level)
 
-            case status.Muting(muting):
+            case status.Muting(param=muting):
                 self._attr_is_volume_muted = bool(muting == status.Muting.Param.ON)
 
-            case status.InputSource(source):
+            case status.InputSource(param=source):
                 if source in self._source_mapping:
                     self._attr_source = self._source_mapping[source]
                 else:
@@ -373,7 +373,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
 
                 self._query_av_info_delayed()
 
-            case status.ListeningMode(sound_mode):
+            case status.ListeningMode(param=sound_mode):
                 if not self._supports_sound_mode:
                     self._attr_supported_features |= (
                         MediaPlayerEntityFeature.SELECT_SOUND_MODE
@@ -393,13 +393,13 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
 
                 self._query_av_info_delayed()
 
-            case status.HDMIOutput(hdmi_output):
+            case status.HDMIOutput(param=hdmi_output):
                 self._attr_extra_state_attributes[ATTR_VIDEO_OUT] = (
                     self._hdmi_output_mapping[hdmi_output]
                 )
                 self._query_av_info_delayed()
 
-            case status.TunerPreset(preset):
+            case status.TunerPreset(param=preset):
                 self._attr_extra_state_attributes[ATTR_PRESET] = preset
 
             case status.AudioInformation():
@@ -427,11 +427,11 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
             case status.FLDisplay():
                 self._query_av_info_delayed()
 
-            case status.NotAvailable(Kind.AUDIO_INFORMATION):
+            case status.NotAvailable(kind=Kind.AUDIO_INFORMATION):
                 # Not available right now, but still supported
                 self._supports_audio_info = True
 
-            case status.NotAvailable(Kind.VIDEO_INFORMATION):
+            case status.NotAvailable(kind=Kind.VIDEO_INFORMATION):
                 # Not available right now, but still supported
                 self._supports_video_info = True
 


### PR DESCRIPTION
## Proposed change
Match Class patterns are fairly slow, especially when combined with positional patterns. For these Python first needs to lookup `__match_args__`. Using the attribute names is thus not only more explicit but also a bit faster.

_The next major pylint release will also add a check for it._
https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/match-class-positional-attributes.html

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
