### PR TITLE
vesync correct fan set modes

### DIFF
--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -212,17 +212,17 @@ class VeSyncFanHA(VeSyncBaseEntity, FanEntity):
             await self.device.turn_on()
 
         if preset_mode == VS_FAN_MODE_AUTO:
-            success = await self.device.auto_mode()
+            success = await self.device.set_auto_mode()
         elif preset_mode == VS_FAN_MODE_SLEEP:
-            success = await self.device.sleep_mode()
+            success = await self.device.set_sleep_mode()
         elif preset_mode == VS_FAN_MODE_ADVANCED_SLEEP:
-            success = await self.device.advanced_sleep_mode()
+            success = await self.device.set_advanced_sleep_mode()
         elif preset_mode == VS_FAN_MODE_PET:
-            success = await self.device.pet_mode()
+            success = await self.device.set_pet_mode()
         elif preset_mode == VS_FAN_MODE_TURBO:
-            success = await self.device.turbo_mode()
+            success = await self.device.set_turbo_mode()
         elif preset_mode == VS_FAN_MODE_NORMAL:
-            success = await self.device.normal_mode()
+            success = await self.device.set_normal_mode()
         if not success:
             raise HomeAssistantError(self.device.last_response.message)
 

--- a/tests/components/vesync/test_fan.py
+++ b/tests/components/vesync/test_fan.py
@@ -150,7 +150,7 @@ async def test_set_preset_mode(
     with (
         expectation,
         patch(
-            "pyvesync.devices.vesyncfan.VeSyncTowerFan.normal_mode",
+            "pyvesync.devices.vesyncfan.VeSyncTowerFan.set_normal_mode",
             return_value=api_response,
         ) as method_mock,
     ):

--- a/tests/components/vesync/test_fan.py
+++ b/tests/components/vesync/test_fan.py
@@ -138,19 +138,33 @@ async def test_turn_on_off_raises_error(
     ("api_response", "expectation"),
     [(True, NoException), (False, pytest.raises(HomeAssistantError))],
 )
+@pytest.mark.parametrize(
+    ("preset_mode", "patch_target"),
+    [
+        ("normal", "pyvesync.devices.vesyncfan.VeSyncTowerFan.set_normal_mode"),
+        (
+            "advancedSleep",
+            "pyvesync.devices.vesyncfan.VeSyncTowerFan.set_advanced_sleep_mode",
+        ),
+        ("turbo", "pyvesync.devices.vesyncfan.VeSyncTowerFan.set_turbo_mode"),
+        ("auto", "pyvesync.devices.vesyncfan.VeSyncTowerFan.set_auto_mode"),
+    ],
+)
 async def test_set_preset_mode(
     hass: HomeAssistant,
     fan_config_entry: MockConfigEntry,
     api_response: bool,
     expectation,
+    preset_mode: str,
+    patch_target: str,
 ) -> None:
     """Test handling of value in set_preset_mode method. Does this via turn on as it increases test coverage."""
 
-    # If VeSyncTowerFan.normal_mode fails (returns False), then HomeAssistantError is raised
+    # If VeSyncTowerFan.mode fails (returns False), then HomeAssistantError is raised
     with (
         expectation,
         patch(
-            "pyvesync.devices.vesyncfan.VeSyncTowerFan.set_normal_mode",
+            patch_target,
             return_value=api_response,
         ) as method_mock,
     ):
@@ -160,7 +174,7 @@ async def test_set_preset_mode(
             await hass.services.async_call(
                 FAN_DOMAIN,
                 SERVICE_TURN_ON,
-                {ATTR_ENTITY_ID: ENTITY_FAN, ATTR_PRESET_MODE: "normal"},
+                {ATTR_ENTITY_ID: ENTITY_FAN, ATTR_PRESET_MODE: preset_mode},
                 blocking=True,
             )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The old set methods are being removed.  The smart tower fan already has these removed so fails in the current builds releases.  I learned this via discord from a user.     This switches to the non deprecated methods. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
