### PR TITLE
Avoid storing entities list in ONVIF binary_sensor and sensor

### DIFF
--- a/homeassistant/components/onvif/binary_sensor.py
+++ b/homeassistant/components/onvif/binary_sensor.py
@@ -42,8 +42,8 @@ async def async_setup_entry(
     ent_reg = er.async_get(hass)
     for entry in er.async_entries_for_config_entry(ent_reg, config_entry.entry_id):
         if entry.domain == "binary_sensor" and entry.unique_id not in uids:
-            entities.append(ONVIFBinarySensor(entry.unique_id, device, entry=entry))
             uids.add(entry.unique_id)
+            entities.append(ONVIFBinarySensor(entry.unique_id, device, entry=entry))
 
     async_add_entities(entities)
     uids_by_platform = device.events.get_uids_by_platform("binary_sensor")

--- a/homeassistant/components/onvif/sensor.py
+++ b/homeassistant/components/onvif/sensor.py
@@ -39,8 +39,8 @@ async def async_setup_entry(
     ent_reg = er.async_get(hass)
     for entry in er.async_entries_for_config_entry(ent_reg, config_entry.entry_id):
         if entry.domain == "sensor" and entry.unique_id not in uids:
-            entities.append(ONVIFSensor(entry.unique_id, device, entry=entry))
             uids.add(entry.unique_id)
+            entities.append(ONVIFSensor(entry.unique_id, device, entry=entry))
 
     async_add_entities(entities)
     uids_by_platform = device.events.get_uids_by_platform("sensor")

--- a/homeassistant/components/onvif/sensor.py
+++ b/homeassistant/components/onvif/sensor.py
@@ -30,37 +30,37 @@ async def async_setup_entry(
     events = device.events.get_platform("sensor")
     entity_names = build_event_entity_names(events)
 
-    entities = {
-        event.uid: ONVIFSensor(event.uid, device, name=entity_names[event.uid])
-        for event in events
-    }
+    uids = set()
+    entities = []
+    for event in events:
+        uids.add(event.uid)
+        entities.append(ONVIFSensor(event.uid, device, name=entity_names[event.uid]))
 
     ent_reg = er.async_get(hass)
     for entry in er.async_entries_for_config_entry(ent_reg, config_entry.entry_id):
-        if entry.domain == "sensor" and entry.unique_id not in entities:
-            entities[entry.unique_id] = ONVIFSensor(
-                entry.unique_id, device, entry=entry
-            )
+        if entry.domain == "sensor" and entry.unique_id not in uids:
+            entities.append(ONVIFSensor(entry.unique_id, device, entry=entry))
+            uids.add(entry.unique_id)
 
-    async_add_entities(entities.values())
+    async_add_entities(entities)
     uids_by_platform = device.events.get_uids_by_platform("sensor")
 
     @callback
     def async_check_entities() -> None:
         """Check if we have added an entity for the event."""
         nonlocal uids_by_platform
-        if not (missing := uids_by_platform.difference(entities)):
+        if not (missing := uids_by_platform.difference(uids)):
             return
 
         events = device.events.get_platform("sensor")
         entity_names = build_event_entity_names(events)
 
-        new_entities: dict[str, ONVIFSensor] = {
-            uid: ONVIFSensor(uid, device, name=entity_names[uid]) for uid in missing
-        }
+        new_entities = [
+            ONVIFSensor(uid, device, name=entity_names[uid]) for uid in missing
+        ]
         if new_entities:
-            entities.update(new_entities)
-            async_add_entities(new_entities.values())
+            uids.update(missing)
+            async_add_entities(new_entities)
 
     device.events.async_add_listener(async_check_entities)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This optimizes ONVIF binary_sensor and sensor by avoiding keeping the list of entities in memory when only their unique IDs are required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This was requested by @joostlek in https://github.com/home-assistant/core/pull/153505#discussion_r2406691209.

Note this isn't adding tests yet, but I have verified the changes manually.

- This PR fixes or closes issue:
- This PR is related to issue: https://github.com/home-assistant/core/pull/153505#discussion_r2406691209
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
