### PR TITLE
Fix delay_on and auto_off with multiple triggers

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -349,7 +349,7 @@ class TriggerBinarySensorEntity(TriggerEntity, BinarySensorEntity, RestoreEntity
 
         # state without delay.
         if self._attr_is_on == state or delay is None:
-            self._set_state(state, remove_delay=False)
+            self._set_state(state)
             return
 
         if not isinstance(delay, timedelta):
@@ -365,13 +365,11 @@ class TriggerBinarySensorEntity(TriggerEntity, BinarySensorEntity, RestoreEntity
         self._last_delay_from = self._attr_is_on
         self._last_delay_to = state
         self._delay_cancel = async_call_later(
-            self.hass,
-            delay.total_seconds(),
-            partial(self._set_state, state, remove_delay=True),
+            self.hass, delay.total_seconds(), partial(self._set_state, state)
         )
 
     @callback
-    def _set_state(self, state, _=None, *, remove_delay: bool = False):
+    def _set_state(self, state, _=None):
         """Set up auto off."""
         self._attr_is_on = state
         self.async_write_ha_state()
@@ -398,7 +396,7 @@ class TriggerBinarySensorEntity(TriggerEntity, BinarySensorEntity, RestoreEntity
         auto_off_time = dt_util.utcnow() + auto_off_delay
         self._set_auto_off(auto_off_time)
 
-        if remove_delay and self._delay_cancel:
+        if self._delay_cancel:
             self._delay_cancel()
             self._delay_cancel = None
 

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -372,6 +372,7 @@ class TriggerBinarySensorEntity(TriggerEntity, BinarySensorEntity, RestoreEntity
     def _set_state(self, state, _=None):
         """Set up auto off."""
         self._attr_is_on = state
+        self._delay_cancel = None
         self.async_write_ha_state()
 
         if not state:
@@ -395,10 +396,6 @@ class TriggerBinarySensorEntity(TriggerEntity, BinarySensorEntity, RestoreEntity
 
         auto_off_time = dt_util.utcnow() + auto_off_delay
         self._set_auto_off(auto_off_time)
-
-        if self._delay_cancel:
-            self._delay_cancel()
-            self._delay_cancel = None
 
     def _set_auto_off(self, auto_off_time: datetime) -> None:
         @callback

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -349,7 +349,7 @@ class TriggerBinarySensorEntity(TriggerEntity, BinarySensorEntity, RestoreEntity
 
         # state without delay.
         if self._attr_is_on == state or delay is None:
-            self._set_state(state)
+            self._set_state(state, remove_delay=False)
             return
 
         if not isinstance(delay, timedelta):
@@ -365,11 +365,13 @@ class TriggerBinarySensorEntity(TriggerEntity, BinarySensorEntity, RestoreEntity
         self._last_delay_from = self._attr_is_on
         self._last_delay_to = state
         self._delay_cancel = async_call_later(
-            self.hass, delay.total_seconds(), partial(self._set_state, state, True)
+            self.hass,
+            delay.total_seconds(),
+            partial(self._set_state, state, remove_delay=True),
         )
 
     @callback
-    def _set_state(self, state, remove_delay: bool = False, _=None):
+    def _set_state(self, state, _=None, *, remove_delay: bool = False):
         """Set up auto off."""
         self._attr_is_on = state
         self.async_write_ha_state()

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -365,11 +365,11 @@ class TriggerBinarySensorEntity(TriggerEntity, BinarySensorEntity, RestoreEntity
         self._last_delay_from = self._attr_is_on
         self._last_delay_to = state
         self._delay_cancel = async_call_later(
-            self.hass, delay.total_seconds(), partial(self._set_state, state)
+            self.hass, delay.total_seconds(), partial(self._set_state, state, True)
         )
 
     @callback
-    def _set_state(self, state, _=None):
+    def _set_state(self, state, remove_delay: bool = False, _=None):
         """Set up auto off."""
         self._attr_is_on = state
         self.async_write_ha_state()
@@ -395,6 +395,10 @@ class TriggerBinarySensorEntity(TriggerEntity, BinarySensorEntity, RestoreEntity
 
         auto_off_time = dt_util.utcnow() + auto_off_delay
         self._set_auto_off(auto_off_time)
+
+        if remove_delay and self._delay_cancel:
+            self._delay_cancel()
+            self._delay_cancel = None
 
     def _set_auto_off(self, auto_off_time: datetime) -> None:
         @callback

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -1192,6 +1192,76 @@ async def test_template_with_trigger_templated_auto_off(
         (
             1,
             ConfigurationStyle.TRIGGER,
+            _BEER_TRIGGER_VALUE_TEMPLATE,
+            {
+                "device_class": "motion",
+                "delay_on": "00:00:02",
+                "auto_off": "00:00:01",
+            },
+        )
+    ],
+)
+@pytest.mark.usefixtures("setup_binary_sensor")
+async def test_template_trigger_delay_on_and_auto_off(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test binary sensor template with delay_on, auto_off, and multiple triggers."""
+    state = hass.states.get(TEST_ENTITY_ID)
+    assert state.state == STATE_UNKNOWN
+
+    context = Context()
+    hass.bus.async_fire("test_event", {"beer": 2}, context=context)
+    await hass.async_block_till_done()
+
+    # State should still be unknown
+    state = hass.states.get(TEST_ENTITY_ID)
+    assert state.state == STATE_UNKNOWN
+    last_state = STATE_UNKNOWN
+
+    for _ in range(5):
+        # Now wait and trigger again to test that the 2 second on_delay is not recreated
+        freezer.tick(timedelta(seconds=1))
+        hass.bus.async_fire("test_event", {"beer": 2}, context=context)
+        await hass.async_block_till_done()
+
+        state = hass.states.get(TEST_ENTITY_ID)
+        assert state.state == last_state
+
+        # Now wait for the on delay
+        freezer.tick(timedelta(seconds=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        state = hass.states.get(TEST_ENTITY_ID)
+        assert state.state == STATE_ON
+
+        # Now wait for the auto-off
+        freezer.tick(timedelta(seconds=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        state = hass.states.get(TEST_ENTITY_ID)
+        assert state.state == STATE_OFF
+
+        # Now wait to trigger again
+        freezer.tick(timedelta(seconds=1))
+        hass.bus.async_fire("test_event", {"beer": 2}, context=context)
+        await hass.async_block_till_done()
+
+        # State should still be off
+        state = hass.states.get(TEST_ENTITY_ID)
+        assert state.state == STATE_OFF
+
+        last_state = STATE_OFF
+
+
+@pytest.mark.parametrize(
+    ("count", "style", "state_template", "extra_config"),
+    [
+        (
+            1,
+            ConfigurationStyle.TRIGGER,
             "{{ True }}",
             {
                 "device_class": "motion",

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -1271,7 +1271,7 @@ async def test_template_trigger_delay_on_and_auto_off(
     ],
 )
 @pytest.mark.usefixtures("setup_binary_sensor")
-async def test_template_state_delay_on(
+async def test_template_multiple_states_delay_on(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes an issue when using delay_on and auto_off with multiple triggers.  Ultimately, the combination of the 2 in a trigger based configuration would only turn on twice and never turn on again until the system restarted.

Trigger based template entities need to de-bounce multiple triggers during the `delay_on` period so that the `delay_on` isn't re-created.  We also need to catch any proper state changes, like an `off` state change to cancel the `delay_on` if the off occurs before the delayed on.  Because of this, we had to add the following code in a previous PR:

```
        if (
            self._delay_cancel
            and delay
            and self._attr_is_on == self._last_delay_from
            and state == self._last_delay_to
        ):
            return
```

There is a specific scenario (exactly 2 delay ons) where everything in that condition is met and we abort the state change all together (the bug).  To get past this scenario, we ensure the `self._delay_cancel` is `None` when it's already been executed instead of leaving it populated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/153455
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
