### PR TITLE
Remove deprecated cover state constants

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1472,10 +1472,10 @@ class AlexaModeController(AlexaCapability):
             # Return state instead of position when using ModeController.
             mode = self.entity.state
             if mode in (
-                cover.STATE_OPEN,
-                cover.STATE_OPENING,
-                cover.STATE_CLOSED,
-                cover.STATE_CLOSING,
+                cover.CoverState.OPEN,
+                cover.CoverState.OPENING,
+                cover.CoverState.CLOSED,
+                cover.CoverState.CLOSING,
                 STATE_UNKNOWN,
             ):
                 return f"{cover.ATTR_POSITION}.{mode}"
@@ -1594,11 +1594,11 @@ class AlexaModeController(AlexaCapability):
                 ["Position", AlexaGlobalCatalog.SETTING_OPENING], False
             )
             self._resource.add_mode(
-                f"{cover.ATTR_POSITION}.{cover.STATE_OPEN}",
+                f"{cover.ATTR_POSITION}.{cover.CoverState.OPEN}",
                 [AlexaGlobalCatalog.VALUE_OPEN],
             )
             self._resource.add_mode(
-                f"{cover.ATTR_POSITION}.{cover.STATE_CLOSED}",
+                f"{cover.ATTR_POSITION}.{cover.CoverState.CLOSED}",
                 [AlexaGlobalCatalog.VALUE_CLOSE],
             )
             self._resource.add_mode(
@@ -1651,22 +1651,22 @@ class AlexaModeController(AlexaCapability):
                 raise_labels.append(AlexaSemantics.ACTION_OPEN)
                 self._semantics.add_states_to_value(
                     [AlexaSemantics.STATES_CLOSED],
-                    f"{cover.ATTR_POSITION}.{cover.STATE_CLOSED}",
+                    f"{cover.ATTR_POSITION}.{cover.CoverState.CLOSED}",
                 )
                 self._semantics.add_states_to_value(
                     [AlexaSemantics.STATES_OPEN],
-                    f"{cover.ATTR_POSITION}.{cover.STATE_OPEN}",
+                    f"{cover.ATTR_POSITION}.{cover.CoverState.OPEN}",
                 )
 
             self._semantics.add_action_to_directive(
                 lower_labels,
                 "SetMode",
-                {"mode": f"{cover.ATTR_POSITION}.{cover.STATE_CLOSED}"},
+                {"mode": f"{cover.ATTR_POSITION}.{cover.CoverState.CLOSED}"},
             )
             self._semantics.add_action_to_directive(
                 raise_labels,
                 "SetMode",
-                {"mode": f"{cover.ATTR_POSITION}.{cover.STATE_OPEN}"},
+                {"mode": f"{cover.ATTR_POSITION}.{cover.CoverState.OPEN}"},
             )
 
             return self._semantics.serialize_semantics()

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1261,9 +1261,9 @@ async def async_api_set_mode(
     elif instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
         position = mode.split(".")[1]
 
-        if position == cover.STATE_CLOSED:
+        if position == cover.CoverState.CLOSED:
             service = cover.SERVICE_CLOSE_COVER
-        elif position == cover.STATE_OPEN:
+        elif position == cover.CoverState.OPEN:
             service = cover.SERVICE_OPEN_COVER
         elif position == "custom":
             service = cover.SERVICE_STOP_COVER

--- a/homeassistant/components/comelit/cover.py
+++ b/homeassistant/components/comelit/cover.py
@@ -7,14 +7,7 @@ from typing import Any, cast
 from aiocomelit import ComelitSerialBridgeObject
 from aiocomelit.const import COVER, STATE_COVER, STATE_OFF, STATE_ON
 
-from homeassistant.components.cover import (
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-    CoverDeviceClass,
-    CoverEntity,
-)
+from homeassistant.components.cover import CoverDeviceClass, CoverEntity, CoverState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -128,9 +121,9 @@ class ComelitCoverEntity(ComelitBridgeBaseEntity, RestoreEntity, CoverEntity):
         await super().async_added_to_hass()
 
         if (state := await self.async_get_last_state()) is not None:
-            if state.state == STATE_CLOSED:
-                self._last_action = STATE_COVER.index(STATE_CLOSING)
-            if state.state == STATE_OPEN:
-                self._last_action = STATE_COVER.index(STATE_OPENING)
+            if state.state == CoverState.CLOSED:
+                self._last_action = STATE_COVER.index(CoverState.CLOSING)
+            if state.state == CoverState.OPEN:
+                self._last_action = STATE_COVER.index(CoverState.OPENING)
 
-            self._attr_is_closed = state.state == STATE_CLOSED
+            self._attr_is_closed = state.state == CoverState.CLOSED

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -13,7 +13,7 @@ from propcache.api import cached_property
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (  # noqa: F401
+from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_CLOSE_COVER_TILT,
     SERVICE_OPEN_COVER,
@@ -24,19 +24,9 @@ from homeassistant.const import (  # noqa: F401
     SERVICE_STOP_COVER_TILT,
     SERVICE_TOGGLE,
     SERVICE_TOGGLE_COVER_TILT,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.deprecation import (
-    DeprecatedConstantEnum,
-    all_with_deprecated_constants,
-    check_if_deprecated_constant,
-    dir_with_deprecated_constants,
-)
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
@@ -61,15 +51,6 @@ class CoverState(StrEnum):
     CLOSING = "closing"
     OPEN = "open"
     OPENING = "opening"
-
-
-# STATE_* below are deprecated as of 2024.11
-# when imported from homeassistant.components.cover
-# use the CoverState enum instead.
-_DEPRECATED_STATE_CLOSED = DeprecatedConstantEnum(CoverState.CLOSED, "2025.11")
-_DEPRECATED_STATE_CLOSING = DeprecatedConstantEnum(CoverState.CLOSING, "2025.11")
-_DEPRECATED_STATE_OPEN = DeprecatedConstantEnum(CoverState.OPEN, "2025.11")
-_DEPRECATED_STATE_OPENING = DeprecatedConstantEnum(CoverState.OPENING, "2025.11")
 
 
 class CoverDeviceClass(StrEnum):
@@ -463,11 +444,3 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         return (
             fns["close"] if self._cover_is_last_toggle_direction_open else fns["open"]
         )
-
-
-# These can be removed if no deprecated constant are in this module anymore
-__getattr__ = ft.partial(check_if_deprecated_constant, module_globals=globals())
-__dir__ = ft.partial(
-    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
-)
-__all__ = all_with_deprecated_constants(globals())

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -182,10 +182,10 @@ FAN_SPEED_MAX_SPEED_COUNT = 5
 
 COVER_VALVE_STATES = {
     cover.DOMAIN: {
-        "closed": cover.STATE_CLOSED,
-        "closing": cover.STATE_CLOSING,
-        "open": cover.STATE_OPEN,
-        "opening": cover.STATE_OPENING,
+        "closed": cover.CoverState.CLOSED.value,
+        "closing": cover.CoverState.CLOSING.value,
+        "open": cover.CoverState.OPEN.value,
+        "opening": cover.CoverState.OPENING.value,
     },
     valve.DOMAIN: {
         "closed": valve.STATE_CLOSED,

--- a/tests/components/comelit/test_cover.py
+++ b/tests/components/comelit/test_cover.py
@@ -14,10 +14,6 @@ from homeassistant.components.cover import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
     CoverState,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
@@ -79,7 +75,7 @@ async def test_cover_open(
     mock_serial_bridge.set_device_status.assert_called()
 
     assert (state := hass.states.get(ENTITY_ID))
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     # Finish opening, update status
     mock_serial_bridge.get_all_devices.return_value[COVER] = {
@@ -102,7 +98,7 @@ async def test_cover_open(
     await hass.async_block_till_done()
 
     assert (state := hass.states.get(ENTITY_ID))
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
 
 async def test_cover_close(
@@ -128,7 +124,7 @@ async def test_cover_close(
     mock_serial_bridge.set_device_status.assert_called()
 
     assert (state := hass.states.get(ENTITY_ID))
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
     # Stop cover
     await hass.services.async_call(
@@ -140,7 +136,7 @@ async def test_cover_close(
     mock_serial_bridge.set_device_status.assert_called()
 
     assert (state := hass.states.get(ENTITY_ID))
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
 
 async def test_cover_stop_if_stopped(

--- a/tests/components/cover/test_init.py
+++ b/tests/components/cover/test_init.py
@@ -1,7 +1,5 @@
 """The tests for Cover."""
 
-from enum import Enum
-
 from homeassistant.components import cover
 from homeassistant.components.cover import CoverState
 from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM, SERVICE_TOGGLE
@@ -11,7 +9,7 @@ from homeassistant.setup import async_setup_component
 
 from .common import MockCover
 
-from tests.common import help_test_all, setup_test_component_platform
+from tests.common import setup_test_component_platform
 
 
 async def test_services(
@@ -144,12 +142,3 @@ def is_closed(hass: HomeAssistant, ent: Entity) -> bool:
 def is_closing(hass: HomeAssistant, ent: Entity) -> bool:
     """Return if the cover is closed based on the statemachine."""
     return hass.states.is_state(ent.entity_id, CoverState.CLOSING)
-
-
-def _create_tuples(enum: type[Enum], constant_prefix: str) -> list[tuple[Enum, str]]:
-    return [(enum_field, constant_prefix) for enum_field in enum]
-
-
-def test_all() -> None:
-    """Test module.__all__ is correctly set."""
-    help_test_all(cover)

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -665,10 +665,10 @@ async def test_startstop_lawn_mower(hass: HomeAssistant) -> None:
     [
         (
             cover.DOMAIN,
-            cover.STATE_OPEN,
-            cover.STATE_CLOSED,
-            cover.STATE_OPENING,
-            cover.STATE_CLOSING,
+            cover.CoverState.OPEN,
+            cover.CoverState.CLOSED,
+            cover.CoverState.OPENING,
+            cover.CoverState.CLOSING,
             CoverEntityFeature.STOP
             | CoverEntityFeature.OPEN
             | CoverEntityFeature.CLOSE,
@@ -789,10 +789,10 @@ async def test_startstop_cover_valve(
     [
         (
             cover.DOMAIN,
-            cover.STATE_OPEN,
-            cover.STATE_CLOSED,
-            cover.STATE_OPENING,
-            cover.STATE_CLOSING,
+            cover.CoverState.OPEN,
+            cover.CoverState.CLOSED,
+            cover.CoverState.OPENING,
+            cover.CoverState.CLOSING,
             CoverEntityFeature.STOP
             | CoverEntityFeature.OPEN
             | CoverEntityFeature.CLOSE,
@@ -3202,7 +3202,7 @@ async def test_openclose_cover_valve_unknown_state(
             cover.DOMAIN,
             cover.SERVICE_SET_COVER_POSITION,
             CoverEntityFeature.SET_POSITION,
-            cover.STATE_OPEN,
+            cover.CoverState.OPEN,
         ),
         (
             valve.DOMAIN,
@@ -3251,7 +3251,7 @@ async def test_openclose_cover_valve_assumed_state(
     [
         (
             cover.DOMAIN,
-            cover.STATE_OPEN,
+            cover.CoverState.OPEN,
         ),
         (
             valve.DOMAIN,
@@ -3298,8 +3298,8 @@ async def test_openclose_cover_valve_query_only(
     [
         (
             cover.DOMAIN,
-            cover.STATE_OPEN,
-            cover.STATE_CLOSED,
+            cover.CoverState.OPEN,
+            cover.CoverState.CLOSED,
             CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE,
             cover.SERVICE_OPEN_COVER,
             cover.SERVICE_CLOSE_COVER,
@@ -3400,7 +3400,7 @@ async def test_openclose_cover_secure(hass: HomeAssistant, device_class) -> None
         hass,
         State(
             "cover.bla",
-            cover.STATE_OPEN,
+            cover.CoverState.OPEN,
             {
                 ATTR_DEVICE_CLASS: device_class,
                 ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION,


### PR DESCRIPTION
## Breaking change
State constants for `cover` was previously deprecated and has now been removed

## Proposed change


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 