### PR TITLE
Synology DSM: Don't reinitialize API during configuration

### DIFF
--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -143,6 +143,7 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
         self.reauth_conf: Mapping[str, Any] = {}
         self.reauth_reason: str | None = None
         self.shares: list[SynoFileSharedFolder] | None = None
+        self.api: SynologyDSM | None = None
 
     def _show_form(
         self,
@@ -156,6 +157,7 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
 
         description_placeholders = {}
         data_schema = None
+        self.api = None
 
         if step_id == "link":
             user_input.update(self.discovered_conf)
@@ -194,14 +196,21 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
             else:
                 port = DEFAULT_PORT
 
-        session = async_get_clientsession(self.hass, verify_ssl)
-        api = SynologyDSM(
-            session, host, port, username, password, use_ssl, timeout=DEFAULT_TIMEOUT
-        )
+        if self.api is None:
+            session = async_get_clientsession(self.hass, verify_ssl)
+            self.api = SynologyDSM(
+                session,
+                host,
+                port,
+                username,
+                password,
+                use_ssl,
+                timeout=DEFAULT_TIMEOUT,
+            )
 
         errors = {}
         try:
-            serial = await _login_and_fetch_syno_info(api, otp_code)
+            serial = await _login_and_fetch_syno_info(self.api, otp_code)
         except SynologyDSMLogin2SARequiredException:
             return await self.async_step_2sa(user_input)
         except SynologyDSMLogin2SAFailedException:
@@ -221,10 +230,11 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
             errors["base"] = "missing_data"
 
         if errors:
+            self.api = None
             return self._show_form(step_id, user_input, errors)
 
         with suppress(*SYNOLOGY_CONNECTION_EXCEPTIONS):
-            self.shares = await api.file.get_shared_folders(only_writable=True)
+            self.shares = await self.api.file.get_shared_folders(only_writable=True)
 
         if self.shares and not backup_path:
             return await self.async_step_backup_share(user_input)
@@ -239,14 +249,14 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
             CONF_VERIFY_SSL: verify_ssl,
             CONF_USERNAME: username,
             CONF_PASSWORD: password,
-            CONF_MAC: api.network.macs,
+            CONF_MAC: self.api.network.macs,
         }
         config_options = {
             CONF_BACKUP_PATH: backup_path,
             CONF_BACKUP_SHARE: backup_share,
         }
         if otp_code:
-            config_data[CONF_DEVICE_TOKEN] = api.device_token
+            config_data[CONF_DEVICE_TOKEN] = self.api.device_token
         if user_input.get(CONF_DISKS):
             config_data[CONF_DISKS] = user_input[CONF_DISKS]
         if user_input.get(CONF_VOLUMES):

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -252,9 +252,7 @@ async def test_user_2sa(
     assert result["step_id"] == "2sa"
 
     # Failed the first time because was too slow to enter the code
-    service_2sa.return_value.login = Mock(
-        side_effect=SynologyDSMLogin2SAFailedException
-    )
+    service_2sa.login = AsyncMock(side_effect=SynologyDSMLogin2SAFailedException)
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_OTP_CODE: "000000"}
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Avoid reinitializing the Synology DSM API during configuration, as this loses the device token needed to reestablish login session before HA persists it.

This seems to be a regression introduced by PR #135227 when adding an extra step to the configuration flow to get backup location from the user.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #151423
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
