### PR TITLE
Fix spelling typo in Matter integration test

### DIFF
--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -211,7 +211,7 @@ async def test_node_diagnostics(
         network_type=NetworkType.WIFI,
         node_type=NodeType.END_DEVICE,
         network_name="SuperCoolWiFi",
-        ip_adresses=["192.168.1.1", "fe80::260:97ff:fe02:6ea5"],
+        ip_addresses=["192.168.1.1", "fe80::260:97ff:fe02:6ea5"],
         mac_address="00:11:22:33:44:55",
         available=True,
         active_fabrics=[MatterFabricData(2, 4939, 1, vendor_name="Nabu Casa")],


### PR DESCRIPTION
## Proposed change

Fixed a typo in the Matter integration test file where `ip_adresses` was incorrectly spelled instead of `ip_addresses` in the `NodeDiagnostics` mock object.

This aligns with the correct spelling used in the matter-server library and fixes inconsistency that would cause issues with the frontend implementation.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This change is needed for the corresponding frontend PR: home-assistant/frontend#27336
- The spelling was corrected from `ip_adresses` to `ip_addresses`

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io](https://www.home-assistant.io)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file](https://developers.home-assistant.io/docs/creating_integration_manifest/) has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] Untested files have been added to `.coveragerc`.

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected typo in Matter integration test parameter from `ip_adresses` to `ip_addresses`