### PR TITLE
Schedule update coordinator again if it is active

### DIFF
--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -85,11 +85,8 @@ class Debouncer[_R_co]:
 
             return False
 
-        # Locked means a call is in progress. Any call is good, so abort.
-        if self._execute_lock.locked():
-            return False
-
-        if not self.immediate:
+        # If not immediate or in progress, we schedule a call for later.
+        if not self.immediate or self._execute_lock.locked():
             self._execute_at_end_of_timer = True
             self._schedule_timer()
             return False

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -61,12 +61,12 @@ async def test_immediate_works(hass: HomeAssistant) -> None:
     assert debouncer._job.target == debouncer.function
     assert debouncer._job == before_job
 
-    # Test calling doesn't execute/cooldown if currently executing.
+    # Test calling enabled timer if currently executing.
     await debouncer._execute_lock.acquire()
     await debouncer.async_call()
     assert len(calls) == 2
-    assert debouncer._timer_task is None
-    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is True
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
 
@@ -118,13 +118,13 @@ async def test_immediate_works_with_schedule_call(hass: HomeAssistant) -> None:
     assert debouncer._job.target == debouncer.function
     assert debouncer._job == before_job
 
-    # Test calling doesn't execute/cooldown if currently executing.
+    # Test calling enabled timer if currently executing.
     await debouncer._execute_lock.acquire()
     debouncer.async_schedule_call()
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert debouncer._timer_task is None
-    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is True
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
 
@@ -225,12 +225,12 @@ async def test_immediate_works_with_passed_callback_function_raises(
     assert debouncer._job.target == debouncer.function
     assert debouncer._job == before_job
 
-    # Test calling doesn't execute/cooldown if currently executing.
+    # Test calling enabled timer if currently executing.
     await debouncer._execute_lock.acquire()
     await debouncer.async_call()
     assert len(calls) == 2
-    assert debouncer._timer_task is None
-    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is True
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
 
@@ -288,12 +288,12 @@ async def test_immediate_works_with_passed_coroutine_raises(
     assert debouncer._job.target == debouncer.function
     assert debouncer._job == before_job
 
-    # Test calling doesn't execute/cooldown if currently executing.
+    # Test calling enabled timer if currently executing.
     await debouncer._execute_lock.acquire()
     await debouncer.async_call()
     assert len(calls) == 2
-    assert debouncer._timer_task is None
-    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is True
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
 
@@ -339,12 +339,12 @@ async def test_not_immediate_works(hass: HomeAssistant) -> None:
     # Reset debouncer
     debouncer.async_cancel()
 
-    # Test calling doesn't schedule if currently executing.
+    # Test calling enabled timer if currently executing.
     await debouncer._execute_lock.acquire()
     await debouncer.async_call()
     assert len(calls) == 1
-    assert debouncer._timer_task is None
-    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is True
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
 
@@ -393,13 +393,13 @@ async def test_not_immediate_works_schedule_call(hass: HomeAssistant) -> None:
     # Reset debouncer
     debouncer.async_cancel()
 
-    # Test calling doesn't schedule if currently executing.
+    # Test calling enabled timer if currently executing.
     await debouncer._execute_lock.acquire()
     debouncer.async_schedule_call()
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert debouncer._timer_task is None
-    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is True
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
 
@@ -455,13 +455,13 @@ async def test_immediate_works_with_function_swapped(hass: HomeAssistant) -> Non
     assert debouncer._job.target == debouncer.function
     assert debouncer._job != before_job
 
-    # Test calling doesn't execute/cooldown if currently executing.
+    # Test calling enabled timer if currently executing.
     await debouncer._execute_lock.acquire()
     await debouncer.async_call()
     assert len(calls) == 2
     assert calls == [1, 2]
-    assert debouncer._timer_task is None
-    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is True
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the update coordinator is currently executing, schedule a new attempt to update after debounce period ends. This was previously explicitly skipped. However consider the following case.

```
async def _update()
   a = await get_a()
   # A: User or other logic request a new update here through async_schedule_update()
   b = await get_b()
   return (a,b)
```

The user or code that requested the update at `A` expects that the entities
will get all new data from that time. However since we will ignore that request,
entities will have data for `a` that is before the call to update when logic finishes.

To make sure we avoid this case, always ensure the update coordinator runs again
if a request is received while currently executing a update.

A side effect of this is that it is now possible to schedule a update from inside an update function of the coordinator. That is useful if for example a connection is lost mid update, and we want all entities to indicate directly as unavailable, yet we want to attempt a re-connect as quick as possible in the next update cycle.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Currently includes changes from https://github.com/home-assistant/core/pull/153601

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2817
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
