### PR TITLE
Raise repairs on platform setup for sql

### DIFF
--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -30,6 +30,7 @@ from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger_template_entity import (
     CONF_AVAILABILITY,
@@ -69,6 +70,15 @@ async def async_setup_platform(
 ) -> None:
     """Set up the SQL sensor from yaml."""
     if (conf := discovery_info) is None:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "sensor_platform_yaml_not_supported",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="platform_yaml_not_supported",
+            learn_more_url="https://www.home-assistant.io/integrations/sql/",
+        )
         return
 
     name: Template = conf[CONF_NAME]

--- a/homeassistant/components/sql/strings.json
+++ b/homeassistant/components/sql/strings.json
@@ -169,7 +169,7 @@
     },
     "platform_yaml_not_supported": {
       "title": "Platform YAML is not supported for SQL",
-      "description": "Platform YAML setup is not supported.\nChange from configuring it in the `sensor:` key to use the `sql:` key directly in configuration.yaml.\nSee the documentation for details."
+      "description": "Platform YAML setup is not supported.\nChange from configuring it in the `sensor:` key to use the `sql:` key directly in configuration.yaml.\nClick on learn more to see the documentation for details."
     }
   }
 }

--- a/homeassistant/components/sql/strings.json
+++ b/homeassistant/components/sql/strings.json
@@ -166,6 +166,10 @@
     "entity_id_query_does_full_table_scan": {
       "title": "SQL query does full table scan",
       "description": "The query `{query}` contains the keyword `entity_id` but does not reference the `states_meta` table. This will cause a full table scan and database instability. Please check the documentation and use `states_meta.entity_id` instead."
+    },
+    "platform_yaml_not_supported": {
+      "title": "Platform YAML is not supported for SQL",
+      "description": "Platform YAML setup is not supported.\nChange from configuring it in the `sensor:` key to use the `sql:` key directly in configuration.yaml.\nSee the documentation for details."
     }
   }
 }

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -345,7 +345,7 @@ async def test_templates_with_yaml(
 
 
 async def test_config_from_old_yaml(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: Recorder, hass: HomeAssistant, issue_registry: ir.IssueRegistry
 ) -> None:
     """Test the SQL sensor from old yaml config does not create any entity."""
     config = {
@@ -366,6 +366,9 @@ async def test_config_from_old_yaml(
 
     state = hass.states.get("sensor.count_tables")
     assert not state
+    issue = issue_registry.async_get_issue(DOMAIN, "sensor_platform_yaml_not_supported")
+    assert issue is not None
+    assert issue.severity == ir.IssueSeverity.WARNING
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Breaking change


## Proposed change
Adds repairs for platform setup instead of just silently ignoring it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 