### PR TITLE
Refactor: fixed issue S5655 in wemo coordinator.py

### DIFF
--- a/homeassistant/components/wemo/coordinator.py
+++ b/homeassistant/components/wemo/coordinator.py
@@ -193,7 +193,9 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
         _LOGGER.debug(
             "async_set_options old(%s) new(%s)", repr(self.options), repr(options)
         )
-        for field in fields(options):
+        # Use the dataclass *type* here so static type checkers (mypy/pyright)
+        # know we are iterating over the dataclass fields.
+        for field in fields(Options):
             new_value = getattr(options, field.name)
             if self.options is None or getattr(self.options, field.name) != new_value:
                 # The value changed, call the _async_set_* method for the option.


### PR DESCRIPTION
## Breaking change
None

## Proposed change
This pull request fixes SonarCloud issue S5655 in the homeassistant/components/wemo/coordinator.py file.  
The issue was related to using a non-literal argument type, and this refactor updates it to a more appropriate literal type as suggested by SonarCloud.  

This change improves code quality, readability, and maintainability without affecting the existing functionality of the Wemo integration.  
No functional or logic level modifications were made, only a small code quality refactor as part of the assignment requirement.

## Type of change
- [x] Code quality improvement (refactor)

## Additional information
- Issue fixed: S5655  
- File modified: `homeassistant/components/wemo/coordinator.py`  
- Tools used: VS Code, Git, SonarLint  
- Time spent: ~2.5 hours  
- Tasks done:
  - Analyzed the SonarLint-reported issue (S5655).  
  - Refactored the argument type to follow correct type-hinting guidelines.  
  - Verified the syntax and formatting using `ruff format homeassistant tests`.  
  - Created a new branch `refactor/S5655-change-argument-type-aj`.  
  - Committed and pushed the fix to the forked repository.  
  - Opened a draft pull request to the upstream assignment repository.

## Checklist
- [x] I understand the code I am submitting and can explain how it works.  
- [x] The code compiles and runs without syntax errors.  
- [ ] Local component tests were not executed due to environment limitations.  
- [x] I followed the project’s development and formatting guidelines.    
- [x] There is no commented-out or unused code.  

## Summary
This PR makes a small but valuable code quality improvement by resolving SonarCloud issue S5655 in the Wemo coordinator component.  
It aligns the argument type with best practices and helps maintain consistency across the codebase.  
No behavioral or functional changes were introduced.  

