### PR TITLE
Raise repairs on platform setup for command_line

### DIFF
--- a/homeassistant/components/command_line/binary_sensor.py
+++ b/homeassistant/components/command_line/binary_sensor.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger_template_entity import (
     ManualTriggerEntity,
@@ -29,8 +28,9 @@ from homeassistant.helpers.trigger_template_entity import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_COMMAND_TIMEOUT, DOMAIN, LOGGER, TRIGGER_ENTITY_OPTIONS
+from .const import CONF_COMMAND_TIMEOUT, LOGGER, TRIGGER_ENTITY_OPTIONS
 from .sensor import CommandSensorData
+from .utils import create_platform_yaml_not_supported_issue
 
 DEFAULT_NAME = "Binary Command Sensor"
 DEFAULT_PAYLOAD_ON = "ON"
@@ -47,16 +47,7 @@ async def async_setup_platform(
 ) -> None:
     """Set up the Command line Binary Sensor."""
     if not discovery_info:
-        async_create_issue(
-            hass,
-            DOMAIN,
-            "binary_sensor_platform_yaml_not_supported",
-            is_fixable=False,
-            severity=IssueSeverity.WARNING,
-            translation_key="platform_yaml_not_supported",
-            translation_placeholders={"platform": BINARY_SENSOR_DOMAIN},
-            learn_more_url="https://www.home-assistant.io/integrations/command_line/",
-        )
+        create_platform_yaml_not_supported_issue(hass, BINARY_SENSOR_DOMAIN)
         return
 
     binary_sensor_config = discovery_info

--- a/homeassistant/components/command_line/binary_sensor.py
+++ b/homeassistant/components/command_line/binary_sensor.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timedelta
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    DOMAIN as BINARY_SENSOR_DOMAIN,
+    BinarySensorEntity,
+)
 from homeassistant.const import (
     CONF_COMMAND,
     CONF_NAME,
@@ -17,6 +20,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger_template_entity import (
     ManualTriggerEntity,
@@ -25,7 +29,7 @@ from homeassistant.helpers.trigger_template_entity import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_COMMAND_TIMEOUT, LOGGER, TRIGGER_ENTITY_OPTIONS
+from .const import CONF_COMMAND_TIMEOUT, DOMAIN, LOGGER, TRIGGER_ENTITY_OPTIONS
 from .sensor import CommandSensorData
 
 DEFAULT_NAME = "Binary Command Sensor"
@@ -43,6 +47,16 @@ async def async_setup_platform(
 ) -> None:
     """Set up the Command line Binary Sensor."""
     if not discovery_info:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "binary_sensor_platform_yaml_not_supported",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="platform_yaml_not_supported",
+            translation_placeholders={"platform": BINARY_SENSOR_DOMAIN},
+            learn_more_url="https://www.home-assistant.io/integrations/command_line/",
+        )
         return
 
     binary_sensor_config = discovery_info

--- a/homeassistant/components/command_line/cover.py
+++ b/homeassistant/components/command_line/cover.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger_template_entity import (
     ManualTriggerEntity,
@@ -28,8 +27,12 @@ from homeassistant.helpers.trigger_template_entity import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util, slugify
 
-from .const import CONF_COMMAND_TIMEOUT, DOMAIN, LOGGER, TRIGGER_ENTITY_OPTIONS
-from .utils import async_call_shell_with_timeout, async_check_output_or_log
+from .const import CONF_COMMAND_TIMEOUT, LOGGER, TRIGGER_ENTITY_OPTIONS
+from .utils import (
+    async_call_shell_with_timeout,
+    async_check_output_or_log,
+    create_platform_yaml_not_supported_issue,
+)
 
 SCAN_INTERVAL = timedelta(seconds=15)
 
@@ -42,16 +45,7 @@ async def async_setup_platform(
 ) -> None:
     """Set up cover controlled by shell commands."""
     if not discovery_info:
-        async_create_issue(
-            hass,
-            DOMAIN,
-            "cover_platform_yaml_not_supported",
-            is_fixable=False,
-            severity=IssueSeverity.WARNING,
-            translation_key="platform_yaml_not_supported",
-            translation_placeholders={"platform": COVER_DOMAIN},
-            learn_more_url="https://www.home-assistant.io/integrations/command_line/",
-        )
+        create_platform_yaml_not_supported_issue(hass, COVER_DOMAIN)
         return
 
     covers = []

--- a/homeassistant/components/command_line/cover.py
+++ b/homeassistant/components/command_line/cover.py
@@ -6,7 +6,7 @@ import asyncio
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.cover import CoverEntity
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN, CoverEntity
 from homeassistant.const import (
     CONF_COMMAND_CLOSE,
     CONF_COMMAND_OPEN,
@@ -19,6 +19,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger_template_entity import (
     ManualTriggerEntity,
@@ -27,7 +28,7 @@ from homeassistant.helpers.trigger_template_entity import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util, slugify
 
-from .const import CONF_COMMAND_TIMEOUT, LOGGER, TRIGGER_ENTITY_OPTIONS
+from .const import CONF_COMMAND_TIMEOUT, DOMAIN, LOGGER, TRIGGER_ENTITY_OPTIONS
 from .utils import async_call_shell_with_timeout, async_check_output_or_log
 
 SCAN_INTERVAL = timedelta(seconds=15)
@@ -41,6 +42,16 @@ async def async_setup_platform(
 ) -> None:
     """Set up cover controlled by shell commands."""
     if not discovery_info:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "cover_platform_yaml_not_supported",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="platform_yaml_not_supported",
+            translation_placeholders={"platform": COVER_DOMAIN},
+            learn_more_url="https://www.home-assistant.io/integrations/command_line/",
+        )
         return
 
     covers = []

--- a/homeassistant/components/command_line/notify.py
+++ b/homeassistant/components/command_line/notify.py
@@ -6,13 +6,17 @@ import logging
 import subprocess
 from typing import Any
 
-from homeassistant.components.notify import BaseNotificationService
+from homeassistant.components.notify import (
+    DOMAIN as NOTIFY_DOMAIN,
+    BaseNotificationService,
+)
 from homeassistant.const import CONF_COMMAND
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.issue_registry import IssueSeverity, create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util.process import kill_subprocess
 
-from .const import CONF_COMMAND_TIMEOUT, LOGGER
+from .const import CONF_COMMAND_TIMEOUT, DOMAIN, LOGGER
 from .utils import render_template_args
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,6 +29,16 @@ def get_service(
 ) -> CommandLineNotificationService | None:
     """Get the Command Line notification service."""
     if not discovery_info:
+        create_issue(
+            hass,
+            DOMAIN,
+            "notify_platform_yaml_not_supported",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="platform_yaml_not_supported",
+            translation_placeholders={"platform": NOTIFY_DOMAIN},
+            learn_more_url="https://www.home-assistant.io/integrations/command_line/",
+        )
         return None
 
     notify_config = discovery_info

--- a/homeassistant/components/command_line/notify.py
+++ b/homeassistant/components/command_line/notify.py
@@ -12,33 +12,23 @@ from homeassistant.components.notify import (
 )
 from homeassistant.const import CONF_COMMAND
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.issue_registry import IssueSeverity, create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util.process import kill_subprocess
 
-from .const import CONF_COMMAND_TIMEOUT, DOMAIN, LOGGER
-from .utils import render_template_args
+from .const import CONF_COMMAND_TIMEOUT, LOGGER
+from .utils import create_platform_yaml_not_supported_issue, render_template_args
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_service(
+async def async_get_service(
     hass: HomeAssistant,
     config: ConfigType,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> CommandLineNotificationService | None:
     """Get the Command Line notification service."""
     if not discovery_info:
-        create_issue(
-            hass,
-            DOMAIN,
-            "notify_platform_yaml_not_supported",
-            is_fixable=False,
-            severity=IssueSeverity.WARNING,
-            translation_key="platform_yaml_not_supported",
-            translation_placeholders={"platform": NOTIFY_DOMAIN},
-            learn_more_url="https://www.home-assistant.io/integrations/command_line/",
-        )
+        create_platform_yaml_not_supported_issue(hass, NOTIFY_DOMAIN)
         return None
 
     notify_config = discovery_info

--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from jsonpath import jsonpath
 
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     CONF_COMMAND,
     CONF_NAME,
@@ -19,6 +20,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger_template_entity import (
     ManualTriggerSensorEntity,
@@ -31,6 +33,7 @@ from .const import (
     CONF_COMMAND_TIMEOUT,
     CONF_JSON_ATTRIBUTES,
     CONF_JSON_ATTRIBUTES_PATH,
+    DOMAIN,
     LOGGER,
     TRIGGER_ENTITY_OPTIONS,
 )
@@ -49,6 +52,16 @@ async def async_setup_platform(
 ) -> None:
     """Set up the Command Sensor."""
     if not discovery_info:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "sensor_platform_yaml_not_supported",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="platform_yaml_not_supported",
+            translation_placeholders={"platform": SENSOR_DOMAIN},
+            learn_more_url="https://www.home-assistant.io/integrations/command_line/",
+        )
         return
 
     sensor_config = discovery_info

--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger_template_entity import (
     ManualTriggerSensorEntity,
@@ -33,11 +32,14 @@ from .const import (
     CONF_COMMAND_TIMEOUT,
     CONF_JSON_ATTRIBUTES,
     CONF_JSON_ATTRIBUTES_PATH,
-    DOMAIN,
     LOGGER,
     TRIGGER_ENTITY_OPTIONS,
 )
-from .utils import async_check_output_or_log, render_template_args
+from .utils import (
+    async_check_output_or_log,
+    create_platform_yaml_not_supported_issue,
+    render_template_args,
+)
 
 DEFAULT_NAME = "Command Sensor"
 
@@ -52,16 +54,7 @@ async def async_setup_platform(
 ) -> None:
     """Set up the Command Sensor."""
     if not discovery_info:
-        async_create_issue(
-            hass,
-            DOMAIN,
-            "sensor_platform_yaml_not_supported",
-            is_fixable=False,
-            severity=IssueSeverity.WARNING,
-            translation_key="platform_yaml_not_supported",
-            translation_placeholders={"platform": SENSOR_DOMAIN},
-            learn_more_url="https://www.home-assistant.io/integrations/command_line/",
-        )
+        create_platform_yaml_not_supported_issue(hass, SENSOR_DOMAIN)
         return
 
     sensor_config = discovery_info

--- a/homeassistant/components/command_line/strings.json
+++ b/homeassistant/components/command_line/strings.json
@@ -7,8 +7,8 @@
   },
   "issues": {
     "platform_yaml_not_supported": {
-      "title": "Platform YAML is not supported for Command Line",
-      "description": "Platform YAML setup is not supported.\nChange from configuring it in the `{platform}:` key to use the `command_line:` key directly in configuration.yaml.\nSee the documentation for details."
+      "title": "Platform YAML is not supported in Command Line",
+      "description": "Platform YAML setup is not supported.\nChange from configuring it in the `sensor:` key to using the `command_line:` key directly in configuration.yaml.\nTo see the detailed documentation, select Learn more."
     }
   }
 }

--- a/homeassistant/components/command_line/strings.json
+++ b/homeassistant/components/command_line/strings.json
@@ -8,7 +8,7 @@
   "issues": {
     "platform_yaml_not_supported": {
       "title": "Platform YAML is not supported for Command Line",
-      "description": "Platform YAML setup is not supported.\nChange from configuring it in the `{platform}:` key to use the `command_line:` key directly in config.yaml.\nSee the documentation for details."
+      "description": "Platform YAML setup is not supported.\nChange from configuring it in the `{platform}:` key to use the `command_line:` key directly in configuration.yaml.\nSee the documentation for details."
     }
   }
 }

--- a/homeassistant/components/command_line/strings.json
+++ b/homeassistant/components/command_line/strings.json
@@ -4,5 +4,11 @@
       "description": "Reloads command line configuration from the YAML-configuration.",
       "name": "[%key:common::action::reload%]"
     }
+  },
+  "issues": {
+    "platform_yaml_not_supported": {
+      "title": "Platform YAML is not supported for Command Line",
+      "description": "Platform YAML setup is not supported.\nChange from configuring it in the `{platform}:` key to use the `command_line:` key directly in config.yaml.\nSee the documentation for details."
+    }
   }
 }

--- a/homeassistant/components/command_line/strings.json
+++ b/homeassistant/components/command_line/strings.json
@@ -1,14 +1,14 @@
 {
+  "issues": {
+    "platform_yaml_not_supported": {
+      "description": "Platform YAML setup is not supported.\nChange from configuring it using the `{platform}:` key to using the `command_line:` key directly in configuration.yaml.\nTo see the detailed documentation, select Learn more.",
+      "title": "Platform YAML is not supported in Command Line"
+    }
+  },
   "services": {
     "reload": {
       "description": "Reloads command line configuration from the YAML-configuration.",
       "name": "[%key:common::action::reload%]"
-    }
-  },
-  "issues": {
-    "platform_yaml_not_supported": {
-      "title": "Platform YAML is not supported in Command Line",
-      "description": "Platform YAML setup is not supported.\nChange from configuring it in the `sensor:` key to using the `command_line:` key directly in configuration.yaml.\nTo see the detailed documentation, select Learn more."
     }
   }
 }

--- a/homeassistant/components/command_line/strings.json
+++ b/homeassistant/components/command_line/strings.json
@@ -1,7 +1,7 @@
 {
   "issues": {
     "platform_yaml_not_supported": {
-      "description": "Platform YAML setup is not supported.\nChange from configuring it using the `{platform}:` key to using the `command_line:` key directly in configuration.yaml.\nTo see the detailed documentation, select Learn more.",
+      "description": "Platform YAML setup is not supported.\nChange from configuring it using the `{platform}:` key to using the `command_line:` key directly in configuration.yaml and restart Home Assistant to resolve the issue.\nTo see the detailed documentation, select Learn more.",
       "title": "Platform YAML is not supported in Command Line"
     }
   },

--- a/homeassistant/components/command_line/switch.py
+++ b/homeassistant/components/command_line/switch.py
@@ -22,7 +22,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger_template_entity import (
     ManualTriggerEntity,
@@ -31,8 +30,12 @@ from homeassistant.helpers.trigger_template_entity import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util, slugify
 
-from .const import CONF_COMMAND_TIMEOUT, DOMAIN, LOGGER, TRIGGER_ENTITY_OPTIONS
-from .utils import async_call_shell_with_timeout, async_check_output_or_log
+from .const import CONF_COMMAND_TIMEOUT, LOGGER, TRIGGER_ENTITY_OPTIONS
+from .utils import (
+    async_call_shell_with_timeout,
+    async_check_output_or_log,
+    create_platform_yaml_not_supported_issue,
+)
 
 SCAN_INTERVAL = timedelta(seconds=30)
 
@@ -45,16 +48,7 @@ async def async_setup_platform(
 ) -> None:
     """Find and return switches controlled by shell commands."""
     if not discovery_info:
-        async_create_issue(
-            hass,
-            DOMAIN,
-            "switch_platform_yaml_not_supported",
-            is_fixable=False,
-            severity=IssueSeverity.WARNING,
-            translation_key="platform_yaml_not_supported",
-            translation_placeholders={"platform": SWITCH_DOMAIN},
-            learn_more_url="https://www.home-assistant.io/integrations/command_line/",
-        )
+        create_platform_yaml_not_supported_issue(hass, SWITCH_DOMAIN)
         return
 
     switches = []

--- a/homeassistant/components/command_line/switch.py
+++ b/homeassistant/components/command_line/switch.py
@@ -6,7 +6,11 @@ import asyncio
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    ENTITY_ID_FORMAT,
+    SwitchEntity,
+)
 from homeassistant.const import (
     CONF_COMMAND_OFF,
     CONF_COMMAND_ON,
@@ -18,6 +22,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger_template_entity import (
     ManualTriggerEntity,
@@ -26,7 +31,7 @@ from homeassistant.helpers.trigger_template_entity import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util, slugify
 
-from .const import CONF_COMMAND_TIMEOUT, LOGGER, TRIGGER_ENTITY_OPTIONS
+from .const import CONF_COMMAND_TIMEOUT, DOMAIN, LOGGER, TRIGGER_ENTITY_OPTIONS
 from .utils import async_call_shell_with_timeout, async_check_output_or_log
 
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -40,6 +45,16 @@ async def async_setup_platform(
 ) -> None:
     """Find and return switches controlled by shell commands."""
     if not discovery_info:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "switch_platform_yaml_not_supported",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="platform_yaml_not_supported",
+            translation_placeholders={"platform": SWITCH_DOMAIN},
+            learn_more_url="https://www.home-assistant.io/integrations/command_line/",
+        )
         return
 
     switches = []

--- a/homeassistant/components/command_line/utils.py
+++ b/homeassistant/components/command_line/utils.py
@@ -6,9 +6,10 @@ import asyncio
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import Template
 
-from .const import LOGGER
+from .const import DOMAIN, LOGGER
 
 _EXEC_FAILED_CODE = 127
 
@@ -93,3 +94,19 @@ def render_template_args(hass: HomeAssistant, command: str) -> str | None:
     LOGGER.debug("Running command: %s", command)
 
     return command
+
+
+def create_platform_yaml_not_supported_issue(
+    hass: HomeAssistant, platform_domain: str
+) -> None:
+    """Create an issue when platform yaml is used."""
+    async_create_issue(
+        hass,
+        DOMAIN,
+        "binary_sensor_platform_yaml_not_supported",
+        is_fixable=False,
+        severity=IssueSeverity.WARNING,
+        translation_key="platform_yaml_not_supported",
+        translation_placeholders={"platform": platform_domain},
+        learn_more_url="https://www.home-assistant.io/integrations/command_line/",
+    )

--- a/homeassistant/components/command_line/utils.py
+++ b/homeassistant/components/command_line/utils.py
@@ -103,7 +103,7 @@ def create_platform_yaml_not_supported_issue(
     async_create_issue(
         hass,
         DOMAIN,
-        "binary_sensor_platform_yaml_not_supported",
+        f"{platform_domain}_platform_yaml_not_supported",
         is_fixable=False,
         severity=IssueSeverity.WARNING,
         translation_key="platform_yaml_not_supported",

--- a/homeassistant/components/command_line/utils.py
+++ b/homeassistant/components/command_line/utils.py
@@ -105,7 +105,7 @@ def create_platform_yaml_not_supported_issue(
         DOMAIN,
         f"{platform_domain}_platform_yaml_not_supported",
         is_fixable=False,
-        severity=IssueSeverity.WARNING,
+        severity=IssueSeverity.ERROR,
         translation_key="platform_yaml_not_supported",
         translation_placeholders={"platform": platform_domain},
         learn_more_url="https://www.home-assistant.io/integrations/command_line/",

--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -80,7 +80,7 @@ async def test_setup_platform_yaml(
         DOMAIN, "binary_sensor_platform_yaml_not_supported"
     )
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity == ir.IssueSeverity.ERROR
     assert issue.translation_placeholders == {"platform": BINARY_SENSOR_DOMAIN}
 
 

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -31,7 +31,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.util import dt as dt_util
 
 from . import mock_asyncio_subprocess_run
@@ -39,7 +39,9 @@ from . import mock_asyncio_subprocess_run
 from tests.common import async_fire_time_changed
 
 
-async def test_setup_platform_yaml(hass: HomeAssistant) -> None:
+async def test_setup_platform_yaml(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
     """Test setting up the platform with platform yaml."""
     await setup.async_setup_component(
         hass,
@@ -55,6 +57,10 @@ async def test_setup_platform_yaml(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
+    issue = issue_registry.async_get_issue(DOMAIN, "cover_platform_yaml_not_supported")
+    assert issue is not None
+    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.translation_placeholders == {"platform": COVER_DOMAIN}
 
 
 async def test_no_poll_when_cover_has_no_command_state(hass: HomeAssistant) -> None:

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -59,7 +59,7 @@ async def test_setup_platform_yaml(
     assert len(hass.states.async_all()) == 0
     issue = issue_registry.async_get_issue(DOMAIN, "cover_platform_yaml_not_supported")
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity == ir.IssueSeverity.ERROR
     assert issue.translation_placeholders == {"platform": COVER_DOMAIN}
 
 

--- a/tests/components/command_line/test_notify.py
+++ b/tests/components/command_line/test_notify.py
@@ -14,9 +14,12 @@ from homeassistant import setup
 from homeassistant.components.command_line import DOMAIN
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 
 
-async def test_setup_platform_yaml(hass: HomeAssistant) -> None:
+async def test_setup_platform_yaml(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
     """Test setting up the platform with platform yaml."""
     await setup.async_setup_component(
         hass,
@@ -32,6 +35,10 @@ async def test_setup_platform_yaml(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
+    issue = issue_registry.async_get_issue(DOMAIN, "notify_platform_yaml_not_supported")
+    assert issue is not None
+    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.translation_placeholders == {"platform": NOTIFY_DOMAIN}
 
 
 @pytest.mark.parametrize(

--- a/tests/components/command_line/test_notify.py
+++ b/tests/components/command_line/test_notify.py
@@ -37,7 +37,7 @@ async def test_setup_platform_yaml(
     assert len(hass.states.async_all()) == 0
     issue = issue_registry.async_get_issue(DOMAIN, "notify_platform_yaml_not_supported")
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity == ir.IssueSeverity.ERROR
     assert issue.translation_placeholders == {"platform": NOTIFY_DOMAIN}
 
 

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -17,9 +17,10 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.util import dt as dt_util
 
 from . import mock_asyncio_subprocess_run
@@ -27,7 +28,9 @@ from . import mock_asyncio_subprocess_run
 from tests.common import async_fire_time_changed
 
 
-async def test_setup_platform_yaml(hass: HomeAssistant) -> None:
+async def test_setup_platform_yaml(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
     """Test setting up the platform with platform yaml."""
     await setup.async_setup_component(
         hass,
@@ -43,6 +46,10 @@ async def test_setup_platform_yaml(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
+    issue = issue_registry.async_get_issue(DOMAIN, "sensor_platform_yaml_not_supported")
+    assert issue is not None
+    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.translation_placeholders == {"platform": SENSOR_DOMAIN}
 
 
 @pytest.mark.parametrize(

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -48,7 +48,7 @@ async def test_setup_platform_yaml(
     assert len(hass.states.async_all()) == 0
     issue = issue_registry.async_get_issue(DOMAIN, "sensor_platform_yaml_not_supported")
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity == ir.IssueSeverity.ERROR
     assert issue.translation_placeholders == {"platform": SENSOR_DOMAIN}
 
 

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.util import dt as dt_util
 
 from . import mock_asyncio_subprocess_run
@@ -37,7 +37,9 @@ from . import mock_asyncio_subprocess_run
 from tests.common import async_fire_time_changed
 
 
-async def test_setup_platform_yaml(hass: HomeAssistant) -> None:
+async def test_setup_platform_yaml(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
     """Test setting up the platform with platform yaml."""
     await setup.async_setup_component(
         hass,
@@ -53,6 +55,10 @@ async def test_setup_platform_yaml(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
+    issue = issue_registry.async_get_issue(DOMAIN, "switch_platform_yaml_not_supported")
+    assert issue is not None
+    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.translation_placeholders == {"platform": SWITCH_DOMAIN}
 
 
 async def test_state_integration_yaml(hass: HomeAssistant) -> None:

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -57,7 +57,7 @@ async def test_setup_platform_yaml(
     assert len(hass.states.async_all()) == 0
     issue = issue_registry.async_get_issue(DOMAIN, "switch_platform_yaml_not_supported")
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity == ir.IssueSeverity.ERROR
     assert issue.translation_placeholders == {"platform": SWITCH_DOMAIN}
 
 


### PR DESCRIPTION
## Breaking change


## Proposed change
Adds repairs for platform setup instead of just silently ignoring it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #153474
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 