### PR TITLE
Get Enphase_envoy collar grid status from admin_state_str rather then from grid_state

### DIFF
--- a/homeassistant/components/enphase_envoy/icons.json
+++ b/homeassistant/components/enphase_envoy/icons.json
@@ -38,6 +38,25 @@
       },
       "available_energy": {
         "default": "mdi:battery-50"
+      },
+      "grid_status": {
+        "default": "mdi:transmission-tower",
+        "state": {
+          "off_grid": "mdi:transmission-tower-off",
+          "synchronizing": "mdi:sync-alert"
+        }
+      },
+      "mid_state": {
+        "default": "mdi:electric-switch-closed",
+        "state": {
+          "open": "mdi:electric-switch"
+        }
+      },
+      "admin_state": {
+        "default": "mdi:transmission-tower",
+        "state": {
+          "off_grid": "mdi:transmission-tower-off"
+        }
       }
     },
     "switch": {

--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -819,7 +819,7 @@ COLLAR_SENSORS = (
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda collar: dt_util.utc_from_timestamp(collar.last_report_date),
     ),
-    # grid_status does not seem to change when off-grid, but rather amin_state_str
+    # grid_state does not seem to change when off-grid, but rather admin_state_str
     EnvoyCollarSensorEntityDescription(
         key="grid_state",
         translation_key="grid_status",

--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -813,10 +813,17 @@ COLLAR_SENSORS = (
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda collar: dt_util.utc_from_timestamp(collar.last_report_date),
     ),
+    # grid_status does not seem to change when off-grid, but rather amin_state_str
     EnvoyCollarSensorEntityDescription(
         key="grid_state",
         translation_key="grid_status",
         value_fn=lambda collar: collar.grid_state,
+    ),
+    # grid_status off-grid shows in admin_state rather than in grid_state
+    EnvoyCollarSensorEntityDescription(
+        key="admin_state_str",
+        translation_key="admin_state",
+        value_fn=lambda collar: collar.admin_state_str,
     ),
     EnvoyCollarSensorEntityDescription(
         key="mid_state",

--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -799,6 +799,12 @@ class EnvoyCollarSensorEntityDescription(SensorEntityDescription):
     value_fn: Callable[[EnvoyCollar], datetime.datetime | int | float | str]
 
 
+# translations don't accept uppercase
+ADMIN_STATE_MAP = {
+    "ENCMN_MDE_ON_GRID": "on_grid",
+    "ENCMN_MDE_OFF_GRID": "off_grid",
+}
+
 COLLAR_SENSORS = (
     EnvoyCollarSensorEntityDescription(
         key="temperature",
@@ -820,10 +826,13 @@ COLLAR_SENSORS = (
         value_fn=lambda collar: collar.grid_state,
     ),
     # grid_status off-grid shows in admin_state rather than in grid_state
+    # map values as translations don't accept uppercase which these are
     EnvoyCollarSensorEntityDescription(
         key="admin_state_str",
         translation_key="admin_state",
-        value_fn=lambda collar: collar.admin_state_str,
+        value_fn=lambda collar: ADMIN_STATE_MAP.get(
+            collar.admin_state_str, collar.admin_state_str
+        ),
     ),
     EnvoyCollarSensorEntityDescription(
         key="mid_state",

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -413,6 +413,9 @@
       },
       "mid_state": {
         "name": "MID state"
+      },
+      "admin_state": {
+        "name": "admin state"
       }
     },
     "switch": {

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -409,13 +409,26 @@
         "name": "Last report duration"
       },
       "grid_status": {
-        "name": "[%key:component::enphase_envoy::entity::binary_sensor::grid_status::name%]"
+        "name": "[%key:component::enphase_envoy::entity::binary_sensor::grid_status::name%]",
+        "state": {
+          "on_grid": "On grid",
+          "off_grid": "Off grid",
+          "synchronizing": "Synchronizing to grid"
+        }
       },
       "mid_state": {
-        "name": "MID state"
+        "name": "MID state",
+        "state": {
+          "open": "[%key:common::state::open%]",
+          "close": "[%key:common::state::closed%]"
+        }
       },
       "admin_state": {
-        "name": "admin state"
+        "name": "Admin state",
+        "state": {
+          "on_grid": "[%key:component::enphase_envoy::entity::sensor::grid_status::state::on_grid%]",
+          "off_grid": "[%key:component::enphase_envoy::entity::sensor::grid_status::state::off_grid%]"
+        }
       }
     },
     "switch": {

--- a/tests/components/enphase_envoy/snapshots/test_sensor.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_sensor.ambr
@@ -14021,7 +14021,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'admin state',
+    'original_name': 'Admin state',
     'platform': 'enphase_envoy',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -14034,14 +14034,14 @@
 # name: test_sensor[envoy_metered_batt_relay][sensor.collar_482520020939_admin_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Collar 482520020939 admin state',
+      'friendly_name': 'Collar 482520020939 Admin state',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.collar_482520020939_admin_state',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'ENCMN_MDE_ON_GRID',
+    'state': 'on_grid',
   })
 # ---
 # name: test_sensor[envoy_metered_batt_relay][sensor.collar_482520020939_grid_status-entry]

--- a/tests/components/enphase_envoy/snapshots/test_sensor.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_sensor.ambr
@@ -13996,6 +13996,54 @@
     'state': '2025-07-19T17:17:31+00:00',
   })
 # ---
+# name: test_sensor[envoy_metered_batt_relay][sensor.collar_482520020939_admin_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.collar_482520020939_admin_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'admin state',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'admin_state',
+    'unique_id': '482520020939_admin_state_str',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_metered_batt_relay][sensor.collar_482520020939_admin_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Collar 482520020939 admin state',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.collar_482520020939_admin_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'ENCMN_MDE_ON_GRID',
+  })
+# ---
 # name: test_sensor[envoy_metered_batt_relay][sensor.collar_482520020939_grid_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In HA version 2025.9 support for the Enphase Collar was added to the enphase_envoy integration. Collar support included display of grid_state as on/off grid. After some time of field use, it turns out the grid_state field of the envoy does not reflect the actual grid connection status, but rather the admin_state_str field of the Collar device does.

This PR repairs this issue with correctly displaying the grid connection status by using the admin_state_str field rather then the grid_state field. Grid_state is maintained for now until it is clear what state this field reflects.

Updated sensor code and test snapshot for changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41188
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
