### PR TITLE
Shelly's energy sensors naming paradigm standardization

### DIFF
--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -122,8 +122,8 @@ class RpcSensor(ShellyRpcAttributeEntity, SensorEntity):
         return self.option_map[attribute_value]
 
 
-class RpcConsumedEnergySensor(RpcSensor):
-    """Represent a RPC sensor."""
+class RpcEnergyConsumedSensor(RpcSensor):
+    """Represent a RPC energy consumed sensor."""
 
     @property
     def native_value(self) -> StateType:
@@ -926,7 +926,7 @@ RPC_SENSORS: Final = {
     "consumed_energy_switch": RpcSensorDescription(
         key="switch",
         sub_key="ret_aenergy",
-        name="Consumed energy",
+        name="Energy consumed",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: status["total"],
@@ -934,7 +934,7 @@ RPC_SENSORS: Final = {
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_registry_enabled_default=False,
-        entity_class=RpcConsumedEnergySensor,
+        entity_class=RpcEnergyConsumedSensor,
         removal_condition=lambda _, status, key: (
             status[key].get("ret_aenergy") is None
         ),
@@ -975,7 +975,7 @@ RPC_SENSORS: Final = {
     "consumed_energy_pm1": RpcSensorDescription(
         key="pm1",
         sub_key="ret_aenergy",
-        name="Consumed energy",
+        name="Energy consumed",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: status["total"],
@@ -983,7 +983,7 @@ RPC_SENSORS: Final = {
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_registry_enabled_default=False,
-        entity_class=RpcConsumedEnergySensor,
+        entity_class=RpcEnergyConsumedSensor,
     ),
     "energy_cct": RpcSensorDescription(
         key="cct",

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -912,7 +912,7 @@ RPC_SENSORS: Final = {
     "ret_energy": RpcSensorDescription(
         key="switch",
         sub_key="ret_aenergy",
-        name="Returned energy",
+        name="Energy returned",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: status["total"],
@@ -964,7 +964,7 @@ RPC_SENSORS: Final = {
     "ret_energy_pm1": RpcSensorDescription(
         key="pm1",
         sub_key="ret_aenergy",
-        name="Returned energy",
+        name="Energy returned",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: status["total"],

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -1086,7 +1086,7 @@ RPC_SENSORS: Final = {
     "total_act_ret": RpcSensorDescription(
         key="emdata",
         sub_key="total_act_ret",
-        name="Total active returned energy",
+        name="Energy returned",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: float(status),
@@ -1097,7 +1097,7 @@ RPC_SENSORS: Final = {
     "total_act_ret_energy": RpcSensorDescription(
         key="em1data",
         sub_key="total_act_ret_energy",
-        name="Total active returned energy",
+        name="Energy returned",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: float(status),
@@ -1109,7 +1109,7 @@ RPC_SENSORS: Final = {
     "a_total_act_ret_energy": RpcSensorDescription(
         key="emdata",
         sub_key="a_total_act_ret_energy",
-        name="Total active returned energy",
+        name="Energy returned",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: float(status),
@@ -1123,7 +1123,7 @@ RPC_SENSORS: Final = {
     "b_total_act_ret_energy": RpcSensorDescription(
         key="emdata",
         sub_key="b_total_act_ret_energy",
-        name="Total active returned energy",
+        name="Energy returned",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: float(status),
@@ -1137,7 +1137,7 @@ RPC_SENSORS: Final = {
     "c_total_act_ret_energy": RpcSensorDescription(
         key="emdata",
         sub_key="c_total_act_ret_energy",
-        name="Total active returned energy",
+        name="Energy returned",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: float(status),

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -1021,7 +1021,7 @@ RPC_SENSORS: Final = {
     "total_act": RpcSensorDescription(
         key="emdata",
         sub_key="total_act",
-        name="Total active energy",
+        name="Energy",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: float(status),
@@ -1032,7 +1032,7 @@ RPC_SENSORS: Final = {
     "total_act_energy": RpcSensorDescription(
         key="em1data",
         sub_key="total_act_energy",
-        name="Total active energy",
+        name="Energy",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: float(status),
@@ -1044,7 +1044,7 @@ RPC_SENSORS: Final = {
     "a_total_act_energy": RpcSensorDescription(
         key="emdata",
         sub_key="a_total_act_energy",
-        name="Total active energy",
+        name="Energy",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: float(status),
@@ -1058,7 +1058,7 @@ RPC_SENSORS: Final = {
     "b_total_act_energy": RpcSensorDescription(
         key="emdata",
         sub_key="b_total_act_energy",
-        name="Total active energy",
+        name="Energy",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: float(status),
@@ -1072,7 +1072,7 @@ RPC_SENSORS: Final = {
     "c_total_act_energy": RpcSensorDescription(
         key="emdata",
         sub_key="c_total_act_energy",
-        name="Total active energy",
+        name="Energy",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: float(status),

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -886,8 +886,7 @@ RPC_SENSORS: Final = {
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
-        removal_condition=lambda _config, status, key: status[key].get("n_current")
-        is None,
+        removal_condition=lambda _, status, key: status[key].get("n_current") is None,
         entity_registry_enabled_default=False,
     ),
     "total_current": RpcSensorDescription(
@@ -902,7 +901,7 @@ RPC_SENSORS: Final = {
     "energy": RpcSensorDescription(
         key="switch",
         sub_key="aenergy",
-        name="Total energy",
+        name="Energy",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: status["total"],
@@ -920,7 +919,7 @@ RPC_SENSORS: Final = {
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        removal_condition=lambda _config, status, key: (
+        removal_condition=lambda _, status, key: (
             status[key].get("ret_aenergy") is None
         ),
     ),
@@ -936,7 +935,7 @@ RPC_SENSORS: Final = {
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_registry_enabled_default=False,
         entity_class=RpcConsumedEnergySensor,
-        removal_condition=lambda _config, status, key: (
+        removal_condition=lambda _, status, key: (
             status[key].get("ret_aenergy") is None
         ),
     ),
@@ -954,7 +953,7 @@ RPC_SENSORS: Final = {
     "energy_pm1": RpcSensorDescription(
         key="pm1",
         sub_key="aenergy",
-        name="Total energy",
+        name="Energy",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value=lambda status, _: status["total"],
@@ -1337,7 +1336,7 @@ RPC_SENSORS: Final = {
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        removal_condition=lambda _config, status, key: (status[key]["battery"] is None),
+        removal_condition=lambda _, status, key: (status[key]["battery"] is None),
     ),
     "voltmeter": RpcSensorDescription(
         key="voltmeter",
@@ -1354,9 +1353,7 @@ RPC_SENSORS: Final = {
         key="voltmeter",
         sub_key="xvoltage",
         name="Voltmeter value",
-        removal_condition=lambda _config, status, key: (
-            status[key].get("xvoltage") is None
-        ),
+        removal_condition=lambda _, status, key: (status[key].get("xvoltage") is None),
         unit=lambda config: config["xvoltage"]["unit"] or None,
     ),
     "analoginput": RpcSensorDescription(

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -3406,7 +3406,7 @@
     'state': '3105.57642',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_a_total_active_returned_energy-entry]
+# name: test_shelly_pro_3em[sensor.test_name_phase_a_energy_returned-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3421,7 +3421,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_phase_a_total_active_returned_energy',
+    'entity_id': 'sensor.test_name_phase_a_energy_returned',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3439,7 +3439,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Total active returned energy',
+    'original_name': 'Energy returned',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3449,16 +3449,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_a_total_active_returned_energy-state]
+# name: test_shelly_pro_3em[sensor.test_name_phase_a_energy_returned-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Phase A Total active returned energy',
+      'friendly_name': 'Test name Phase A Energy returned',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_phase_a_total_active_returned_energy',
+    'entity_id': 'sensor.test_name_phase_a_energy_returned',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3856,7 +3856,7 @@
     'state': '195.76572',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_b_total_active_returned_energy-entry]
+# name: test_shelly_pro_3em[sensor.test_name_phase_b_energy_returned-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3871,7 +3871,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_phase_b_total_active_returned_energy',
+    'entity_id': 'sensor.test_name_phase_b_energy_returned',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3889,7 +3889,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Total active returned energy',
+    'original_name': 'Energy returned',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3899,16 +3899,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_b_total_active_returned_energy-state]
+# name: test_shelly_pro_3em[sensor.test_name_phase_b_energy_returned-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Phase B Total active returned energy',
+      'friendly_name': 'Test name Phase B Energy returned',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_phase_b_total_active_returned_energy',
+    'entity_id': 'sensor.test_name_phase_b_energy_returned',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4306,7 +4306,7 @@
     'state': '2114.07205',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_c_total_active_returned_energy-entry]
+# name: test_shelly_pro_3em[sensor.test_name_phase_c_energy_returned-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -4321,7 +4321,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_phase_c_total_active_returned_energy',
+    'entity_id': 'sensor.test_name_phase_c_energy_returned',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4339,7 +4339,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Total active returned energy',
+    'original_name': 'Energy returned',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -4349,16 +4349,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_c_total_active_returned_energy-state]
+# name: test_shelly_pro_3em[sensor.test_name_phase_c_energy_returned-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Phase C Total active returned energy',
+      'friendly_name': 'Test name Phase C Energy returned',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_phase_c_total_active_returned_energy',
+    'entity_id': 'sensor.test_name_phase_c_energy_returned',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4701,7 +4701,7 @@
     'state': '2413.825',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_total_active_returned_energy-entry]
+# name: test_shelly_pro_3em[sensor.test_name_energy_returned-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -4716,7 +4716,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_total_active_returned_energy',
+    'entity_id': 'sensor.test_name_energy_returned',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4734,7 +4734,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Total active returned energy',
+    'original_name': 'Energy returned',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -4744,16 +4744,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_total_active_returned_energy-state]
+# name: test_shelly_pro_3em[sensor.test_name_energy_returned-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Total active returned energy',
+      'friendly_name': 'Test name Energy returned',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_total_active_returned_energy',
+    'entity_id': 'sensor.test_name_energy_returned',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -1743,7 +1743,7 @@
     'state': '-52',
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_consumed_energy-entry]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_energy_consumed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1758,7 +1758,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_switch_0_consumed_energy',
+    'entity_id': 'sensor.test_name_switch_0_energy_consumed',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1776,7 +1776,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Consumed energy',
+    'original_name': 'Energy consumed',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1786,16 +1786,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_consumed_energy-state]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_energy_consumed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Switch 0 Consumed energy',
+      'friendly_name': 'Test name Switch 0 Energy consumed',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_switch_0_consumed_energy',
+    'entity_id': 'sensor.test_name_switch_0_energy_consumed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2200,7 +2200,7 @@
     'state': '216.2',
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_consumed_energy-entry]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_energy_consumed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2215,7 +2215,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_switch_1_consumed_energy',
+    'entity_id': 'sensor.test_name_switch_1_energy_consumed',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2233,7 +2233,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Consumed energy',
+    'original_name': 'Energy consumed',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2243,16 +2243,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_consumed_energy-state]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_energy_consumed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Switch 1 Consumed energy',
+      'friendly_name': 'Test name Switch 1 Energy consumed',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_switch_1_consumed_energy',
+    'entity_id': 'sensor.test_name_switch_1_energy_consumed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -1970,7 +1970,7 @@
     'state': '0.0',
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_returned_energy-entry]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_energy_returned-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1985,7 +1985,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_switch_0_returned_energy',
+    'entity_id': 'sensor.test_name_switch_0_energy_returned',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2003,7 +2003,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Returned energy',
+    'original_name': 'Energy returned',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2013,16 +2013,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_returned_energy-state]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_energy_returned-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Switch 0 Returned energy',
+      'friendly_name': 'Test name Switch 0 Energy returned',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_switch_0_returned_energy',
+    'entity_id': 'sensor.test_name_switch_0_energy_returned',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2427,7 +2427,7 @@
     'state': '0.0',
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_returned_energy-entry]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_energy_returned-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2442,7 +2442,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_switch_1_returned_energy',
+    'entity_id': 'sensor.test_name_switch_1_energy_returned',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2460,7 +2460,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Returned energy',
+    'original_name': 'Energy returned',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2470,16 +2470,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_returned_energy-state]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_energy_returned-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Switch 1 Returned energy',
+      'friendly_name': 'Test name Switch 1 Energy returned',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_switch_1_returned_energy',
+    'entity_id': 'sensor.test_name_switch_1_energy_returned',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -767,7 +767,7 @@
     'state': '36.4',
   })
 # ---
-# name: test_shelly_2pm_gen3_cover[sensor.test_name_total_energy-entry]
+# name: test_shelly_2pm_gen3_cover[sensor.test_name_energy-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -782,7 +782,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_total_energy',
+    'entity_id': 'sensor.test_name_energy',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -800,7 +800,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Total energy',
+    'original_name': 'Energy',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -810,16 +810,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_2pm_gen3_cover[sensor.test_name_total_energy-state]
+# name: test_shelly_2pm_gen3_cover[sensor.test_name_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Total energy',
+      'friendly_name': 'Test name Energy',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_total_energy',
+    'entity_id': 'sensor.test_name_energy',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2085,7 +2085,7 @@
     'state': '40.6',
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_total_energy-entry]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_energy-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2100,7 +2100,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_switch_0_total_energy',
+    'entity_id': 'sensor.test_name_switch_0_energy',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2118,7 +2118,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Total energy',
+    'original_name': 'Energy',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2128,16 +2128,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_total_energy-state]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_0_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Switch 0 Total energy',
+      'friendly_name': 'Test name Switch 0 Energy',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_switch_0_total_energy',
+    'entity_id': 'sensor.test_name_switch_0_energy',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2542,7 +2542,7 @@
     'state': '40.6',
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_total_energy-entry]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_energy-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2557,7 +2557,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_switch_1_total_energy',
+    'entity_id': 'sensor.test_name_switch_1_energy',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2575,7 +2575,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Total energy',
+    'original_name': 'Energy',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2585,16 +2585,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_total_energy-state]
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_switch_1_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Switch 1 Total energy',
+      'friendly_name': 'Test name Switch 1 Energy',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_switch_1_total_energy',
+    'entity_id': 'sensor.test_name_switch_1_energy',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -3347,7 +3347,7 @@
     'state': '0.99',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_a_total_active_energy-entry]
+# name: test_shelly_pro_3em[sensor.test_name_phase_a_energy-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3362,7 +3362,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_phase_a_total_active_energy',
+    'entity_id': 'sensor.test_name_phase_a_energy',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3380,7 +3380,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Total active energy',
+    'original_name': 'Energy',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3390,16 +3390,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_a_total_active_energy-state]
+# name: test_shelly_pro_3em[sensor.test_name_phase_a_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Phase A Total active energy',
+      'friendly_name': 'Test name Phase A Energy',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_phase_a_total_active_energy',
+    'entity_id': 'sensor.test_name_phase_a_energy',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3797,7 +3797,7 @@
     'state': '0.36',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_b_total_active_energy-entry]
+# name: test_shelly_pro_3em[sensor.test_name_phase_b_energy-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3812,7 +3812,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_phase_b_total_active_energy',
+    'entity_id': 'sensor.test_name_phase_b_energy',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3830,7 +3830,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Total active energy',
+    'original_name': 'Energy',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3840,16 +3840,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_b_total_active_energy-state]
+# name: test_shelly_pro_3em[sensor.test_name_phase_b_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Phase B Total active energy',
+      'friendly_name': 'Test name Phase B Energy',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_phase_b_total_active_energy',
+    'entity_id': 'sensor.test_name_phase_b_energy',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4247,7 +4247,7 @@
     'state': '0.72',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_c_total_active_energy-entry]
+# name: test_shelly_pro_3em[sensor.test_name_phase_c_energy-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -4262,7 +4262,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_phase_c_total_active_energy',
+    'entity_id': 'sensor.test_name_phase_c_energy',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4280,7 +4280,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Total active energy',
+    'original_name': 'Energy',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -4290,16 +4290,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_c_total_active_energy-state]
+# name: test_shelly_pro_3em[sensor.test_name_phase_c_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Phase C Total active energy',
+      'friendly_name': 'Test name Phase C Energy',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_phase_c_total_active_energy',
+    'entity_id': 'sensor.test_name_phase_c_energy',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4586,7 +4586,7 @@
     'state': '46.3',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_total_active_energy-entry]
+# name: test_shelly_pro_3em[sensor.test_name_energy-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -4601,7 +4601,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_total_active_energy',
+    'entity_id': 'sensor.test_name_energy',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4619,7 +4619,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Total active energy',
+    'original_name': 'Energy',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -4629,16 +4629,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_total_active_energy-state]
+# name: test_shelly_pro_3em[sensor.test_name_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name Total active energy',
+      'friendly_name': 'Test name Energy',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_total_active_energy',
+    'entity_id': 'sensor.test_name_energy',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/shelly/snapshots/test_sensor.ambr
+++ b/tests/components/shelly/snapshots/test_sensor.ambr
@@ -457,7 +457,7 @@
     'state': '98.76543',
   })
 # ---
-# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_total_energy-entry]
+# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_energy-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -472,7 +472,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_test_switch_0_total_energy',
+    'entity_id': 'sensor.test_name_test_switch_0_energy',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -490,7 +490,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'test switch_0 total energy',
+    'original_name': 'test switch_0 energy',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -500,16 +500,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_total_energy-state]
+# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name test switch_0 total energy',
+      'friendly_name': 'Test name test switch_0 energy',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_test_switch_0_total_energy',
+    'entity_id': 'sensor.test_name_test_switch_0_energy',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/shelly/snapshots/test_sensor.ambr
+++ b/tests/components/shelly/snapshots/test_sensor.ambr
@@ -339,7 +339,7 @@
     'state': '5.0',
   })
 # ---
-# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_consumed_energy-entry]
+# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_energy_consumed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -354,7 +354,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_test_switch_0_consumed_energy',
+    'entity_id': 'sensor.test_name_test_switch_0_energy_consumed',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -372,7 +372,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'test switch_0 consumed energy',
+    'original_name': 'test switch_0 energy consumed',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -382,16 +382,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_consumed_energy-state]
+# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_energy_consumed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name test switch_0 consumed energy',
+      'friendly_name': 'Test name test switch_0 energy consumed',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_test_switch_0_consumed_energy',
+    'entity_id': 'sensor.test_name_test_switch_0_energy_consumed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/shelly/snapshots/test_sensor.ambr
+++ b/tests/components/shelly/snapshots/test_sensor.ambr
@@ -398,7 +398,7 @@
     'state': '1135.80246',
   })
 # ---
-# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_returned_energy-entry]
+# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_energy_returned-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -413,7 +413,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_test_switch_0_returned_energy',
+    'entity_id': 'sensor.test_name_test_switch_0_energy_returned',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -431,7 +431,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'test switch_0 returned energy',
+    'original_name': 'test switch_0 energy returned',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -441,16 +441,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_returned_energy-state]
+# name: test_rpc_switch_energy_sensors[sensor.test_name_test_switch_0_energy_returned-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Test name test switch_0 returned energy',
+      'friendly_name': 'Test name test switch_0 energy returned',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_test_switch_0_returned_energy',
+    'entity_id': 'sensor.test_name_test_switch_0_energy_returned',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1649,7 +1649,7 @@ async def test_rpc_switch_energy_sensors(
     monkeypatch.setattr(mock_rpc_device, "status", status)
     await init_integration(hass, 3)
 
-    for entity in ("total_energy", "returned_energy", "consumed_energy"):
+    for entity in ("energy", "returned_energy", "consumed_energy"):
         entity_id = f"{SENSOR_DOMAIN}.test_name_test_switch_0_{entity}"
 
         state = hass.states.get(entity_id)
@@ -1899,14 +1899,14 @@ async def test_rpc_pm1_consumed_energy_sensor(
     monkeypatch.setattr(mock_rpc_device, "status", status)
     await init_integration(hass, 3)
 
-    assert (state := hass.states.get(f"{SENSOR_DOMAIN}.test_name_total_energy"))
+    assert (state := hass.states.get(f"{SENSOR_DOMAIN}.test_name_energy"))
     assert state.state == "3.0"
 
     assert (state := hass.states.get(f"{SENSOR_DOMAIN}.test_name_returned_energy"))
     assert state.state == "1.0"
 
     entity_id = f"{SENSOR_DOMAIN}.test_name_consumed_energy"
-    # consumed energy = total energy - returned energy
+    # consumed energy = energy - returned energy
     assert (state := hass.states.get(entity_id))
     assert state.state == "2.0"
 

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -707,27 +707,19 @@ async def test_rpc_energy_meter_1_sensors(
     assert (entry := entity_registry.async_get("sensor.test_name_energy_meter_1_power"))
     assert entry.unique_id == "123456789ABC-em1:1-power_em1"
 
-    assert (
-        state := hass.states.get("sensor.test_name_energy_meter_0_total_active_energy")
-    )
+    assert (state := hass.states.get("sensor.test_name_energy_meter_0_energy"))
     assert state.state == "123.4564"
 
     assert (
-        entry := entity_registry.async_get(
-            "sensor.test_name_energy_meter_0_total_active_energy"
-        )
+        entry := entity_registry.async_get("sensor.test_name_energy_meter_0_energy")
     )
     assert entry.unique_id == "123456789ABC-em1data:0-total_act_energy"
 
-    assert (
-        state := hass.states.get("sensor.test_name_energy_meter_1_total_active_energy")
-    )
+    assert (state := hass.states.get("sensor.test_name_energy_meter_1_energy"))
     assert state.state == "987.6543"
 
     assert (
-        entry := entity_registry.async_get(
-            "sensor.test_name_energy_meter_1_total_active_energy"
-        )
+        entry := entity_registry.async_get("sensor.test_name_energy_meter_1_energy")
     )
     assert entry.unique_id == "123456789ABC-em1data:1-total_act_energy"
 

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1641,7 +1641,7 @@ async def test_rpc_switch_energy_sensors(
     monkeypatch.setattr(mock_rpc_device, "status", status)
     await init_integration(hass, 3)
 
-    for entity in ("energy", "energy_returned", "consumed_energy"):
+    for entity in ("energy", "energy_returned", "energy_consumed"):
         entity_id = f"{SENSOR_DOMAIN}.test_name_test_switch_0_{entity}"
 
         state = hass.states.get(entity_id)
@@ -1671,7 +1671,7 @@ async def test_rpc_switch_no_energy_returned_sensor(
     await init_integration(hass, 3)
 
     assert hass.states.get("sensor.test_name_test_switch_0_energy_returned") is None
-    assert hass.states.get("sensor.test_name_test_switch_0_consumed_energy") is None
+    assert hass.states.get("sensor.test_name_test_switch_0_energy_consumed") is None
 
 
 async def test_rpc_shelly_ev_sensors(
@@ -1869,7 +1869,7 @@ async def test_rpc_presencezone_component(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_rpc_pm1_consumed_energy_sensor(
+async def test_rpc_pm1_energy_consumed_sensor(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
     entity_registry: EntityRegistry,
@@ -1897,8 +1897,8 @@ async def test_rpc_pm1_consumed_energy_sensor(
     assert (state := hass.states.get(f"{SENSOR_DOMAIN}.test_name_energy_returned"))
     assert state.state == "1.0"
 
-    entity_id = f"{SENSOR_DOMAIN}.test_name_consumed_energy"
-    # consumed energy = energy - energy returned
+    entity_id = f"{SENSOR_DOMAIN}.test_name_energy_consumed"
+    # energy consumed = energy - energy returned
     assert (state := hass.states.get(entity_id))
     assert state.state == "2.0"
 
@@ -1908,14 +1908,14 @@ async def test_rpc_pm1_consumed_energy_sensor(
 
 @pytest.mark.parametrize(("key"), ["aenergy", "ret_aenergy"])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_rpc_pm1_consumed_energy_sensor_non_float_value(
+async def test_rpc_pm1_energy_consumed_sensor_non_float_value(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
     key: str,
 ) -> None:
     """Test energy sensors for switch component."""
-    entity_id = f"{SENSOR_DOMAIN}.test_name_consumed_energy"
+    entity_id = f"{SENSOR_DOMAIN}.test_name_energy_consumed"
     status = {
         "sys": {},
         "pm1:0": {

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1641,7 +1641,7 @@ async def test_rpc_switch_energy_sensors(
     monkeypatch.setattr(mock_rpc_device, "status", status)
     await init_integration(hass, 3)
 
-    for entity in ("energy", "returned_energy", "consumed_energy"):
+    for entity in ("energy", "energy_returned", "consumed_energy"):
         entity_id = f"{SENSOR_DOMAIN}.test_name_test_switch_0_{entity}"
 
         state = hass.states.get(entity_id)
@@ -1652,12 +1652,12 @@ async def test_rpc_switch_energy_sensors(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_rpc_switch_no_returned_energy_sensor(
+async def test_rpc_switch_no_energy_returned_sensor(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test switch component without returned energy sensor."""
+    """Test switch component without energy returned sensor."""
     status = {
         "sys": {},
         "switch:0": {
@@ -1670,7 +1670,7 @@ async def test_rpc_switch_no_returned_energy_sensor(
     monkeypatch.setattr(mock_rpc_device, "status", status)
     await init_integration(hass, 3)
 
-    assert hass.states.get("sensor.test_name_test_switch_0_returned_energy") is None
+    assert hass.states.get("sensor.test_name_test_switch_0_energy_returned") is None
     assert hass.states.get("sensor.test_name_test_switch_0_consumed_energy") is None
 
 
@@ -1894,11 +1894,11 @@ async def test_rpc_pm1_consumed_energy_sensor(
     assert (state := hass.states.get(f"{SENSOR_DOMAIN}.test_name_energy"))
     assert state.state == "3.0"
 
-    assert (state := hass.states.get(f"{SENSOR_DOMAIN}.test_name_returned_energy"))
+    assert (state := hass.states.get(f"{SENSOR_DOMAIN}.test_name_energy_returned"))
     assert state.state == "1.0"
 
     entity_id = f"{SENSOR_DOMAIN}.test_name_consumed_energy"
-    # consumed energy = energy - returned energy
+    # consumed energy = energy - energy returned
     assert (state := hass.states.get(entity_id))
     assert state.state == "2.0"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up to https://github.com/home-assistant/core/pull/153053 from https://github.com/home-assistant/core/issues/152866#issuecomment-3368061216:
1) `Energy returned` vs `Returned energy` (aswell `Consumed energy`)
    * ~Up to a debate and not yet part of the draft~
    * First introduced for gen1 devices: https://github.com/home-assistant/core/blob/0f34f5139a074d29abd2a8f831fd86b61e6d5e27/homeassistant/components/shelly/sensor.py#L316
 2) `ret_aenergy` may be supported for rpc switches, but not all of them return it. This is even clearly stated by the use of the `removal_condition` therefore this proposal:
    1) ~Offers a solution in terms of the conditional existence of `Energy`/`Total Energy`, but it would add a new sensor with a new unique name and therefore would not carry the history with it... (possible breaking change, that's why it's just a draft for now).~
    2) BUT! Would like to argue that the prefix `Total` is not really needed and could have remained under the name `Energy` because that way it works for both contexts:
        * W/ `ret_aenergy`: A triad of `Energy`, `Energy returned`, `Energy consumed` is sufficiently descriptive
        * W/O `ret_aenergy`: Only `Energy` is present
    3) ~Or is there some way to conditionally name sensors?~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
