### PR TITLE
Revert "Add comment on conversion factor for Carbon monoxide on dependency molecular weight"

### DIFF
--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -174,9 +174,7 @@ class CarbonMonoxideConcentrationConverter(BaseUnitConverter):
     UNIT_CLASS = "carbon_monoxide"
     _UNIT_CONVERSION: dict[str | None, float] = {
         CONCENTRATION_PARTS_PER_MILLION: 1,
-        # concentration (mg/m3) = 0.0409 x concentration (ppm) x molecular weight
-        # Carbon monoxide molecular weight: 28.01 g/mol
-        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: 0.0409 * 28.01,
+        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: 1.145609,
     }
     VALID_UNITS = {
         CONCENTRATION_PARTS_PER_MILLION,


### PR DESCRIPTION
Reverts home-assistant/core#152535

We need to revert it because parent PR #152456 breaks unit conversion in recorder