### PR TITLE
Remove deprecated alarm panel constants

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Final
 
 from .generated.entity_platforms import EntityPlatforms
 from .helpers.deprecation import (
-    DeprecatedConstant,
     DeprecatedConstantEnum,
     EnumWithDeprecatedMembers,
     all_with_deprecated_constants,
@@ -315,60 +314,6 @@ STATE_UNAVAILABLE: Final = "unavailable"
 STATE_OK: Final = "ok"
 STATE_PROBLEM: Final = "problem"
 
-
-# #### ALARM CONTROL PANEL STATES ####
-# STATE_ALARM_* below are deprecated as of 2024.11
-# use the AlarmControlPanelState enum instead.
-_DEPRECATED_STATE_ALARM_DISARMED: Final = DeprecatedConstant(
-    "disarmed",
-    "AlarmControlPanelState.DISARMED",
-    "2025.11",
-)
-_DEPRECATED_STATE_ALARM_ARMED_HOME: Final = DeprecatedConstant(
-    "armed_home",
-    "AlarmControlPanelState.ARMED_HOME",
-    "2025.11",
-)
-_DEPRECATED_STATE_ALARM_ARMED_AWAY: Final = DeprecatedConstant(
-    "armed_away",
-    "AlarmControlPanelState.ARMED_AWAY",
-    "2025.11",
-)
-_DEPRECATED_STATE_ALARM_ARMED_NIGHT: Final = DeprecatedConstant(
-    "armed_night",
-    "AlarmControlPanelState.ARMED_NIGHT",
-    "2025.11",
-)
-_DEPRECATED_STATE_ALARM_ARMED_VACATION: Final = DeprecatedConstant(
-    "armed_vacation",
-    "AlarmControlPanelState.ARMED_VACATION",
-    "2025.11",
-)
-_DEPRECATED_STATE_ALARM_ARMED_CUSTOM_BYPASS: Final = DeprecatedConstant(
-    "armed_custom_bypass",
-    "AlarmControlPanelState.ARMED_CUSTOM_BYPASS",
-    "2025.11",
-)
-_DEPRECATED_STATE_ALARM_PENDING: Final = DeprecatedConstant(
-    "pending",
-    "AlarmControlPanelState.PENDING",
-    "2025.11",
-)
-_DEPRECATED_STATE_ALARM_ARMING: Final = DeprecatedConstant(
-    "arming",
-    "AlarmControlPanelState.ARMING",
-    "2025.11",
-)
-_DEPRECATED_STATE_ALARM_DISARMING: Final = DeprecatedConstant(
-    "disarming",
-    "AlarmControlPanelState.DISARMING",
-    "2025.11",
-)
-_DEPRECATED_STATE_ALARM_TRIGGERED: Final = DeprecatedConstant(
-    "triggered",
-    "AlarmControlPanelState.TRIGGERED",
-    "2025.11",
-)
 
 # #### STATE AND EVENT ATTRIBUTES ####
 # Attribution

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -8,13 +8,11 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant import const
-from homeassistant.components import alarm_control_panel
 
 from .common import (
     extract_stack_to_frame,
     help_test_all,
     import_and_test_deprecated_constant,
-    import_and_test_deprecated_constant_enum,
 )
 
 
@@ -49,30 +47,6 @@ def test_deprecated_constant_name_changes(
         f"{replacement.__class__.__name__}.{replacement.name}",
         replacement,
         breaks_in_version,
-    )
-
-
-def _create_tuples_alarm_states(
-    enum: type[Enum], constant_prefix: str, remove_in_version: str
-) -> list[tuple[Enum, str]]:
-    return [(enum_field, constant_prefix, remove_in_version) for enum_field in enum]
-
-
-@pytest.mark.parametrize(
-    ("enum", "constant_prefix", "remove_in_version"),
-    _create_tuples_alarm_states(
-        alarm_control_panel.AlarmControlPanelState, "STATE_ALARM_", "2025.11"
-    ),
-)
-def test_deprecated_constants_alarm(
-    caplog: pytest.LogCaptureFixture,
-    enum: Enum,
-    constant_prefix: str,
-    remove_in_version: str,
-) -> None:
-    """Test deprecated constants."""
-    import_and_test_deprecated_constant_enum(
-        caplog, const, enum, constant_prefix, remove_in_version
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated alarm constants

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
The alarm panel constants are listed as deprecated, with final date of 2025.11, which is the next HA release.

So I assume that these can these can be removed.
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
