### PR TITLE
Fix Tuya cover position when only control is available

### DIFF
--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -301,8 +301,11 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             and (current_state := self.device.status.get(self._current_state))
             is not None
         ):
+            if current_state == "stop":
+                # If the cover is stopped, we can't know if it's open or closed
+                return None
             return self.entity_description.current_state_inverse is not (
-                current_state in (True, "fully_close")
+                current_state in (True, "close", "fully_close")
             )
 
         return None

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -300,10 +300,8 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             self._current_state is not None
             and (current_state := self.device.status.get(self._current_state))
             is not None
+            and current_state != "stop"
         ):
-            if current_state == "stop":
-                # If the cover is stopped, we can't know if it's open or closed
-                return None
             return self.entity_description.current_state_inverse is not (
                 current_state in (True, "close", "fully_close")
             )

--- a/tests/components/tuya/test_cover.py
+++ b/tests/components/tuya/test_cover.py
@@ -18,7 +18,13 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_CLOSED,
+    STATE_OPEN,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceNotSupported
 from homeassistant.helpers import entity_registry as er
@@ -311,3 +317,38 @@ async def test_clkg_wltqkykhni0papzj_action(
         mock_device.id,
         expected_commands,
     )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["cl_rD7uqAAgQOpSA2Rx"],
+)
+@pytest.mark.parametrize(
+    ("initial_control", "expected_state"),
+    [
+        ("open", STATE_OPEN),
+        ("stop", STATE_UNKNOWN),
+        ("close", STATE_CLOSED),
+    ],
+)
+@patch("homeassistant.components.tuya.PLATFORMS", [Platform.COVER])
+async def test_cl_rD7uqAAgQOpSA2Rx_state(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+    initial_control: str,
+    expected_state: str,
+) -> None:
+    """Test cover position for n3xgr5pdmpinictg device.
+
+    See https://github.com/home-assistant/core/issues/153537
+    """
+    entity_id = "cover.kit_blinds_curtain"
+    mock_device.status["control"] = initial_control
+
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    assert state.state == expected_state


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Before #152801, the state of the curtains was always `unknown`
However, the fix was incomplete and resulted in the state being always `open`

Before #152801, the mapping was:
- `open` => `unknown`
- `stop` => `unknown`
- `close` => `unknown`

After #152801, we ended up with:
- `open` => `open`
- `stop` => `open`
- `close` => `open`

With this fix, we have correct:
- `open` => `open`
- `stop` => `unknown`
- `close` => `close`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
