### PR TITLE
Fail creating config entry in reauth or reconfigure flows

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3214,13 +3214,11 @@ class ConfigFlow(ConfigEntryBaseFlow):
     ) -> ConfigFlowResult:
         """Finish config flow and create a config entry."""
         if self.source in {SOURCE_REAUTH, SOURCE_RECONFIGURE}:
-            report_usage(
-                f"creates a new entry in a '{self.source}' flow, "
-                "when it is expected to update an existing entry and abort",
-                core_behavior=ReportBehavior.LOG,
-                breaks_in_ha_version="2025.11",
-                integration_domain=self.handler,
+            raise HomeAssistantError(
+                "Creates a new entry in a '{self.source}' flow, "
+                "when it is expected to update an existing entry and abort"
             )
+
         result = super().async_create_entry(
             title=title,
             data=data,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3215,7 +3215,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         """Finish config flow and create a config entry."""
         if self.source in {SOURCE_REAUTH, SOURCE_RECONFIGURE}:
             raise HomeAssistantError(
-                "Creates a new entry in a '{self.source}' flow, "
+                f"Creates a new entry in a '{self.source}' flow, "
                 "when it is expected to update an existing entry and abort"
             )
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -8887,7 +8887,7 @@ async def test_state_cache_is_cleared_on_entry_disable(hass: HomeAssistant) -> N
     "source",
     [config_entries.SOURCE_REAUTH, config_entries.SOURCE_RECONFIGURE],
 )
-async def test_create_entry_reauth_reconfigure(
+async def test_create_entry_reauth_reconfigure_fails(
     hass: HomeAssistant,
     source: str,
     original_unique_id: str | None,
@@ -8937,25 +8937,9 @@ async def test_create_entry_reauth_reconfigure(
 
     with (
         mock_config_flow("test", TestFlow),
-        patch.object(frame, "_REPORTED_INTEGRATIONS", set()),
+        pytest.raises(HomeAssistantError),
     ):
-        result = await getattr(entry, f"start_{source}_flow")(hass)
-        await hass.async_block_till_done()
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-
-    entries = hass.config_entries.async_entries("test")
-    assert len(entries) == count
-    if count == 1:
-        # Show that the previous entry got binned and recreated
-        assert entries[0].entry_id != entry.entry_id
-
-    assert (
-        f"Detected that integration 'test' creates a new entry in a '{source}' flow, "
-        "when it is expected to update an existing entry and abort. This will stop "
-        "working in Home Assistant 2025.11, please create a bug report at "
-        "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+"
-        "label%3A%22integration%3A+test%22"
-    ) in caplog.text
+        await getattr(entry, f"start_{source}_flow")(hass)
 
 
 async def test_async_update_entry_unique_id_collision(


### PR DESCRIPTION
## Breaking change
Has been deprecated and will now fail to create a new config entry when the flow source is `reauth` or `reconfigure`

## Proposed change


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 