### PR TITLE
Update Shelly block valve platform to use entity description

### DIFF
--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -79,6 +79,9 @@ def async_setup_block_attribute_entities(
                 continue
 
             # Filter out non-existing sensors and sensors without a value
+            if description.models and coordinator.model not in description.models:
+                continue
+
             if getattr(block, sensor_id, None) is None:
                 continue
 
@@ -301,6 +304,7 @@ class BlockEntityDescription(EntityDescription):
     available: Callable[[Block], bool] | None = None
     # Callable (settings, block), return true if entity should be removed
     removal_condition: Callable[[dict, Block], bool] | None = None
+    models: set[str] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/shelly/valve.py
+++ b/homeassistant/components/shelly/valve.py
@@ -27,7 +27,7 @@ from .entity import (
     async_setup_block_attribute_entities,
     async_setup_entry_rpc,
 )
-from .utils import async_remove_shelly_entity, get_device_entry_gen
+from .utils import get_device_entry_gen
 
 PARALLEL_UPDATES = 0
 
@@ -42,12 +42,15 @@ class RpcValveDescription(RpcEntityDescription, ValveEntityDescription):
     """Class to describe a RPC virtual valve."""
 
 
-GAS_VALVE = BlockValveDescription(
-    key="valve|valve",
-    name="Valve",
-    available=lambda block: block.valve not in ("failure", "checking"),
-    removal_condition=lambda _, block: block.valve in ("not_connected", "unknown"),
-)
+BLOCK_VALVES: dict[tuple[str, str], BlockValveDescription] = {
+    ("valve", "valve"): BlockValveDescription(
+        key="valve|valve",
+        name="Valve",
+        available=lambda block: block.valve not in ("failure", "checking"),
+        removal_condition=lambda _, block: block.valve in ("not_connected", "unknown"),
+        models={MODEL_GAS},
+    ),
+}
 
 
 class RpcShellyBaseWaterValve(ShellyRpcAttributeEntity, ValveEntity):
@@ -162,19 +165,15 @@ def async_setup_block_entry(
 ) -> None:
     """Set up valve for device."""
     coordinator = config_entry.runtime_data.block
-    assert coordinator and coordinator.device.blocks
+    assert coordinator
 
-    if coordinator.model == MODEL_GAS:
-        async_setup_block_attribute_entities(
-            hass,
-            async_add_entities,
-            coordinator,
-            {("valve", "valve"): GAS_VALVE},
-            BlockShellyValve,
-        )
-        # Remove deprecated switch entity for gas valve
-        unique_id = f"{coordinator.mac}-valve_0-valve"
-        async_remove_shelly_entity(hass, "switch", unique_id)
+    async_setup_block_attribute_entities(
+        hass,
+        async_add_entities,
+        coordinator,
+        BLOCK_VALVES,
+        BlockShellyValve,
+    )
 
 
 class BlockShellyValve(ShellyBlockAttributeEntity, ValveEntity):

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from datetime import timedelta
 from unittest.mock import AsyncMock, Mock
 
-from aioshelly.const import MODEL_1PM, MODEL_GAS, MODEL_MOTION
+from aioshelly.const import MODEL_1PM, MODEL_MOTION
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCallError
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -556,23 +556,6 @@ async def test_rpc_auth_error(
     assert "context" in flow
     assert flow["context"].get("source") == SOURCE_REAUTH
     assert flow["context"].get("entry_id") == entry.entry_id
-
-
-async def test_remove_gas_valve_switch(
-    hass: HomeAssistant,
-    mock_block_device: Mock,
-    entity_registry: EntityRegistry,
-) -> None:
-    """Test removing deprecated switch entity for Shelly Gas Valve."""
-    entity_id = register_entity(
-        hass,
-        SWITCH_DOMAIN,
-        "test_name_valve",
-        "valve_0-valve",
-    )
-    await init_integration(hass, 1, MODEL_GAS)
-
-    assert entity_registry.async_get(entity_id) is None
 
 
 async def test_wall_display_relay_mode(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Update Shelly Block based devices valve platfrom to fully utilize Entity Description.
- Added models filtering as in RPC devices (this is already covered by test, verified that changing the model will fail the test)
- Removed clean-up code from https://github.com/home-assistant/core/pull/119817

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
