### PR TITLE
Add workaround for partial local_strategy in Tuya

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -266,7 +266,7 @@ class CustomManager(Manager):
             new_status = []
             for item in status:
                 if (dpId := item.get("dpId")) and dpId not in device.local_strategy:
-                    LOGGER.debug(f"Ignoring dpId {dpId} missing from local_strategy")
+                    LOGGER.debug("Ignoring dpId %s missing from local_strategy", dpId)
                     continue
                 new_status.append(item)
             status = new_status

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -319,6 +319,8 @@ async def initialize_entry(
     mock_config_entry.add_to_hass(hass)
 
     # Initialize the component
-    with patch("homeassistant.components.tuya.Manager", return_value=mock_manager):
+    with patch(
+        "homeassistant.components.tuya.CustomManager", return_value=mock_manager
+    ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -73,8 +73,8 @@ async def mock_loaded_entry(
     mock_config_entry.add_to_hass(hass)
 
     # Initialize the component
-    with (
-        patch("homeassistant.components.tuya.Manager", return_value=mock_manager),
+    with patch(
+        "homeassistant.components.tuya.CustomManager", return_value=mock_manager
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice, Manager
 
+from homeassistant.components.tuya import CustomManager
 from homeassistant.components.tuya.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -65,3 +68,108 @@ async def test_fixtures_valid(hass: HomeAssistant) -> None:
             assert key not in details, (
                 f"Please remove data[`'{key}']` from {device_code}.json"
             )
+
+
+async def test_manager_fix() -> None:
+    """Test manager fix for Tuya SDK.
+
+    See https://github.com/home-assistant/core/issues/151239
+
+    dpId `101` is present in the status update but not in the local_strategy, causing
+    all subsequent dpId (`3`, `15`, `5`, `9`) in the message to be ignored.
+    """
+    with patch("tuya_sharing.manager.CustomerTokenInfo"):
+        manager = CustomManager("test", "test", "test", "test")
+
+    device = CustomerDevice(
+        support_local=True,
+        local_strategy={
+            3: {
+                "value_convert": "default",
+                "status_code": "humidity",
+                "config_item": {
+                    "statusFormat": '{"humidity":"$"}',
+                    "valueDesc": '{"unit":"%","min":0,"max":100,"scale":0,"step":1}',
+                    "valueType": "Integer",
+                    "enumMappingMap": {},
+                    "pid": "rknwi0ctbbghzgla",
+                },
+            },
+            5: {
+                "value_convert": "default",
+                "status_code": "temp_current",
+                "config_item": {
+                    "statusFormat": '{"temp_current":"$"}',
+                    "valueDesc": '{"unit":"℃","min":0,"max":1000,"scale":1,"step":1}',
+                    "valueType": "Integer",
+                    "enumMappingMap": {},
+                    "pid": "rknwi0ctbbghzgla",
+                },
+            },
+            9: {
+                "value_convert": "default",
+                "status_code": "temp_unit_convert",
+                "config_item": {
+                    "statusFormat": '{"temp_unit_convert":"$"}',
+                    "valueDesc": '{"range":["c","f"]}',
+                    "valueType": "Enum",
+                    "enumMappingMap": {},
+                    "pid": "rknwi0ctbbghzgla",
+                },
+            },
+            15: {
+                "value_convert": "default",
+                "status_code": "battery_percentage",
+                "config_item": {
+                    "statusFormat": '{"battery_percentage":"$"}',
+                    "valueDesc": '{"unit":"%","min":0,"max":100,"scale":0,"step":1}',
+                    "valueType": "Integer",
+                    "enumMappingMap": {},
+                    "pid": "rknwi0ctbbghzgla",
+                },
+            },
+        },
+        status={
+            "humidity": 321,
+            "temp_current": 321,
+            "temp_unit_convert": "f",
+            "battery_percentage": 321,
+        },
+    )
+    manager.device_map = {"bfe251cfa8882fae3cpvup": device}
+
+    manager.on_message(
+        {
+            "protocol": 20,
+            "data": {
+                "bizCode": "online",
+                "bizData": {"devId": "bfe251cfa8882fae3cpvup", "time": 1759226706159},
+                "ts": 1759226706408,
+            },
+            "t": 1759226706408,
+        }
+    )
+    manager.on_message(
+        {
+            "protocol": 4,
+            "data": {
+                "devId": "bfe251cfa8882fae3cpvup",
+                "dataId": "2711cd0c-c215-48f4-b535-243640e3b5b3",
+                "productKey": "rknwi0ctbbghzgla",
+                "status": [
+                    {"dpId": 101, "t": 1759226706567, "value": 456},
+                    {"dpId": 3, "t": 1759226706567, "value": 87},
+                    {"dpId": 15, "t": 1759226706567, "value": 40},
+                    {"dpId": 5, "t": 1759226706567, "value": 76},
+                    {"dpId": 9, "t": 1759226706567, "value": "c"},
+                ],
+            },
+            "t": 1759226707104,
+        }
+    )
+    assert device.status == {
+        "humidity": 87,
+        "temp_current": 76,
+        "temp_unit_convert": "c",
+        "battery_percentage": 40,
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a status update is received with a dpId not present in the local_strategy, all subsequent dpId are ignored resulting in missing update in Home Assistant.

Workaround for https://github.com/home-assistant/core/issues/151239

Can be removed when fix is implemented in library
- https://github.com/tuya/tuya-device-sharing-sdk/pull/23
- https://github.com/tuya/tuya-device-sharing-sdk/pull/39

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
