### PR TITLE
Migrate Nederlandse Spoorwegen sensor to timestamp

### DIFF
--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
+    SensorDeviceClass,
     SensorEntity,
 )
 from homeassistant.config_entries import SOURCE_IMPORT
@@ -142,6 +143,7 @@ async def async_setup_entry(
 class NSDepartureSensor(SensorEntity):
     """Implementation of a NS Departure Sensor."""
 
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_attribution = "Data provided by NS"
     _attr_icon = "mdi:train"
 
@@ -161,7 +163,6 @@ class NSDepartureSensor(SensorEntity):
         self._via = via
         self._heading = heading
         self._time = time
-        self._state: str | None = None
         self._trips: list[Trip] | None = None
         self._first_trip: Trip | None = None
         self._next_trip: Trip | None = None
@@ -170,11 +171,6 @@ class NSDepartureSensor(SensorEntity):
     def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
-
-    @property
-    def native_value(self) -> str | None:
-        """Return the next departure time."""
-        return self._state
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
@@ -269,7 +265,7 @@ class NSDepartureSensor(SensorEntity):
             (datetime.now() + timedelta(minutes=30)).time() < self._time
             or (datetime.now() - timedelta(minutes=30)).time() > self._time
         ):
-            self._state = None
+            self._attr_native_value = None
             self._trips = None
             self._first_trip = None
             return
@@ -309,7 +305,7 @@ class NSDepartureSensor(SensorEntity):
                 if len(filtered_times) > 0:
                     sorted_times = sorted(filtered_times, key=lambda x: x[1])
                     self._first_trip = self._trips[sorted_times[0][0]]
-                    self._state = sorted_times[0][1].strftime("%H:%M")
+                    self._attr_native_value = sorted_times[0][1]
 
                     # Filter again to remove trains that leave at the exact same time.
                     filtered_times = [
@@ -326,7 +322,7 @@ class NSDepartureSensor(SensorEntity):
 
                 else:
                     self._first_trip = None
-                    self._state = None
+                    self._attr_native_value = None
 
         except (
             requests.exceptions.ConnectionError,

--- a/tests/components/nederlandse_spoorwegen/snapshots/test_sensor.ambr
+++ b/tests/components/nederlandse_spoorwegen/snapshots/test_sensor.ambr
@@ -13,6 +13,7 @@
       'departure_platform_planned': '4',
       'departure_time_actual': '16:35',
       'departure_time_planned': '16:34',
+      'device_class': 'timestamp',
       'friendly_name': 'To work',
       'going': True,
       'icon': 'mdi:train',
@@ -32,6 +33,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '16:35',
+    'state': '2025-09-15T14:35:00+00:00',
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Nederlandse Spoorwegen entity is now displayed as a timestamp entity, rather than a str. Please adapt your automations and scripts.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate Nederlandse Spoorwegen sensor to timestamp

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
