### PR TITLE
Do not auto-set up ZHA zeroconf discoveries during onboarding

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -744,6 +744,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
 
         # Without confirmation, discovery can automatically progress into parts of the
         # config flow logic that interacts with hardware.
+        # Ignore Zeroconf discoveries during onboarding, as they may be in use already.
         if user_input is not None or (
             not onboarding.async_is_onboarded(self.hass)
             and not zha_config_entries

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -745,7 +745,9 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
         # Without confirmation, discovery can automatically progress into parts of the
         # config flow logic that interacts with hardware.
         if user_input is not None or (
-            not onboarding.async_is_onboarded(self.hass) and not zha_config_entries
+            not onboarding.async_is_onboarded(self.hass)
+            and not zha_config_entries
+            and self.source != SOURCE_ZEROCONF
         ):
             # Probe the radio type if we don't have one yet
             if self._radio_mgr.radio_type is None:


### PR DESCRIPTION
## Proposed change

This PR changes ZHA's behavior to only automatically set up USB and hardware discovered coordinators (e.g. Yellow) when onboarding a new Home Assistant instance.

Zeroconf discovered network coordinators will no longer be set up without any confirmation before/during onboarding, instead requiring you to click on "Add" on the integrations page for the network coordinator you want to add.

### Keeping original intent

USB and hardware discoveries, for which this was originally added (included in https://github.com/home-assistant/core/pull/76795), are unaffected by this change and will still be set up without any confirmation before/during onboarding. So, setting up a new HA Yellow or HA Green with a USB coordinator attached will still automatically configure ZHA.


### Reasons behind this change

https://github.com/home-assistant/core/issues/153883 reported that before onboarding a new HA Blue, ZHA automatically discovered and configured a network coordinator that was already in use, wiping its settings in the progress, and breaking the main HA instance that was using this coordinator.

It's fine to keep the automatic setup for USB and hardware discoveries, as you have to make an explicit choice to plug in a USB coordinator before/during onboarding. With network coordinators, you do not have that choice, unless you want to fully disconnect your HA system before/during onboarding, but that's not ideal due to a lot of other reasons.

Since it's still easily possible to add network coordinators via the integrations page, we don't really add additional friction for first time users with network coordinators .



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/153883
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
