### PR TITLE
Add beufort as valid wind speed unit in weather

### DIFF
--- a/homeassistant/components/weather/const.py
+++ b/homeassistant/components/weather/const.py
@@ -82,6 +82,7 @@ VALID_UNITS_WIND_SPEED: set[str] = {
     UnitOfSpeed.KNOTS,
     UnitOfSpeed.METERS_PER_SECOND,
     UnitOfSpeed.MILES_PER_HOUR,
+    UnitOfSpeed.BEAUFORT,
 }
 
 UNIT_CONVERSIONS: dict[str, Callable[[float, str, str], float]] = {

--- a/homeassistant/components/weather/const.py
+++ b/homeassistant/components/weather/const.py
@@ -77,12 +77,12 @@ VALID_UNITS_VISIBILITY: set[str] = {
     UnitOfLength.MILES,
 }
 VALID_UNITS_WIND_SPEED: set[str] = {
+    UnitOfSpeed.BEAUFORT,
     UnitOfSpeed.FEET_PER_SECOND,
     UnitOfSpeed.KILOMETERS_PER_HOUR,
     UnitOfSpeed.KNOTS,
     UnitOfSpeed.METERS_PER_SECOND,
     UnitOfSpeed.MILES_PER_HOUR,
-    UnitOfSpeed.BEAUFORT,
 }
 
 UNIT_CONVERSIONS: dict[str, Callable[[float, str, str], float]] = {

--- a/tests/components/weather/test_websocket_api.py
+++ b/tests/components/weather/test_websocket_api.py
@@ -33,7 +33,7 @@ async def test_device_class_units(
             "pressure_unit": ["hPa", "inHg", "mbar", "mmHg"],
             "temperature_unit": ["°C", "°F"],
             "visibility_unit": ["km", "mi"],
-            "wind_speed_unit": ["ft/s", "km/h", "kn", "m/s", "mph"],
+            "wind_speed_unit": ["Beaufort", "ft/s", "km/h", "kn", "m/s", "mph"],
         }
     }
 


### PR DESCRIPTION
## Breaking change


## Proposed change
Add beufort as valid wind speed unit in weather

https://github.com/orgs/home-assistant/discussions/1214

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2820
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 