### PR TITLE
Optimize Enphase_Envoy CT sensor entity code

### DIFF
--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -399,330 +399,189 @@ class EnvoyCTSensorEntityDescription(SensorEntityDescription):
     cttype: str | None = None
 
 
-CT_NET_CONSUMPTION_SENSORS = (
-    EnvoyCTSensorEntityDescription(
-        key="lifetime_net_consumption",
-        translation_key="lifetime_net_consumption",
-        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        device_class=SensorDeviceClass.ENERGY,
-        suggested_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
-        suggested_display_precision=3,
-        value_fn=attrgetter("energy_delivered"),
-        on_phase=None,
-        cttype=CtType.NET_CONSUMPTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="lifetime_net_production",
-        translation_key="lifetime_net_production",
-        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        device_class=SensorDeviceClass.ENERGY,
-        suggested_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
-        suggested_display_precision=3,
-        value_fn=attrgetter("energy_received"),
-        on_phase=None,
-        cttype=CtType.NET_CONSUMPTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="net_consumption",
-        translation_key="net_consumption",
-        native_unit_of_measurement=UnitOfPower.WATT,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.POWER,
-        suggested_unit_of_measurement=UnitOfPower.KILO_WATT,
-        suggested_display_precision=3,
-        value_fn=attrgetter("active_power"),
-        on_phase=None,
-        cttype=CtType.NET_CONSUMPTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="frequency",
-        translation_key="net_ct_frequency",
-        native_unit_of_measurement=UnitOfFrequency.HERTZ,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.FREQUENCY,
-        suggested_display_precision=1,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("frequency"),
-        on_phase=None,
-        cttype=CtType.NET_CONSUMPTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="voltage",
-        translation_key="net_ct_voltage",
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        suggested_display_precision=1,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("voltage"),
-        on_phase=None,
-        cttype=CtType.NET_CONSUMPTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="net_ct_current",
-        translation_key="net_ct_current",
-        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.CURRENT,
-        suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        suggested_display_precision=3,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("current"),
-        on_phase=None,
-        cttype=CtType.NET_CONSUMPTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="net_ct_powerfactor",
-        translation_key="net_ct_powerfactor",
-        device_class=SensorDeviceClass.POWER_FACTOR,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("power_factor"),
-        on_phase=None,
-        cttype=CtType.NET_CONSUMPTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="net_consumption_ct_metering_status",
-        translation_key="net_ct_metering_status",
-        device_class=SensorDeviceClass.ENUM,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        options=list(CtMeterStatus),
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("metering_status"),
-        on_phase=None,
-        cttype=CtType.NET_CONSUMPTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="net_consumption_ct_status_flags",
-        translation_key="net_ct_status_flags",
-        state_class=None,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
-        value_fn=lambda ct: 0 if ct.status_flags is None else len(ct.status_flags),
-        on_phase=None,
-        cttype=CtType.NET_CONSUMPTION,
-    ),
-)
-
-
-CT_NET_CONSUMPTION_PHASE_SENSORS = {
-    (on_phase := PHASENAMES[phase]): [
-        replace(
-            sensor,
-            key=f"{sensor.key}_l{phase + 1}",
-            translation_key=f"{sensor.translation_key}_phase",
-            entity_registry_enabled_default=False,
-            on_phase=on_phase,
-            translation_placeholders={"phase_name": f"l{phase + 1}"},
+# All ct types unified in common setup
+CT_SENSORS = (
+    [
+        EnvoyCTSensorEntityDescription(
+            key=key,
+            translation_key=key,
+            native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            device_class=SensorDeviceClass.ENERGY,
+            suggested_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
+            suggested_display_precision=3,
+            value_fn=attrgetter("energy_delivered"),
+            on_phase=None,
+            cttype=cttype,
         )
-        for sensor in list(CT_NET_CONSUMPTION_SENSORS)
+        for cttype, key in (
+            (CtType.NET_CONSUMPTION, "lifetime_net_consumption"),
+            # Production CT energy_delivered is not used
+            (CtType.STORAGE, "lifetime_battery_discharged"),
+        )
     ]
-    for phase in range(3)
-}
-
-CT_PRODUCTION_SENSORS = (
-    EnvoyCTSensorEntityDescription(
-        key="production_ct_frequency",
-        translation_key="production_ct_frequency",
-        native_unit_of_measurement=UnitOfFrequency.HERTZ,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.FREQUENCY,
-        suggested_display_precision=1,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("frequency"),
-        on_phase=None,
-        cttype=CtType.PRODUCTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="production_ct_voltage",
-        translation_key="production_ct_voltage",
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        suggested_display_precision=1,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("voltage"),
-        on_phase=None,
-        cttype=CtType.PRODUCTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="production_ct_current",
-        translation_key="production_ct_current",
-        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.CURRENT,
-        suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        suggested_display_precision=3,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("current"),
-        on_phase=None,
-        cttype=CtType.PRODUCTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="production_ct_powerfactor",
-        translation_key="production_ct_powerfactor",
-        device_class=SensorDeviceClass.POWER_FACTOR,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("power_factor"),
-        on_phase=None,
-        cttype=CtType.PRODUCTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="production_ct_metering_status",
-        translation_key="production_ct_metering_status",
-        device_class=SensorDeviceClass.ENUM,
-        options=list(CtMeterStatus),
-        entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("metering_status"),
-        on_phase=None,
-        cttype=CtType.PRODUCTION,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="production_ct_status_flags",
-        translation_key="production_ct_status_flags",
-        state_class=None,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
-        value_fn=lambda ct: 0 if ct.status_flags is None else len(ct.status_flags),
-        on_phase=None,
-        cttype=CtType.PRODUCTION,
-    ),
-)
-
-CT_PRODUCTION_PHASE_SENSORS = {
-    (on_phase := PHASENAMES[phase]): [
-        replace(
-            sensor,
-            key=f"{sensor.key}_l{phase + 1}",
-            translation_key=f"{sensor.translation_key}_phase",
-            entity_registry_enabled_default=False,
-            on_phase=on_phase,
-            translation_placeholders={"phase_name": f"l{phase + 1}"},
+    + [
+        EnvoyCTSensorEntityDescription(
+            key=key,
+            translation_key=key,
+            native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            device_class=SensorDeviceClass.ENERGY,
+            suggested_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
+            suggested_display_precision=3,
+            value_fn=attrgetter("energy_received"),
+            on_phase=None,
+            cttype=cttype,
         )
-        for sensor in list(CT_PRODUCTION_SENSORS)
+        for cttype, key in (
+            (CtType.NET_CONSUMPTION, "lifetime_net_production"),
+            # Production CT energy_received is not used
+            (CtType.STORAGE, "lifetime_battery_charged"),
+        )
     ]
-    for phase in range(3)
-}
-
-CT_STORAGE_SENSORS = (
-    EnvoyCTSensorEntityDescription(
-        key="lifetime_battery_discharged",
-        translation_key="lifetime_battery_discharged",
-        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        device_class=SensorDeviceClass.ENERGY,
-        suggested_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
-        suggested_display_precision=3,
-        value_fn=attrgetter("energy_delivered"),
-        on_phase=None,
-        cttype=CtType.STORAGE,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="lifetime_battery_charged",
-        translation_key="lifetime_battery_charged",
-        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        device_class=SensorDeviceClass.ENERGY,
-        suggested_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
-        suggested_display_precision=3,
-        value_fn=attrgetter("energy_received"),
-        on_phase=None,
-        cttype=CtType.STORAGE,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="battery_discharge",
-        translation_key="battery_discharge",
-        native_unit_of_measurement=UnitOfPower.WATT,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.POWER,
-        suggested_unit_of_measurement=UnitOfPower.KILO_WATT,
-        suggested_display_precision=3,
-        value_fn=attrgetter("active_power"),
-        on_phase=None,
-        cttype=CtType.STORAGE,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="storage_ct_frequency",
-        translation_key="storage_ct_frequency",
-        native_unit_of_measurement=UnitOfFrequency.HERTZ,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.FREQUENCY,
-        suggested_display_precision=1,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("frequency"),
-        on_phase=None,
-        cttype=CtType.STORAGE,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="storage_voltage",
-        translation_key="storage_ct_voltage",
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        suggested_display_precision=1,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("voltage"),
-        on_phase=None,
-        cttype=CtType.STORAGE,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="storage_ct_current",
-        translation_key="storage_ct_current",
-        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.CURRENT,
-        suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        suggested_display_precision=3,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("current"),
-        on_phase=None,
-        cttype=CtType.STORAGE,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="storage_ct_powerfactor",
-        translation_key="storage_ct_powerfactor",
-        device_class=SensorDeviceClass.POWER_FACTOR,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("power_factor"),
-        on_phase=None,
-        cttype=CtType.STORAGE,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="storage_ct_metering_status",
-        translation_key="storage_ct_metering_status",
-        device_class=SensorDeviceClass.ENUM,
-        options=list(CtMeterStatus),
-        entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
-        value_fn=attrgetter("metering_status"),
-        on_phase=None,
-        cttype=CtType.STORAGE,
-    ),
-    EnvoyCTSensorEntityDescription(
-        key="storage_ct_status_flags",
-        translation_key="storage_ct_status_flags",
-        state_class=None,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
-        value_fn=lambda ct: 0 if ct.status_flags is None else len(ct.status_flags),
-        on_phase=None,
-        cttype=CtType.STORAGE,
-    ),
+    + [
+        EnvoyCTSensorEntityDescription(
+            key=key,
+            translation_key=key,
+            native_unit_of_measurement=UnitOfPower.WATT,
+            state_class=SensorStateClass.MEASUREMENT,
+            device_class=SensorDeviceClass.POWER,
+            suggested_unit_of_measurement=UnitOfPower.KILO_WATT,
+            suggested_display_precision=3,
+            value_fn=attrgetter("active_power"),
+            on_phase=None,
+            cttype=cttype,
+        )
+        for cttype, key in (
+            (CtType.NET_CONSUMPTION, "net_consumption"),
+            # Production CT active_power is not used
+            (CtType.STORAGE, "battery_discharge"),
+        )
+    ]
+    + [
+        EnvoyCTSensorEntityDescription(
+            key=key,
+            translation_key=(translation_key if translation_key != "" else key),
+            native_unit_of_measurement=UnitOfFrequency.HERTZ,
+            state_class=SensorStateClass.MEASUREMENT,
+            device_class=SensorDeviceClass.FREQUENCY,
+            suggested_display_precision=1,
+            entity_registry_enabled_default=False,
+            value_fn=attrgetter("frequency"),
+            on_phase=None,
+            cttype=cttype,
+        )
+        for cttype, key, translation_key in (
+            (CtType.NET_CONSUMPTION, "frequency", "net_ct_frequency"),
+            (CtType.PRODUCTION, "production_ct_frequency", ""),
+            (CtType.STORAGE, "storage_ct_frequency", ""),
+        )
+    ]
+    + [
+        EnvoyCTSensorEntityDescription(
+            key=key,
+            translation_key=(translation_key if translation_key != "" else key),
+            native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+            state_class=SensorStateClass.MEASUREMENT,
+            device_class=SensorDeviceClass.VOLTAGE,
+            suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
+            suggested_display_precision=1,
+            entity_registry_enabled_default=False,
+            value_fn=attrgetter("voltage"),
+            on_phase=None,
+            cttype=cttype,
+        )
+        for cttype, key, translation_key in (
+            (CtType.NET_CONSUMPTION, "voltage", "net_ct_voltage"),
+            (CtType.PRODUCTION, "production_ct_voltage", ""),
+            (CtType.STORAGE, "storage_voltage", "storage_ct_voltage"),
+        )
+    ]
+    + [
+        EnvoyCTSensorEntityDescription(
+            key=key,
+            translation_key=key,
+            native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+            state_class=SensorStateClass.MEASUREMENT,
+            device_class=SensorDeviceClass.CURRENT,
+            suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+            suggested_display_precision=3,
+            entity_registry_enabled_default=False,
+            value_fn=attrgetter("current"),
+            on_phase=None,
+            cttype=cttype,
+        )
+        for cttype, key in (
+            (CtType.NET_CONSUMPTION, "net_ct_current"),
+            (CtType.PRODUCTION, "production_ct_current"),
+            (CtType.STORAGE, "storage_ct_current"),
+        )
+    ]
+    + [
+        EnvoyCTSensorEntityDescription(
+            key=key,
+            translation_key=key,
+            device_class=SensorDeviceClass.POWER_FACTOR,
+            state_class=SensorStateClass.MEASUREMENT,
+            suggested_display_precision=2,
+            entity_registry_enabled_default=False,
+            value_fn=attrgetter("power_factor"),
+            on_phase=None,
+            cttype=cttype,
+        )
+        for cttype, key in (
+            (CtType.NET_CONSUMPTION, "net_ct_powerfactor"),
+            (CtType.PRODUCTION, "production_ct_powerfactor"),
+            (CtType.STORAGE, "storage_ct_powerfactor"),
+        )
+    ]
+    + [
+        EnvoyCTSensorEntityDescription(
+            key=key,
+            translation_key=(translation_key if translation_key != "" else key),
+            device_class=SensorDeviceClass.ENUM,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            options=list(CtMeterStatus),
+            entity_registry_enabled_default=False,
+            value_fn=attrgetter("metering_status"),
+            on_phase=None,
+            cttype=cttype,
+        )
+        for cttype, key, translation_key in (
+            (
+                CtType.NET_CONSUMPTION,
+                "net_consumption_ct_metering_status",
+                "net_ct_metering_status",
+            ),
+            (CtType.PRODUCTION, "production_ct_metering_status", ""),
+            (CtType.STORAGE, "storage_ct_metering_status", ""),
+        )
+    ]
+    + [
+        EnvoyCTSensorEntityDescription(
+            key=key,
+            translation_key=(translation_key if translation_key != "" else key),
+            state_class=None,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
+            value_fn=lambda ct: 0 if ct.status_flags is None else len(ct.status_flags),
+            on_phase=None,
+            cttype=cttype,
+        )
+        for cttype, key, translation_key in (
+            (
+                CtType.NET_CONSUMPTION,
+                "net_consumption_ct_status_flags",
+                "net_ct_status_flags",
+            ),
+            (CtType.PRODUCTION, "production_ct_status_flags", ""),
+            (CtType.STORAGE, "storage_ct_status_flags", ""),
+        )
+    ]
 )
 
 
-CT_STORAGE_PHASE_SENSORS = {
+CT_PHASE_SENSORS = {
     (on_phase := PHASENAMES[phase]): [
         replace(
             sensor,
@@ -732,7 +591,7 @@ CT_STORAGE_PHASE_SENSORS = {
             on_phase=on_phase,
             translation_placeholders={"phase_name": f"l{phase + 1}"},
         )
-        for sensor in list(CT_STORAGE_SENSORS)
+        for sensor in list(CT_SENSORS)
     ]
     for phase in range(3)
 }
@@ -1044,24 +903,14 @@ async def async_setup_entry(
     if envoy_data.ctmeters:
         entities.extend(
             EnvoyCTEntity(coordinator, description)
-            for sensors in (
-                CT_NET_CONSUMPTION_SENSORS,
-                CT_PRODUCTION_SENSORS,
-                CT_STORAGE_SENSORS,
-            )
-            for description in sensors
+            for description in CT_SENSORS
             if description.cttype in envoy_data.ctmeters
         )
     # Add Current Transformer phase entities
     if ctmeters_phases := envoy_data.ctmeters_phases:
         entities.extend(
             EnvoyCTPhaseEntity(coordinator, description)
-            for sensors in (
-                CT_NET_CONSUMPTION_PHASE_SENSORS,
-                CT_PRODUCTION_PHASE_SENSORS,
-                CT_STORAGE_PHASE_SENSORS,
-            )
-            for phase, descriptions in sensors.items()
+            for phase, descriptions in CT_PHASE_SENSORS.items()
             for description in descriptions
             if (cttype := description.cttype) in ctmeters_phases
             and phase in ctmeters_phases[cttype]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The most recent version of the pyenphase library, 2.4.0 which is now used by this integration, offers current transformer (CT) data also in a dict of data keyed by CT type. The previous CT type specific data structures are still available, but internally just point to entries in the new dict.

In a previous PR (#153621) the data source for the CT was switched to use the new data dict. With that step now completed, the sensor CT entity code can be optimized to use common entity definition code for all CT types. Although optimization of the 3 existing CT only gains a 150 line code reduction, it serves as a preparation for a next PR. In that PR, 4 more CT types will be added and this optimization allows avoiding hundreds of lines of new code. 

This PR updates the sensor code for current transformer entity definition to use a common list of Sensor entity descriptions.

Sensor.py

- Replace CT_NET_CONSUMPTION_SENSORS, CT_PRODUCTION_SENSORS and CT_STORAGE_SENSORS tuples by a single CT_SENSOR list.
- Replace CT_NET_CONSUMPTION_PHASE_SENSORS, CT_PRODUCTION_PHASE_SENSORS and CT_STORAGE_PHASE_SENSORS tuples by a single CT_PHASE_SENSOR list sourced from the new CT_SENSOR list.

As this change is fully backward compatible and returning same entities and data as before, all tests and snapshots remain unchanged and pass as before.

This PR is a part of preparatory code optimizations for a future addition of more current transformer types.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
