### PR TITLE
Migrate entity_id to support multiple google_travel_time sensors

### DIFF
--- a/homeassistant/components/google_travel_time/config_flow.py
+++ b/homeassistant/components/google_travel_time/config_flow.py
@@ -208,7 +208,7 @@ async def validate_input(
 class GoogleTravelTimeConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Google Maps Travel Time."""
 
-    VERSION = 2
+    VERSION = 3
 
     @staticmethod
     @callback

--- a/homeassistant/components/google_travel_time/const.py
+++ b/homeassistant/components/google_travel_time/const.py
@@ -24,6 +24,8 @@ CONF_TRANSIT_ROUTING_PREFERENCE = "transit_routing_preference"
 CONF_TIME_TYPE = "time_type"
 CONF_TIME = "time"
 
+ATTR_DURATION = "duration"
+
 ARRIVAL_TIME = "Arrival Time"
 DEPARTURE_TIME = "Departure Time"
 TIME_TYPES = [ARRIVAL_TIME, DEPARTURE_TIME]

--- a/homeassistant/components/google_travel_time/strings.json
+++ b/homeassistant/components/google_travel_time/strings.json
@@ -106,6 +106,10 @@
     "routes_api_disabled": {
       "title": "The Routes API must be enabled",
       "description": "Your Google Travel Time integration `{entry_title}` uses an API key which does not have the Routes API enabled.\n\n Please follow the instructions to [enable the API for your project]({enable_api_url}) and make sure your [API key restrictions]({api_key_restrictions_url}) allow access to the Routes API.\n\n After enabling the API this issue will be resolved automatically."
+    },
+    "unique_id_migration": {
+      "title": "entity_id has changed",
+      "description": "The entity_id of the Google Travel Time sensor has changed from `{old_entity_id}` to `{new_entity_id}`.\n\nIf you have automations using {old_entity_id}, please update them to use {new_entity_id}."
     }
   }
 }

--- a/tests/components/google_travel_time/test_init.py
+++ b/tests/components/google_travel_time/test_init.py
@@ -10,6 +10,7 @@ from homeassistant.components.google_travel_time.const import (
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .const import DEFAULT_OPTIONS, MOCK_CONFIG
 
@@ -50,7 +51,6 @@ async def test_migrate_entry_v1_v2(
     updated_entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
 
     assert updated_entry.state is ConfigEntryState.LOADED
-    assert updated_entry.version == 2
     assert updated_entry.options[CONF_TIME] == v2
 
 
@@ -77,6 +77,44 @@ async def test_migrate_entry_v1_v2_invalid_time(
     updated_entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
 
     assert updated_entry.state is ConfigEntryState.LOADED
-    assert updated_entry.version == 2
     assert updated_entry.options[CONF_TIME] is None
     assert "Invalid time format found while migrating" in caplog.text
+
+
+@pytest.mark.usefixtures("routes_mock", "mock_setup_entry")
+async def test_migrate_entry_v2_v3(
+    hass: HomeAssistant,
+) -> None:
+    """Test successful migration of entry data."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        data=MOCK_CONFIG,
+        options={
+            **DEFAULT_OPTIONS,
+        },
+    )
+    mock_entry.add_to_hass(hass)
+
+    entity_registry = er.async_get(hass)
+
+    old_entity = entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        mock_entry.entry_id,
+        suggested_object_id="google_travel_time",
+        config_entry=mock_entry,
+    )
+    assert old_entity.entity_id == "sensor.google_travel_time"
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    updated_entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
+    assert updated_entry.state is ConfigEntryState.LOADED
+
+    old_unique_id = mock_entry.entry_id
+    new_unique_id = f"{old_unique_id}_duration"
+
+    new_entity_id = entity_registry.async_get_entity_id("sensor", DOMAIN, new_unique_id)
+    assert new_entity_id == f"{old_entity.entity_id}_duration"

--- a/tests/components/google_travel_time/test_sensor.py
+++ b/tests/components/google_travel_time/test_sensor.py
@@ -46,30 +46,37 @@ def mock_update_empty_fixture(routes_mock: AsyncMock) -> AsyncMock:
 @pytest.mark.usefixtures("routes_mock", "mock_config")
 async def test_sensor(hass: HomeAssistant) -> None:
     """Test that sensor works."""
-    assert hass.states.get("sensor.google_travel_time").state == "27"
+    assert hass.states.get("sensor.google_travel_time_duration").state == "27"
     assert (
-        hass.states.get("sensor.google_travel_time").attributes["attribution"]
+        hass.states.get("sensor.google_travel_time_duration").attributes["attribution"]
         == "Powered by Google"
     )
     assert (
-        hass.states.get("sensor.google_travel_time").attributes["duration"] == "26 mins"
+        hass.states.get("sensor.google_travel_time_duration").attributes["duration"]
+        == "26 mins"
     )
     assert (
-        hass.states.get("sensor.google_travel_time").attributes["duration_in_traffic"]
+        hass.states.get("sensor.google_travel_time_duration").attributes[
+            "duration_in_traffic"
+        ]
         == "27 mins"
     )
     assert (
-        hass.states.get("sensor.google_travel_time").attributes["distance"] == "21.3 km"
+        hass.states.get("sensor.google_travel_time_duration").attributes["distance"]
+        == "21.3 km"
     )
     assert (
-        hass.states.get("sensor.google_travel_time").attributes["origin"] == "location1"
+        hass.states.get("sensor.google_travel_time_duration").attributes["origin"]
+        == "location1"
     )
     assert (
-        hass.states.get("sensor.google_travel_time").attributes["destination"]
+        hass.states.get("sensor.google_travel_time_duration").attributes["destination"]
         == "49.983862755708444,8.223882827079068"
     )
     assert (
-        hass.states.get("sensor.google_travel_time").attributes["unit_of_measurement"]
+        hass.states.get("sensor.google_travel_time_duration").attributes[
+            "unit_of_measurement"
+        ]
         == "min"
     )
 
@@ -81,7 +88,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
 )
 async def test_sensor_empty_response(hass: HomeAssistant) -> None:
     """Test that sensor works for an empty response."""
-    assert hass.states.get("sensor.google_travel_time").state == STATE_UNKNOWN
+    assert hass.states.get("sensor.google_travel_time_duration").state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(
@@ -99,7 +106,7 @@ async def test_sensor_empty_response(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("routes_mock", "mock_config")
 async def test_sensor_departure_time(hass: HomeAssistant) -> None:
     """Test that sensor works for departure time."""
-    assert hass.states.get("sensor.google_travel_time").state == "27"
+    assert hass.states.get("sensor.google_travel_time_duration").state == "27"
 
 
 @pytest.mark.parametrize(
@@ -120,7 +127,7 @@ async def test_sensor_departure_time(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("routes_mock", "mock_config")
 async def test_sensor_arrival_time(hass: HomeAssistant) -> None:
     """Test that sensor works for arrival time."""
-    assert hass.states.get("sensor.google_travel_time").state == "27"
+    assert hass.states.get("sensor.google_travel_time_duration").state == "27"
 
 
 @pytest.mark.parametrize(
@@ -169,7 +176,7 @@ async def test_sensor_exception(
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert hass.states.get("sensor.google_travel_time").state == STATE_UNKNOWN
+    assert hass.states.get("sensor.google_travel_time_duration").state == STATE_UNKNOWN
     assert "Error getting travel time" in caplog.text
 
 
@@ -190,7 +197,7 @@ async def test_sensor_routes_api_disabled(
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert hass.states.get("sensor.google_travel_time").state == STATE_UNKNOWN
+    assert hass.states.get("sensor.google_travel_time_duration").state == STATE_UNKNOWN
     assert "Routes API is disabled for this API key" in caplog.text
 
     assert len(issue_registry.issues) == 1


### PR DESCRIPTION
## Breaking change

The entity_id of the Google Travel Time sensor has changed. If you have automations using the entity_id of the Google Travel Time sensor you have to change these to use the new entity_id.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prepare to split up attributes in distinct entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
