### PR TITLE
Fix progress step recursion

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -649,7 +649,12 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
 
     @property
     def _progress_step_data(self) -> ProgressStepData[_FlowResultT]:
-        """Return progress step data, initializing if needed."""
+        """Return progress step data.
+        
+        A property is used instead of a simple attribute as derived classes
+        do not call super().__init__.
+        The property makes sure that the dict is initialized if needed.
+        """
         if not self.__progress_step_data:
             self.__progress_step_data = {
                 "tasks": {},

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -1078,6 +1078,10 @@ def progress_step[
                 # Clean up task reference
                 progress_step_data["tasks"].pop(step_id, None)
 
+            # If the result type is FlowResultType.SHOW_PROGRESS_DONE
+            # an earlier show progress step has already been run and stored its result.
+            # In this case we should not overwrite the result,
+            # but just use the stored one.
             if progress_task_result["type"] != FlowResultType.SHOW_PROGRESS_DONE:
                 progress_step_data["next_step_result"] = progress_task_result
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -1043,21 +1043,21 @@ def progress_step[
                 )
                 progress_step_data["tasks"][step_id] = progress_task
 
-                if not progress_task.done():
-                    # Handle description placeholders
-                    placeholders = None
-                    if description_placeholders is not None:
-                        if callable(description_placeholders):
-                            placeholders = description_placeholders(self)
-                        else:
-                            placeholders = description_placeholders
+            if not progress_task.done():
+                # Handle description placeholders
+                placeholders = None
+                if description_placeholders is not None:
+                    if callable(description_placeholders):
+                        placeholders = description_placeholders(self)
+                    else:
+                        placeholders = description_placeholders
 
-                    return self.async_show_progress(
-                        step_id=step_id,
-                        progress_action=step_id,
-                        progress_task=progress_task,
-                        description_placeholders=placeholders,
-                    )
+                return self.async_show_progress(
+                    step_id=step_id,
+                    progress_action=step_id,
+                    progress_task=progress_task,
+                    description_placeholders=placeholders,
+                )
 
             # Task is done or this is a subsequent call
             try:

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -811,7 +811,6 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
                     "abort_description_placeholders"
                 ],
             )
-        progress_step_data["next_step_result"] = None
         return next_step_result
 
     @callback

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -795,14 +795,15 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         without using async_show_progress_done.
         If no next step is set, abort the flow.
         """
-        if self._progress_step_data["next_step_result"] is None:
+        if (next_step_result := self._progress_step_data["next_step_result"]) is None:
             return self.async_abort(
                 reason=self._progress_step_data["abort_reason"],
                 description_placeholders=self._progress_step_data[
                     "abort_description_placeholders"
                 ],
             )
-        return self._progress_step_data["next_step_result"]
+        self._progress_step_data["next_step_result"] = None
+        return next_step_result
 
     @callback
     def async_external_step(
@@ -1051,7 +1052,7 @@ def progress_step[
 
             # Task is done or this is a subsequent call
             try:
-                self._progress_step_data["next_step_result"] = await progress_task
+                progress_task_result = await progress_task
             except AbortFlow as err:
                 self._progress_step_data["abort_reason"] = err.reason
                 self._progress_step_data["abort_description_placeholders"] = (
@@ -1063,6 +1064,9 @@ def progress_step[
             finally:
                 # Clean up task reference
                 self._progress_step_data["tasks"].pop(step_id, None)
+
+            if progress_task_result["type"] != FlowResultType.SHOW_PROGRESS_DONE:
+                self._progress_step_data["next_step_result"] = progress_task_result
 
             return self.async_show_progress_done(
                 next_step_id="_progress_step_progress_done"

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -650,7 +650,7 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
     @property
     def _progress_step_data(self) -> ProgressStepData[_FlowResultT]:
         """Return progress step data.
-        
+
         A property is used instead of a simple attribute as derived classes
         do not call super().__init__.
         The property makes sure that the dict is initialized if needed.

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -1016,20 +1016,20 @@ async def test_progress_step(
 
 @pytest.mark.parametrize(
     (
-        "task_init_side_effect",
-        "task_next_side_effect",
-        "flow_result_before_init",
-        "flow_result_after_init",
-        "flow_result_after_next",
-        "flow_init_events",
-        "flow_next_events",
-        "manager_call_after_init",
-        "manager_call_after_next",
-        "before_init_task_side_effect",
-        "before_next_task_side_effect",
+        "task_init_side_effect",  # side effect for initial step task
+        "task_next_side_effect",  # side effect for next step task
+        "flow_result_before_init",  # result before init task is done
+        "flow_result_after_init",  # result after init task is done
+        "flow_result_after_next",  # result after next task is done
+        "flow_init_events",  # number of events fired after init task is done
+        "flow_next_events",  # number of events fired after next task is done
+        "manager_call_after_init",  # lambda to continue the flow after init task
+        "manager_call_after_next",  # lambda to continue the flow after next task
+        "before_init_task_side_effect",  # function called before init event
+        "before_next_task_side_effect",  # function called before next event
     ),
     [
-        (
+        (  # both steps show progress and complete successfully
             None,
             None,
             data_entry_flow.FlowResultType.SHOW_PROGRESS,
@@ -1042,7 +1042,7 @@ async def test_progress_step(
             lambda received_event, init_task_event, next_task_event: None,
             lambda received_event, init_task_event, next_task_event: None,
         ),
-        (
+        (  # first step aborts
             data_entry_flow.AbortFlow("fail"),
             None,
             data_entry_flow.FlowResultType.SHOW_PROGRESS,
@@ -1055,7 +1055,7 @@ async def test_progress_step(
             lambda received_event, init_task_event, next_task_event: None,
             lambda received_event, init_task_event, next_task_event: None,
         ),
-        (
+        (  # first step shows progress, second step aborts
             None,
             data_entry_flow.AbortFlow("fail"),
             data_entry_flow.FlowResultType.SHOW_PROGRESS,
@@ -1068,7 +1068,7 @@ async def test_progress_step(
             lambda received_event, init_task_event, next_task_event: None,
             lambda received_event, init_task_event, next_task_event: None,
         ),
-        (
+        (  # first step shows progress and second step task is already done
             None,
             None,
             data_entry_flow.FlowResultType.SHOW_PROGRESS,
@@ -1083,7 +1083,7 @@ async def test_progress_step(
             next_task_event: next_task_event.set(),
             lambda received_event, init_task_event, next_task_event: None,
         ),
-        (
+        (  # both step tasks are already done and flow completes immediately
             None,
             None,
             data_entry_flow.FlowResultType.SHOW_PROGRESS_DONE,
@@ -1102,7 +1102,7 @@ async def test_progress_step(
             init_task_event,
             next_task_event: received_event.set(),
         ),
-        (
+        (  # first step task is already done, second step shows progress and completes
             None,
             None,
             data_entry_flow.FlowResultType.SHOW_PROGRESS_DONE,

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -1109,15 +1109,13 @@ async def test_progress_step(
             data_entry_flow.FlowResultType.SHOW_PROGRESS,
             data_entry_flow.FlowResultType.CREATE_ENTRY,
             0,
-            0,
+            1,
             lambda manager, result: manager.async_configure(result["flow_id"]),
             lambda manager, result: manager.async_configure(result["flow_id"]),
             lambda received_event,
             init_task_event,
             next_task_event: received_event.set() or init_task_event.set(),
-            lambda received_event,
-            init_task_event,
-            next_task_event: received_event.set(),
+            lambda received_event, init_task_event, next_task_event: None,
         ),
     ],
 )
@@ -1264,6 +1262,74 @@ async def test_progress_step_done_abort(
     assert len(manager.async_progress()) == 0
     assert len(manager.async_progress_by_handler("test")) == 0
     assert not events
+
+
+async def test_progress_step_result_reset(
+    hass: HomeAssistant,
+    manager: MockFlowManager,
+) -> None:
+    """Test progress_step decorator with reset result."""
+    manager.hass = hass
+    events = []
+    task_init_evt = asyncio.Event()
+    event_received_evt = asyncio.Event()
+
+    @callback
+    def capture_events(event: Event) -> None:
+        events.append(event)
+        event_received_evt.set()
+
+    @manager.mock_reg_handler("test")
+    class TestFlow(data_entry_flow.FlowHandler):
+        VERSION = 5
+
+        @data_entry_flow.progress_step()
+        async def async_step_init(self, user_input=None):
+            await task_init_evt.wait()
+
+            return await self.async_step_finish()
+
+        async def async_step_finish(self, user_input=None):
+            if user_input is None:
+                return self.async_show_form(step_id="finish")
+            return self.async_create_entry(data={})
+
+    hass.bus.async_listen(
+        data_entry_flow.EVENT_DATA_ENTRY_FLOW_PROGRESSED,
+        capture_events,
+    )
+
+    first_result = await manager.async_init("test")
+    assert first_result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert first_result["progress_action"] == "init"
+    assert len(manager.async_progress()) == 1
+    assert len(manager.async_progress_by_handler("test")) == 1
+    assert manager.async_get(first_result["flow_id"])["handler"] == "test"
+
+    # Set task one done and wait for event
+    task_init_evt.set()
+    await event_received_evt.wait()
+    event_received_evt.clear()
+    assert len(events) == 1
+    assert events[0].data == {
+        "handler": "test",
+        "flow_id": first_result["flow_id"],
+        "refresh": True,
+    }
+
+    # Frontend refreshes the flow
+    result = await manager.async_configure(first_result["flow_id"])
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "finish"
+
+    # Continue the flow again from the first result to test idempotency.
+    result = await manager.async_configure(first_result["flow_id"])
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "finish"
+
+    # Finish the flow
+    result = await manager.async_configure(first_result["flow_id"], {})
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_abort_flow_exception_step(manager: MockFlowManager) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- If two subsequent steps both used the progress step decorator the code would recurse infinitely eating memory.
- Fix that by checking if the task result is SHOW_PROGRESS_DONE and in that case do not store the result.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
