### PR TITLE
fix: template binary sensor auto_off ignoring re-triggers

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -352,6 +352,10 @@ class TriggerBinarySensorEntity(TriggerEntity, BinarySensorEntity, RestoreEntity
             self._set_state(state)
             return
 
+        if self._attr_is_on and state:
+            self._set_state(state)
+            return
+
         if not isinstance(delay, timedelta):
             try:
                 delay = cv.positive_time_period(delay)


### PR DESCRIPTION
### Proposed change
- Fix template binary sensor auto_off timer not being re-established when sensor receives re-triggers while already ON.

### Type of change
- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information
 fixes #153455
