### PR TITLE
Move entities to the end of devices in analytics payload

### DIFF
--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -629,7 +629,6 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:  # noqa: C901
 
             devices_info.append(
                 {
-                    "entities": [],
                     "entry_type": device_entry.entry_type,
                     "has_configuration_url": device_entry.configuration_url is not None,
                     "hw_version": device_entry.hw_version,
@@ -638,6 +637,7 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:  # noqa: C901
                     "model_id": device_entry.model_id,
                     "sw_version": device_entry.sw_version,
                     "via_device": device_entry.via_device_id,
+                    "entities": [],
                 }
             )
 

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -1075,7 +1075,6 @@ async def test_devices_payload_no_entities(
             "hue": {
                 "devices": [
                     {
-                        "entities": [],
                         "entry_type": None,
                         "has_configuration_url": True,
                         "hw_version": "test-hw-version",
@@ -1084,9 +1083,9 @@ async def test_devices_payload_no_entities(
                         "model_id": "test-model-id",
                         "sw_version": "test-sw-version",
                         "via_device": None,
+                        "entities": [],
                     },
                     {
-                        "entities": [],
                         "entry_type": None,
                         "has_configuration_url": False,
                         "hw_version": None,
@@ -1095,9 +1094,9 @@ async def test_devices_payload_no_entities(
                         "model_id": None,
                         "sw_version": None,
                         "via_device": None,
+                        "entities": [],
                     },
                     {
-                        "entities": [],
                         "entry_type": None,
                         "has_configuration_url": False,
                         "hw_version": None,
@@ -1106,9 +1105,9 @@ async def test_devices_payload_no_entities(
                         "model_id": "test-model-id",
                         "sw_version": None,
                         "via_device": None,
+                        "entities": [],
                     },
                     {
-                        "entities": [],
                         "entry_type": None,
                         "has_configuration_url": False,
                         "hw_version": None,
@@ -1117,6 +1116,7 @@ async def test_devices_payload_no_entities(
                         "model_id": "test-model-id6",
                         "sw_version": None,
                         "via_device": ["hue", 0],
+                        "entities": [],
                     },
                 ],
                 "entities": [],
@@ -1233,6 +1233,14 @@ async def test_devices_payload_with_entities(
             "hue": {
                 "devices": [
                     {
+                        "entry_type": None,
+                        "has_configuration_url": False,
+                        "hw_version": None,
+                        "manufacturer": "test-manufacturer",
+                        "model": None,
+                        "model_id": "test-model-id",
+                        "sw_version": None,
+                        "via_device": None,
                         "entities": [
                             {
                                 "assumed_state": None,
@@ -1259,6 +1267,8 @@ async def test_devices_payload_with_entities(
                                 "unit_of_measurement": None,
                             },
                         ],
+                    },
+                    {
                         "entry_type": None,
                         "has_configuration_url": False,
                         "hw_version": None,
@@ -1267,8 +1277,6 @@ async def test_devices_payload_with_entities(
                         "model_id": "test-model-id",
                         "sw_version": None,
                         "via_device": None,
-                    },
-                    {
                         "entities": [
                             {
                                 "assumed_state": None,
@@ -1279,14 +1287,6 @@ async def test_devices_payload_with_entities(
                                 "unit_of_measurement": None,
                             },
                         ],
-                        "entry_type": None,
-                        "has_configuration_url": False,
-                        "hw_version": None,
-                        "manufacturer": "test-manufacturer",
-                        "model": None,
-                        "model_id": "test-model-id",
-                        "sw_version": None,
-                        "via_device": None,
                     },
                 ],
                 "entities": [
@@ -1402,7 +1402,6 @@ async def test_analytics_platforms(
             "test": {
                 "devices": [
                     {
-                        "entities": [],
                         "entry_type": None,
                         "has_configuration_url": False,
                         "hw_version": None,
@@ -1411,6 +1410,7 @@ async def test_analytics_platforms(
                         "model_id": "test-model-id",
                         "sw_version": None,
                         "via_device": None,
+                        "entities": [],
                     },
                 ],
                 "entities": [


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move entities to the end of devices.

It's easier to read through the data, when the device information is first and entities later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
