### PR TITLE
Enphase_envoy to use alternate data source for current transformers

### DIFF
--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -396,6 +396,7 @@ class EnvoyCTSensorEntityDescription(SensorEntityDescription):
         int | float | str | CtType | CtMeterStatus | CtStatusFlags | CtState | None,
     ]
     on_phase: str | None
+    cttype: str | None = None
 
 
 CT_NET_CONSUMPTION_SENSORS = (
@@ -409,6 +410,7 @@ CT_NET_CONSUMPTION_SENSORS = (
         suggested_display_precision=3,
         value_fn=attrgetter("energy_delivered"),
         on_phase=None,
+        cttype=CtType.NET_CONSUMPTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="lifetime_net_production",
@@ -420,6 +422,7 @@ CT_NET_CONSUMPTION_SENSORS = (
         suggested_display_precision=3,
         value_fn=attrgetter("energy_received"),
         on_phase=None,
+        cttype=CtType.NET_CONSUMPTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="net_consumption",
@@ -431,6 +434,7 @@ CT_NET_CONSUMPTION_SENSORS = (
         suggested_display_precision=3,
         value_fn=attrgetter("active_power"),
         on_phase=None,
+        cttype=CtType.NET_CONSUMPTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="frequency",
@@ -442,6 +446,7 @@ CT_NET_CONSUMPTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("frequency"),
         on_phase=None,
+        cttype=CtType.NET_CONSUMPTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="voltage",
@@ -454,6 +459,7 @@ CT_NET_CONSUMPTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("voltage"),
         on_phase=None,
+        cttype=CtType.NET_CONSUMPTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="net_ct_current",
@@ -466,6 +472,7 @@ CT_NET_CONSUMPTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("current"),
         on_phase=None,
+        cttype=CtType.NET_CONSUMPTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="net_ct_powerfactor",
@@ -476,6 +483,7 @@ CT_NET_CONSUMPTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("power_factor"),
         on_phase=None,
+        cttype=CtType.NET_CONSUMPTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="net_consumption_ct_metering_status",
@@ -486,6 +494,7 @@ CT_NET_CONSUMPTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("metering_status"),
         on_phase=None,
+        cttype=CtType.NET_CONSUMPTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="net_consumption_ct_status_flags",
@@ -495,6 +504,7 @@ CT_NET_CONSUMPTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=lambda ct: 0 if ct.status_flags is None else len(ct.status_flags),
         on_phase=None,
+        cttype=CtType.NET_CONSUMPTION,
     ),
 )
 
@@ -525,6 +535,7 @@ CT_PRODUCTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("frequency"),
         on_phase=None,
+        cttype=CtType.PRODUCTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="production_ct_voltage",
@@ -537,6 +548,7 @@ CT_PRODUCTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("voltage"),
         on_phase=None,
+        cttype=CtType.PRODUCTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="production_ct_current",
@@ -549,6 +561,7 @@ CT_PRODUCTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("current"),
         on_phase=None,
+        cttype=CtType.PRODUCTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="production_ct_powerfactor",
@@ -559,6 +572,7 @@ CT_PRODUCTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("power_factor"),
         on_phase=None,
+        cttype=CtType.PRODUCTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="production_ct_metering_status",
@@ -569,6 +583,7 @@ CT_PRODUCTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("metering_status"),
         on_phase=None,
+        cttype=CtType.PRODUCTION,
     ),
     EnvoyCTSensorEntityDescription(
         key="production_ct_status_flags",
@@ -578,6 +593,7 @@ CT_PRODUCTION_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=lambda ct: 0 if ct.status_flags is None else len(ct.status_flags),
         on_phase=None,
+        cttype=CtType.PRODUCTION,
     ),
 )
 
@@ -607,6 +623,7 @@ CT_STORAGE_SENSORS = (
         suggested_display_precision=3,
         value_fn=attrgetter("energy_delivered"),
         on_phase=None,
+        cttype=CtType.STORAGE,
     ),
     EnvoyCTSensorEntityDescription(
         key="lifetime_battery_charged",
@@ -618,6 +635,7 @@ CT_STORAGE_SENSORS = (
         suggested_display_precision=3,
         value_fn=attrgetter("energy_received"),
         on_phase=None,
+        cttype=CtType.STORAGE,
     ),
     EnvoyCTSensorEntityDescription(
         key="battery_discharge",
@@ -629,6 +647,7 @@ CT_STORAGE_SENSORS = (
         suggested_display_precision=3,
         value_fn=attrgetter("active_power"),
         on_phase=None,
+        cttype=CtType.STORAGE,
     ),
     EnvoyCTSensorEntityDescription(
         key="storage_ct_frequency",
@@ -640,6 +659,7 @@ CT_STORAGE_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("frequency"),
         on_phase=None,
+        cttype=CtType.STORAGE,
     ),
     EnvoyCTSensorEntityDescription(
         key="storage_voltage",
@@ -652,6 +672,7 @@ CT_STORAGE_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("voltage"),
         on_phase=None,
+        cttype=CtType.STORAGE,
     ),
     EnvoyCTSensorEntityDescription(
         key="storage_ct_current",
@@ -664,6 +685,7 @@ CT_STORAGE_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("current"),
         on_phase=None,
+        cttype=CtType.STORAGE,
     ),
     EnvoyCTSensorEntityDescription(
         key="storage_ct_powerfactor",
@@ -674,6 +696,7 @@ CT_STORAGE_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("power_factor"),
         on_phase=None,
+        cttype=CtType.STORAGE,
     ),
     EnvoyCTSensorEntityDescription(
         key="storage_ct_metering_status",
@@ -684,6 +707,7 @@ CT_STORAGE_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=attrgetter("metering_status"),
         on_phase=None,
+        cttype=CtType.STORAGE,
     ),
     EnvoyCTSensorEntityDescription(
         key="storage_ct_status_flags",
@@ -693,6 +717,7 @@ CT_STORAGE_SENSORS = (
         entity_registry_enabled_default=False,
         value_fn=lambda ct: 0 if ct.status_flags is None else len(ct.status_flags),
         on_phase=None,
+        cttype=CtType.STORAGE,
     ),
 )
 
@@ -1015,50 +1040,31 @@ async def async_setup_entry(
             for description in NET_CONSUMPTION_PHASE_SENSORS[use_phase]
             if phase is not None
         )
-    # Add net consumption CT entities
-    if ctmeter := envoy_data.ctmeter_consumption:
+    # Add Current Transformer entities
+    if envoy_data.ctmeters:
         entities.extend(
-            EnvoyConsumptionCTEntity(coordinator, description)
-            for description in CT_NET_CONSUMPTION_SENSORS
-            if ctmeter.measurement_type == CtType.NET_CONSUMPTION
+            EnvoyCTEntity(coordinator, description)
+            for sensors in (
+                CT_NET_CONSUMPTION_SENSORS,
+                CT_PRODUCTION_SENSORS,
+                CT_STORAGE_SENSORS,
+            )
+            for description in sensors
+            if description.cttype in envoy_data.ctmeters
         )
-    # For each net consumption ct phase reported add net consumption entities
-    if phase_data := envoy_data.ctmeter_consumption_phases:
+    # Add Current Transformer phase entities
+    if ctmeters_phases := envoy_data.ctmeters_phases:
         entities.extend(
-            EnvoyConsumptionCTPhaseEntity(coordinator, description)
-            for use_phase, phase in phase_data.items()
-            for description in CT_NET_CONSUMPTION_PHASE_SENSORS[use_phase]
-            if phase.measurement_type == CtType.NET_CONSUMPTION
-        )
-    # Add production CT entities
-    if ctmeter := envoy_data.ctmeter_production:
-        entities.extend(
-            EnvoyProductionCTEntity(coordinator, description)
-            for description in CT_PRODUCTION_SENSORS
-            if ctmeter.measurement_type == CtType.PRODUCTION
-        )
-    # For each production ct phase reported add production ct entities
-    if phase_data := envoy_data.ctmeter_production_phases:
-        entities.extend(
-            EnvoyProductionCTPhaseEntity(coordinator, description)
-            for use_phase, phase in phase_data.items()
-            for description in CT_PRODUCTION_PHASE_SENSORS[use_phase]
-            if phase.measurement_type == CtType.PRODUCTION
-        )
-    # Add storage CT entities
-    if ctmeter := envoy_data.ctmeter_storage:
-        entities.extend(
-            EnvoyStorageCTEntity(coordinator, description)
-            for description in CT_STORAGE_SENSORS
-            if ctmeter.measurement_type == CtType.STORAGE
-        )
-    # For each storage ct phase reported add storage ct entities
-    if phase_data := envoy_data.ctmeter_storage_phases:
-        entities.extend(
-            EnvoyStorageCTPhaseEntity(coordinator, description)
-            for use_phase, phase in phase_data.items()
-            for description in CT_STORAGE_PHASE_SENSORS[use_phase]
-            if phase.measurement_type == CtType.STORAGE
+            EnvoyCTPhaseEntity(coordinator, description)
+            for sensors in (
+                CT_NET_CONSUMPTION_PHASE_SENSORS,
+                CT_PRODUCTION_PHASE_SENSORS,
+                CT_STORAGE_PHASE_SENSORS,
+            )
+            for phase, descriptions in sensors.items()
+            for description in descriptions
+            if (cttype := description.cttype) in ctmeters_phases
+            and phase in ctmeters_phases[cttype]
         )
 
     if envoy_data.inverters:
@@ -1245,8 +1251,8 @@ class EnvoyNetConsumptionPhaseEntity(EnvoySystemSensorEntity):
         return self.entity_description.value_fn(system_net_consumption)
 
 
-class EnvoyConsumptionCTEntity(EnvoySystemSensorEntity):
-    """Envoy net consumption CT entity."""
+class EnvoyCTEntity(EnvoySystemSensorEntity):
+    """Envoy CT entity."""
 
     entity_description: EnvoyCTSensorEntityDescription
 
@@ -1255,13 +1261,13 @@ class EnvoyConsumptionCTEntity(EnvoySystemSensorEntity):
         self,
     ) -> int | float | str | CtType | CtMeterStatus | CtStatusFlags | None:
         """Return the state of the CT sensor."""
-        if (ctmeter := self.data.ctmeter_consumption) is None:
+        if (cttype := self.entity_description.cttype) not in self.data.ctmeters:
             return None
-        return self.entity_description.value_fn(ctmeter)
+        return self.entity_description.value_fn(self.data.ctmeters[cttype])
 
 
-class EnvoyConsumptionCTPhaseEntity(EnvoySystemSensorEntity):
-    """Envoy net consumption CT phase entity."""
+class EnvoyCTPhaseEntity(EnvoySystemSensorEntity):
+    """Envoy CT phase entity."""
 
     entity_description: EnvoyCTSensorEntityDescription
 
@@ -1272,78 +1278,14 @@ class EnvoyConsumptionCTPhaseEntity(EnvoySystemSensorEntity):
         """Return the state of the CT phase sensor."""
         if TYPE_CHECKING:
             assert self.entity_description.on_phase
-        if (ctmeter := self.data.ctmeter_consumption_phases) is None:
+        if (cttype := self.entity_description.cttype) not in self.data.ctmeters_phases:
+            return None
+        if (phase := self.entity_description.on_phase) not in self.data.ctmeters_phases[
+            cttype
+        ]:
             return None
         return self.entity_description.value_fn(
-            ctmeter[self.entity_description.on_phase]
-        )
-
-
-class EnvoyProductionCTEntity(EnvoySystemSensorEntity):
-    """Envoy net consumption CT entity."""
-
-    entity_description: EnvoyCTSensorEntityDescription
-
-    @property
-    def native_value(
-        self,
-    ) -> int | float | str | CtType | CtMeterStatus | CtStatusFlags | None:
-        """Return the state of the CT sensor."""
-        if (ctmeter := self.data.ctmeter_production) is None:
-            return None
-        return self.entity_description.value_fn(ctmeter)
-
-
-class EnvoyProductionCTPhaseEntity(EnvoySystemSensorEntity):
-    """Envoy net consumption CT phase entity."""
-
-    entity_description: EnvoyCTSensorEntityDescription
-
-    @property
-    def native_value(
-        self,
-    ) -> int | float | str | CtType | CtMeterStatus | CtStatusFlags | None:
-        """Return the state of the CT phase sensor."""
-        if TYPE_CHECKING:
-            assert self.entity_description.on_phase
-        if (ctmeter := self.data.ctmeter_production_phases) is None:
-            return None
-        return self.entity_description.value_fn(
-            ctmeter[self.entity_description.on_phase]
-        )
-
-
-class EnvoyStorageCTEntity(EnvoySystemSensorEntity):
-    """Envoy net storage CT entity."""
-
-    entity_description: EnvoyCTSensorEntityDescription
-
-    @property
-    def native_value(
-        self,
-    ) -> int | float | str | CtType | CtMeterStatus | CtStatusFlags | None:
-        """Return the state of the CT sensor."""
-        if (ctmeter := self.data.ctmeter_storage) is None:
-            return None
-        return self.entity_description.value_fn(ctmeter)
-
-
-class EnvoyStorageCTPhaseEntity(EnvoySystemSensorEntity):
-    """Envoy net storage CT phase entity."""
-
-    entity_description: EnvoyCTSensorEntityDescription
-
-    @property
-    def native_value(
-        self,
-    ) -> int | float | str | CtType | CtMeterStatus | CtStatusFlags | None:
-        """Return the state of the CT phase sensor."""
-        if TYPE_CHECKING:
-            assert self.entity_description.on_phase
-        if (ctmeter := self.data.ctmeter_storage_phases) is None:
-            return None
-        return self.entity_description.value_fn(
-            ctmeter[self.entity_description.on_phase]
+            self.data.ctmeters_phases[cttype][phase]
         )
 
 

--- a/tests/components/enphase_envoy/test_sensor.py
+++ b/tests/components/enphase_envoy/test_sensor.py
@@ -5,7 +5,8 @@ import logging
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-from pyenphase.const import PHASENAMES
+from pyenphase.const import PHASENAMES, PhaseNames
+from pyenphase.models.meters import CtType
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -1137,7 +1138,7 @@ async def test_sensor_missing_data(
     entity_registry: er.EntityRegistry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test enphase_envoy sensor platform midding data handling."""
+    """Test enphase_envoy sensor platform missing data handling."""
     with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, config_entry)
 
@@ -1153,6 +1154,12 @@ async def test_sensor_missing_data(
     mock_envoy.data.ctmeter_production_phases = None
     mock_envoy.data.ctmeter_consumption_phases = None
     mock_envoy.data.ctmeter_storage_phases = None
+    del mock_envoy.data.ctmeters[CtType.NET_CONSUMPTION]
+    del mock_envoy.data.ctmeters_phases[CtType.NET_CONSUMPTION][PhaseNames.PHASE_2]
+    del mock_envoy.data.ctmeters[CtType.PRODUCTION]
+    del mock_envoy.data.ctmeters_phases[CtType.PRODUCTION][PhaseNames.PHASE_2]
+    del mock_envoy.data.ctmeters[CtType.STORAGE]
+    del mock_envoy.data.ctmeters_phases[CtType.STORAGE][PhaseNames.PHASE_2]
 
     # use different inverter serial to test 'expected inverter missing' code
     mock_envoy.data.inverters["2"] = mock_envoy.data.inverters.pop("1")
@@ -1182,6 +1189,25 @@ async def test_sensor_missing_data(
     # test the original inverter is now unknown
     assert (entity_state := hass.states.get("sensor.inverter_1"))
     assert entity_state.state == STATE_UNKNOWN
+
+    del mock_envoy.data.ctmeters_phases[CtType.PRODUCTION]
+    del mock_envoy.data.ctmeters_phases[CtType.STORAGE]
+    # force HA to detect changed data by changing raw
+    mock_envoy.data.raw = {"I": "am changed again"}
+
+    # Move time to next update
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    for entity in (
+        "metering_status_production_ct",
+        "metering_status_production_ct_l1",
+        "metering_status_storage_ct",
+        "metering_status_storage_ct_l1",
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{entity}"))
+        assert entity_state.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The most recent version of the pyenphase library, 2.4.0 which is now used by this integration, offers current transformer (CT) data also in a dict of data keyed by CT type. The previous CT type specific data structures are still available, but internally just point to entries in the new dict.

This PR updates the sensor code for current transformer entities to use the new data dict as source of data and abandon the use of the CT Type specific data structures of pyenphase.

sensor.py:
- In each existing CT_xxxx_SENSORS tuple specify the CT types for each member.
- Replace the 3 EnvoyxxxxCTEntity classes by a single EnvoyCTEntity class using the added cttype field to obtain the data from the pyenphase ctmeters data dict.
- Replace the 3 EnvoyxxxxCTPhaseEntity classes by a single EnvoyCTPhaseEntity class using the added cttype field to obtain the data from the pyenphase ctmeters_phases data dict.
- In async_setup_entry use the new  EnvoyCTEntity and EnvoyCTPhaseEntity classes and modfied CT_xxxx_SENSORS tuples to add the sensor entities

test_sensor.py:
- update the test_sensor_missing_data test to also delete data from the new pyenphase mocked data as that data is now used for data source.

As this change is fully backward compatible and returning same data as before, all other tests and snapshots remain unchanged and pass as before.

This PR is a is part of prepratory code optimizations for a future addition of more current transformer types. 

(xxxx is production, consumption or storage)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
