### PR TITLE
Add jet lag prevention event support to Sleep as Android integration

### DIFF
--- a/homeassistant/components/sleep_as_android/event.py
+++ b/homeassistant/components/sleep_as_android/event.py
@@ -38,6 +38,7 @@ class SleepAsAndroidEvent(StrEnum):
     SLEEP_PHASE = "sleep_phase"
     SLEEP_TRACKING = "sleep_tracking"
     SOUND_EVENT = "sound_event"
+    JET_LAG_PREVENTION = "jet_lag_prevention"
 
 
 EVENT_DESCRIPTIONS: tuple[SleepAsAndroidEventEntityDescription, ...] = (
@@ -119,6 +120,15 @@ EVENT_DESCRIPTIONS: tuple[SleepAsAndroidEventEntityDescription, ...] = (
             "antisnoring",
             "apnea_alarm",
         ],
+    ),
+    SleepAsAndroidEventEntityDescription(
+        key=SleepAsAndroidEvent.JET_LAG_PREVENTION,
+        translation_key=SleepAsAndroidEvent.JET_LAG_PREVENTION,
+        event_types=[
+            "jet_lag_start",
+            "jet_lag_stop",
+        ],
+        entity_registry_enabled_default=False,
     ),
 )
 

--- a/homeassistant/components/sleep_as_android/icons.json
+++ b/homeassistant/components/sleep_as_android/icons.json
@@ -24,6 +24,9 @@
       },
       "sleep_health": {
         "default": "mdi:heart-pulse"
+      },
+      "jet_lag_prevention": {
+        "default": "mdi:airplane-clock"
       }
     },
     "sensor": {

--- a/homeassistant/components/sleep_as_android/strings.json
+++ b/homeassistant/components/sleep_as_android/strings.json
@@ -117,6 +117,17 @@
             }
           }
         }
+      },
+      "jet_lag_prevention": {
+        "name": "Jet lag prevention",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "jet_lag_start": "[%key:component::sleep_as_android::entity::event::lullaby::state_attributes::event_type::state::start%]",
+              "jet_lag_stop": "[%key:common::state::stopped%]"
+            }
+          }
+        }
       }
     },
     "sensor": {

--- a/tests/components/sleep_as_android/snapshots/test_event.ambr
+++ b/tests/components/sleep_as_android/snapshots/test_event.ambr
@@ -65,6 +65,64 @@
     'state': 'unknown',
   })
 # ---
+# name: test_setup[event.sleep_as_android_jet_lag_prevention-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'jet_lag_start',
+        'jet_lag_stop',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.sleep_as_android_jet_lag_prevention',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Jet lag prevention',
+    'platform': 'sleep_as_android',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SleepAsAndroidEvent.JET_LAG_PREVENTION: 'jet_lag_prevention'>,
+    'unique_id': '01JRD840SAZ55DGXBD78PTQ4EF_jet_lag_prevention',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[event.sleep_as_android_jet_lag_prevention-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'event_type': None,
+      'event_types': list([
+        'jet_lag_start',
+        'jet_lag_stop',
+      ]),
+      'friendly_name': 'Sleep as Android Jet lag prevention',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.sleep_as_android_jet_lag_prevention',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_setup[event.sleep_as_android_lullaby-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/sleep_as_android/test_event.py
+++ b/tests/components/sleep_as_android/test_event.py
@@ -27,6 +27,7 @@ def event_only() -> Generator[None]:
         yield
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @freeze_time("2025-01-01T03:30:00.000Z")
 async def test_setup(
     hass: HomeAssistant,
@@ -123,8 +124,11 @@ async def test_setup(
                 "value2": "label",
             },
         ),
+        ("jet_lag_prevention", {"event": "jet_lag_start"}),
+        ("jet_lag_prevention", {"event": "jet_lag_stop"}),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @freeze_time("2025-01-01T03:30:00.000+00:00")
 async def test_webhook_event(
     hass: HomeAssistant,


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The jet lag prevention feature in Sleep as Android now triggers events when it starts/stops

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41249
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
