### PR TITLE
Translatable error msg to frontend if new dashboard url already in use

### DIFF
--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -287,7 +287,11 @@ class DashboardsCollection(collection.DictStorageCollection):
             raise vol.Invalid("Url path needs to contain a hyphen (-)")
 
         if url_path in self.hass.data[DATA_PANELS]:
-            raise vol.Invalid("Panel url path needs to be unique")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="url_already_exists",
+                translation_placeholders={"url": url_path},
+            )
 
         return self.CREATE_SCHEMA(data)  # type: ignore[no-any-return]
 

--- a/homeassistant/components/lovelace/strings.json
+++ b/homeassistant/components/lovelace/strings.json
@@ -1,4 +1,9 @@
 {
+  "exceptions": {
+    "url_already_exists": {
+      "message": "The {url} URL is already in use. Please choose a different one."
+    }
+  },
   "services": {
     "reload_resources": {
       "description": "Reloads dashboard resources from the YAML-configuration.",
@@ -11,11 +16,6 @@
       "mode": "[%key:common::config_flow::data::mode%]",
       "resources": "Resources",
       "views": "Views"
-    }
-  },
-  "exceptions": {
-    "url_already_exists": {
-      "message": "The {url} URL is already in use. Please choose a different one."
     }
   }
 }

--- a/homeassistant/components/lovelace/strings.json
+++ b/homeassistant/components/lovelace/strings.json
@@ -1,7 +1,7 @@
 {
   "exceptions": {
     "url_already_exists": {
-      "message": "The {url} URL is already in use. Please choose a different one."
+      "message": "The URL \"{url}\" is already in use. Please choose a different one."
     }
   },
   "services": {

--- a/homeassistant/components/lovelace/strings.json
+++ b/homeassistant/components/lovelace/strings.json
@@ -12,5 +12,10 @@
       "resources": "Resources",
       "views": "Views"
     }
+  },
+  "exceptions": {
+    "url_already_exists": {
+      "message": "The {url} URL is already in use. Please choose a different one."
+    }
   }
 }

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -509,6 +509,7 @@ async def test_storage_dashboards(
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["translation_key"] == "url_already_exists"
+    assert response["error"]["translation_placeholders"]["url"] == "created-url-path"
 
     # Delete dashboards
     await client.send_json(

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -374,7 +374,7 @@ async def test_storage_dashboards(
     assert response["success"]
     assert response["result"] == []
 
-    # Add a wrong dashboard
+    # Add a wrong dashboard (no hyphen)
     await client.send_json(
         {
             "id": 6,
@@ -484,16 +484,35 @@ async def test_storage_dashboards(
     assert response["result"][0]["show_in_sidebar"] is False
     assert response["result"][0]["require_admin"] is False
 
-    # Add dashboard with existing url path
+    # Add a wrong dashboard (missing title)
     await client.send_json(
-        {"id": 14, "type": "lovelace/dashboards/create", "url_path": "created-url-path"}
+        {
+            "id": 14,
+            "type": "lovelace/dashboards/create",
+            "url_path": "path",
+        }
     )
     response = await client.receive_json()
     assert not response["success"]
+    assert response["error"]["code"] == "invalid_format"
+
+    # Add dashboard with existing url path
+    await client.send_json(
+        {
+            "id": 15,
+            "type": "lovelace/dashboards/create",
+            "url_path": "created-url-path",
+            "title": "Another title",
+        }
+    )
+    response = await client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "home_assistant_error"
+    assert response["error"]["translation_key"] == "url_already_exists"
 
     # Delete dashboards
     await client.send_json(
-        {"id": 15, "type": "lovelace/dashboards/delete", "dashboard_id": dashboard_id}
+        {"id": 16, "type": "lovelace/dashboards/delete", "dashboard_id": dashboard_id}
     )
     response = await client.receive_json()
     assert response["success"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the user tries to create a new dashboard with a URL that already exist, the current error message contains technical details and is not translatable ([frontend issue 27162](https://github.com/home-assistant/frontend/issues/27162)). According to discussions in https://github.com/home-assistant/frontend/pull/27207 and  https://github.com/home-assistant/frontend/pull/27207, this needs to be fixed in the backend.

Changing the exception raised to HomeAssistantError instead of volutuous.Invalid allows it to pass along the translation information to the frontend without the technical details.

It also turns out the old test that was supposed to verify that a duplicate dashboard would be rejected actually was testing that a dashboard without a title would be rejected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/27162
- This PR is related to issue:
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/27306

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
