### PR TITLE
Fix Bayesian ConfigFlow templates in 2025.10

### DIFF
--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -108,7 +108,8 @@ NUMERIC_STATE_SCHEMA = vol.All(
             vol.Optional(CONF_BELOW): vol.Coerce(float),
             vol.Required(CONF_P_GIVEN_T): vol.Coerce(float),
             vol.Optional(CONF_P_GIVEN_F): vol.Coerce(float),
-        }
+        },
+        required=True,
     ),
     above_greater_than_below,
 )

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -328,7 +328,6 @@ class BayesianBinarySensor(BinarySensorEntity):
             )
             for observation in observations
         ]
-
         self._probability_threshold = probability_threshold
         self._attr_device_class = device_class
         self._attr_is_on = False

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
+from homeassistant.config_entries import ConfigSubentryData
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_RELOAD,
@@ -26,7 +27,7 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
 
-from tests.common import get_fixture_path
+from tests.common import MockConfigEntry, get_fixture_path
 
 
 async def test_load_values_when_added_to_hass(hass: HomeAssistant) -> None:
@@ -295,6 +296,43 @@ async def test_sensor_value_template(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "binary_sensor", config)
     await hass.async_block_till_done()
 
+    await _test_sensor_value_template(hass)
+
+
+async def test_sensor_value_template_config_entry(hass: HomeAssistant) -> None:
+    """Test sensor on template platform observations."""
+    template_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "Test_Binary",
+            "prior": 0.2,
+            "probability_threshold": 0.32,
+        },
+        subentries_data=[
+            ConfigSubentryData(
+                data={
+                    "platform": "template",
+                    "value_template": "{{states('sensor.test_monitored') == 'off'}}",
+                    "prob_given_true": 0.8,
+                    "prob_given_false": 0.4,
+                },
+                subentry_type="observation",
+                title="observation_1",
+                unique_id=None,
+            )
+        ],
+        title="Test_Binary",
+    )
+    template_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(template_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await _test_sensor_value_template(hass)
+
+
+async def _test_sensor_value_template(hass: HomeAssistant) -> None:
     hass.states.async_set("sensor.test_monitored", "on")
 
     state = hass.states.get("binary_sensor.test_binary")

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -316,6 +316,7 @@ async def test_sensor_value_template_config_entry(hass: HomeAssistant) -> None:
                     "value_template": "{{states('sensor.test_monitored') == 'off'}}",
                     "prob_given_true": 0.8,
                     "prob_given_false": 0.4,
+                    "name": "observation_1",
                 },
                 subentry_type="observation",
                 title="observation_1",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the ConfigFlow subentries were enabled for bayesian, the config validation returned template strings only. This led to template strings being passed where templates were expected. In turn this led to templates being created without `hass` as an argument/outside the event loop.

This was missed by tests as they did not actually test the Config Entry setup

This PR adds a test of the config entry setup and enforces valid creation of the template objects

Discord discussion: https://discord.com/channels/330944238910963714/1422692977406378014
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
