### PR TITLE
Replace remaining ZHA "radio" strings with "adapter"

### DIFF
--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -4,7 +4,7 @@
     "step": {
       "choose_serial_port": {
         "title": "Select a serial port",
-        "description": "Select the serial port for your Zigbee radio",
+        "description": "Select the serial port for your Zigbee adapter",
         "data": {
           "path": "Serial device path"
         }
@@ -16,10 +16,10 @@
         "description": "Do you want to set up {name}?"
       },
       "manual_pick_radio_type": {
-        "title": "Select a radio type",
-        "description": "Pick your Zigbee radio type",
+        "title": "Select an adapter type",
+        "description": "Pick your Zigbee adapter type",
         "data": {
-          "radio_type": "Radio type"
+          "radio_type": "Adapter type"
         }
       },
       "manual_port_config": {
@@ -37,8 +37,8 @@
         }
       },
       "verify_radio": {
-        "title": "Radio is not recommended",
-        "description": "The radio you are using ({name}) is not recommended and support for it may be removed in the future. Please see the Zigbee Home Automation integration's documentation for [a list of recommended adapters]({docs_recommended_adapters_url})."
+        "title": "Adapter is not recommended",
+        "description": "The adapter you are using ({name}) is not recommended and support for it may be removed in the future. Please see the Zigbee Home Automation integration's documentation for [a list of recommended adapters]({docs_recommended_adapters_url})."
       },
       "choose_setup_strategy": {
         "title": "Set up Zigbee",
@@ -70,11 +70,11 @@
       },
       "choose_formation_strategy": {
         "title": "Network formation",
-        "description": "Choose the network settings for your radio.",
+        "description": "Choose the network settings for your adapter.",
         "menu_options": {
           "form_new_network": "Erase network settings and create a new network",
           "form_initial_network": "Create a network",
-          "reuse_settings": "Keep radio network settings",
+          "reuse_settings": "Keep adapter network settings",
           "choose_automatic_backup": "Restore an automatic backup",
           "upload_manual_backup": "Upload a manual backup"
         },
@@ -101,10 +101,10 @@
         }
       },
       "maybe_confirm_ezsp_restore": {
-        "title": "Overwrite radio IEEE address",
-        "description": "Your backup has a different IEEE address than your radio. For your network to function properly, the IEEE address of your radio should also be changed.\n\nThis is a permanent operation.",
+        "title": "Overwrite adapter IEEE address",
+        "description": "Your backup has a different IEEE address than your adapter. For your network to function properly, the IEEE address of your adapter should also be changed.\n\nThis is a permanent operation.",
         "data": {
-          "overwrite_coordinator_ieee": "Permanently replace the radio IEEE address"
+          "overwrite_coordinator_ieee": "Permanently replace the adapter IEEE address"
         }
       }
     },
@@ -133,7 +133,7 @@
       },
       "prompt_migrate_or_reconfigure": {
         "title": "Migrate or re-configure",
-        "description": "Are you migrating to a new radio or re-configuring the current radio?",
+        "description": "Are you migrating to a new adapter or re-configuring the current adapter?",
         "menu_options": {
           "intent_migrate": "Migrate to a new adapter",
           "intent_reconfigure": "Re-configure the current adapter"
@@ -597,7 +597,7 @@
         "step": {
           "init": {
             "title": "[%key:component::zha::issues::inconsistent_network_settings::title%]",
-            "description": "Your Zigbee radio's network settings are inconsistent with the most recent network backup. This usually happens if another Zigbee integration (e.g. Zigbee2MQTT or deCONZ) has overwritten them.\n\n{diff}\n\nIf you did not intentionally change your network settings, restore from the most recent backup: your devices will not work otherwise.",
+            "description": "Your Zigbee adapter's network settings are inconsistent with the most recent network backup. This usually happens if another Zigbee integration (e.g. Zigbee2MQTT or deCONZ) has overwritten them.\n\n{diff}\n\nIf you did not intentionally change your network settings, restore from the most recent backup: your devices will not work otherwise.",
             "menu_options": {
               "use_new_settings": "Keep the new settings",
               "restore_old_settings": "Restore backup (recommended)"


### PR DESCRIPTION
## Proposed change
https://github.com/home-assistant/core/pull/153206 replaced a couple of ZHA "radio" strings with "adapter", so we now use both "radio" and "adapter" in the ZHA config flow. This PR replaces the remaining "radio" occurrences with "adapter".

### Reason
IMO, there's no reason to have this split between "radio" and "adapter", as we're basically always referring to the same thing. Using both words interchangeably makes this confusing for the user, especially if this is done in the [same dialog](https://github.com/user-attachments/assets/71c818b7-6844-4fa2-bb1f-aae759a5809f).

(or is there some other upcoming change to all strings with "radio" I've missed?)

### Note
Whilst working on this, I noticed that the current text for the multi-pan firmware repair/issue is very outdated, hence the strings for those are fixed in https://github.com/home-assistant/core/pull/153232 (including replacing "radio" with "adapter" in those two strings).
If needed, I can also pull the radio/adapter rename from that into this PR, but that doesn't make a lot of sense to do IMO, as the rest of the string would still be broken.

We may also want to include this (and https://github.com/home-assistant/core/pull/153232) in 2025.10.0, since this was done for https://github.com/home-assistant/core/pull/153206.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
