### PR TITLE
Fix cancel propagation in update coordinator and config entry

### DIFF
--- a/homeassistant/components/history_stats/config_flow.py
+++ b/homeassistant/components/history_stats/config_flow.py
@@ -211,7 +211,7 @@ async def ws_start_preview(
 
     @callback
     def async_preview_updated(
-        last_exception: Exception | None, state: str, attributes: Mapping[str, Any]
+        last_exception: BaseException | None, state: str, attributes: Mapping[str, Any]
     ) -> None:
         """Forward config entry state events to websocket."""
         if last_exception:

--- a/homeassistant/components/history_stats/sensor.py
+++ b/homeassistant/components/history_stats/sensor.py
@@ -241,7 +241,9 @@ class HistoryStatsSensor(HistoryStatsSensorBase):
 
     async def async_start_preview(
         self,
-        preview_callback: Callable[[Exception | None, str, Mapping[str, Any]], None],
+        preview_callback: Callable[
+            [BaseException | None, str, Mapping[str, Any]], None
+        ],
     ) -> CALLBACK_TYPE:
         """Render a preview."""
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -755,6 +755,7 @@ class ConfigEntry[_DataT = Any]:
         error_reason_translation_placeholders = None
 
         try:
+            result = False
             with async_start_setup(
                 hass, integration=self.domain, group=self.entry_id, phase=setup_phase
             ):
@@ -775,8 +776,6 @@ class ConfigEntry[_DataT = Any]:
                 self.domain,
                 error_reason,
             )
-            await self._async_process_on_unload(hass)
-            result = False
         except ConfigEntryAuthFailed as exc:
             message = str(exc)
             auth_base_message = "could not authenticate"
@@ -792,9 +791,7 @@ class ConfigEntry[_DataT = Any]:
                 self.domain,
                 auth_message,
             )
-            await self._async_process_on_unload(hass)
             self.async_start_reauth(hass)
-            result = False
         except ConfigEntryNotReady as exc:
             message = str(exc)
             error_reason_translation_key = exc.translation_key
@@ -835,14 +832,39 @@ class ConfigEntry[_DataT = Any]:
                     functools.partial(self._async_setup_again, hass),
                 )
 
-            await self._async_process_on_unload(hass)
             return
-        # pylint: disable-next=broad-except
-        except (asyncio.CancelledError, SystemExit, Exception):
+
+        except asyncio.CancelledError:
+            # We want to propagate CancelledError if we are being cancelled.
+            if (task := asyncio.current_task()) and task.cancelling() > 0:
+                _LOGGER.exception(
+                    "Setup of config entry '%s' for %s integration cancelled",
+                    self.title,
+                    self.domain,
+                )
+                self._async_set_state(
+                    hass,
+                    ConfigEntryState.SETUP_ERROR,
+                    None,
+                    None,
+                    None,
+                )
+                raise
+
+            # This was not a "real" cancellation, log it and treat as a normal error.
             _LOGGER.exception(
                 "Error setting up entry %s for %s", self.title, integration.domain
             )
-            result = False
+
+        # pylint: disable-next=broad-except
+        except (SystemExit, Exception):
+            _LOGGER.exception(
+                "Error setting up entry %s for %s", self.title, integration.domain
+            )
+
+        finally:
+            if not result and domain_is_integration:
+                await self._async_process_on_unload(hass)
 
         #
         # After successfully calling async_setup_entry, it is important that this function

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -754,8 +754,8 @@ class ConfigEntry[_DataT = Any]:
         error_reason_translation_key = None
         error_reason_translation_placeholders = None
 
+        result = False
         try:
-            result = False
             with async_start_setup(
                 hass, integration=self.domain, group=self.entry_id, phase=setup_phase
             ):

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -492,7 +492,15 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
                 self.config_entry.async_start_reauth(self.hass)
         except NotImplementedError as err:
             self.last_exception = err
+            self.last_update_success = False
             raise
+
+        except asyncio.CancelledError as err:
+            self.last_exception = err
+            self.last_update_success = False
+
+            if (task := asyncio.current_task()) and task.cancelling() > 0:
+                raise
 
         except Exception as err:
             self.last_exception = err

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -131,7 +131,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         self._request_refresh_task: asyncio.TimerHandle | None = None
         self._retry_after: float | None = None
         self.last_update_success = True
-        self.last_exception: Exception | None = None
+        self.last_exception: BaseException | None = None
 
         if request_refresh_debouncer is None:
             request_refresh_debouncer = Debouncer(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -9727,3 +9727,30 @@ async def test_config_flow_create_entry_with_next_flow(hass: HomeAssistant) -> N
     assert result["next_flow"][0] == config_entries.FlowType.CONFIG_FLOW
     # Verify the target flow exists
     hass.config_entries.flow.async_get(result["next_flow"][1])
+
+async def test_canceled_exceptions_are_propagated(
+    hass: HomeAssistant, manager: config_entries.ConfigEntries
+) -> None:
+    """Tests that base exceptions like cancellations are not swallowed."""
+    entry = MockConfigEntry(title="test_title", domain="test")
+    start = asyncio.Event()
+    abort = asyncio.Event()
+
+    async def _setup(_: HomeAssistant, __: ConfigEntry) -> bool:
+        start.set()
+        await abort.wait()
+        return True
+
+    mock_integration(hass, MockModule("test", async_setup_entry=_setup))
+    mock_platform(hass, "test.config_flow", None)
+
+    entry.add_to_hass(hass)
+
+    task = hass.async_create_task(manager.async_setup(entry.entry_id))
+    await start.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    abort.set()

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -9728,6 +9728,7 @@ async def test_config_flow_create_entry_with_next_flow(hass: HomeAssistant) -> N
     # Verify the target flow exists
     hass.config_entries.flow.async_get(result["next_flow"][1])
 
+
 async def test_canceled_exceptions_are_propagated(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:

--- a/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/__init__.py
+++ b/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/__init__.py
@@ -13,6 +13,5 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Mock an unsuccessful entry setup."""
-    asyncio.current_task().cancel()
-    await asyncio.sleep(0)
+    """Mock an leaked cancellation, without our own task being cancelled."""
+    raise asyncio.CancelledError


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

There exist code paths where the setup of a integration could be cancelled. In this case the CancelledError must be propagated by the tasks to ensure full task cancellation. We avoid propagation if the calling task is not cancelled since that would be a leaked cancellation exception that should not continue upstream.

This should also ensure that any registered cleanup functions in the config entry is run to de-register any other callbacks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/112472
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
