### PR TITLE
ESPHome to set Z-Wave discovery as next_flow

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -22,19 +22,23 @@ import voluptuous as vol
 
 from homeassistant.components import zeroconf
 from homeassistant.config_entries import (
+    SOURCE_ESPHOME,
     SOURCE_IGNORE,
     SOURCE_REAUTH,
     SOURCE_RECONFIGURE,
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
+    FlowType,
     OptionsFlow,
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import AbortFlow
+from homeassistant.data_entry_flow import AbortFlow, FlowResultType
+from homeassistant.helpers import discovery_flow
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.esphome import ESPHomeServiceInfo
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -75,6 +79,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize flow."""
         self._host: str | None = None
+        self._connected_address: str | None = None
         self.__name: str | None = None
         self._port: int | None = None
         self._password: str | None = None
@@ -498,18 +503,53 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         await self.hass.config_entries.async_remove(
             self._entry_with_name_conflict.entry_id
         )
-        return self._async_create_entry()
+        return await self._async_create_entry()
 
-    @callback
-    def _async_create_entry(self) -> ConfigFlowResult:
+    async def _async_create_entry(self) -> ConfigFlowResult:
         """Create the config entry."""
         assert self._name is not None
+        assert self._device_info is not None
+
+        # Check if Z-Wave capabilities are present and start discovery flow
+        next_flow_id: str | None = None
+        if self._device_info.zwave_proxy_feature_flags:
+            assert self._connected_address is not None
+            assert self._port is not None
+
+            # Start Z-Wave discovery flow and get the flow ID
+            zwave_result = await self.hass.config_entries.flow.async_init(
+                "zwave_js",
+                context={
+                    "source": SOURCE_ESPHOME,
+                    "discovery_key": discovery_flow.DiscoveryKey(
+                        domain=DOMAIN,
+                        key=self._device_info.mac_address,
+                        version=1,
+                    ),
+                },
+                data=ESPHomeServiceInfo(
+                    name=self._device_info.name,
+                    zwave_home_id=self._device_info.zwave_home_id or None,
+                    ip_address=self._connected_address,
+                    port=self._port,
+                    noise_psk=self._noise_psk,
+                ),
+            )
+            if zwave_result["type"] in (
+                FlowResultType.ABORT,
+                FlowResultType.CREATE_ENTRY,
+            ):
+                _LOGGER.debug("Starting Z-Wave JS config flow failed: %s", zwave_result)
+            else:
+                next_flow_id = zwave_result["flow_id"]
+
         return self.async_create_entry(
             title=self._name,
             data=self._async_make_config_data(),
             options={
                 CONF_ALLOW_SERVICE_CALLS: DEFAULT_NEW_CONFIG_ALLOW_ALLOW_SERVICE_CALLS,
             },
+            next_flow=(FlowType.CONFIG_FLOW, next_flow_id) if next_flow_id else None,
         )
 
     @callback
@@ -556,7 +596,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             if entry.data.get(CONF_DEVICE_NAME) == self._device_name:
                 self._entry_with_name_conflict = entry
                 return await self.async_step_name_conflict()
-        return self._async_create_entry()
+        return await self._async_create_entry()
 
     async def _async_reauth_validated_connection(self) -> ConfigFlowResult:
         """Handle reauth validated connection."""
@@ -703,6 +743,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         try:
             await cli.connect()
             self._device_info = await cli.device_info()
+            self._connected_address = cli.connected_address
         except InvalidAuthAPIError:
             return ERROR_INVALID_PASSWORD_AUTH
         except RequiresEncryptionAPIError:

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -539,7 +539,9 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 FlowResultType.ABORT,
                 FlowResultType.CREATE_ENTRY,
             ):
-                _LOGGER.debug("Starting Z-Wave JS config flow failed: %s", zwave_result)
+                _LOGGER.debug(
+                    "Unable to continue created Z-Wave JS config flow: %s", zwave_result
+                )
             else:
                 next_flow_id = zwave_result["flow_id"]
 

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -3,7 +3,7 @@
 from ipaddress import ip_address
 import json
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioesphomeapi import (
     APIClient,
@@ -34,7 +34,9 @@ from homeassistant.config_entries import SOURCE_IGNORE, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import discovery_flow
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.esphome import ESPHomeServiceInfo
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -2619,3 +2621,127 @@ async def test_discovery_dhcp_no_probe_same_host_port_none(
 
     # Host should remain unchanged
     assert entry.data[CONF_HOST] == "192.168.43.183"
+
+
+@pytest.mark.usefixtures("mock_setup_entry", "mock_zeroconf")
+async def test_user_flow_starts_zwave_discovery(
+    hass: HomeAssistant, mock_client: APIClient
+) -> None:
+    """Test that the user flow starts Z-Wave JS discovery when device has Z-Wave capabilities."""
+    # Mock device with Z-Wave capabilities
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(
+            uses_password=False,
+            name="test-zwave-device",
+            mac_address="11:22:33:44:55:BB",
+            zwave_proxy_feature_flags=1,
+            zwave_home_id=1234567890,
+        )
+    )
+    mock_client.connected_address = "mock-connected-address"
+
+    # Track flow.async_init calls and async_get calls
+    original_async_init = hass.config_entries.flow.async_init
+    original_async_get = hass.config_entries.flow.async_get
+    flow_init_calls = []
+    zwave_flow_id = "mock-zwave-flow-id"
+
+    async def track_async_init(*args, **kwargs):
+        flow_init_calls.append((args, kwargs))
+        # For the Z-Wave flow, return a mock result with the flow_id
+        if args and args[0] == "zwave_js":
+            return {"flow_id": zwave_flow_id, "type": FlowResultType.FORM}
+        # Otherwise call the original
+        return await original_async_init(*args, **kwargs)
+
+    def mock_async_get(flow_id: str):
+        # Return a mock flow for the Z-Wave flow_id
+        if flow_id == zwave_flow_id:
+            return MagicMock()
+        return original_async_get(flow_id)
+
+    with (
+        patch.object(
+            hass.config_entries.flow, "async_init", side_effect=track_async_init
+        ),
+        patch.object(hass.config_entries.flow, "async_get", side_effect=mock_async_get),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={CONF_HOST: "192.168.1.100", CONF_PORT: 6053},
+        )
+
+    # Verify the entry was created
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "test-zwave-device"
+    assert result["data"] == {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: 6053,
+        CONF_PASSWORD: "",
+        CONF_NOISE_PSK: "",
+        CONF_DEVICE_NAME: "test-zwave-device",
+    }
+
+    # First call is ESPHome flow, second should be Z-Wave flow
+    assert len(flow_init_calls) == 2
+    zwave_call_args, zwave_call_kwargs = flow_init_calls[1]
+    assert zwave_call_args[0] == "zwave_js"
+    assert zwave_call_kwargs["context"] == {
+        "source": config_entries.SOURCE_ESPHOME,
+        "discovery_key": discovery_flow.DiscoveryKey(
+            domain="esphome", key="11:22:33:44:55:BB", version=1
+        ),
+    }
+    assert zwave_call_kwargs["data"] == ESPHomeServiceInfo(
+        name="test-zwave-device",
+        zwave_home_id=1234567890,
+        ip_address="mock-connected-address",
+        port=6053,
+        noise_psk=None,
+    )
+
+    # Verify next_flow was set
+    assert result["next_flow"] == (config_entries.FlowType.CONFIG_FLOW, zwave_flow_id)
+
+
+@pytest.mark.usefixtures("mock_setup_entry", "mock_zeroconf")
+async def test_user_flow_no_zwave_discovery_without_capabilities(
+    hass: HomeAssistant, mock_client: APIClient
+) -> None:
+    """Test that the user flow does not start Z-Wave JS discovery when device has no Z-Wave capabilities."""
+    # Mock device without Z-Wave capabilities
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(
+            uses_password=False,
+            name="test-regular-device",
+            mac_address="11:22:33:44:55:CC",
+        )
+    )
+
+    # Track flow.async_init calls
+    original_async_init = hass.config_entries.flow.async_init
+    flow_init_calls = []
+
+    async def track_async_init(*args, **kwargs):
+        flow_init_calls.append((args, kwargs))
+        return await original_async_init(*args, **kwargs)
+
+    with patch.object(
+        hass.config_entries.flow, "async_init", side_effect=track_async_init
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={CONF_HOST: "192.168.1.101", CONF_PORT: 6053},
+        )
+
+    # Verify the entry was created
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "test-regular-device"
+
+    # Verify Z-Wave discovery flow was NOT started (only ESPHome flow)
+    assert len(flow_init_calls) == 1
+
+    # Verify next_flow was not set
+    assert "next_flow" not in result

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -2745,3 +2745,77 @@ async def test_user_flow_no_zwave_discovery_without_capabilities(
 
     # Verify next_flow was not set
     assert "next_flow" not in result
+
+
+@pytest.mark.usefixtures("mock_setup_entry", "mock_zeroconf")
+async def test_user_flow_zwave_discovery_aborts(
+    hass: HomeAssistant, mock_client: APIClient
+) -> None:
+    """Test that the user flow handles Z-Wave discovery abort gracefully."""
+    # Mock device with Z-Wave capabilities
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(
+            uses_password=False,
+            name="test-zwave-device",
+            mac_address="11:22:33:44:55:DD",
+            zwave_proxy_feature_flags=1,
+            zwave_home_id=9876543210,
+        )
+    )
+    mock_client.connected_address = "192.168.1.102"
+
+    # Track flow.async_init calls
+    original_async_init = hass.config_entries.flow.async_init
+    flow_init_calls = []
+
+    async def track_async_init(*args, **kwargs):
+        flow_init_calls.append((args, kwargs))
+        # For the Z-Wave flow, return an ABORT result
+        if args and args[0] == "zwave_js":
+            return {
+                "type": FlowResultType.ABORT,
+                "reason": "already_configured",
+            }
+        # Otherwise call the original
+        return await original_async_init(*args, **kwargs)
+
+    with patch.object(
+        hass.config_entries.flow, "async_init", side_effect=track_async_init
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={CONF_HOST: "192.168.1.102", CONF_PORT: 6053},
+        )
+
+    # Verify the ESPHome entry was still created despite Z-Wave flow aborting
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "test-zwave-device"
+    assert result["data"] == {
+        CONF_HOST: "192.168.1.102",
+        CONF_PORT: 6053,
+        CONF_PASSWORD: "",
+        CONF_NOISE_PSK: "",
+        CONF_DEVICE_NAME: "test-zwave-device",
+    }
+
+    # Verify Z-Wave discovery flow was attempted
+    assert len(flow_init_calls) == 2
+    zwave_call_args, zwave_call_kwargs = flow_init_calls[1]
+    assert zwave_call_args[0] == "zwave_js"
+    assert zwave_call_kwargs["context"]["source"] == config_entries.SOURCE_ESPHOME
+    assert zwave_call_kwargs["context"]["discovery_key"] == discovery_flow.DiscoveryKey(
+        domain=DOMAIN,
+        key="11:22:33:44:55:DD",
+        version=1,
+    )
+    assert zwave_call_kwargs["data"] == ESPHomeServiceInfo(
+        name="test-zwave-device",
+        zwave_home_id=9876543210,
+        ip_address="192.168.1.102",
+        port=6053,
+        noise_psk=None,
+    )
+
+    # Verify next_flow was NOT set since Z-Wave flow aborted
+    assert "next_flow" not in result


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When ESPHome during the config flow realizes that it is a Z-Wave device, instantiate the Z-Wave config flow and continue directly into it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
