### PR TITLE
Protect internal coordinator state

### DIFF
--- a/homeassistant/components/canary/alarm_control_panel.py
+++ b/homeassistant/components/canary/alarm_control_panel.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
         for location_id, location in coordinator.data["locations"].items()
     ]
 
-    async_add_entities(alarms, True)
+    async_add_entities(alarms)
 
 
 class CanaryAlarm(

--- a/homeassistant/components/canary/camera.py
+++ b/homeassistant/components/canary/camera.py
@@ -68,8 +68,7 @@ async def async_setup_entry(
             for location_id, location in coordinator.data["locations"].items()
             for device in location.devices
             if device.is_online
-        ),
-        True,
+        )
     )
 
 

--- a/homeassistant/components/canary/sensor.py
+++ b/homeassistant/components/canary/sensor.py
@@ -80,7 +80,7 @@ async def async_setup_entry(
                     if device_type.get("name") in sensor_type[4]
                 )
 
-    async_add_entities(sensors, True)
+    async_add_entities(sensors)
 
 
 class CanarySensor(CoordinatorEntity[CanaryDataUpdateCoordinator], SensorEntity):

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -55,6 +55,9 @@ class Debouncer[_R_co]:
         if self._execute_lock_owner is asyncio.current_task():
             raise RuntimeError("Debouncer lock is not re-entrant")
 
+        if self._execute_lock.locked():
+            self.logger.debug("Debouncer lock is already acquired, waiting")
+
         async with self._execute_lock:
             self._execute_lock_owner = asyncio.current_task()
             try:

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -57,8 +57,10 @@ class Debouncer[_R_co]:
 
         async with self._execute_lock:
             self._execute_lock_owner = asyncio.current_task()
-            yield
-            self._execute_lock_owner = None
+            try:
+                yield
+            finally:
+                self._execute_lock_owner = None
 
     @property
     def function(self) -> Callable[[], _R_co] | None:

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
+from contextlib import asynccontextmanager
 from logging import Logger
+from typing import Any
 
 from homeassistant.core import HassJob, HomeAssistant, callback
 
@@ -36,6 +38,7 @@ class Debouncer[_R_co]:
         self._timer_task: asyncio.TimerHandle | None = None
         self._execute_at_end_of_timer: bool = False
         self._execute_lock = asyncio.Lock()
+        self._execute_lock_owner: asyncio.Task[Any] | None = None
         self._background = background
         self._job: HassJob[[], _R_co] | None = (
             None
@@ -46,10 +49,16 @@ class Debouncer[_R_co]:
         )
         self._shutdown_requested = False
 
-    @property
-    def lock(self) -> asyncio.Lock:
-        """Return the lock used to ensure only one call is running at a time."""
-        return self._execute_lock
+    @asynccontextmanager
+    async def async_lock(self) -> AsyncGenerator[None]:
+        """Return an async context manager to lock the debouncer."""
+        if self._execute_lock_owner is asyncio.current_task():
+            raise RuntimeError("Debouncer lock is not re-entrant")
+
+        async with self._execute_lock:
+            self._execute_lock_owner = asyncio.current_task()
+            yield
+            self._execute_lock_owner = None
 
     @property
     def function(self) -> Callable[[], _R_co] | None:
@@ -103,7 +112,7 @@ class Debouncer[_R_co]:
         if not self._async_schedule_or_call_now():
             return
 
-        async with self._execute_lock:
+        async with self.async_lock():
             # Abort if timer got set while we're waiting for the lock.
             if self._timer_task:
                 return
@@ -127,7 +136,7 @@ class Debouncer[_R_co]:
         if self._execute_lock.locked():
             return
 
-        async with self._execute_lock:
+        async with self.async_lock():
             # Abort if timer got set while we're waiting for the lock.
             if self._timer_task:
                 return

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -47,6 +47,11 @@ class Debouncer[_R_co]:
         self._shutdown_requested = False
 
     @property
+    def lock(self) -> asyncio.Lock:
+        """Return the lock used to ensure only one call is running at a time."""
+        return self._execute_lock
+
+    @property
     def function(self) -> Callable[[], _R_co] | None:
         """Return the function being wrapped by the Debouncer."""
         return self._function

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -277,7 +277,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
     async def _handle_refresh_interval(self, _now: datetime | None = None) -> None:
         """Handle a refresh interval occurrence."""
         self._unsub_refresh = None
-        async with self._debounced_refresh.lock:
+        async with self._debounced_refresh.async_lock():
             await self._async_refresh(log_failures=True, scheduled=True)
 
     async def async_request_refresh(self) -> None:
@@ -300,7 +300,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         fails. Additionally logging is handled by config entry setup
         to ensure that multiple retries do not cause log spam.
         """
-        async with self._debounced_refresh.lock:
+        async with self._debounced_refresh.async_lock():
             await self._async_config_entry_first_refresh()
 
     async def _async_config_entry_first_refresh(self) -> None:
@@ -376,7 +376,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
 
     async def async_refresh(self) -> None:
         """Refresh data and log errors."""
-        async with self._debounced_refresh.lock:
+        async with self._debounced_refresh.async_lock():
             await self._async_refresh(log_failures=True)
 
     async def _async_refresh(  # noqa: C901

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -125,7 +125,7 @@ async def test_sensors_attributes_pro(hass: HomeAssistant, canary) -> None:
 
     future = utcnow() + timedelta(seconds=30)
     async_fire_time_changed(hass, future)
-    await hass.async_block_till_done(True)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     state2 = hass.states.get(entity_id)
     assert state2
@@ -140,7 +140,7 @@ async def test_sensors_attributes_pro(hass: HomeAssistant, canary) -> None:
 
     future += timedelta(seconds=30)
     async_fire_time_changed(hass, future)
-    await hass.async_block_till_done(True)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     state3 = hass.states.get(entity_id)
     assert state3

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util.dt import utcnow
 
 from . import init_integration, mock_device, mock_location, mock_reading
@@ -126,8 +125,7 @@ async def test_sensors_attributes_pro(hass: HomeAssistant, canary) -> None:
 
     future = utcnow() + timedelta(seconds=30)
     async_fire_time_changed(hass, future)
-    await async_update_entity(hass, entity_id)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(True)
 
     state2 = hass.states.get(entity_id)
     assert state2
@@ -142,8 +140,7 @@ async def test_sensors_attributes_pro(hass: HomeAssistant, canary) -> None:
 
     future += timedelta(seconds=30)
     async_fire_time_changed(hass, future)
-    await async_update_entity(hass, entity_id)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(True)
 
     state3 = hass.states.get(entity_id)
     assert state3

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -922,7 +922,7 @@ async def test_coordinator_updates(
         supervisor_client.refresh_updates.assert_not_called()
 
     async_fire_time_changed(hass, dt_util.now() + timedelta(minutes=20))
-    await hass.async_block_till_done(True)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     # Scheduled refresh, no update refresh call
     supervisor_client.refresh_updates.assert_not_called()
@@ -944,7 +944,7 @@ async def test_coordinator_updates(
     async_fire_time_changed(
         hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
     )
-    await hass.async_block_till_done(True)
+    await hass.async_block_till_done(wait_background_tasks=True)
     supervisor_client.refresh_updates.assert_called_once()
 
     supervisor_client.refresh_updates.reset_mock()

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -922,7 +922,7 @@ async def test_coordinator_updates(
         supervisor_client.refresh_updates.assert_not_called()
 
     async_fire_time_changed(hass, dt_util.now() + timedelta(minutes=20))
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(True)
 
     # Scheduled refresh, no update refresh call
     supervisor_client.refresh_updates.assert_not_called()
@@ -944,7 +944,7 @@ async def test_coordinator_updates(
     async_fire_time_changed(
         hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(True)
     supervisor_client.refresh_updates.assert_called_once()
 
     supervisor_client.refresh_updates.reset_mock()

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -157,8 +157,8 @@ async def test_trophy_title_coordinator_auth_failed(
 
     freezer.tick(timedelta(days=1))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(True)
+    await hass.async_block_till_done(True)
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -194,8 +194,8 @@ async def test_trophy_title_coordinator_update_data_failed(
 
     freezer.tick(timedelta(days=1))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(True)
+    await hass.async_block_till_done(True)
 
     runtime_data: PlaystationNetworkRuntimeData = config_entry.runtime_data
     assert runtime_data.trophy_titles.last_update_success is False
@@ -254,8 +254,8 @@ async def test_trophy_title_coordinator_play_new_game(
 
     freezer.tick(timedelta(days=1))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(True)
+    await hass.async_block_till_done(True)
 
     assert len(mock_psnawpapi.user.return_value.trophy_titles.mock_calls) == 2
 

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -157,8 +157,8 @@ async def test_trophy_title_coordinator_auth_failed(
 
     freezer.tick(timedelta(days=1))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done(True)
-    await hass.async_block_till_done(True)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -194,8 +194,8 @@ async def test_trophy_title_coordinator_update_data_failed(
 
     freezer.tick(timedelta(days=1))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done(True)
-    await hass.async_block_till_done(True)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     runtime_data: PlaystationNetworkRuntimeData = config_entry.runtime_data
     assert runtime_data.trophy_titles.last_update_success is False
@@ -254,8 +254,8 @@ async def test_trophy_title_coordinator_play_new_game(
 
     freezer.tick(timedelta(days=1))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done(True)
-    await hass.async_block_till_done(True)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     assert len(mock_psnawpapi.user.return_value.trophy_titles.mock_calls) == 2
 

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -1,5 +1,6 @@
 """Tests for the update coordinator."""
 
+import asyncio
 from datetime import datetime, timedelta
 import logging
 from unittest.mock import AsyncMock, Mock, patch
@@ -403,6 +404,70 @@ async def test_update_interval_not_present(
 
     # Test we stop don't update after we lose last subscriber
     assert crd.data is None
+
+
+async def test_update_locks(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    crd: update_coordinator.DataUpdateCoordinator[int],
+) -> None:
+    """Test update interval works."""
+    start = asyncio.Event()
+    block = asyncio.Event()
+
+    async def _update_method() -> int:
+        start.set()
+        await block.wait()
+        block.clear()
+        return 0
+
+    crd.update_method = _update_method
+
+    # Add subscriber
+    update_callback = Mock()
+    crd.async_add_listener(update_callback)
+
+    assert crd.update_interval
+
+    # Trigger timed update, ensure it is started
+    freezer.tick(crd.update_interval)
+    async_fire_time_changed(hass)
+    await start.wait()
+    start.clear()
+
+    # Trigger direct update
+    task = hass.async_create_background_task(crd.async_refresh(), "", eager_start=True)
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+
+    # Ensure it has not started
+    assert not start.is_set()
+
+    # Unblock interval update
+    block.set()
+
+    # Check that direct update starts
+    await start.wait()
+    start.clear()
+
+    # Request update. This should not be blocking
+    # since the lock is held, it should be queued
+    await crd.async_request_refresh()
+    assert not start.is_set()
+
+    # Unblock second update
+    block.set()
+    # Check that task finishes
+    await task
+
+    # Check that queued update starts
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await start.wait()
+    start.clear()
+
+    # Unblock queued update
+    block.set()
 
 
 async def test_refresh_recover(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update coordinator is triggered from background interval, debouncer and from direct async_refresh() call. All of these can execute the _async_refresh function at the same time causing the state to be broken.

Ensure all paths lock the same async lock to ensure we protect the internal state of the coordinator.

Correct a few more integrations that was missed during the changes to background task in https://github.com/home-assistant/core/pull/112726

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/112726
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
