### PR TITLE
Portainer fix CONF_VERIFY_SSL

### DIFF
--- a/homeassistant/components/portainer/__init__.py
+++ b/homeassistant/components/portainer/__init__.py
@@ -57,4 +57,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: PortainerConfigEntry) 
         data[CONF_API_TOKEN] = data.pop(CONF_API_KEY)
         hass.config_entries.async_update_entry(entry=entry, data=data, version=2)
 
+    if entry.version < 3:
+        data = dict(entry.data)
+        # Verify SSL was never set, so at first set it to False
+        data[CONF_VERIFY_SSL] = False
+        hass.config_entries.async_update_entry(entry=entry, data=data, version=3)
+
     return True

--- a/homeassistant/components/portainer/__init__.py
+++ b/homeassistant/components/portainer/__init__.py
@@ -59,8 +59,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: PortainerConfigEntry) 
 
     if entry.version < 3:
         data = dict(entry.data)
-        # Verify SSL was never set, so at first set it to False
-        data[CONF_VERIFY_SSL] = False
+        data[CONF_VERIFY_SSL] = True
         hass.config_entries.async_update_entry(entry=entry, data=data, version=3)
 
     return True

--- a/tests/components/portainer/test_init.py
+++ b/tests/components/portainer/test_init.py
@@ -47,7 +47,7 @@ async def test_setup_exceptions(
 
 
 async def test_migrations(hass: HomeAssistant) -> None:
-    """Test migration from v1 to v2 config entry."""
+    """Test migration from v1 config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/portainer/test_init.py
+++ b/tests/components/portainer/test_init.py
@@ -11,7 +11,13 @@ import pytest
 
 from homeassistant.components.portainer.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_API_KEY, CONF_API_TOKEN, CONF_HOST, CONF_URL
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_API_TOKEN,
+    CONF_HOST,
+    CONF_URL,
+    CONF_VERIFY_SSL,
+)
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
@@ -40,7 +46,7 @@ async def test_setup_exceptions(
     assert mock_config_entry.state == expected_state
 
 
-async def test_v1_migration(hass: HomeAssistant) -> None:
+async def test_migrations(hass: HomeAssistant) -> None:
     """Test migration from v1 to v2 config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -52,11 +58,14 @@ async def test_v1_migration(hass: HomeAssistant) -> None:
         version=1,
     )
     entry.add_to_hass(hass)
+    assert entry.version == 1
+    assert CONF_VERIFY_SSL not in entry.data
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.version == 2
+    assert entry.version == 3
     assert CONF_HOST not in entry.data
     assert CONF_API_KEY not in entry.data
     assert entry.data[CONF_URL] == "http://test_host"
     assert entry.data[CONF_API_TOKEN] == "test_key"
+    assert entry.data[CONF_VERIFY_SSL] is False

--- a/tests/components/portainer/test_init.py
+++ b/tests/components/portainer/test_init.py
@@ -68,4 +68,4 @@ async def test_migrations(hass: HomeAssistant) -> None:
     assert CONF_API_KEY not in entry.data
     assert entry.data[CONF_URL] == "http://test_host"
     assert entry.data[CONF_API_TOKEN] == "test_key"
-    assert entry.data[CONF_VERIFY_SSL] is False
+    assert entry.data[CONF_VERIFY_SSL] is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Portainer was missing a migration when CONF_VERIFY_SSL was added. This fixes it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
