### PR TITLE
Limit SimpliSafe websocket connection attempts during startup

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -100,8 +100,9 @@ ATTR_PIN_VALUE = "pin"
 ATTR_TIMESTAMP = "timestamp"
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
-DEFAULT_SOCKET_MIN_RETRY = 15
 
+WEBSOCKET_RECONNECT_RETRIES = 3
+WEBSOCKET_RETRY_DELAY = 2
 
 EVENT_SIMPLISAFE_EVENT = "SIMPLISAFE_EVENT"
 EVENT_SIMPLISAFE_NOTIFICATION = "SIMPLISAFE_NOTIFICATION"
@@ -419,6 +420,7 @@ class SimpliSafe:
         self._api = api
         self._hass = hass
         self._system_notifications: dict[int, set[SystemNotification]] = {}
+        self._websocket_reconnect_retries: int = 0
         self._websocket_reconnect_task: asyncio.Task | None = None
         self.entry = entry
         self.initial_event_to_use: dict[int, dict[str, Any]] = {}
@@ -469,6 +471,8 @@ class SimpliSafe:
         """Start a websocket reconnection loop."""
         assert self._api.websocket
 
+        self._websocket_reconnect_retries += 1
+
         try:
             await self._api.websocket.async_connect()
             await self._api.websocket.async_listen()
@@ -480,8 +484,18 @@ class SimpliSafe:
         except Exception as err:  # noqa: BLE001
             LOGGER.error("Unknown exception while connecting to websocket: %s", err)
 
-        LOGGER.debug("Reconnecting to websocket")
-        await self._async_cancel_websocket_loop()
+        if self._websocket_reconnect_retries >= WEBSOCKET_RECONNECT_RETRIES:
+            LOGGER.error("Max websocket connection retries exceeded")
+            return
+
+        delay = WEBSOCKET_RETRY_DELAY * (2 ** (self._websocket_reconnect_retries - 1))
+        LOGGER.info(
+            "Retrying websocket connection in %s seconds (attempt %s/%s)",
+            delay,
+            self._websocket_reconnect_retries,
+            WEBSOCKET_RECONNECT_RETRIES,
+        )
+        await asyncio.sleep(delay)
         self._websocket_reconnect_task = self._hass.async_create_task(
             self._async_start_websocket_loop()
         )

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -476,6 +476,7 @@ class SimpliSafe:
         try:
             await self._api.websocket.async_connect()
             await self._api.websocket.async_listen()
+            self._websocket_reconnect_retries = 0
         except asyncio.CancelledError:
             LOGGER.debug("Request to cancel websocket loop received")
             raise

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -476,7 +476,6 @@ class SimpliSafe:
         try:
             await self._api.websocket.async_connect()
             await self._api.websocket.async_listen()
-            self._websocket_reconnect_retries = 0
         except asyncio.CancelledError:
             LOGGER.debug("Request to cancel websocket loop received")
             raise
@@ -484,6 +483,8 @@ class SimpliSafe:
             LOGGER.error("Failed to connect to websocket: %s", err)
         except Exception as err:  # noqa: BLE001
             LOGGER.error("Unknown exception while connecting to websocket: %s", err)
+        else:
+            self._websocket_reconnect_retries = 0
 
         if self._websocket_reconnect_retries >= WEBSOCKET_RECONNECT_RETRIES:
             LOGGER.error("Max websocket connection retries exceeded")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It appears that SimpliSafe's websocket connection sometimes doesn't work; when that happens, we currently go into a rapid, never-ending reconnection loop (bad for them _and_ us). This PR adds max connection attempts + a retry backoff. If we don't end up reconnecting to the websocket, the core functionality (system arming/disarming, etc.) still functions via their REST API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/153608
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
