### PR TITLE
Move state conversion from library to nasweb integration code

### DIFF
--- a/homeassistant/components/nasweb/manifest.json
+++ b/homeassistant/components/nasweb/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/nasweb",
   "integration_type": "hub",
   "iot_class": "local_push",
-  "requirements": ["webio-api==0.1.11"]
+  "requirements": ["webio-api==0.1.12"]
 }

--- a/homeassistant/components/nasweb/sensor.py
+++ b/homeassistant/components/nasweb/sensor.py
@@ -6,6 +6,13 @@ import logging
 import time
 
 from webio_api import Input as NASwebInput, TempSensor
+from webio_api.const import (
+    STATE_INPUT_ACTIVE,
+    STATE_INPUT_NORMAL,
+    STATE_INPUT_PROBLEM,
+    STATE_INPUT_TAMPER,
+    STATE_INPUT_UNDEFINED,
+)
 
 from homeassistant.components.sensor import (
     DOMAIN as DOMAIN_SENSOR,
@@ -28,11 +35,6 @@ from . import NASwebConfigEntry
 from .const import DOMAIN, KEY_TEMP_SENSOR, STATUS_UPDATE_MAX_TIME_INTERVAL
 
 SENSOR_INPUT_TRANSLATION_KEY = "sensor_input"
-STATE_UNDEFINED = "undefined"
-STATE_TAMPER = "tamper"
-STATE_ACTIVE = "active"
-STATE_NORMAL = "normal"
-STATE_PROBLEM = "problem"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,11 +124,11 @@ class InputStateSensor(BaseSensorEntity):
 
     _attr_device_class = SensorDeviceClass.ENUM
     _attr_options: list[str] = [
-        STATE_UNDEFINED,
-        STATE_TAMPER,
-        STATE_ACTIVE,
-        STATE_NORMAL,
-        STATE_PROBLEM,
+        STATE_INPUT_ACTIVE,
+        STATE_INPUT_NORMAL,
+        STATE_INPUT_PROBLEM,
+        STATE_INPUT_TAMPER,
+        STATE_INPUT_UNDEFINED,
     ]
     _attr_translation_key = SENSOR_INPUT_TRANSLATION_KEY
 

--- a/homeassistant/components/nasweb/switch.py
+++ b/homeassistant/components/nasweb/switch.py
@@ -7,6 +7,7 @@ import time
 from typing import Any
 
 from webio_api import Output as NASwebOutput
+from webio_api.const import STATE_ENTITY_UNAVAILABLE, STATE_OUTPUT_OFF, STATE_OUTPUT_ON
 
 from homeassistant.components.switch import DOMAIN as DOMAIN_SWITCH, SwitchEntity
 from homeassistant.core import HomeAssistant, callback
@@ -24,6 +25,12 @@ from .const import DOMAIN, STATUS_UPDATE_MAX_TIME_INTERVAL
 from .coordinator import NASwebCoordinator
 
 OUTPUT_TRANSLATION_KEY = "switch_output"
+
+NASWEB_STATE_TO_HA_STATE = {
+    STATE_ENTITY_UNAVAILABLE: None,
+    STATE_OUTPUT_ON: True,
+    STATE_OUTPUT_OFF: False,
+}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -105,7 +112,7 @@ class RelaySwitch(SwitchEntity, BaseCoordinatorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_is_on = self._output.state
+        self._attr_is_on = NASWEB_STATE_TO_HA_STATE[self._output.state]
         if (
             self.coordinator.last_update is None
             or time.time() - self._output.last_update >= STATUS_UPDATE_MAX_TIME_INTERVAL

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3135,7 +3135,7 @@ weatherflow4py==1.4.1
 webexpythonsdk==2.0.1
 
 # homeassistant.components.nasweb
-webio-api==0.1.11
+webio-api==0.1.12
 
 # homeassistant.components.webmin
 webmin-xmlrpc==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2594,7 +2594,7 @@ watergate-local-api==2024.4.1
 weatherflow4py==1.4.1
 
 # homeassistant.components.nasweb
-webio-api==0.1.11
+webio-api==0.1.12
 
 # homeassistant.components.webmin
 webmin-xmlrpc==0.0.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR moves state conversion from the library to integration code, enabling future implementation of error handling (e.g. KeyError) 
Change made per request in [this comment](https://github.com/home-assistant/core/pull/141582#discussion_r2316820522).
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

Library version diff: https://github.com/nasWebio/webio_api/compare/0.1.11...0.1.12

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
