### PR TITLE
Do not reset the adapter twice during ZHA options flow migration

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from abc import abstractmethod
 import collections
-from enum import StrEnum
 from contextlib import suppress
+from enum import StrEnum
 import json
 from typing import Any
 
@@ -98,6 +98,7 @@ ZEROCONF_PROPERTIES_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
+
 
 class OptionsMigrationIntent(StrEnum):
     """Zigbee options flow intents."""
@@ -933,6 +934,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
 
 class ZhaOptionsFlowHandler(BaseZhaFlow, OptionsFlow):
     """Handle an options flow."""
+
     _migration_intent: OptionsMigrationIntent
 
     def __init__(self, config_entry: ConfigEntry) -> None:
@@ -1019,8 +1021,7 @@ class ZhaOptionsFlowHandler(BaseZhaFlow, OptionsFlow):
         # Reload ZHA after we finish
         await self.hass.config_entries.async_setup(self.config_entry.entry_id)
 
-        # Intentionally do not set `data` to avoid creating `options`, we set it above
-        return self.async_create_entry(title=self._title, data={})
+        return self.async_abort(reason="reconfigure_successful")
 
     def async_remove(self):
         """Maybe reload ZHA if the flow is aborted."""

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 import collections
+from enum import StrEnum
 from contextlib import suppress
 import json
 from typing import Any
@@ -82,9 +83,6 @@ FORMATION_UPLOAD_MANUAL_BACKUP = "upload_manual_backup"
 CHOOSE_AUTOMATIC_BACKUP = "choose_automatic_backup"
 OVERWRITE_COORDINATOR_IEEE = "overwrite_coordinator_ieee"
 
-OPTIONS_INTENT_MIGRATE = "intent_migrate"
-OPTIONS_INTENT_RECONFIGURE = "intent_reconfigure"
-
 UPLOADED_BACKUP_FILE = "uploaded_backup_file"
 
 REPAIR_MY_URL = "https://my.home-assistant.io/redirect/repairs/"
@@ -100,6 +98,12 @@ ZEROCONF_PROPERTIES_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
+
+class OptionsMigrationIntent(StrEnum):
+    """Zigbee options flow intents."""
+
+    MIGRATE = "intent_migrate"
+    RECONFIGURE = "intent_reconfigure"
 
 
 def _format_backup_choice(
@@ -929,6 +933,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
 
 class ZhaOptionsFlowHandler(BaseZhaFlow, OptionsFlow):
     """Handle an options flow."""
+    _migration_intent: OptionsMigrationIntent
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
@@ -971,8 +976,8 @@ class ZhaOptionsFlowHandler(BaseZhaFlow, OptionsFlow):
         return self.async_show_menu(
             step_id="prompt_migrate_or_reconfigure",
             menu_options=[
-                OPTIONS_INTENT_RECONFIGURE,
-                OPTIONS_INTENT_MIGRATE,
+                OptionsMigrationIntent.RECONFIGURE,
+                OptionsMigrationIntent.MIGRATE,
             ],
         )
 
@@ -980,30 +985,26 @@ class ZhaOptionsFlowHandler(BaseZhaFlow, OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Virtual step for when the user is reconfiguring the integration."""
+        self._migration_intent = OptionsMigrationIntent.RECONFIGURE
         return await self.async_step_choose_serial_port()
 
     async def async_step_intent_migrate(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Confirm the user wants to reset their current radio."""
+        self._migration_intent = OptionsMigrationIntent.MIGRATE
+        return await self.async_step_choose_serial_port()
 
-        if user_input is not None:
-            await self._radio_mgr.async_reset_adapter()
-
-            return await self.async_step_instruct_unplug()
-
-        return self.async_show_form(step_id="intent_migrate")
-
-    async def async_step_instruct_unplug(
+    async def async_step_maybe_reset_old_radio(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Instruct the user to unplug the current radio, if possible."""
+        """Erase the old radio's network settings before migration."""
 
-        if user_input is not None:
-            # Now that the old radio is gone, we can scan for serial ports again
-            return await self.async_step_choose_serial_port()
+        # If we are reconfiguring, the old radio will not be available
+        if self._migration_intent is OptionsMigrationIntent.RECONFIGURE:
+            return await self.async_step_maybe_confirm_ezsp_restore()
 
-        return self.async_show_form(step_id="instruct_unplug")
+        return await super().async_step_maybe_reset_old_radio(user_input)
 
     async def _async_create_radio_entry(self):
         """Re-implementation of the base flow's final step to update the config."""

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -147,10 +147,6 @@
         "title": "[%key:component::zha::options::step::prompt_migrate_or_reconfigure::menu_options::intent_migrate%]",
         "description": "Before plugging in your new adapter, your old adapter needs to be reset. An automatic backup will be performed. If you are using a combined Z-Wave and Zigbee adapter like the HUSBZB-1, this will only reset the Zigbee portion.\n\n*Note: if you are migrating from a **ConBee/RaspBee**, make sure it is running firmware `0x26720700` or newer! Otherwise, some devices may not be controllable after migrating until they are power cycled.*\n\nDo you wish to continue?"
       },
-      "instruct_unplug": {
-        "title": "Unplug your old adapter",
-        "description": "Your old adapter has been reset. If the hardware is no longer needed, you can now unplug it.\n\nYou can now plug in your new adapter."
-      },
       "choose_serial_port": {
         "title": "[%key:component::zha::config::step::choose_serial_port::title%]",
         "data": {

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -236,7 +236,8 @@
       "cannot_resolve_path": "[%key:component::zha::config::abort::cannot_resolve_path%]",
       "wrong_firmware_installed": "[%key:component::zha::config::abort::wrong_firmware_installed%]",
       "cannot_restore_backup": "[%key:component::zha::config::abort::cannot_restore_backup%]",
-      "cannot_restore_backup_no_ieee_confirm": "[%key:component::zha::config::abort::cannot_restore_backup_no_ieee_confirm%]"
+      "cannot_restore_backup_no_ieee_confirm": "[%key:component::zha::config::abort::cannot_restore_backup_no_ieee_confirm%]",
+      "reconfigure_successful": "[%key:component::zha::config::abort::reconfigure_successful%]"
     }
   },
   "config_panel": {

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -2102,7 +2102,7 @@ async def test_options_flow_defaults(
     assert result1["step_id"] == "prompt_migrate_or_reconfigure"
     result2 = await hass.config_entries.options.async_configure(
         flow["flow_id"],
-        user_input={"next_step_id": config_flow.OPTIONS_INTENT_RECONFIGURE},
+        user_input={"next_step_id": config_flow.OptionsMigrationIntent.RECONFIGURE},
     )
 
     # Current path is the default
@@ -2240,7 +2240,7 @@ async def test_options_flow_defaults_socket(hass: HomeAssistant) -> None:
     assert result1["step_id"] == "prompt_migrate_or_reconfigure"
     result2 = await hass.config_entries.options.async_configure(
         flow["flow_id"],
-        user_input={"next_step_id": config_flow.OPTIONS_INTENT_RECONFIGURE},
+        user_input={"next_step_id": config_flow.OptionsMigrationIntent.RECONFIGURE},
     )
 
     # Radio path must be manually entered
@@ -2320,7 +2320,7 @@ async def test_options_flow_restarts_running_zha_if_cancelled(
     assert result1["step_id"] == "prompt_migrate_or_reconfigure"
     result2 = await hass.config_entries.options.async_configure(
         flow["flow_id"],
-        user_input={"next_step_id": config_flow.OPTIONS_INTENT_RECONFIGURE},
+        user_input={"next_step_id": config_flow.OptionsMigrationIntent.RECONFIGURE},
     )
 
     # Radio path must be manually entered
@@ -2375,7 +2375,7 @@ async def test_options_flow_migration_reset_old_adapter(
     assert result1["step_id"] == "prompt_migrate_or_reconfigure"
     result2 = await hass.config_entries.options.async_configure(
         flow["flow_id"],
-        user_input={"next_step_id": config_flow.OPTIONS_INTENT_MIGRATE},
+        user_input={"next_step_id": config_flow.OptionsMigrationIntent.MIGRATE},
     )
 
     # User must explicitly approve radio reset

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -2180,8 +2180,8 @@ async def test_options_flow_defaults(
     )
     await hass.async_block_till_done()
 
-    assert result7["type"] is FlowResultType.CREATE_ENTRY
-    assert result7["data"] == {}
+    assert result7["type"] is FlowResultType.ABORT
+    assert result7["reason"] == "reconfigure_successful"
 
     # The updated entry contains correct settings
     assert entry.data == {

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -160,7 +160,7 @@ def mock_detect_radio_type(
 
 def com_port(device="/dev/ttyUSB1234") -> ListPortInfo:
     """Mock of a serial port."""
-    port = ListPortInfo("/dev/ttyUSB1234")
+    port = ListPortInfo(device)
     port.serial_number = "1234"
     port.manufacturer = "Virtual serial port"
     port.device = device
@@ -2336,19 +2336,18 @@ async def test_options_flow_restarts_running_zha_if_cancelled(
     async_setup_entry.assert_called_once_with(hass, entry)
 
 
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 async def test_options_flow_migration_reset_old_adapter(
-    hass: HomeAssistant, mock_app
+    hass: HomeAssistant, backup, mock_app
 ) -> None:
-    """Test options flow for migrating from an old radio."""
+    """Test options flow for migrating resets the old radio, not the new one."""
 
     entry = MockConfigEntry(
         version=config_flow.ZhaConfigFlowHandler.VERSION,
         domain=DOMAIN,
         data={
             CONF_DEVICE: {
-                CONF_DEVICE_PATH: "/dev/serial/by-id/old_radio",
+                CONF_DEVICE_PATH: "/dev/ttyUSB_old",
                 CONF_BAUDRATE: 12345,
                 CONF_FLOW_CONTROL: None,
             },
@@ -2366,39 +2365,158 @@ async def test_options_flow_migration_reset_old_adapter(
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_unload", return_value=True
     ):
-        result1 = await hass.config_entries.options.async_configure(
+        result_init = await hass.config_entries.options.async_configure(
             flow["flow_id"], user_input={}
         )
 
     entry.mock_state(hass, ConfigEntryState.NOT_LOADED)
 
-    assert result1["step_id"] == "prompt_migrate_or_reconfigure"
-    result2 = await hass.config_entries.options.async_configure(
-        flow["flow_id"],
-        user_input={"next_step_id": config_flow.OptionsMigrationIntent.MIGRATE},
+    assert result_init["step_id"] == "prompt_migrate_or_reconfigure"
+
+    with (
+        patch(
+            "homeassistant.components.zha.radio_manager.ZhaRadioManager.detect_radio_type",
+            return_value=ProbeResult.RADIO_TYPE_DETECTED,
+        ),
+        patch(
+            "serial.tools.list_ports.comports",
+            MagicMock(return_value=[com_port("/dev/ttyUSB_new")]),
+        ),
+        patch(
+            "homeassistant.components.zha.radio_manager.ZhaRadioManager._async_read_backups_from_database",
+            return_value=[backup],
+        ),
+    ):
+        result_migrate = await hass.config_entries.options.async_configure(
+            flow["flow_id"],
+            user_input={"next_step_id": config_flow.OptionsMigrationIntent.MIGRATE},
+        )
+
+        # Now we choose the new radio
+        assert result_migrate["step_id"] == "choose_serial_port"
+
+        result_port = await hass.config_entries.options.async_configure(
+            flow["flow_id"],
+            user_input={
+                CONF_DEVICE_PATH: "/dev/ttyUSB_new - Some serial port, s/n: 1234 - Virtual serial port"
+            },
+        )
+
+    assert result_port["step_id"] == "choose_migration_strategy"
+
+    # A temporary radio manager is created to reset the old adapter
+    mock_radio_manager = AsyncMock()
+
+    with patch(
+        "homeassistant.components.zha.config_flow.ZhaRadioManager",
+        spec=ZhaRadioManager,
+        side_effect=[mock_radio_manager],
+    ):
+        result_strategy = await hass.config_entries.options.async_configure(
+            flow["flow_id"],
+            user_input={
+                "next_step_id": config_flow.MIGRATION_STRATEGY_RECOMMENDED,
+            },
+        )
+
+    # The old adapter is reset, not the new one
+    assert mock_radio_manager.device_path == "/dev/ttyUSB_old"
+    assert mock_radio_manager.async_reset_adapter.call_count == 1
+
+    assert result_strategy["type"] is FlowResultType.ABORT
+    assert result_strategy["reason"] == "reconfigure_successful"
+
+    # The entry is updated
+    assert entry.data["device"]["path"] == "/dev/ttyUSB_new"
+
+
+@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
+async def test_options_flow_reconfigure_no_reset(
+    hass: HomeAssistant, backup, mock_app
+) -> None:
+    """Test options flow for reconfiguring does not require the old adapter."""
+
+    entry = MockConfigEntry(
+        version=config_flow.ZhaConfigFlowHandler.VERSION,
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE: {
+                CONF_DEVICE_PATH: "/dev/ttyUSB_old",
+                CONF_BAUDRATE: 12345,
+                CONF_FLOW_CONTROL: None,
+            },
+            CONF_RADIO_TYPE: "znp",
+        },
     )
+    entry.add_to_hass(hass)
 
-    # User must explicitly approve radio reset
-    assert result2["step_id"] == "intent_migrate"
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
-    mock_app.reset_network_info = AsyncMock()
+    flow = await hass.config_entries.options.async_init(entry.entry_id)
 
-    result3 = await hass.config_entries.options.async_configure(
-        flow["flow_id"],
-        user_input={},
-    )
+    # ZHA gets unloaded
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_unload", return_value=True
+    ):
+        result_init = await hass.config_entries.options.async_configure(
+            flow["flow_id"], user_input={}
+        )
 
-    mock_app.reset_network_info.assert_awaited_once()
+    entry.mock_state(hass, ConfigEntryState.NOT_LOADED)
 
-    # Now we can unplug the old radio
-    assert result3["step_id"] == "instruct_unplug"
+    assert result_init["step_id"] == "prompt_migrate_or_reconfigure"
 
-    # And move on to choosing the new radio
-    result4 = await hass.config_entries.options.async_configure(
-        flow["flow_id"],
-        user_input={},
-    )
-    assert result4["step_id"] == "choose_serial_port"
+    with (
+        patch(
+            "homeassistant.components.zha.radio_manager.ZhaRadioManager.detect_radio_type",
+            return_value=ProbeResult.RADIO_TYPE_DETECTED,
+        ),
+        patch(
+            "serial.tools.list_ports.comports",
+            MagicMock(return_value=[com_port("/dev/ttyUSB_new")]),
+        ),
+        patch(
+            "homeassistant.components.zha.radio_manager.ZhaRadioManager._async_read_backups_from_database",
+            return_value=[backup],
+        ),
+    ):
+        result_reconfigure = await hass.config_entries.options.async_configure(
+            flow["flow_id"],
+            user_input={"next_step_id": config_flow.OptionsMigrationIntent.RECONFIGURE},
+        )
+
+        # Now we choose the new radio
+        assert result_reconfigure["step_id"] == "choose_serial_port"
+
+        result_port = await hass.config_entries.options.async_configure(
+            flow["flow_id"],
+            user_input={
+                CONF_DEVICE_PATH: "/dev/ttyUSB_new - Some serial port, s/n: 1234 - Virtual serial port"
+            },
+        )
+
+    assert result_port["step_id"] == "choose_migration_strategy"
+
+    with patch(
+        "homeassistant.components.zha.config_flow.ZhaRadioManager"
+    ) as mock_radio_manager:
+        result_strategy = await hass.config_entries.options.async_configure(
+            flow["flow_id"],
+            user_input={
+                "next_step_id": config_flow.MIGRATION_STRATEGY_RECOMMENDED,
+            },
+        )
+
+    # A temp radio manager is never created
+    assert mock_radio_manager.call_count == 0
+
+    assert result_strategy["type"] is FlowResultType.ABORT
+    assert result_strategy["reason"] == "reconfigure_successful"
+
+    # The entry is updated
+    assert entry.data["device"]["path"] == "/dev/ttyUSB_new"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The recent config flow simplification created a bug where we try to reset the adapter twice, with the second reset failing. This PR consolidates the two flows to use the same logic for resetting the adapter and replaces the final step of the flow with the same `reconfigure_successful` message as the config flow migration.

In the future, we should get rid of the options flow entirely and just allow editing the serial port settings from the frontend, since migration is now handled by discovery/manually setting up ZHA again.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
