### PR TITLE
Switch Roborock to v4 of the code login api

### DIFF
--- a/homeassistant/components/roborock/config_flow.py
+++ b/homeassistant/components/roborock/config_flow.py
@@ -82,7 +82,7 @@ class RoborockFlowHandler(ConfigFlow, domain=DOMAIN):
         assert self._client
         errors: dict[str, str] = {}
         try:
-            await self._client.request_code()
+            await self._client.request_code_v4()
         except RoborockAccountDoesNotExist:
             errors["base"] = "invalid_email"
         except RoborockUrlException:
@@ -111,7 +111,7 @@ class RoborockFlowHandler(ConfigFlow, domain=DOMAIN):
             code = user_input[CONF_ENTRY_CODE]
             _LOGGER.debug("Logging into Roborock account using email provided code")
             try:
-                user_data = await self._client.code_login(code)
+                user_data = await self._client.code_login_v4(code)
             except RoborockInvalidCode:
                 errors["base"] = "invalid_code"
             except RoborockException:

--- a/tests/components/roborock/test_config_flow.py
+++ b/tests/components/roborock/test_config_flow.py
@@ -46,7 +46,7 @@ async def test_config_flow_success(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "user"
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code"
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code_v4"
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"], {CONF_USERNAME: USER_EMAIL}
@@ -56,7 +56,7 @@ async def test_config_flow_success(
             assert result["step_id"] == "code"
             assert result["errors"] == {}
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login",
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login_v4",
             return_value=USER_DATA,
         ):
             result = await hass.config_entries.flow.async_configure(
@@ -101,7 +101,7 @@ async def test_config_flow_failures_request_code(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "user"
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code",
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code_v4",
             side_effect=request_code_side_effect,
         ):
             result = await hass.config_entries.flow.async_configure(
@@ -111,7 +111,7 @@ async def test_config_flow_failures_request_code(
             assert result["errors"] == request_code_errors
         # Recover from error
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code"
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code_v4"
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"], {CONF_USERNAME: USER_EMAIL}
@@ -121,7 +121,7 @@ async def test_config_flow_failures_request_code(
             assert result["step_id"] == "code"
             assert result["errors"] == {}
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login",
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login_v4",
             return_value=USER_DATA,
         ):
             result = await hass.config_entries.flow.async_configure(
@@ -163,7 +163,7 @@ async def test_config_flow_failures_code_login(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "user"
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code"
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code_v4"
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"], {CONF_USERNAME: USER_EMAIL}
@@ -174,7 +174,7 @@ async def test_config_flow_failures_code_login(
             assert result["errors"] == {}
         # Raise exception for invalid code
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login",
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login_v4",
             side_effect=code_login_side_effect,
         ):
             result = await hass.config_entries.flow.async_configure(
@@ -183,7 +183,7 @@ async def test_config_flow_failures_code_login(
         assert result["type"] is FlowResultType.FORM
         assert result["errors"] == code_login_errors
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login",
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login_v4",
             return_value=USER_DATA,
         ):
             result = await hass.config_entries.flow.async_configure(
@@ -236,7 +236,7 @@ async def test_reauth_flow(
     # Request a new code
     with (
         patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code"
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code_v4"
         ),
         patch("homeassistant.components.roborock.async_setup_entry", return_value=True),
     ):
@@ -250,7 +250,7 @@ async def test_reauth_flow(
     new_user_data.rriot.s = "new_password_hash"
     with (
         patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login",
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login_v4",
             return_value=new_user_data,
         ),
         patch("homeassistant.components.roborock.async_setup_entry", return_value=True),
@@ -280,7 +280,7 @@ async def test_account_already_configured(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "user"
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code"
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code_v4"
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"], {CONF_USERNAME: USER_EMAIL}
@@ -289,7 +289,7 @@ async def test_account_already_configured(
         assert result["step_id"] == "code"
         assert result["type"] is FlowResultType.FORM
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login",
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login_v4",
             return_value=USER_DATA,
         ):
             result = await hass.config_entries.flow.async_configure(
@@ -313,7 +313,7 @@ async def test_reauth_wrong_account(
         "homeassistant.components.roborock.async_setup_entry", return_value=True
     ):
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code"
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code_v4"
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"], {CONF_USERNAME: USER_EMAIL}
@@ -324,7 +324,7 @@ async def test_reauth_wrong_account(
         new_user_data = deepcopy(USER_DATA)
         new_user_data.rruid = "new_rruid"
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login",
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login_v4",
             return_value=new_user_data,
         ):
             result = await hass.config_entries.flow.async_configure(
@@ -354,7 +354,7 @@ async def test_discovery_not_setup(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "user"
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code"
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code_v4"
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"], {CONF_USERNAME: USER_EMAIL}
@@ -364,7 +364,7 @@ async def test_discovery_not_setup(
             assert result["step_id"] == "code"
             assert result["errors"] == {}
         with patch(
-            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login",
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login_v4",
             return_value=USER_DATA,
         ):
             result = await hass.config_entries.flow.async_configure(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Roborock changed their login api so now accounts are region specific. Old accounts work fine, but new accounts need to specify region and use the new api. This change is us switching over tot he new api.

Would be good to include in a minor version if possible as any user who has made an account in the past ~1.5 weeks would be unable to add their device without this change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #152589
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
