### PR TITLE
Fix device actions in template entities

### DIFF
--- a/homeassistant/components/template/button.py
+++ b/homeassistant/components/template/button.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.entity_platform import (
 )
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import CONF_PRESS, DOMAIN
+from .const import CONF_PRESS
 from .helpers import async_setup_template_entry, async_setup_template_platform
 from .schemas import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
@@ -104,11 +104,11 @@ class StateButtonEntity(TemplateEntity, ButtonEntity):
 
         # Scripts can be an empty list, therefore we need to check for None
         if (action := config.get(CONF_PRESS)) is not None:
-            self.add_script(CONF_PRESS, action, self._attr_name, DOMAIN)
+            self.add_actions(CONF_PRESS, action, self._attr_name)
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._attr_state = None
 
     async def async_press(self) -> None:
         """Press the button."""
         if script := self._action_scripts.get(CONF_PRESS):
-            await self.async_run_script(script, context=self._context)
+            await self.async_run_actions(script, context=self._context)

--- a/homeassistant/components/template/helpers.py
+++ b/homeassistant/components/template/helpers.py
@@ -276,4 +276,6 @@ def async_setup_template_preview[T: TemplateEntity](
         config[CONF_STATE] = config.pop(CONF_VALUE_TEMPLATE)
 
     validated_config = schema(config | {CONF_NAME: name})
-    return state_entity_cls(hass, validated_config, None)
+    return state_entity_cls(
+        hass, {"__is_preview_entity": True, **validated_config}, None
+    )

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator, Sequence
+from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
@@ -162,7 +162,7 @@ class AbstractTemplateLock(AbstractTemplateEntity, LockEntity):
 
     def _iterate_scripts(
         self, config: dict[str, Any]
-    ) -> Generator[tuple[str, Sequence[dict[str, Any]], LockEntityFeature | int]]:
+    ) -> Generator[tuple[str, list[dict[str, Any]], LockEntityFeature | int]]:
         for action_id, supported_feature in (
             (CONF_LOCK, 0),
             (CONF_UNLOCK, 0),
@@ -258,7 +258,7 @@ class AbstractTemplateLock(AbstractTemplateEntity, LockEntity):
 
         tpl_vars = {ATTR_CODE: kwargs.get(ATTR_CODE) if kwargs else None}
 
-        await self.async_run_script(
+        await self.async_run_actions(
             self._action_scripts[CONF_LOCK],
             run_variables=tpl_vars,
             context=self._context,
@@ -276,7 +276,7 @@ class AbstractTemplateLock(AbstractTemplateEntity, LockEntity):
 
         tpl_vars = {ATTR_CODE: kwargs.get(ATTR_CODE) if kwargs else None}
 
-        await self.async_run_script(
+        await self.async_run_actions(
             self._action_scripts[CONF_UNLOCK],
             run_variables=tpl_vars,
             context=self._context,
@@ -294,7 +294,7 @@ class AbstractTemplateLock(AbstractTemplateEntity, LockEntity):
 
         tpl_vars = {ATTR_CODE: kwargs.get(ATTR_CODE) if kwargs else None}
 
-        await self.async_run_script(
+        await self.async_run_actions(
             self._action_scripts[CONF_OPEN],
             run_variables=tpl_vars,
             context=self._context,
@@ -335,7 +335,7 @@ class StateLockEntity(TemplateEntity, AbstractTemplateLock):
         for action_id, action_config, supported_feature in self._iterate_scripts(
             config
         ):
-            self.add_script(action_id, action_config, name, DOMAIN)
+            self.add_actions(action_id, action_config, name)
             self._attr_supported_features |= supported_feature
 
     @callback
@@ -395,7 +395,7 @@ class TriggerLockEntity(TriggerEntity, AbstractTemplateLock):
         for action_id, action_config, supported_feature in self._iterate_scripts(
             config
         ):
-            self.add_script(action_id, action_config, name, DOMAIN)
+            self.add_actions(action_id, action_config, name)
             self._attr_supported_features |= supported_feature
 
     @callback

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator
-from .const import CONF_MAX, CONF_MIN, CONF_STEP, DOMAIN
+from .const import CONF_MAX, CONF_MIN, CONF_STEP
 from .entity import AbstractTemplateEntity
 from .helpers import (
     async_setup_template_entry,
@@ -137,7 +137,7 @@ class AbstractTemplateNumber(AbstractTemplateEntity, NumberEntity):
             self._attr_native_value = value
             self.async_write_ha_state()
         if set_value := self._action_scripts.get(CONF_SET_VALUE):
-            await self.async_run_script(
+            await self.async_run_actions(
                 set_value,
                 run_variables={ATTR_VALUE: value},
                 context=self._context,
@@ -163,7 +163,7 @@ class StateNumberEntity(TemplateEntity, AbstractTemplateNumber):
         if TYPE_CHECKING:
             assert name is not None
 
-        self.add_script(CONF_SET_VALUE, config[CONF_SET_VALUE], name, DOMAIN)
+        self.add_actions(CONF_SET_VALUE, config[CONF_SET_VALUE], name)
 
     @callback
     def _async_setup_templates(self) -> None:
@@ -224,11 +224,10 @@ class TriggerNumberEntity(TriggerEntity, AbstractTemplateNumber):
                 self._to_render_simple.append(key)
                 self._parse_result.add(key)
 
-        self.add_script(
+        self.add_actions(
             CONF_SET_VALUE,
             config[CONF_SET_VALUE],
             self._rendered.get(CONF_NAME, DEFAULT_NAME),
-            DOMAIN,
         )
 
     def _handle_coordinator_update(self):

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -25,7 +25,6 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator
-from .const import DOMAIN
 from .entity import AbstractTemplateEntity
 from .helpers import (
     async_setup_template_entry,
@@ -128,7 +127,7 @@ class AbstractTemplateSelect(AbstractTemplateEntity, SelectEntity):
             self._attr_current_option = option
             self.async_write_ha_state()
         if select_option := self._action_scripts.get(CONF_SELECT_OPTION):
-            await self.async_run_script(
+            await self.async_run_actions(
                 select_option,
                 run_variables={ATTR_OPTION: option},
                 context=self._context,
@@ -155,7 +154,7 @@ class TemplateSelect(TemplateEntity, AbstractTemplateSelect):
             assert name is not None
 
         if (select_option := config.get(CONF_SELECT_OPTION)) is not None:
-            self.add_script(CONF_SELECT_OPTION, select_option, name, DOMAIN)
+            self.add_actions(CONF_SELECT_OPTION, select_option, name)
 
     @callback
     def _async_setup_templates(self) -> None:
@@ -197,11 +196,10 @@ class TriggerSelectEntity(TriggerEntity, AbstractTemplateSelect):
 
         # Scripts can be an empty list, therefore we need to check for None
         if (select_option := config.get(CONF_SELECT_OPTION)) is not None:
-            self.add_script(
+            self.add_actions(
                 CONF_SELECT_OPTION,
                 select_option,
                 self._rendered.get(CONF_NAME, DEFAULT_NAME),
-                DOMAIN,
             )
 
     def _handle_coordinator_update(self):

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -37,7 +37,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator
-from .const import CONF_TURN_OFF, CONF_TURN_ON, DOMAIN
+from .const import CONF_TURN_OFF, CONF_TURN_ON
 from .entity import AbstractTemplateEntity
 from .helpers import (
     async_setup_template_entry,
@@ -161,7 +161,7 @@ class AbstractTemplateSwitch(AbstractTemplateEntity, SwitchEntity, RestoreEntity
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Fire the on action."""
         if on_script := self._action_scripts.get(CONF_TURN_ON):
-            await self.async_run_script(on_script, context=self._context)
+            await self.async_run_actions(on_script, context=self._context)
         if self._attr_assumed_state:
             self._attr_is_on = True
             self.async_write_ha_state()
@@ -169,7 +169,7 @@ class AbstractTemplateSwitch(AbstractTemplateEntity, SwitchEntity, RestoreEntity
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Fire the off action."""
         if off_script := self._action_scripts.get(CONF_TURN_OFF):
-            await self.async_run_script(off_script, context=self._context)
+            await self.async_run_actions(off_script, context=self._context)
         if self._attr_assumed_state:
             self._attr_is_on = False
             self.async_write_ha_state()
@@ -196,9 +196,9 @@ class StateSwitchEntity(TemplateEntity, AbstractTemplateSwitch):
 
         # Scripts can be an empty list, therefore we need to check for None
         if (on_action := config.get(CONF_TURN_ON)) is not None:
-            self.add_script(CONF_TURN_ON, on_action, name, DOMAIN)
+            self.add_actions(CONF_TURN_ON, on_action, name)
         if (off_action := config.get(CONF_TURN_OFF)) is not None:
-            self.add_script(CONF_TURN_OFF, off_action, name, DOMAIN)
+            self.add_actions(CONF_TURN_OFF, off_action, name)
 
     @callback
     def _update_state(self, result):
@@ -254,9 +254,9 @@ class TriggerSwitchEntity(TriggerEntity, AbstractTemplateSwitch):
 
         name = self._rendered.get(CONF_NAME, DEFAULT_NAME)
         if on_action := config.get(CONF_TURN_ON):
-            self.add_script(CONF_TURN_ON, on_action, name, DOMAIN)
+            self.add_actions(CONF_TURN_ON, on_action, name)
         if off_action := config.get(CONF_TURN_OFF):
-            self.add_script(CONF_TURN_OFF, off_action, name, DOMAIN)
+            self.add_actions(CONF_TURN_OFF, off_action, name)
 
         if CONF_STATE in config:
             self._to_render_simple.append(CONF_STATE)

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -462,6 +462,8 @@ class TemplateEntity(AbstractTemplateEntity):
 
         async_at_start(self.hass, self._async_template_startup)
 
+        await self.async_setup_actions()
+
     async def async_update(self) -> None:
         """Call for forced update."""
         assert self._template_result_info

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -39,6 +39,7 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
 
     async def async_added_to_hass(self) -> None:
         """Handle being added to Home Assistant."""
+        await self.async_setup_actions()
         await super().async_added_to_hass()
         if self.coordinator.data is not None:
             self._process_data()

--- a/homeassistant/components/template/update.py
+++ b/homeassistant/components/template/update.py
@@ -34,7 +34,6 @@ from homeassistant.helpers.trigger_template_entity import CONF_PICTURE
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator
-from .const import DOMAIN
 from .entity import AbstractTemplateEntity
 from .helpers import (
     async_setup_template_entry,
@@ -263,7 +262,7 @@ class AbstractTemplateUpdate(AbstractTemplateEntity, UpdateEntity):
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
-        await self.async_run_script(
+        await self.async_run_actions(
             self._action_scripts[CONF_INSTALL],
             run_variables={ATTR_SPECIFIC_VERSION: version, ATTR_BACKUP: backup},
             context=self._context,
@@ -291,7 +290,7 @@ class StateUpdateEntity(TemplateEntity, AbstractTemplateUpdate):
 
         # Scripts can be an empty list, therefore we need to check for None
         if (install_action := config.get(CONF_INSTALL)) is not None:
-            self.add_script(CONF_INSTALL, install_action, name, DOMAIN)
+            self.add_actions(CONF_INSTALL, install_action, name)
             self._attr_supported_features |= UpdateEntityFeature.INSTALL
 
     @property
@@ -389,11 +388,10 @@ class TriggerUpdateEntity(TriggerEntity, AbstractTemplateUpdate):
 
         # Scripts can be an empty list, therefore we need to check for None
         if (install_action := config.get(CONF_INSTALL)) is not None:
-            self.add_script(
+            self.add_actions(
                 CONF_INSTALL,
                 install_action,
                 self._rendered.get(CONF_NAME, DEFAULT_NAME),
-                DOMAIN,
             )
             self._attr_supported_features |= UpdateEntityFeature.INSTALL
 

--- a/tests/components/template/test_entity.py
+++ b/tests/components/template/test_entity.py
@@ -1,9 +1,21 @@
 """Test abstract template entity."""
 
+from typing import Any
+
 import pytest
 
 from homeassistant.components.template import entity as abstract_entity
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from .conftest import ConfigurationStyle
+from .test_switch import (
+    TEST_ENTITY_ID as SWITCH_ENTITY_ID,
+    TEST_OBJECT_ID,
+    setup_switch_config,
+)
+
+from tests.common import MockConfigEntry
 
 
 async def test_template_entity_not_implemented(hass: HomeAssistant) -> None:
@@ -11,3 +23,73 @@ async def test_template_entity_not_implemented(hass: HomeAssistant) -> None:
 
     with pytest.raises(TypeError):
         _ = abstract_entity.AbstractTemplateEntity(hass, {})
+
+
+async def setup_switch(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    config: dict[str, Any],
+) -> None:
+    """Do the setup of all template switch configuration styles."""
+    if style == ConfigurationStyle.LEGACY:
+        config = {TEST_OBJECT_ID: config}
+    else:
+        config = {"name": TEST_OBJECT_ID, **config}
+
+    await setup_switch_config(hass, 1, style, config)
+
+
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+async def test_device_actions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    style: ConfigurationStyle,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that device actions work for template entities."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_entry = entity_registry.async_get_or_create(
+        "fake_integration", "test", "5678", device_id=device_entry.id
+    )
+
+    await setup_switch(
+        hass,
+        style,
+        {
+            "turn_on": {
+                "domain": "fake_integration",
+                "type": "turn_on",
+                "device_id": device_entry.id,
+                "entity_id": entity_entry.id,
+                "metadata": {"secondary": False},
+            },
+            "turn_off": {
+                "domain": "fake_integration",
+                "type": "turn_off",
+                "device_id": device_entry.id,
+                "entity_id": entity_entry.id,
+                "metadata": {"secondary": False},
+            },
+        },
+    )
+
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": SWITCH_ENTITY_ID},
+        blocking=True,
+    )
+
+    assert (
+        "not a valid value for dictionary value @ data['entity_id']" not in caplog.text
+    )

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -135,8 +135,7 @@ async def async_ensure_triggered_entity_updates(
         await hass.async_block_till_done()
 
 
-@pytest.fixture
-async def setup_switch(
+async def setup_switch_config(
     hass: HomeAssistant,
     count: int,
     style: ConfigurationStyle,
@@ -149,6 +148,17 @@ async def setup_switch(
         await async_setup_modern_format(hass, count, switch_config)
     elif style == ConfigurationStyle.TRIGGER:
         await async_setup_trigger_format(hass, count, switch_config)
+
+
+@pytest.fixture
+async def setup_switch(
+    hass: HomeAssistant,
+    count: int,
+    style: ConfigurationStyle,
+    switch_config: dict[str, Any],
+) -> None:
+    """Do setup of switch integration."""
+    await setup_switch_config(hass, count, style, switch_config)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes an issue with device actions.  https://github.com/home-assistant/core/issues/145728  Previously device actions would error through the UI because the UI would use the entity entry id instead of the entity_id.  This would cause the following error in the logs when running actions:

 ```
2025-05-27 16:42:42.997 ERROR (MainThread) [homeassistant.helpers.script.ac_template_turn_on] AC Template turn_on: Error executing script. Invalid data for device at pos 1: not a valid value for dictionary value @ data['entity_id']
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/145728
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
