### PR TITLE
Handle ESPHome discoveries with uninitialized Z-Wave antennas

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -1501,6 +1501,9 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         if not is_hassio(self.hass):
             return self.async_abort(reason="not_hassio")
 
+        if not discovery_info.zwave_home_id:
+            return self.async_abort(reason="no_home_id")
+
         if (
             discovery_info.zwave_home_id
             and (

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -22,8 +22,7 @@
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "reset_failed": "Failed to reset adapter.",
       "usb_ports_failed": "Failed to get USB devices.",
-      "not_hassio": "ESPHome discovery requires Home Assistant to configure the Z-Wave add-on.",
-      "no_home_id": "Home ID of discovered Z-Wave adapter is unknown."
+      "not_hassio": "ESPHome discovery requires Home Assistant to configure the Z-Wave add-on."
     },
     "error": {
       "addon_start_failed": "Failed to start the Z-Wave add-on. Check the configuration.",

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -22,7 +22,8 @@
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "reset_failed": "Failed to reset adapter.",
       "usb_ports_failed": "Failed to get USB devices.",
-      "not_hassio": "ESPHome discovery requires Home Assistant to configure the Z-Wave add-on."
+      "not_hassio": "ESPHome discovery requires Home Assistant to configure the Z-Wave add-on.",
+      "no_home_id": "Home ID of discovered Z-Wave adapter is unknown."
     },
     "error": {
       "addon_start_failed": "Failed to start the Z-Wave add-on. Check the configuration.",

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1524,6 +1524,24 @@ async def test_esphome_discovery_usb_same_home_id(
     }
 
 
+@pytest.mark.usefixtures("supervisor")
+async def test_esphome_discovery_no_home_id(hass: HomeAssistant) -> None:
+    """Test ESPHome discovery aborts when home ID is missing."""
+    discovery_info_no_home_id = ESPHomeServiceInfo(
+        name="mock-name",
+        zwave_home_id=None,
+        ip_address="192.168.1.100",
+        port=6053,
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ESPHOME},
+        data=discovery_info_no_home_id,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_home_id"
+
+
 @pytest.mark.usefixtures("supervisor", "addon_installed")
 async def test_discovery_addon_not_running(
     hass: HomeAssistant,

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -51,10 +51,16 @@ ADDON_DISCOVERY_INFO = {
     "port": 3001,
 }
 
-
 ESPHOME_DISCOVERY_INFO = ESPHomeServiceInfo(
     name="mock-name",
     zwave_home_id=1234,
+    ip_address="192.168.1.100",
+    port=6053,
+)
+
+ESPHOME_DISCOVERY_INFO_CLEAN = ESPHomeServiceInfo(
+    name="mock-name",
+    zwave_home_id=None,
     ip_address="192.168.1.100",
     port=6053,
 )
@@ -1167,31 +1173,22 @@ async def test_usb_discovery_migration_restore_driver_ready_timeout(
     assert "keep_old_devices" in entry.data
 
 
+@pytest.mark.parametrize(
+    "service_info", [ESPHOME_DISCOVERY_INFO, ESPHOME_DISCOVERY_INFO_CLEAN]
+)
 @pytest.mark.usefixtures("supervisor", "addon_not_installed", "addon_info")
 async def test_esphome_discovery_intent_custom(
     hass: HomeAssistant,
     install_addon: AsyncMock,
     set_addon_options: AsyncMock,
     start_addon: AsyncMock,
+    service_info: ESPHomeServiceInfo,
 ) -> None:
     """Test ESPHome discovery success path."""
-    # Make sure it works only on hassio
-    with patch(
-        "homeassistant.components.zwave_js.config_flow.is_hassio", return_value=False
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_ESPHOME},
-            data=ESPHOME_DISCOVERY_INFO,
-        )
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "not_hassio"
-
-    # Test working version
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ESPHOME},
-        data=ESPHOME_DISCOVERY_INFO,
+        data=service_info,
     )
 
     assert result["type"] is FlowResultType.MENU
@@ -1272,7 +1269,7 @@ async def test_esphome_discovery_intent_custom(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == TITLE
-    assert result["result"].unique_id == str(ESPHOME_DISCOVERY_INFO.zwave_home_id)
+    assert result["result"].unique_id == "1234"
     assert result["data"] == {
         "url": "ws://host1:3001",
         "usb_path": None,
@@ -1525,21 +1522,18 @@ async def test_esphome_discovery_usb_same_home_id(
 
 
 @pytest.mark.usefixtures("supervisor")
-async def test_esphome_discovery_no_home_id(hass: HomeAssistant) -> None:
-    """Test ESPHome discovery aborts when home ID is missing."""
-    discovery_info_no_home_id = ESPHomeServiceInfo(
-        name="mock-name",
-        zwave_home_id=None,
-        ip_address="192.168.1.100",
-        port=6053,
-    )
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_ESPHOME},
-        data=discovery_info_no_home_id,
-    )
+async def test_esphome_discovery_not_hassio(hass: HomeAssistant) -> None:
+    """Test ESPHome discovery aborts when not hassio."""
+    with patch(
+        "homeassistant.components.zwave_js.config_flow.is_hassio", return_value=False
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ESPHOME},
+            data=ESPHOME_DISCOVERY_INFO,
+        )
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "no_home_id"
+    assert result["reason"] == "not_hassio"
 
 
 @pytest.mark.usefixtures("supervisor", "addon_installed")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #153522 we switched to always set the Home ID. However, there are 2 cases where this is not the case: when a PoE adapter running ESPHome is not connected to ZWA-2 and when a Z-Wave antenna has never been used. With this PR, those 2 cases will now no longer cause duplicate discoveries once configured.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
