### PR TITLE
Update LetPot integration quality scale to silver

### DIFF
--- a/homeassistant/components/letpot/manifest.json
+++ b/homeassistant/components/letpot/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["letpot"],
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["letpot==0.6.2"]
 }

--- a/homeassistant/components/letpot/quality_scale.yaml
+++ b/homeassistant/components/letpot/quality_scale.yaml
@@ -41,7 +41,10 @@ rules:
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: todo
+  log-when-unavailable:
+    status: done
+    comment: |
+      Logging handled by library when (un)available once (push) or coordinator (pull).
   parallel-updates: done
   reauthentication-flow: done
   test-coverage: done


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update the integration quality scale score for LetPot to silver, as I believe all requirements are met 🥳

This PR changes:

- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected - _Push: unavailable handled by library, which logs with info [once when unavailable](https://github.com/jpelgrom/python-letpot/blob/3ba1457a2e9048149bc03e0fcc9a9045b723ec00/letpot/deviceclient.py#L286) and [once when connection restored](https://github.com/jpelgrom/python-letpot/blob/3ba1457a2e9048149bc03e0fcc9a9045b723ec00/letpot/deviceclient.py#L256), matching HA guidelines. Pull: coordinator, integration raises `UpdateFailed` if unable to get data._

All silver checks:

- [x] `action-exceptions` - Service actions raise exceptions when encountering failures - _Actions are for entities only, which all use a [decorator](https://github.com/home-assistant/core/blob/9ac93920d8235edce74d00bf8a893ba98bf91725/homeassistant/components/letpot/entity.py#L44) for error handling._
- [x] `config-entry-unloading` - Support config entry unloading - _Push connection connects in [coordinator _async_setup](https://github.com/home-assistant/core/blob/9ac93920d8235edce74d00bf8a893ba98bf91725/homeassistant/components/letpot/coordinator.py#L58), disconnects in [init async_unload_entry.](https://github.com/home-assistant/core/blob/9ac93920d8235edce74d00bf8a893ba98bf91725/homeassistant/components/letpot/__init__.py#L100)_
- [ ] `docs-configuration-parameters` - The documentation describes all integration configuration options - _The integration does not have configuration options._
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters - _See [docs](https://github.com/home-assistant/home-assistant.io/blob/d01374e926307a2e36a86aa688f068ccb57a8755/source/_integrations/letpot.markdown?plain=1#L47-L55)_
- [x] `entity-unavailable` - Mark entity unavailable if appropriate - _Integration pulls [periodically](https://github.com/home-assistant/core/blob/9ac93920d8235edce74d00bf8a893ba98bf91725/homeassistant/components/letpot/coordinator.py#L46) to detect availability changes, raising `UpdateFailed` which also marks as (un)available automatically._
- [x] `integration-owner` - Has an integration owner - _👋_
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected - _Push: unavailable handled by library, which logs with info [once when unavailable](https://github.com/jpelgrom/python-letpot/blob/3ba1457a2e9048149bc03e0fcc9a9045b723ec00/letpot/deviceclient.py#L286) and [once when connection restored](https://github.com/jpelgrom/python-letpot/blob/3ba1457a2e9048149bc03e0fcc9a9045b723ec00/letpot/deviceclient.py#L256), matching HA guidelines. Pull: coordinator, integration raises `UpdateFailed` if unable to get data._
- [x] `parallel-updates` - Number of parallel updates is specified - _Either 0 or 1, listed at the top of each domain's file._
- [x] `reauthentication-flow` - Reauthentication needs to be available via the UI - _Reauth flow _available_ in case of [authentication](https://github.com/home-assistant/core/blob/9ac93920d8235edce74d00bf8a893ba98bf91725/homeassistant/components/letpot/__init__.py#L70) [failure](https://github.com/home-assistant/core/blob/9ac93920d8235edce74d00bf8a893ba98bf91725/homeassistant/components/letpot/__init__.py#L65)_
- [x] `test-coverage` - Above 95% test coverage for all integration modules - _It's at 100%_

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#41194
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
