### PR TITLE
Fix Z-Wave RGB light turn on causing rare `ZeroDivisionError`

### DIFF
--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -666,7 +666,8 @@ class ZwaveColorOnOffLight(ZwaveLight):
             if blue is not None:
                 last_color[ColorComponent.BLUE] = blue
 
-            if last_color:
+            # Only store the last color if we're aware of it, i.e. ignore off light
+            if last_color and max(last_color.values()) > 0:
                 self._last_on_color = last_color
 
         if self._target_brightness:

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -612,10 +612,7 @@ class ZwaveColorOnOffLight(ZwaveLight):
             # If brightness gets set, preserve the color and mix it with the new brightness
             if self.color_mode == ColorMode.HS:
                 scale = brightness / 255
-            if (
-                self._last_on_color is not None
-                and None not in self._last_on_color.values()
-            ):
+            if self._last_on_color is not None:
                 # Changed brightness from 0 to >0
                 old_brightness = max(self._last_on_color.values())
                 new_scale = brightness / old_brightness

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -631,8 +631,9 @@ class ZwaveColorOnOffLight(ZwaveLight):
             elif current_brightness is not None:
                 scale = current_brightness / 255
 
-        # Reset last color until turning off again
+        # Reset last color and brightness until turning off again
         self._last_on_color = None
+        self._last_brightness = None
 
         if new_colors is None:
             new_colors = self._get_new_colors(
@@ -648,8 +649,10 @@ class ZwaveColorOnOffLight(ZwaveLight):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
 
-        # Remember last color and brightness to restore it when turning on
-        self._last_brightness = self.brightness
+        # Remember last color and brightness to restore it when turning on,
+        # only if we're sure the light is turned on to avoid overwriting good values
+        if self._last_brightness is None:
+            self._last_brightness = self.brightness
         if self._current_color and isinstance(self._current_color.value, dict):
             red = self._current_color.value.get(COLOR_SWITCH_COMBINED_RED)
             green = self._current_color.value.get(COLOR_SWITCH_COMBINED_GREEN)

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -1073,6 +1073,16 @@ async def test_light_color_only(
     )
     await update_color(0, 0, 0)
 
+    # Turn off again and make sure last color/brightness is still preserved
+    # when turning on light again in the next step
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: HSM200_V1_ENTITY},
+        blocking=True,
+    )
+    await update_color(0, 0, 0)
+
     client.async_send_command.reset_mock()
 
     # Assert that the brightness is preserved when turning on with color

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -1105,6 +1105,92 @@ async def test_light_color_only(
 
     client.async_send_command.reset_mock()
 
+    await update_color(0, 0, 123)
+
+    # Turn off twice
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: HSM200_V1_ENTITY},
+        blocking=True,
+    )
+    await update_color(0, 0, 0)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: HSM200_V1_ENTITY},
+        blocking=True,
+    )
+    await update_color(0, 0, 0)
+
+    state = hass.states.get(HSM200_V1_ENTITY)
+    assert state.state == STATE_OFF
+
+    client.async_send_command.reset_mock()
+
+    # Assert that turning on after successive off calls works and keeps the last color
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: HSM200_V1_ENTITY, ATTR_BRIGHTNESS: 150},
+        blocking=True,
+    )
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args_list[0][0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == node.node_id
+    assert args["valueId"] == {
+        "commandClass": 51,
+        "endpoint": 0,
+        "property": "targetColor",
+    }
+    assert args["value"] == {"red": 0, "green": 0, "blue": 150}
+
+    client.async_send_command.reset_mock()
+
+    await update_color(0, 0, 150)
+
+    # Force the light to turn off
+    await update_color(0, 0, 0)
+
+    # Turn off already off light, we won't be aware of last color and brightness
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: HSM200_V1_ENTITY},
+        blocking=True,
+    )
+    await update_color(0, 0, 0)
+
+    state = hass.states.get(HSM200_V1_ENTITY)
+    assert state.state == STATE_OFF
+
+    client.async_send_command.reset_mock()
+
+    # Assert that turning on light after off call with unknown off color/brightness state
+    # works and that light turns on to white with specified brightness
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: HSM200_V1_ENTITY, ATTR_BRIGHTNESS: 160},
+        blocking=True,
+    )
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args_list[0][0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == node.node_id
+    assert args["valueId"] == {
+        "commandClass": 51,
+        "endpoint": 0,
+        "property": "targetColor",
+    }
+    assert args["value"] == {"red": 160, "green": 160, "blue": 160}
+
+    client.async_send_command.reset_mock()
+
+    await update_color(160, 160, 160)
+
     # Clear the color value to trigger an unknown state
     event = Event(
         type="value updated",


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where turning on a Z-Wave JS "color only" (aka "non-dimmable") RGB light can raise a `ZeroDivisionError` in some cases. Regression tests are also added.


### Details

This issue happens when multiple `light.turn_off` calls are executed successively, then followed by a `light.turn_on` call with brightness only. This only happens for "color only" RGB lights, so for `ZwaveColorOnOffLight`.

The two commits fixing the related issues also have a more detailed commit message on what they're doing and why.


### General overview on why this happens

The `last_color` and `last_brightness` are [always set in the `turn_off` action](https://github.com/home-assistant/core/blob/72e78b6719f1c450150e568a78f257a5c89f7032/homeassistant/components/zwave_js/light.py#L654-L670), even if they're already set, causing good values to be overwritten with unwanted ones if the light is already off.
So, it's easy to see how the `0, 0, 0` values in `_last_on_color` causes the issue [here](https://github.com/home-assistant/core/blob/72e78b6719f1c450150e568a78f257a5c89f7032/homeassistant/components/zwave_js/light.py#L615-L625).

The issue can also be caused if another source turns off the light (e.g. ESPHome -> Z-Wave JS, skipping HA), thus setting the light color values to `0, 0, 0` and when HA later tries to turn off the (already off) light again using `light.turn_off`, we'd see the same issue. This is a slightly different case, as `_last_on_color` would not be set before and we're not overwriting it unexpectedly. We can only turn on the light with a white color afterwards, since we don't know the actual previous color, but we still need to avoid the `ZeroDivisionError` in this case, too.

Adding the tests revealed the issues were both `_last_on_color` and `_last_brightness` are overwritten by successive off calls, as well as causing the `ZeroDivisionError` due to color/brightness scaling math when a black color is saved to `_last_on_color`.


#### Origin

The code for this was introduced in with the support for "non-dimmable"/"color only" RGB lights:
- https://github.com/home-assistant/core/pull/127808


#### Possible PR titles for changelog (remove this later)

- Fix Z-Wave JS RGB light turn on causing rare `ZeroDivisionError` (too long)
- Fix rare `ZeroDivisionError` when turning on Z-Wave JS RGB light (too long)


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #146200
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
