### PR TITLE
Fix WLED custom palette causing error 255

### DIFF
--- a/homeassistant/components/wled/select.py
+++ b/homeassistant/components/wled/select.py
@@ -1,4 +1,4 @@
-"""Support for LED selects."""
+"""Support for WLED select entities (with 'Custom' palette handling)."""
 
 from __future__ import annotations
 
@@ -80,7 +80,7 @@ class WLEDPresetSelect(WLEDEntity, SelectEntity):
 
         self._attr_unique_id = f"{coordinator.data.info.mac_address}_preset"
         sorted_values = sorted(
-            coordinator.data.presets.values(), key=lambda preset: preset.name
+            self.coordinator.data.presets.values(), key=lambda preset: preset.name
         )
         self._attr_options = [preset.name for preset in sorted_values]
 
@@ -144,7 +144,7 @@ class WLEDPlaylistSelect(WLEDEntity, SelectEntity):
 
 
 class WLEDPaletteSelect(WLEDEntity, SelectEntity):
-    """Defines a WLED Palette select."""
+    """Define a WLED Palette select (segment-scoped)."""
 
     _attr_entity_category = EntityCategory.CONFIG
     _attr_translation_key = "color_palette"
@@ -161,10 +161,14 @@ class WLEDPaletteSelect(WLEDEntity, SelectEntity):
             self._attr_translation_placeholders = {"segment": str(segment)}
 
         self._attr_unique_id = f"{coordinator.data.info.mac_address}_palette_{segment}"
+        # Options are all known palette names from the device, plus a 'Custom' catch‑all
         sorted_values = sorted(
             coordinator.data.palettes.values(), key=lambda palette: palette.name
         )
         self._attr_options = [palette.name for palette in sorted_values]
+        if "Custom" not in self._attr_options:
+            self._attr_options.append("Custom")
+
         self._segment = segment
 
     @property
@@ -174,20 +178,43 @@ class WLEDPaletteSelect(WLEDEntity, SelectEntity):
             self.coordinator.data.state.segments[self._segment]
         except KeyError:
             return False
-
         return super().available
 
     @property
     def current_option(self) -> str | None:
-        """Return the current selected color palette."""
-        return self.coordinator.data.palettes[
-            int(self.coordinator.data.state.segments[self._segment].palette_id)
-        ].name
+        """Return the current selected color palette name or 'Custom'."""
+        seg = self.coordinator.data.state.segments[self._segment]
+
+        # Prefer a string palette name if the segment exposes one
+        for name_attr in ("color_palette", "palette_name"):
+            name_val = getattr(seg, name_attr, None)
+            if isinstance(name_val, str) and name_val:
+                if any(
+                    p.name == name_val for p in self.coordinator.data.palettes.values()
+                ):
+                    return name_val
+                return "Custom"
+
+        # Fall back to numeric fields
+        for id_attr in ("palette_id", "palette", "color_palette_id", "pal"):
+            id_val = getattr(seg, id_attr, None)
+            if id_val is not None:
+                try:
+                    pid = int(id_val)
+                except (TypeError, ValueError):
+                    break
+                palette = self.coordinator.data.palettes.get(pid)
+                return palette.name if palette is not None else "Custom"
+
+        return "Custom"
 
     @wled_exception_handler
     async def async_select_option(self, option: str) -> None:
         """Set WLED segment to the selected color palette."""
-        await self.coordinator.wled.segment(segment_id=self._segment, palette=option)
+        # For named palettes, send the string name exactly as chosen.
+        # Only use 255 when the user selects the catch-all "Custom".
+        value = 255 if option == "Custom" else option
+        await self.coordinator.wled.segment(segment_id=self._segment, palette=value)
 
 
 @callback
@@ -196,7 +223,7 @@ def async_update_segments(
     current_ids: set[int],
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Update segments."""
+    """Update segment-scoped palette selects based on current segments."""
     segment_ids = {
         segment.segment_id
         for segment in coordinator.data.state.segments.values()
@@ -210,4 +237,5 @@ def async_update_segments(
         current_ids.add(segment_id)
         new_entities.append(WLEDPaletteSelect(coordinator, segment_id))
 
-    async_add_entities(new_entities)
+    if new_entities:
+        async_add_entities(new_entities)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is to allow for custom WLED palettes, a state that is currently not supported.  Custom palettes start at 255 and decrement from there, but do not have a name.  This fix adds "Custom" to the name so that no error occurs.

See issue https://github.com/home-assistant/core/issues/128181 for examples.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
