### PR TITLE
Fix ViCare pressure sensors missing unit of measurement

### DIFF
--- a/homeassistant/components/vicare/const.py
+++ b/homeassistant/components/vicare/const.py
@@ -34,12 +34,13 @@ CONF_HEATING_TYPE = "heating_type"
 
 DEFAULT_CACHE_DURATION = 60
 
+VICARE_BAR = "bar"
+VICARE_CUBIC_METER = "cubicMeter"
+VICARE_KW = "kilowatt"
+VICARE_KWH = "kilowattHour"
 VICARE_PERCENT = "percent"
 VICARE_W = "watt"
-VICARE_KW = "kilowatt"
 VICARE_WH = "wattHour"
-VICARE_KWH = "kilowattHour"
-VICARE_CUBIC_METER = "cubicMeter"
 
 
 class HeatingType(enum.Enum):

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -41,6 +41,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
+    VICARE_BAR,
     VICARE_CUBIC_METER,
     VICARE_KW,
     VICARE_KWH,
@@ -62,20 +63,22 @@ from .utils import (
 _LOGGER = logging.getLogger(__name__)
 
 VICARE_UNIT_TO_DEVICE_CLASS = {
-    VICARE_WH: SensorDeviceClass.ENERGY,
-    VICARE_KWH: SensorDeviceClass.ENERGY,
-    VICARE_W: SensorDeviceClass.POWER,
-    VICARE_KW: SensorDeviceClass.POWER,
+    VICARE_BAR: SensorDeviceClass.PRESSURE,
     VICARE_CUBIC_METER: SensorDeviceClass.GAS,
+    VICARE_KW: SensorDeviceClass.POWER,
+    VICARE_KWH: SensorDeviceClass.ENERGY,
+    VICARE_WH: SensorDeviceClass.ENERGY,
+    VICARE_W: SensorDeviceClass.POWER,
 }
 
 VICARE_UNIT_TO_HA_UNIT = {
+    VICARE_BAR: UnitOfPressure.BAR,
+    VICARE_CUBIC_METER: UnitOfVolume.CUBIC_METERS,
+    VICARE_KW: UnitOfPower.KILO_WATT,
+    VICARE_KWH: UnitOfEnergy.KILO_WATT_HOUR,
     VICARE_PERCENT: PERCENTAGE,
     VICARE_W: UnitOfPower.WATT,
-    VICARE_KW: UnitOfPower.KILO_WATT,
     VICARE_WH: UnitOfEnergy.WATT_HOUR,
-    VICARE_KWH: UnitOfEnergy.KILO_WATT_HOUR,
-    VICARE_CUBIC_METER: UnitOfVolume.CUBIC_METERS,
 }
 
 

--- a/tests/components/vicare/snapshots/test_sensor.ambr
+++ b/tests/components/vicare/snapshots/test_sensor.ambr
@@ -2561,6 +2561,9 @@
     }),
     'name': None,
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
     'original_icon': None,
@@ -2571,7 +2574,7 @@
     'supported_features': 0,
     'translation_key': 'supply_pressure',
     'unique_id': 'gateway0_deviceSerialVitocal250A-supply_pressure',
-    'unit_of_measurement': None,
+    'unit_of_measurement': <UnitOfPressure.BAR: 'bar'>,
   })
 # ---
 # name: test_all_entities[type:heatpump-vicare/Vitocal250A.json][sensor.model0_supply_pressure-state]
@@ -2580,6 +2583,7 @@
       'device_class': 'pressure',
       'friendly_name': 'model0 Supply pressure',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.BAR: 'bar'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.model0_supply_pressure',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes a bug where the uom for pressure sensors was removed.

In detail: The function transforming the ViCare units to HomeAssistant units was missing a `VICARE_BAR` to `UnitOfPressure.BAR` entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
