### PR TITLE
Remove deprecated state constants from lock

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -13,28 +13,16 @@ from propcache.api import cached_property
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (  # noqa: F401
-    _DEPRECATED_STATE_JAMMED,
-    _DEPRECATED_STATE_LOCKED,
-    _DEPRECATED_STATE_LOCKING,
-    _DEPRECATED_STATE_UNLOCKED,
-    _DEPRECATED_STATE_UNLOCKING,
+from homeassistant.const import (
     ATTR_CODE,
     ATTR_CODE_FORMAT,
     SERVICE_LOCK,
     SERVICE_OPEN,
     SERVICE_UNLOCK,
-    STATE_OPEN,
-    STATE_OPENING,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.deprecation import (
-    all_with_deprecated_constants,
-    check_if_deprecated_constant,
-    dir_with_deprecated_constants,
-)
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType, StateType
@@ -317,11 +305,3 @@ class LockEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             return
 
         self._lock_option_default_code = ""
-
-
-# These can be removed if no deprecated constant are in this module anymore
-__getattr__ = ft.partial(check_if_deprecated_constant, module_globals=globals())
-__dir__ = ft.partial(
-    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
-)
-__all__ = all_with_deprecated_constants(globals())

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -315,34 +315,6 @@ STATE_UNAVAILABLE: Final = "unavailable"
 STATE_OK: Final = "ok"
 STATE_PROBLEM: Final = "problem"
 
-# #### LOCK STATES ####
-# STATE_* below are deprecated as of 2024.10
-# use the LockState enum instead.
-_DEPRECATED_STATE_LOCKED: Final = DeprecatedConstant(
-    "locked",
-    "LockState.LOCKED",
-    "2025.10",
-)
-_DEPRECATED_STATE_UNLOCKED: Final = DeprecatedConstant(
-    "unlocked",
-    "LockState.UNLOCKED",
-    "2025.10",
-)
-_DEPRECATED_STATE_LOCKING: Final = DeprecatedConstant(
-    "locking",
-    "LockState.LOCKING",
-    "2025.10",
-)
-_DEPRECATED_STATE_UNLOCKING: Final = DeprecatedConstant(
-    "unlocking",
-    "LockState.UNLOCKING",
-    "2025.10",
-)
-_DEPRECATED_STATE_JAMMED: Final = DeprecatedConstant(
-    "jammed",
-    "LockState.JAMMED",
-    "2025.10",
-)
 
 # #### ALARM CONTROL PANEL STATES ####
 # STATE_ALARM_* below are deprecated as of 2024.11

--- a/tests/components/lock/test_init.py
+++ b/tests/components/lock/test_init.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from enum import Enum
 import re
 from typing import Any
 
 import pytest
 
-from homeassistant.components import lock
 from homeassistant.components.lock import (
     ATTR_CODE,
     CONF_DEFAULT_CODE,
@@ -25,8 +23,6 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
 from .conftest import MockLock
-
-from tests.common import help_test_all, import_and_test_deprecated_constant_enum
 
 
 async def help_test_async_lock_service(
@@ -382,38 +378,3 @@ async def test_lock_with_illegal_default_code(
         == rf"The code for lock.test_lock doesn't match pattern ^\d{{{4}}}$"
     )
     assert exc.value.translation_key == "add_default_code"
-
-
-def test_all() -> None:
-    """Test module.__all__ is correctly set."""
-    help_test_all(lock)
-
-
-def _create_tuples(
-    enum: type[Enum], constant_prefix: str, remove_in_version: str
-) -> list[tuple[Enum, str]]:
-    return [
-        (enum_field, constant_prefix, remove_in_version)
-        for enum_field in enum
-        if enum_field
-        not in [
-            lock.LockState.OPEN,
-            lock.LockState.OPENING,
-        ]
-    ]
-
-
-@pytest.mark.parametrize(
-    ("enum", "constant_prefix", "remove_in_version"),
-    _create_tuples(lock.LockState, "STATE_", "2025.10"),
-)
-def test_deprecated_constants(
-    caplog: pytest.LogCaptureFixture,
-    enum: Enum,
-    constant_prefix: str,
-    remove_in_version: str,
-) -> None:
-    """Test deprecated constants."""
-    import_and_test_deprecated_constant_enum(
-        caplog, lock, enum, constant_prefix, remove_in_version
-    )

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -66,22 +66,6 @@ def _create_tuples_lock_states(
     ]
 
 
-@pytest.mark.parametrize(
-    ("enum", "constant_prefix", "remove_in_version"),
-    _create_tuples_lock_states(lock.LockState, "STATE_", "2025.10"),
-)
-def test_deprecated_constants_lock(
-    caplog: pytest.LogCaptureFixture,
-    enum: Enum,
-    constant_prefix: str,
-    remove_in_version: str,
-) -> None:
-    """Test deprecated constants."""
-    import_and_test_deprecated_constant_enum(
-        caplog, const, enum, constant_prefix, remove_in_version
-    )
-
-
 def _create_tuples_alarm_states(
     enum: type[Enum], constant_prefix: str, remove_in_version: str
 ) -> list[tuple[Enum, str]]:

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant import const
-from homeassistant.components import alarm_control_panel, lock
+from homeassistant.components import alarm_control_panel
 
 from .common import (
     extract_stack_to_frame,
@@ -52,37 +52,15 @@ def test_deprecated_constant_name_changes(
     )
 
 
-def _create_tuples_lock_states(
-    enum: type[Enum], constant_prefix: str, remove_in_version: str
-) -> list[tuple[Enum, str]]:
-    return [
-        (enum_field, constant_prefix, remove_in_version)
-        for enum_field in enum
-        if enum_field
-        not in [
-            lock.LockState.OPEN,
-            lock.LockState.OPENING,
-        ]
-    ]
-
-
 def _create_tuples_alarm_states(
     enum: type[Enum], constant_prefix: str, remove_in_version: str
 ) -> list[tuple[Enum, str]]:
-    return [
-        (enum_field, constant_prefix, remove_in_version)
-        for enum_field in enum
-        if enum_field
-        not in [
-            lock.LockState.OPEN,
-            lock.LockState.OPENING,
-        ]
-    ]
+    return [(enum_field, constant_prefix, remove_in_version) for enum_field in enum]
 
 
 @pytest.mark.parametrize(
     ("enum", "constant_prefix", "remove_in_version"),
-    _create_tuples_lock_states(
+    _create_tuples_alarm_states(
         alarm_control_panel.AlarmControlPanelState, "STATE_ALARM_", "2025.11"
     ),
 )


### PR DESCRIPTION
## Breaking change
Removes previously deprecated state constants from `lock`

## Proposed change


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 