### PR TITLE
Add translations and icons to OralB integration

### DIFF
--- a/homeassistant/components/oralb/icons.json
+++ b/homeassistant/components/oralb/icons.json
@@ -1,0 +1,61 @@
+{
+  "entity": {
+    "sensor": {
+      "pressure": {
+        "default": "mdi:tooth-outline",
+        "state": {
+          "high": "mdi:tooth",
+          "low": "mdi:alert",
+          "power_button_pressed": "mdi:power",
+          "button_pressed": "mdi:radiobox-marked"
+        }
+      },
+      "sector": {
+        "default": "mdi:circle-outline",
+        "state": {
+          "sector_1": "mdi:circle-slice-2",
+          "sector_2": "mdi:circle-slice-4",
+          "sector_3": "mdi:circle-slice-6",
+          "sector_4": "mdi:circle-slice-8",
+          "success": "mdi:check-circle-outline"
+        }
+      },
+      "toothbrush_state": {
+        "default": "mdi:toothbrush-electric",
+        "state": {
+          "initializing": "mdi:sync",
+          "idle": "mdi:toothbrush-electric",
+          "running": "mdi:waveform",
+          "charging": "mdi:battery-charging",
+          "setup": "mdi:wrench",
+          "flight_menu": "mdi:airplane",
+          "selection_menu": "mdi:menu",
+          "off": "mdi:power",
+          "sleeping": "mdi:sleep",
+          "transport": "mdi:dolly"
+        }
+      },
+      "number_of_sectors": {
+        "default": "mdi:chart-pie"
+      },
+      "mode": {
+        "default": "mdi:toothbrush-paste",
+        "state": {
+          "daily_clean": "mdi:repeat-once",
+          "sensitive": "mdi:feather",
+          "gum_care": "mdi:tooth-outline",
+          "intense": "mdi:shape-circle-plus",
+          "whitening": "mdi:shimmer",
+          "whiten": "mdi:shimmer",
+          "tongue_cleaning": "mdi:gate-and",
+          "super_sensitive": "mdi:feather",
+          "massage": "mdi:spa",
+          "deep_clean": "mdi:water",
+          "turbo": "mdi:car-turbocharger",
+          "off": "mdi:power",
+          "settings": "mdi:cog-outline"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/oralb/sensor.py
+++ b/homeassistant/components/oralb/sensor.py
@@ -3,6 +3,13 @@
 from __future__ import annotations
 
 from oralb_ble import OralBSensor, SensorUpdate
+from oralb_ble.parser import (
+    IO_SERIES_MODES,
+    PRESSURE,
+    SECTOR_MAP,
+    SMART_SERIES_MODES,
+    STATES,
+)
 
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothDataProcessor,
@@ -39,6 +46,8 @@ SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
         key=OralBSensor.SECTOR,
         translation_key="sector",
         entity_category=EntityCategory.DIAGNOSTIC,
+        options=[v.replace(" ", "_") for v in set(SECTOR_MAP.values()) | {"no_sector"}],
+        device_class=SensorDeviceClass.ENUM,
     ),
     OralBSensor.NUMBER_OF_SECTORS: SensorEntityDescription(
         key=OralBSensor.NUMBER_OF_SECTORS,
@@ -53,16 +62,26 @@ SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
     ),
     OralBSensor.TOOTHBRUSH_STATE: SensorEntityDescription(
         key=OralBSensor.TOOTHBRUSH_STATE,
+        translation_key="toothbrush_state",
+        options=[v.replace(" ", "_") for v in set(STATES.values())],
+        device_class=SensorDeviceClass.ENUM,
         name=None,
     ),
     OralBSensor.PRESSURE: SensorEntityDescription(
         key=OralBSensor.PRESSURE,
         translation_key="pressure",
+        options=[v.replace(" ", "_") for v in set(PRESSURE.values()) | {"low"}],
+        device_class=SensorDeviceClass.ENUM,
     ),
     OralBSensor.MODE: SensorEntityDescription(
         key=OralBSensor.MODE,
         translation_key="mode",
         entity_category=EntityCategory.DIAGNOSTIC,
+        options=[
+            v.replace(" ", "_")
+            for v in set(IO_SERIES_MODES.values()) | set(SMART_SERIES_MODES.values())
+        ],
+        device_class=SensorDeviceClass.ENUM,
     ),
     OralBSensor.SIGNAL_STRENGTH: SensorEntityDescription(
         key=OralBSensor.SIGNAL_STRENGTH,
@@ -134,7 +153,15 @@ class OralBBluetoothSensorEntity(
     @property
     def native_value(self) -> str | int | None:
         """Return the native value."""
-        return self.processor.entity_data.get(self.entity_key)
+        value = self.processor.entity_data.get(self.entity_key)
+        if isinstance(value, str):
+            value = value.replace(" ", "_")
+            if (
+                self.entity_description.options is not None
+                and value not in self.entity_description.options
+            ):  # append unknown values to enum
+                self.entity_description.options.append(value)
+        return value
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/oralb/strings.json
+++ b/homeassistant/components/oralb/strings.json
@@ -22,7 +22,15 @@
   "entity": {
     "sensor": {
       "sector": {
-        "name": "Sector"
+        "name": "Sector",
+        "state": {
+          "no_sector": "No sector",
+          "sector_1": "Sector 1",
+          "sector_2": "Sector 2",
+          "sector_3": "Sector 3",
+          "sector_4": "Sector 4",
+          "success": "Success"
+        }
       },
       "number_of_sectors": {
         "name": "Number of sectors"
@@ -31,10 +39,48 @@
         "name": "Sector timer"
       },
       "pressure": {
-        "name": "Pressure"
+        "name": "Pressure",
+        "state": {
+          "normal": "[%key:common::state::normal%]",
+          "high": "[%key:common::state::high%]",
+          "low": "[%key:common::state::low%]",
+          "power_button_pressed": "Power button pressed",
+          "button_pressed": "Button pressed"
+        }
       },
       "mode": {
-        "name": "Brushing mode"
+        "name": "Brushing mode",
+        "state": {
+          "daily_clean": "Daily clean",
+          "sensitive": "Sensitive",
+          "gum_care": "Gum care",
+          "intense": "Intense",
+          "whitening": "Whiten",
+          "whiten": "[%key:component::oralb::entity::sensor::mode::state::whitening%]",
+          "tongue_cleaning": "Tongue clean",
+          "super_sensitive": "Super sensitive",
+          "massage": "Massage",
+          "deep_clean": "Deep clean",
+          "turbo": "Turbo",
+          "off": "[%key:common::state::off%]",
+          "settings": "Settings"
+        }
+      },
+      "toothbrush_state": {
+        "state": {
+          "initializing": "Initializing",
+          "idle": "[%key:common::state::idle%]",
+          "running": "Running",
+          "charging": "[%key:common::state::charging%]",
+          "setup": "Setup",
+          "flight_menu": "Flight menu",
+          "selection_menu": "Selection menu",
+          "off": "[%key:common::state::off%]",
+          "sleeping": "Sleeping",
+          "transport": "Transport",
+          "final_test": "Final test",
+          "pcb_test": "PCB test"
+        }
       }
     }
   }

--- a/tests/components/oralb/test_sensor.py
+++ b/tests/components/oralb/test_sensor.py
@@ -101,7 +101,7 @@ async def test_sensors_io_series_4(hass: HomeAssistant) -> None:
 
     toothbrush_sensor = hass.states.get("sensor.io_series_4_48be_brushing_mode")
     toothbrush_sensor_attrs = toothbrush_sensor.attributes
-    assert toothbrush_sensor.state == "gum care"
+    assert toothbrush_sensor.state == "gum_care"
     assert (
         toothbrush_sensor_attrs[ATTR_FRIENDLY_NAME] == "IO Series 4 48BE Brushing mode"
     )
@@ -133,7 +133,7 @@ async def test_sensors_io_series_4(hass: HomeAssistant) -> None:
 
     toothbrush_sensor = hass.states.get("sensor.io_series_4_48be_brushing_mode")
     # Sleepy devices should keep their state over time
-    assert toothbrush_sensor.state == "gum care"
+    assert toothbrush_sensor.state == "gum_care"
     toothbrush_sensor_attrs = toothbrush_sensor.attributes
     assert toothbrush_sensor_attrs[ATTR_ASSUMED_STATE] is True
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Adds translations and icons for sensor states. To be translatable,  in the following states , spaces have been replaced with underscores: 

- Toothbrush state:

  - `flight menu` → `flight_menu`
  - `selection menu` → `selection_menu`
  - `final test` → `final_test`
  - `pcb test` → `pcb_test`
  
- Brushing mode:

  - `daily clean` → `daily_clean`
  - `gum care` → `gum_care`
  - `tongue cleaning` → `tongue_cleaning`
  - `super sensitive` → `super_sensitive`
  - `deep clean` → `deep_clean`

- Pressure:

  - `power button pressed` → `power_button_pressed`
  - `button pressed` → `button_pressed`

- Sector:

  - `no sector` → `no_sector`
  - `sector 1` → `sector_1`
  - `sector 2` → `sector_2`
  - `sector 3` → `sector_3`
  - `sector 4` → `sector_4`


This is a breaking change, automations have to be updated.

Changed sensors to Enum sensors for easier state selection in the automation editor.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
