### PR TITLE
Fix next event in workday calendar

### DIFF
--- a/homeassistant/components/workday/calendar.py
+++ b/homeassistant/components/workday/calendar.py
@@ -10,6 +10,7 @@ from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from . import WorkdayConfigEntry
 from .const import CONF_EXCLUDES, CONF_OFFSET, CONF_WORKDAYS
@@ -87,11 +88,12 @@ class WorkdayCalendarEntity(BaseWorkdayEntity, CalendarEntity):
     @property
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
-        return (
-            sorted(self.event_list, key=lambda e: e.start)[0]
-            if self.event_list
-            else None
+        sorted_list: list[CalendarEvent] | None = (
+            sorted(self.event_list, key=lambda e: e.start) if self.event_list else None
         )
+        if not sorted_list:
+            return None
+        return [d for d in sorted_list if d.start >= dt_util.utcnow().date()][0]
 
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime

--- a/tests/components/workday/test_calendar.py
+++ b/tests/components/workday/test_calendar.py
@@ -70,6 +70,11 @@ async def test_holiday_calendar_entity(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
+    # Binary sensor added to ensure same state for both entities
+    state = hass.states.get("binary_sensor.workday_sensor")
+    assert state is not None
+    assert state.state == "on"
+
     state = hass.states.get("calendar.workday_sensor_calendar")
     assert state is not None
     assert state.state == "on"
@@ -77,6 +82,10 @@ async def test_holiday_calendar_entity(
     freezer.move_to(datetime(2023, 1, 7, 0, 1, 1, tzinfo=zone))  # Workday
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.workday_sensor")
+    assert state is not None
+    assert state.state == "off"
 
     state = hass.states.get("calendar.workday_sensor_calendar")
     assert state is not None


### PR DESCRIPTION
## Breaking change


## Proposed change
Correcting the `async_get_events` method unfortunately broke the `event` property which is now fixed.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #153435
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 