### PR TITLE
Add Shelly support for valve entities

### DIFF
--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -308,3 +308,7 @@ DEVICE_UNIT_MAP = {
 MAX_SCRIPT_SIZE = 5120
 
 All_LIGHT_TYPES = ("cct", "light", "rgb", "rgbw")
+
+# Shelly-X specific models
+MODEL_NEO_WATER_VALVE = "NeoWaterValve"
+MODEL_FRANKEVER_WATER_VALVE = "WaterValve"

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -186,6 +186,9 @@ def async_setup_rpc_attribute_entities(
 
         for key in key_instances:
             # Filter non-existing sensors
+            if description.models and coordinator.model not in description.models:
+                continue
+
             if description.role and description.role != coordinator.device.config[
                 key
             ].get("role", "generic"):
@@ -316,6 +319,7 @@ class RpcEntityDescription(EntityDescription):
     options_fn: Callable[[dict], list[str]] | None = None
     entity_class: Callable | None = None
     role: str | None = None
+    models: set[str] | None = None
 
 
 @dataclass(frozen=True)

--- a/homeassistant/components/shelly/valve.py
+++ b/homeassistant/components/shelly/valve.py
@@ -17,6 +17,7 @@ from homeassistant.components.valve import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import MODEL_FRANKEVER_WATER_VALVE, MODEL_NEO_WATER_VALVE
 from .coordinator import ShellyBlockCoordinator, ShellyConfigEntry, ShellyRpcCoordinator
 from .entity import (
     BlockEntityDescription,
@@ -114,12 +115,14 @@ RPC_VALVES: dict[str, RpcValveDescription] = {
         sub_key="value",
         role="position",
         entity_class=RpcShellyWaterValve,
+        models={MODEL_FRANKEVER_WATER_VALVE},
     ),
     "neo_water_valve": RpcValveDescription(
         key="boolean",
         sub_key="value",
         role="state",
         entity_class=RpcShellyNeoWaterValve,
+        models={MODEL_NEO_WATER_VALVE},
     ),
 }
 

--- a/homeassistant/components/shelly/valve.py
+++ b/homeassistant/components/shelly/valve.py
@@ -102,11 +102,11 @@ class RpcShellyNeoWaterValve(RpcShellyBaseWaterValve):
 
     async def async_open_valve(self, **kwargs: Any) -> None:
         """Open valve."""
-        await self.call_rpc("Boolean.Set", {"id": self._id, "value": True})
+        await self.coordinator.device.boolean_set(self._id, True)
 
     async def async_close_valve(self, **kwargs: Any) -> None:
         """Close valve."""
-        await self.call_rpc("Boolean.Set", {"id": self._id, "value": False})
+        await self.coordinator.device.boolean_set(self._id, False)
 
 
 RPC_VALVES: dict[str, RpcValveDescription] = {

--- a/homeassistant/components/shelly/valve.py
+++ b/homeassistant/components/shelly/valve.py
@@ -89,7 +89,7 @@ class RpcShellyWaterValve(RpcShellyBaseWaterValve):
 
 
 class RpcShellyNeoWaterValve(RpcShellyBaseWaterValve):
-    """Entity that controls a valve on RPC Shelly NEO Water Walve."""
+    """Entity that controls a valve on RPC Shelly NEO Water Valve."""
 
     _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
     _attr_reports_position = False
@@ -108,7 +108,7 @@ class RpcShellyNeoWaterValve(RpcShellyBaseWaterValve):
         await self.call_rpc("Boolean.Set", {"id": self._id, "value": False})
 
 
-RPC_VAVLES: dict[str, RpcValveDescription] = {
+RPC_VALVES: dict[str, RpcValveDescription] = {
     "water_valve": RpcValveDescription(
         key="number",
         sub_key="value",
@@ -147,7 +147,7 @@ def async_setup_rpc_entry(
     assert coordinator
 
     async_setup_entry_rpc(
-        hass, config_entry, async_add_entities, RPC_VAVLES, RpcShellyWaterValve
+        hass, config_entry, async_add_entities, RPC_VALVES, RpcShellyWaterValve
     )
 
 

--- a/tests/components/shelly/test_valve.py
+++ b/tests/components/shelly/test_valve.py
@@ -6,6 +6,10 @@ from unittest.mock import Mock
 from aioshelly.const import MODEL_GAS
 import pytest
 
+from homeassistant.components.shelly.const import (
+    MODEL_FRANKEVER_WATER_VALVE,
+    MODEL_NEO_WATER_VALVE,
+)
 from homeassistant.components.valve import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
@@ -98,7 +102,7 @@ async def test_rpc_water_valve(
     status["number:200"] = {"value": 0}
     monkeypatch.setattr(mock_rpc_device, "status", status)
 
-    await init_integration(hass, 3)
+    await init_integration(hass, 3, model=MODEL_FRANKEVER_WATER_VALVE)
     entity_id = "valve.test_name"
 
     assert (entry := entity_registry.async_get(entity_id))
@@ -184,7 +188,7 @@ async def test_rpc_neo_water_valve(
     status["boolean:200"] = {"value": False}
     monkeypatch.setattr(mock_rpc_device, "status", status)
 
-    await init_integration(hass, 3)
+    await init_integration(hass, 3, model=MODEL_NEO_WATER_VALVE)
     entity_id = "valve.test_name"
 
     assert (entry := entity_registry.async_get(entity_id))

--- a/tests/components/shelly/test_valve.py
+++ b/tests/components/shelly/test_valve.py
@@ -205,9 +205,7 @@ async def test_rpc_neo_water_valve(
         blocking=True,
     )
 
-    mock_rpc_device.call_rpc.assert_called_once_with(
-        "Boolean.Set", {"id": 200, "value": True}
-    )
+    mock_rpc_device.boolean_set.assert_called_once_with(200, True)
 
     status["boolean:200"] = {"value": True}
     monkeypatch.setattr(mock_rpc_device, "status", status)
@@ -218,7 +216,7 @@ async def test_rpc_neo_water_valve(
     assert state.state == ValveState.OPEN
 
     # Close valve
-    mock_rpc_device.call_rpc.reset_mock()
+    mock_rpc_device.boolean_set.reset_mock()
     await hass.services.async_call(
         VALVE_DOMAIN,
         SERVICE_CLOSE_VALVE,
@@ -226,9 +224,7 @@ async def test_rpc_neo_water_valve(
         blocking=True,
     )
 
-    mock_rpc_device.call_rpc.assert_called_once_with(
-        "Boolean.Set", {"id": 200, "value": False}
-    )
+    mock_rpc_device.boolean_set.assert_called_once_with(200, False)
 
     status["boolean:200"] = {"value": False}
     monkeypatch.setattr(mock_rpc_device, "status", status)

--- a/tests/components/shelly/test_valve.py
+++ b/tests/components/shelly/test_valve.py
@@ -1,12 +1,23 @@
 """Tests for Shelly valve platform."""
 
+from copy import deepcopy
 from unittest.mock import Mock
 
 from aioshelly.const import MODEL_GAS
 import pytest
 
-from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN, ValveState
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_CLOSE_VALVE, SERVICE_OPEN_VALVE
+from homeassistant.components.valve import (
+    ATTR_CURRENT_POSITION,
+    ATTR_POSITION,
+    DOMAIN as VALVE_DOMAIN,
+    ValveState,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_CLOSE_VALVE,
+    SERVICE_OPEN_VALVE,
+    SERVICE_SET_VALVE_POSITION,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 
@@ -60,6 +71,164 @@ async def test_block_device_gas_valve(
 
     monkeypatch.setattr(mock_block_device.blocks[GAS_VALVE_BLOCK_ID], "valve", "closed")
     mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == ValveState.CLOSED
+
+
+async def test_rpc_water_valve(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test RPC device Shelly Water Valve."""
+    config = deepcopy(mock_rpc_device.config)
+    config["number:200"] = {
+        "name": "Position",
+        "min": 0,
+        "max": 100,
+        "meta": {"ui": {"step": 10, "view": "slider", "unit": "%"}},
+        "role": "position",
+    }
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    status = deepcopy(mock_rpc_device.status)
+    status["number:200"] = {"value": 0}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
+    await init_integration(hass, 3)
+    entity_id = "valve.test_name"
+
+    assert (entry := entity_registry.async_get(entity_id))
+    assert entry.unique_id == "123456789ABC-number:200-water_valve"
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == ValveState.CLOSED
+
+    # Open valve
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_OPEN_VALVE,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    mock_rpc_device.number_set.assert_called_once_with(200, 100)
+
+    status["number:200"] = {"value": 100}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+    mock_rpc_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == ValveState.OPEN
+
+    # Close valve
+    mock_rpc_device.number_set.reset_mock()
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_CLOSE_VALVE,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    mock_rpc_device.number_set.assert_called_once_with(200, 0)
+
+    status["number:200"] = {"value": 0}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+    mock_rpc_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == ValveState.CLOSED
+
+    # Set valve position to 50%
+    mock_rpc_device.number_set.reset_mock()
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_SET_VALVE_POSITION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_POSITION: 50},
+        blocking=True,
+    )
+
+    mock_rpc_device.number_set.assert_called_once_with(200, 50)
+
+    status["number:200"] = {"value": 50}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+    mock_rpc_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == ValveState.OPEN
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 50
+
+
+async def test_rpc_neo_water_valve(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test RPC device Shelly NEO Water Valve."""
+    config = deepcopy(mock_rpc_device.config)
+    config["boolean:200"] = {
+        "name": "State",
+        "meta": {"ui": {"view": "toggle"}},
+        "role": "state",
+    }
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    status = deepcopy(mock_rpc_device.status)
+    status["boolean:200"] = {"value": False}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
+    await init_integration(hass, 3)
+    entity_id = "valve.test_name"
+
+    assert (entry := entity_registry.async_get(entity_id))
+    assert entry.unique_id == "123456789ABC-boolean:200-neo_water_valve"
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == ValveState.CLOSED
+
+    # Open valve
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_OPEN_VALVE,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    mock_rpc_device.call_rpc.assert_called_once_with(
+        "Boolean.Set", {"id": 200, "value": True}
+    )
+
+    status["boolean:200"] = {"value": True}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+    mock_rpc_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == ValveState.OPEN
+
+    # Close valve
+    mock_rpc_device.call_rpc.reset_mock()
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_CLOSE_VALVE,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    mock_rpc_device.call_rpc.assert_called_once_with(
+        "Boolean.Set", {"id": 200, "value": False}
+    )
+
+    status["boolean:200"] = {"value": False}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+    mock_rpc_device.mock_update()
     await hass.async_block_till_done()
 
     assert (state := hass.states.get(entity_id))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add native Valve entities for "Powered by Shelly" valves instead of slider/switches
Related to discussion at https://github.com/home-assistant/core/pull/151940#issuecomment-3272218832
Currently Shelly has two types of valves:
- Water valve which supports position
- NEO water valve which supports only close/open

Note: Follow up PR will deprecate the non native entities (`switch` and `number`) and make them disabled by default, this is separated to another PR to be combined with similar for Thermostats

<img width="655" height="125" alt="image" src="https://github.com/user-attachments/assets/d995522c-b758-4007-9901-788469a3ec1e" />

<img width="633" height="100" alt="image" src="https://github.com/user-attachments/assets/57bbca31-c47d-4628-9d62-7b08d4812b4e" />

<img width="540" height="569" alt="image" src="https://github.com/user-attachments/assets/d74770c2-57f2-4d57-bada-f60afb48fec7" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
