### PR TITLE
Fix ZHA unable to select "none" flow control

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -320,7 +320,9 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
                 }
             )
 
-            if await self._radio_mgr.radio_type.controller.probe(user_input):
+            if await self._radio_mgr.radio_type.controller.probe(
+                self._radio_mgr.device_settings
+            ):
                 return await self.async_step_verify_radio()
 
             errors["base"] = "cannot_connect"


### PR DESCRIPTION
## Proposed change

After https://github.com/home-assistant/core/pull/152389, the "none" flow control option in the `manual_port_config` config flow step broke.
This PR fixes the issue by correctly passing `None` to zigpy, instead of `"none"` (string). A regression test is also added.

### Explanation

The config flow step previously passed the unmodified `user_input` to the probe function, instead of the corrected `DEVICE_SCHEMA` from `self._radio_mgr.device_settings`, where the flow control option string `"none"` from the UI gets converted to `None`. So, we always failed probing when using the "none" flow control option.

This wasn't caught in tests, as we never actually checked what we passed to the probe function.
This is now done in an existing test for the `manual_port_config` config flow step. Furthermore, all flow control variations selectable from the UI are now tested: `"hardware"`, `"software"`, and `"none"`.

Do note that because there are now two `parametrize` decorators on this test, it will be run (2*3 =) 6 times, instead of only 2 times. This should still be fine, as this test is relatively fast, but we can adjust or split the test if needed.

Calls to probe function with `"none"` flow control option selected in the UI:
```diff
- {'path': '/dev/cu.usbserial-202207141443481', 'baudrate': 115200, 'flow_control': 'none'}
+ {'path': '/dev/cu.usbserial-202207141443481', 'baudrate': 115200, 'flow_control': None}
```

<details><summary>Example screenshot of broken config flow before these changes</summary>
<p>

<img width="639" height="718" alt="Bildschirmfoto 2025-09-30 um 05 06 11" src="https://github.com/user-attachments/assets/a9016d73-ddf0-493b-9fc6-52a1ecde1aa9" />

</p>
</details> 


### Side notes

- We should make these options translatable in the future. 
- Where are all the [`data_description` strings](https://github.com/home-assistant/core/blob/976cea600f353ac7cbc56ef5b4c871fe09a30098/homeassistant/components/zha/strings.json#L33-L36) supposed to show in this step?
  (see screenshot above for reference of how the config flow step looks)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
