### PR TITLE
Adjust OTBR config entry name for ZBT-2

### DIFF
--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -75,6 +75,9 @@ async def _title(hass: HomeAssistant, discovery_info: HassioServiceInfo) -> str:
     if device and ("Connect_ZBT-1" in device or "SkyConnect" in device):
         return f"Home Assistant Connect ZBT-1 ({discovery_info.name})"
 
+    if device and "Nabu_Casa_ZBT-2" in device:
+        return f"Home Assistant Connect ZBT-2 ({discovery_info.name})"
+
     return discovery_info.name
 
 

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -461,6 +461,10 @@ async def test_hassio_discovery_flow_yellow(
             "/dev/serial/by-id/usb-Nabu_Casa_Home_Assistant_Connect_ZBT-1_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
             "Home Assistant Connect ZBT-1 (Silicon Labs Multiprotocol)",
         ),
+        (
+            "/dev/serial/by-id/usb-Nabu_Casa_ZBT-2_10B41DE58A94-if00",
+            "Home Assistant Connect ZBT-2 (Silicon Labs Multiprotocol)",
+        ),
     ],
 )
 @pytest.mark.usefixtures("get_border_agent_id")


### PR DESCRIPTION
## Proposed change

This adjusts the config entry for the OpenThread border router integration when setting up Home Assistant Connect ZBT-2 to include the product name in the title, instead of showing a generic "OpenThread Border Router" name. This is similar to the behavior for ZBT-1/SkyConnect and Yellow.

A test is also added with the device path of a ZBT-2 to verify the name is correctly included.

Do note that migrating Thread between adapters won't change the OTBR integration name. It can be manually renamed, or deleted and it should instantly be set up again with the new name.


<details><summary>Before/after screenshots (click to open)</summary>
<p>

Before:
<img width="585" height="229" alt="image" src="https://github.com/user-attachments/assets/7bab686a-7b43-4ca3-b6ad-75c6165278e7" />

After:
<img width="585" height="231" alt="image" src="https://github.com/user-attachments/assets/ec1dabd4-d616-416b-b6f2-5c25d56e1eb6" />

</p>
</details> 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
