### PR TITLE
Fix spelling error in logbook tests

### DIFF
--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -2277,11 +2277,11 @@ async def test_live_stream_with_one_second_commit_interval(
 
     hass.bus.async_fire("mock_event", {"device_id": device.id, "message": "5"})
 
-    recieved_rows = []
+    received_rows = []
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
     assert msg["type"] == "event"
-    recieved_rows.extend(msg["event"]["events"])
+    received_rows.extend(msg["event"]["events"])
 
     hass.bus.async_fire("mock_event", {"device_id": device.id, "message": "6"})
 
@@ -2289,14 +2289,14 @@ async def test_live_stream_with_one_second_commit_interval(
 
     hass.bus.async_fire("mock_event", {"device_id": device.id, "message": "7"})
 
-    while len(recieved_rows) < 7:
+    while len(received_rows) < 7:
         msg = await asyncio.wait_for(websocket_client.receive_json(), 2.5)
         assert msg["id"] == 7
         assert msg["type"] == "event"
-        recieved_rows.extend(msg["event"]["events"])
+        received_rows.extend(msg["event"]["events"])
 
     # Make sure we get rows back in order
-    assert recieved_rows == [
+    assert received_rows == [
         {"domain": "test", "message": "1", "name": "device name", "when": ANY},
         {"domain": "test", "message": "2", "name": "device name", "when": ANY},
         {"domain": "test", "message": "3", "name": "device name", "when": ANY},
@@ -3018,15 +3018,15 @@ async def test_live_stream_with_changed_state_change(
     await hass.async_block_till_done()
     hass.states.async_set("binary_sensor.is_light", STATE_ON)
 
-    recieved_rows = []
-    while len(recieved_rows) < 3:
+    received_rows = []
+    while len(received_rows) < 3:
         msg = await asyncio.wait_for(websocket_client.receive_json(), 2.5)
         assert msg["id"] == 7
         assert msg["type"] == "event"
-        recieved_rows.extend(msg["event"]["events"])
+        received_rows.extend(msg["event"]["events"])
 
     # Make sure we get rows back in order
-    assert recieved_rows == [
+    assert received_rows == [
         {"entity_id": "binary_sensor.is_light", "state": "unknown", "when": ANY},
         {"entity_id": "binary_sensor.is_light", "state": "on", "when": ANY},
         {"entity_id": "binary_sensor.is_light", "state": "off", "when": ANY},


### PR DESCRIPTION
## Proposed change

So , I have fixed a spelling error in the logbook websocket API tests. The variable name `recieved_rows` was incorrectly spelled and has been changed to `received_rows` throughout the test file.

This is a simple typo fix that improves code quality and consistency.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr