### PR TITLE
Setup platform services during integration start in sensibo

### DIFF
--- a/homeassistant/components/sensibo/__init__.py
+++ b/homeassistant/components/sensibo/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.typing import ConfigType
 
@@ -19,9 +19,11 @@ from .util import NoDevicesError, NoUsernameError, async_validate_api
 
 type SensiboConfigEntry = ConfigEntry[SensiboDataUpdateCoordinator]
 
+CONFiG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Sonos component."""
+    """Set up the Sensibo component."""
     async_setup_services(hass)
 
     return True

--- a/homeassistant/components/sensibo/__init__.py
+++ b/homeassistant/components/sensibo/__init__.py
@@ -10,12 +10,21 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, LOGGER, PLATFORMS
 from .coordinator import SensiboDataUpdateCoordinator
+from .services import async_setup_services
 from .util import NoDevicesError, NoUsernameError, async_validate_api
 
 type SensiboConfigEntry = ConfigEntry[SensiboDataUpdateCoordinator]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Sonos component."""
+    async_setup_services(hass)
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: SensiboConfigEntry) -> bool:

--- a/homeassistant/components/sensibo/__init__.py
+++ b/homeassistant/components/sensibo/__init__.py
@@ -19,7 +19,7 @@ from .util import NoDevicesError, NoUsernameError, async_validate_api
 
 type SensiboConfigEntry = ConfigEntry[SensiboDataUpdateCoordinator]
 
-CONFiG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -5,26 +5,14 @@ from __future__ import annotations
 from bisect import bisect_left
 from typing import TYPE_CHECKING, Any
 
-import voluptuous as vol
-
 from homeassistant.components.climate import (
-    ATTR_FAN_MODE,
-    ATTR_HVAC_MODE,
-    ATTR_SWING_MODE,
     ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import (
-    ATTR_MODE,
-    ATTR_STATE,
-    ATTR_TEMPERATURE,
-    PRECISION_TENTHS,
-    UnitOfTemperature,
-)
-from homeassistant.core import HomeAssistant, SupportsResponse
+from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS, UnitOfTemperature
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.unit_conversion import TemperatureConverter
 
@@ -32,30 +20,6 @@ from . import SensiboConfigEntry
 from .const import DOMAIN
 from .coordinator import SensiboDataUpdateCoordinator
 from .entity import SensiboDeviceBaseEntity, async_handle_api_call
-
-SERVICE_ASSUME_STATE = "assume_state"
-SERVICE_ENABLE_TIMER = "enable_timer"
-ATTR_MINUTES = "minutes"
-SERVICE_ENABLE_PURE_BOOST = "enable_pure_boost"
-SERVICE_DISABLE_PURE_BOOST = "disable_pure_boost"
-SERVICE_FULL_STATE = "full_state"
-SERVICE_ENABLE_CLIMATE_REACT = "enable_climate_react"
-SERVICE_GET_DEVICE_CAPABILITIES = "get_device_capabilities"
-ATTR_HIGH_TEMPERATURE_THRESHOLD = "high_temperature_threshold"
-ATTR_HIGH_TEMPERATURE_STATE = "high_temperature_state"
-ATTR_LOW_TEMPERATURE_THRESHOLD = "low_temperature_threshold"
-ATTR_LOW_TEMPERATURE_STATE = "low_temperature_state"
-ATTR_SMART_TYPE = "smart_type"
-
-ATTR_AC_INTEGRATION = "ac_integration"
-ATTR_GEO_INTEGRATION = "geo_integration"
-ATTR_INDOOR_INTEGRATION = "indoor_integration"
-ATTR_OUTDOOR_INTEGRATION = "outdoor_integration"
-ATTR_SENSITIVITY = "sensitivity"
-ATTR_TARGET_TEMPERATURE = "target_temperature"
-ATTR_HORIZONTAL_SWING_MODE = "horizontal_swing_mode"
-ATTR_LIGHT = "light"
-BOOST_INCLUSIVE = "boost_inclusive"
 
 AVAILABLE_FAN_MODES = {
     "quiet",
@@ -161,66 +125,6 @@ async def async_setup_entry(
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()
-
-    platform = entity_platform.async_get_current_platform()
-    platform.async_register_entity_service(
-        SERVICE_ASSUME_STATE,
-        {
-            vol.Required(ATTR_STATE): vol.In(["on", "off"]),
-        },
-        "async_assume_state",
-    )
-    platform.async_register_entity_service(
-        SERVICE_ENABLE_TIMER,
-        {
-            vol.Required(ATTR_MINUTES): cv.positive_int,
-        },
-        "async_enable_timer",
-    )
-    platform.async_register_entity_service(
-        SERVICE_ENABLE_PURE_BOOST,
-        {
-            vol.Required(ATTR_AC_INTEGRATION): bool,
-            vol.Required(ATTR_GEO_INTEGRATION): bool,
-            vol.Required(ATTR_INDOOR_INTEGRATION): bool,
-            vol.Required(ATTR_OUTDOOR_INTEGRATION): bool,
-            vol.Required(ATTR_SENSITIVITY): vol.In(["normal", "sensitive"]),
-        },
-        "async_enable_pure_boost",
-    )
-    platform.async_register_entity_service(
-        SERVICE_FULL_STATE,
-        {
-            vol.Required(ATTR_MODE): vol.In(
-                ["cool", "heat", "fan", "auto", "dry", "off"]
-            ),
-            vol.Optional(ATTR_TARGET_TEMPERATURE): int,
-            vol.Optional(ATTR_FAN_MODE): str,
-            vol.Optional(ATTR_SWING_MODE): str,
-            vol.Optional(ATTR_HORIZONTAL_SWING_MODE): str,
-            vol.Optional(ATTR_LIGHT): vol.In(["on", "off", "dim"]),
-        },
-        "async_full_ac_state",
-    )
-    platform.async_register_entity_service(
-        SERVICE_ENABLE_CLIMATE_REACT,
-        {
-            vol.Required(ATTR_HIGH_TEMPERATURE_THRESHOLD): vol.Coerce(float),
-            vol.Required(ATTR_HIGH_TEMPERATURE_STATE): dict,
-            vol.Required(ATTR_LOW_TEMPERATURE_THRESHOLD): vol.Coerce(float),
-            vol.Required(ATTR_LOW_TEMPERATURE_STATE): dict,
-            vol.Required(ATTR_SMART_TYPE): vol.In(
-                ["temperature", "feelslike", "humidity"]
-            ),
-        },
-        "async_enable_climate_react",
-    )
-    platform.async_register_entity_service(
-        SERVICE_GET_DEVICE_CAPABILITIES,
-        {vol.Required(ATTR_HVAC_MODE): vol.Coerce(HVACMode)},
-        "async_get_device_capabilities",
-        supports_response=SupportsResponse.ONLY,
-    )
 
 
 class SensiboClimate(SensiboDeviceBaseEntity, ClimateEntity):

--- a/homeassistant/components/sensibo/services.py
+++ b/homeassistant/components/sensibo/services.py
@@ -44,7 +44,7 @@ BOOST_INCLUSIVE = "boost_inclusive"
 
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
-    """Register Sonos services."""
+    """Register Sensibo services."""
 
     service.async_register_platform_entity_service(
         hass,

--- a/homeassistant/components/sensibo/services.py
+++ b/homeassistant/components/sensibo/services.py
@@ -1,0 +1,124 @@
+"""Sensibo services."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.components.climate import (
+    ATTR_FAN_MODE,
+    ATTR_HVAC_MODE,
+    ATTR_SWING_MODE,
+    DOMAIN as CLIMATE_DOMAIN,
+    HVACMode,
+)
+from homeassistant.const import ATTR_MODE, ATTR_STATE
+from homeassistant.core import HomeAssistant, SupportsResponse, callback
+from homeassistant.helpers import config_validation as cv, service
+
+from .const import DOMAIN
+
+SERVICE_ASSUME_STATE = "assume_state"
+SERVICE_ENABLE_TIMER = "enable_timer"
+ATTR_MINUTES = "minutes"
+SERVICE_ENABLE_PURE_BOOST = "enable_pure_boost"
+SERVICE_DISABLE_PURE_BOOST = "disable_pure_boost"
+SERVICE_FULL_STATE = "full_state"
+SERVICE_ENABLE_CLIMATE_REACT = "enable_climate_react"
+SERVICE_GET_DEVICE_CAPABILITIES = "get_device_capabilities"
+ATTR_HIGH_TEMPERATURE_THRESHOLD = "high_temperature_threshold"
+ATTR_HIGH_TEMPERATURE_STATE = "high_temperature_state"
+ATTR_LOW_TEMPERATURE_THRESHOLD = "low_temperature_threshold"
+ATTR_LOW_TEMPERATURE_STATE = "low_temperature_state"
+ATTR_SMART_TYPE = "smart_type"
+
+ATTR_AC_INTEGRATION = "ac_integration"
+ATTR_GEO_INTEGRATION = "geo_integration"
+ATTR_INDOOR_INTEGRATION = "indoor_integration"
+ATTR_OUTDOOR_INTEGRATION = "outdoor_integration"
+ATTR_SENSITIVITY = "sensitivity"
+ATTR_TARGET_TEMPERATURE = "target_temperature"
+ATTR_HORIZONTAL_SWING_MODE = "horizontal_swing_mode"
+ATTR_LIGHT = "light"
+BOOST_INCLUSIVE = "boost_inclusive"
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register Sonos services."""
+
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_ASSUME_STATE,
+        entity_domain=CLIMATE_DOMAIN,
+        schema={
+            vol.Required(ATTR_STATE): vol.In(["on", "off"]),
+        },
+        func="async_assume_state",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_ENABLE_TIMER,
+        entity_domain=CLIMATE_DOMAIN,
+        schema={
+            vol.Required(ATTR_MINUTES): cv.positive_int,
+        },
+        func="async_enable_timer",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_ENABLE_PURE_BOOST,
+        entity_domain=CLIMATE_DOMAIN,
+        schema={
+            vol.Required(ATTR_AC_INTEGRATION): bool,
+            vol.Required(ATTR_GEO_INTEGRATION): bool,
+            vol.Required(ATTR_INDOOR_INTEGRATION): bool,
+            vol.Required(ATTR_OUTDOOR_INTEGRATION): bool,
+            vol.Required(ATTR_SENSITIVITY): vol.In(["normal", "sensitive"]),
+        },
+        func="async_enable_pure_boost",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_FULL_STATE,
+        entity_domain=CLIMATE_DOMAIN,
+        schema={
+            vol.Required(ATTR_MODE): vol.In(
+                ["cool", "heat", "fan", "auto", "dry", "off"]
+            ),
+            vol.Optional(ATTR_TARGET_TEMPERATURE): int,
+            vol.Optional(ATTR_FAN_MODE): str,
+            vol.Optional(ATTR_SWING_MODE): str,
+            vol.Optional(ATTR_HORIZONTAL_SWING_MODE): str,
+            vol.Optional(ATTR_LIGHT): vol.In(["on", "off", "dim"]),
+        },
+        func="async_full_ac_state",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_ENABLE_CLIMATE_REACT,
+        entity_domain=CLIMATE_DOMAIN,
+        schema={
+            vol.Required(ATTR_HIGH_TEMPERATURE_THRESHOLD): vol.Coerce(float),
+            vol.Required(ATTR_HIGH_TEMPERATURE_STATE): dict,
+            vol.Required(ATTR_LOW_TEMPERATURE_THRESHOLD): vol.Coerce(float),
+            vol.Required(ATTR_LOW_TEMPERATURE_STATE): dict,
+            vol.Required(ATTR_SMART_TYPE): vol.In(
+                ["temperature", "feelslike", "humidity"]
+            ),
+        },
+        func="async_enable_climate_react",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_GET_DEVICE_CAPABILITIES,
+        entity_domain=CLIMATE_DOMAIN,
+        schema={vol.Required(ATTR_HVAC_MODE): vol.Coerce(HVACMode)},
+        func="async_get_device_capabilities",
+        supports_response=SupportsResponse.ONLY,
+    )

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -25,7 +25,9 @@ from homeassistant.components.climate import (
     SERVICE_SET_TEMPERATURE,
     HVACMode,
 )
-from homeassistant.components.sensibo.climate import (
+from homeassistant.components.sensibo.climate import _find_valid_target_temp
+from homeassistant.components.sensibo.const import DOMAIN
+from homeassistant.components.sensibo.services import (
     ATTR_AC_INTEGRATION,
     ATTR_GEO_INTEGRATION,
     ATTR_HIGH_TEMPERATURE_STATE,
@@ -46,9 +48,7 @@ from homeassistant.components.sensibo.climate import (
     SERVICE_ENABLE_TIMER,
     SERVICE_FULL_STATE,
     SERVICE_GET_DEVICE_CAPABILITIES,
-    _find_valid_target_temp,
 )
-from homeassistant.components.sensibo.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,


### PR DESCRIPTION
## Breaking change


## Proposed change
Use `service.async_register_platform_entity_service` to register platform services in `sensibo`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 