### PR TITLE
Shelly's power sensors naming paradigm standardization

### DIFF
--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -551,7 +551,7 @@ RPC_SENSORS: Final = {
     "a_act_power": RpcSensorDescription(
         key="em",
         sub_key="a_act_power",
-        name="Active power",
+        name="Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -561,7 +561,7 @@ RPC_SENSORS: Final = {
     "b_act_power": RpcSensorDescription(
         key="em",
         sub_key="b_act_power",
-        name="Active power",
+        name="Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -571,7 +571,7 @@ RPC_SENSORS: Final = {
     "c_act_power": RpcSensorDescription(
         key="em",
         sub_key="c_act_power",
-        name="Active power",
+        name="Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -581,7 +581,7 @@ RPC_SENSORS: Final = {
     "total_act_power": RpcSensorDescription(
         key="em",
         sub_key="total_act_power",
-        name="Total active power",
+        name="Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -1384,7 +1384,7 @@ RPC_SENSORS: Final = {
         native_unit_of_measurement="pulse",
         state_class=SensorStateClass.TOTAL,
         value=lambda status, _: status["total"],
-        removal_condition=lambda config, _status, key: (
+        removal_condition=lambda config, _, key: (
             config[key]["type"] != "count" or config[key]["enable"] is False
         ),
     ),
@@ -1424,7 +1424,7 @@ RPC_SENSORS: Final = {
     "text_generic": RpcSensorDescription(
         key="text",
         sub_key="value",
-        removal_condition=lambda config, _status, key: not is_view_for_platform(
+        removal_condition=lambda config, _, key: not is_view_for_platform(
             config, key, SENSOR_PLATFORM
         ),
         role="generic",
@@ -1432,7 +1432,7 @@ RPC_SENSORS: Final = {
     "number_generic": RpcSensorDescription(
         key="number",
         sub_key="value",
-        removal_condition=lambda config, _status, key: not is_view_for_platform(
+        removal_condition=lambda config, _, key: not is_view_for_platform(
             config, key, SENSOR_PLATFORM
         ),
         unit=get_virtual_component_unit,
@@ -1441,7 +1441,7 @@ RPC_SENSORS: Final = {
     "enum_generic": RpcSensorDescription(
         key="enum",
         sub_key="value",
-        removal_condition=lambda config, _status, key: not is_view_for_platform(
+        removal_condition=lambda config, _, key: not is_view_for_platform(
             config, key, SENSOR_PLATFORM
         ),
         options_fn=lambda config: config["options"],
@@ -1456,7 +1456,7 @@ RPC_SENSORS: Final = {
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        removal_condition=lambda config, _status, key: config[key].get("enable", False)
+        removal_condition=lambda config, _, key: config[key].get("enable", False)
         is False,
         entity_class=RpcBluTrvSensor,
     ),
@@ -1606,7 +1606,7 @@ RPC_SENSORS: Final = {
     "object_total_act_energy": RpcSensorDescription(
         key="object",
         sub_key="value",
-        name="Total Active Energy",
+        name="Energy",
         value=lambda status, _: float(status["total_act_energy"]),
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -1618,7 +1618,7 @@ RPC_SENSORS: Final = {
     "object_total_power": RpcSensorDescription(
         key="object",
         sub_key="value",
-        name="Total Power",
+        name="Power",
         value=lambda status, _: float(status["total_power"]),
         native_unit_of_measurement=UnitOfPower.WATT,
         suggested_unit_of_measurement=UnitOfPower.KILO_WATT,

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -627,7 +627,7 @@ RPC_SENSORS: Final = {
     "total_aprt_power": RpcSensorDescription(
         key="em",
         sub_key="total_aprt_power",
-        name="Total apparent power",
+        name="Apparent power",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
         device_class=SensorDeviceClass.APPARENT_POWER,
         state_class=SensorStateClass.MEASUREMENT,

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -4760,7 +4760,7 @@
     'state': '0.0',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_total_apparent_power-entry]
+# name: test_shelly_pro_3em[sensor.test_name_apparent_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -4775,7 +4775,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_total_apparent_power',
+    'entity_id': 'sensor.test_name_apparent_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4790,7 +4790,7 @@
     }),
     'original_device_class': <SensorDeviceClass.APPARENT_POWER: 'apparent_power'>,
     'original_icon': None,
-    'original_name': 'Total apparent power',
+    'original_name': 'Apparent power',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -4800,16 +4800,16 @@
     'unit_of_measurement': <UnitOfApparentPower.VOLT_AMPERE: 'VA'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_total_apparent_power-state]
+# name: test_shelly_pro_3em[sensor.test_name_apparent_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'apparent_power',
-      'friendly_name': 'Test name Total apparent power',
+      'friendly_name': 'Test name Apparent power',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfApparentPower.VOLT_AMPERE: 'VA'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_total_apparent_power',
+    'entity_id': 'sensor.test_name_apparent_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -3071,7 +3071,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_a_active_power-entry]
+# name: test_shelly_pro_3em[sensor.test_name_phase_a_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3086,7 +3086,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_phase_a_active_power',
+    'entity_id': 'sensor.test_name_phase_a_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3101,7 +3101,7 @@
     }),
     'original_device_class': <SensorDeviceClass.POWER: 'power'>,
     'original_icon': None,
-    'original_name': 'Active power',
+    'original_name': 'Power',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3111,16 +3111,16 @@
     'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_a_active_power-state]
+# name: test_shelly_pro_3em[sensor.test_name_phase_a_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'power',
-      'friendly_name': 'Test name Phase A Active power',
+      'friendly_name': 'Test name Phase A Power',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_phase_a_active_power',
+    'entity_id': 'sensor.test_name_phase_a_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3521,7 +3521,7 @@
     'state': '227.0',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_b_active_power-entry]
+# name: test_shelly_pro_3em[sensor.test_name_phase_b_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3536,7 +3536,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_phase_b_active_power',
+    'entity_id': 'sensor.test_name_phase_b_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3551,7 +3551,7 @@
     }),
     'original_device_class': <SensorDeviceClass.POWER: 'power'>,
     'original_icon': None,
-    'original_name': 'Active power',
+    'original_name': 'Power',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3561,16 +3561,16 @@
     'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_b_active_power-state]
+# name: test_shelly_pro_3em[sensor.test_name_phase_b_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'power',
-      'friendly_name': 'Test name Phase B Active power',
+      'friendly_name': 'Test name Phase B Power',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_phase_b_active_power',
+    'entity_id': 'sensor.test_name_phase_b_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3971,7 +3971,7 @@
     'state': '230.0',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_c_active_power-entry]
+# name: test_shelly_pro_3em[sensor.test_name_phase_c_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3986,7 +3986,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_phase_c_active_power',
+    'entity_id': 'sensor.test_name_phase_c_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4001,7 +4001,7 @@
     }),
     'original_device_class': <SensorDeviceClass.POWER: 'power'>,
     'original_icon': None,
-    'original_name': 'Active power',
+    'original_name': 'Power',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -4011,16 +4011,16 @@
     'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_phase_c_active_power-state]
+# name: test_shelly_pro_3em[sensor.test_name_phase_c_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'power',
-      'friendly_name': 'Test name Phase C Active power',
+      'friendly_name': 'Test name Phase C Power',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_phase_c_active_power',
+    'entity_id': 'sensor.test_name_phase_c_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4645,7 +4645,7 @@
     'state': '5415.41419',
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_total_active_power-entry]
+# name: test_shelly_pro_3em[sensor.test_name_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -4660,7 +4660,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.test_name_total_active_power',
+    'entity_id': 'sensor.test_name_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4675,7 +4675,7 @@
     }),
     'original_device_class': <SensorDeviceClass.POWER: 'power'>,
     'original_icon': None,
-    'original_name': 'Total active power',
+    'original_name': 'Power',
     'platform': 'shelly',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -4685,16 +4685,16 @@
     'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
   })
 # ---
-# name: test_shelly_pro_3em[sensor.test_name_total_active_power-state]
+# name: test_shelly_pro_3em[sensor.test_name_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'power',
-      'friendly_name': 'Test name Total active power',
+      'friendly_name': 'Test name Power',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_name_total_active_power',
+    'entity_id': 'sensor.test_name_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/shelly/test_devices.py
+++ b/tests/components/shelly/test_devices.py
@@ -347,7 +347,7 @@ async def test_shelly_pro_3em(
     config_entry = await init_integration(hass, gen=2, model=MODEL_PRO_EM3)
 
     # Main device
-    entity_id = "sensor.test_name_total_active_power"
+    entity_id = "sensor.test_name_power"
 
     state = hass.states.get(entity_id)
     assert state
@@ -360,7 +360,7 @@ async def test_shelly_pro_3em(
     assert device_entry.name == "Test name"
 
     # Phase A sub-device
-    entity_id = "sensor.test_name_phase_a_active_power"
+    entity_id = "sensor.test_name_phase_a_power"
 
     state = hass.states.get(entity_id)
     assert state
@@ -373,7 +373,7 @@ async def test_shelly_pro_3em(
     assert device_entry.name == "Test name Phase A"
 
     # Phase B sub-device
-    entity_id = "sensor.test_name_phase_b_active_power"
+    entity_id = "sensor.test_name_phase_b_power"
 
     state = hass.states.get(entity_id)
     assert state
@@ -386,7 +386,7 @@ async def test_shelly_pro_3em(
     assert device_entry.name == "Test name Phase B"
 
     # Phase C sub-device
-    entity_id = "sensor.test_name_phase_c_active_power"
+    entity_id = "sensor.test_name_phase_c_power"
 
     state = hass.states.get(entity_id)
     assert state
@@ -423,7 +423,7 @@ async def test_shelly_pro_3em_with_emeter_name(
     await init_integration(hass, gen=2, model=MODEL_PRO_EM3)
 
     # Main device
-    entity_id = "sensor.test_name_total_active_power"
+    entity_id = "sensor.test_name_power"
 
     state = hass.states.get(entity_id)
     assert state
@@ -436,7 +436,7 @@ async def test_shelly_pro_3em_with_emeter_name(
     assert device_entry.name == "Test name"
 
     # Phase A sub-device
-    entity_id = "sensor.test_name_phase_a_active_power"
+    entity_id = "sensor.test_name_phase_a_power"
 
     state = hass.states.get(entity_id)
     assert state
@@ -449,7 +449,7 @@ async def test_shelly_pro_3em_with_emeter_name(
     assert device_entry.name == "Test name Phase A"
 
     # Phase B sub-device
-    entity_id = "sensor.test_name_phase_b_active_power"
+    entity_id = "sensor.test_name_phase_b_power"
 
     state = hass.states.get(entity_id)
     assert state
@@ -462,7 +462,7 @@ async def test_shelly_pro_3em_with_emeter_name(
     assert device_entry.name == "Test name Phase B"
 
     # Phase C sub-device
-    entity_id = "sensor.test_name_phase_c_active_power"
+    entity_id = "sensor.test_name_phase_c_power"
 
     state = hass.states.get(entity_id)
     assert state


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up to https://github.com/home-assistant/core/pull/153729 from https://github.com/home-assistant/core/pull/153729#issuecomment-3369202129:
* Rename `Active power` to `Power`
* Rename `Total apparent power` to `Apparent power`
  *as separation into multiple devices already brings enough clarity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
