### PR TITLE
Fix restore cover state for Comelit SimpleHome

### DIFF
--- a/homeassistant/components/comelit/cover.py
+++ b/homeassistant/components/comelit/cover.py
@@ -130,9 +130,9 @@ class ComelitCoverEntity(ComelitBridgeBaseEntity, RestoreEntity, CoverEntity):
         await super().async_added_to_hass()
 
         if (state := await self.async_get_last_state()) is not None:
-            if state.state in (STATE_CLOSED):
+            if state.state == STATE_CLOSED:
                 self._last_action = STATE_COVER.index(STATE_CLOSING)
-            if state.state in (STATE_OPEN):
+            if state.state == STATE_OPEN:
                 self._last_action = STATE_COVER.index(STATE_OPENING)
 
             self._attr_is_closed = state.state == STATE_CLOSED

--- a/homeassistant/components/comelit/cover.py
+++ b/homeassistant/components/comelit/cover.py
@@ -7,7 +7,14 @@ from typing import Any, cast
 from aiocomelit import ComelitSerialBridgeObject
 from aiocomelit.const import COVER, STATE_COVER, STATE_OFF, STATE_ON
 
-from homeassistant.components.cover import CoverDeviceClass, CoverEntity
+from homeassistant.components.cover import (
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
+    CoverDeviceClass,
+    CoverEntity,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -62,7 +69,6 @@ class ComelitCoverEntity(ComelitBridgeBaseEntity, RestoreEntity, CoverEntity):
         super().__init__(coordinator, device, config_entry_entry_id)
         # Device doesn't provide a status so we assume UNKNOWN at first startup
         self._last_action: int | None = None
-        self._last_state: str | None = None
 
     def _current_action(self, action: str) -> bool:
         """Return the current cover action."""
@@ -98,7 +104,6 @@ class ComelitCoverEntity(ComelitBridgeBaseEntity, RestoreEntity, CoverEntity):
     @bridge_api_call
     async def _cover_set_state(self, action: int, state: int) -> None:
         """Set desired cover state."""
-        self._last_state = self.state
         await self.coordinator.api.set_device_status(COVER, self._device.index, action)
         self.coordinator.data[COVER][self._device.index].status = state
         self.async_write_ha_state()
@@ -124,5 +129,10 @@ class ComelitCoverEntity(ComelitBridgeBaseEntity, RestoreEntity, CoverEntity):
 
         await super().async_added_to_hass()
 
-        if last_state := await self.async_get_last_state():
-            self._last_state = last_state.state
+        if (state := await self.async_get_last_state()) is not None:
+            if state.state in (STATE_CLOSED):
+                self._last_action = STATE_COVER.index(STATE_CLOSING)
+            if state.state in (STATE_OPEN):
+                self._last_action = STATE_COVER.index(STATE_OPENING)
+
+            self._attr_is_closed = state.state == STATE_CLOSED

--- a/tests/components/comelit/test_cover.py
+++ b/tests/components/comelit/test_cover.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 from aiocomelit.api import ComelitSerialBridgeObject
 from aiocomelit.const import COVER, WATT
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.comelit.const import SCAN_INTERVAL
@@ -17,14 +18,20 @@ from homeassistant.components.cover import (
     STATE_CLOSING,
     STATE_OPEN,
     STATE_OPENING,
+    CoverState,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    mock_restore_cache,
+    snapshot_platform,
+)
 
 ENTITY_ID = "cover.cover0"
 
@@ -162,37 +169,26 @@ async def test_cover_stop_if_stopped(
     assert state.state == STATE_UNKNOWN
 
 
+@pytest.mark.parametrize(
+    "cover_state",
+    [
+        CoverState.OPEN,
+        CoverState.CLOSED,
+    ],
+)
 async def test_cover_restore_state(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
     mock_serial_bridge: AsyncMock,
     mock_serial_bridge_config_entry: MockConfigEntry,
+    cover_state: CoverState,
 ) -> None:
     """Test cover restore state on reload."""
 
-    mock_serial_bridge.reset_mock()
+    mock_restore_cache(hass, [State(ENTITY_ID, cover_state)])
     await setup_integration(hass, mock_serial_bridge_config_entry)
 
     assert (state := hass.states.get(ENTITY_ID))
-    assert state.state == STATE_UNKNOWN
-
-    # Open cover
-    await hass.services.async_call(
-        COVER_DOMAIN,
-        SERVICE_OPEN_COVER,
-        {ATTR_ENTITY_ID: ENTITY_ID},
-        blocking=True,
-    )
-    mock_serial_bridge.set_device_status.assert_called()
-
-    assert (state := hass.states.get(ENTITY_ID))
-    assert state.state == STATE_OPENING
-
-    await hass.config_entries.async_reload(mock_serial_bridge_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert (state := hass.states.get(ENTITY_ID))
-    assert state.state == STATE_OPENING
+    assert state.state == cover_state
 
 
 async def test_cover_dynamic(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix restore cover state for Comelit SimpleHome

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
