### PR TITLE
Debounce updates in Idasen Desk

### DIFF
--- a/tests/components/idasen_desk/__init__.py
+++ b/tests/components/idasen_desk/__init__.py
@@ -38,6 +38,8 @@ NOT_IDASEN_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     tx_power=-127,
 )
 
+UPDATE_DEBOUNCE_TIME = 0.2
+
 
 async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
     """Set up the IKEA Idasen Desk integration in Home Assistant."""

--- a/tests/components/idasen_desk/test_sensor.py
+++ b/tests/components/idasen_desk/test_sensor.py
@@ -2,18 +2,23 @@
 
 from unittest.mock import MagicMock
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
-from . import init_integration
+from . import UPDATE_DEBOUNCE_TIME, init_integration
+
+from tests.common import async_fire_time_changed
 
 EXPECTED_INITIAL_HEIGHT = "1"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_height_sensor(hass: HomeAssistant, mock_desk_api: MagicMock) -> None:
+async def test_height_sensor(
+    hass: HomeAssistant, mock_desk_api: MagicMock, freezer: FrozenDateTimeFactory
+) -> None:
     """Test height sensor."""
     await init_integration(hass)
 
@@ -24,6 +29,15 @@ async def test_height_sensor(hass: HomeAssistant, mock_desk_api: MagicMock) -> N
 
     mock_desk_api.height = 1.2
     mock_desk_api.trigger_update_callback(None)
+    await hass.async_block_till_done()
+
+    # Initial state should still be the same due to debounce
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == EXPECTED_INITIAL_HEIGHT
+
+    freezer.tick(UPDATE_DEBOUNCE_TIME)
+    async_fire_time_changed(hass)
 
     state = hass.states.get(entity_id)
     assert state
@@ -34,6 +48,7 @@ async def test_height_sensor(hass: HomeAssistant, mock_desk_api: MagicMock) -> N
 async def test_sensor_available(
     hass: HomeAssistant,
     mock_desk_api: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test sensor available property."""
     await init_integration(hass)
@@ -45,6 +60,9 @@ async def test_sensor_available(
 
     mock_desk_api.is_connected = False
     mock_desk_api.trigger_update_callback(None)
+
+    freezer.tick(UPDATE_DEBOUNCE_TIME)
+    async_fire_time_changed(hass)
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/idasen_desk/test_sensor.py
+++ b/tests/components/idasen_desk/test_sensor.py
@@ -31,7 +31,7 @@ async def test_height_sensor(
     mock_desk_api.trigger_update_callback(None)
     await hass.async_block_till_done()
 
-    # Initial state should still be the same due to debounce
+    # State should still be the same due to the debouncer
     state = hass.states.get(entity_id)
     assert state
     assert state.state == EXPECTED_INITIAL_HEIGHT


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The desk sends a lot of updates when moving. This adds a debounce to reduce the number of state updates.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #147320
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
