### PR TITLE
Express NotFullyLocked as jammed for Matter locks

### DIFF
--- a/tests/components/matter/snapshots/test_lock.ambr
+++ b/tests/components/matter/snapshots/test_lock.ambr
@@ -46,7 +46,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unlocked',
+    'state': 'jammed',
   })
 # ---
 # name: test_locks[door_lock_with_unbolt][lock.mock_door_lock-entry]

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -84,7 +84,7 @@ async def test_lock(
 
     state = hass.states.get("lock.mock_door_lock")
     assert state
-    assert state.state == LockState.UNLOCKED
+    assert state.state == LockState.JAMMED
 
     set_node_attribute(matter_node, 1, 257, 0, 2)
     await trigger_subscription_callback(hass, matter_client)
@@ -248,7 +248,7 @@ async def test_lock_with_unbolt(
     assert state
     assert state.state == LockState.OPENING
 
-    set_node_attribute(matter_node, 1, 257, 0, 0)
+    set_node_attribute(matter_node, 1, 257, 0, 2)
     await trigger_subscription_callback(hass, matter_client)
 
     state = hass.states.get("lock.mock_door_lock")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Previously, partially locked Matter locks would be shown in Home Assistant as unlocked. Now, they will appear as jammed. This brings Matter locks in line with other Home Assistant locks, especially HomeKit which already exposes locks this way. Without this change, partially engaged locks will appear unlocked, though probably won't open, frustrating users.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


The Level Bolt (and perhaps other locks) report as NotFullyLocked when the bolt is partially engaged. On the pre-Matter (HomeKit) version of the lock, this was expressed in Home Assistant as "jammed" which could be used to detect this condition and use an automation to fully lock or unlock as desired.

Once the lock upgraded to Matter, Home Assistant could no longer see this condition, and instead reports partially locked as "unlocked", which is not super accurate (if partially engaged, the door won't open), but it's also not fully locked either.

Supporting evidence:

The core lock code in Home Assistant suggests that this is the correct use of jammed ("incomplete locking"), see https://github.com/home-assistant/core/blob/0cda0c449f7e20a5c9dbe29a97b19d7450d9650f/homeassistant/components/lock/__init__.py#L202-L204.

Google Home currently reports a partially locked Matter lock as "jammed" in its UI.

<img width="1206" height="446" alt="IMG_3518" src="https://github.com/user-attachments/assets/4bd7c502-da05-420a-9d17-879588ac5bd5" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

See https://community.home-assistant.io/t/lock-entity-state-for-matter-notfullylocked/816170.


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- TODO [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
