### PR TITLE
Prepare VegeHub integration for options flow

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1709,8 +1709,8 @@ build.json @home-assistant/supervisor
 /tests/components/vallox/ @andre-richter @slovdahl @viiru- @yozik04
 /homeassistant/components/valve/ @home-assistant/core
 /tests/components/valve/ @home-assistant/core
-/homeassistant/components/vegehub/ @ghowevege
-/tests/components/vegehub/ @ghowevege
+/homeassistant/components/vegehub/ @thulrus @vegetronix
+/tests/components/vegehub/ @thulrus @vegetronix
 /homeassistant/components/velbus/ @Cereal2nd @brefra
 /tests/components/velbus/ @Cereal2nd @brefra
 /homeassistant/components/velux/ @Julius2342 @DeerMaximum @pawlizio @wollew

--- a/homeassistant/components/vegehub/const.py
+++ b/homeassistant/components/vegehub/const.py
@@ -7,3 +7,8 @@ NAME = "VegeHub"
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
 MANUFACTURER = "vegetronix"
 MODEL = "VegeHub"
+OPTION_DATA_TYPE_CHOICES = [
+    "Raw Voltage",
+    "VH400",
+    "THERM200",
+]

--- a/homeassistant/components/vegehub/manifest.json
+++ b/homeassistant/components/vegehub/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "vegehub",
   "name": "Vegetronix VegeHub",
-  "codeowners": ["@ghowevege"],
+  "codeowners": ["@thulrus", "@vegetronix"],
   "config_flow": true,
   "dependencies": ["http", "webhook"],
   "documentation": "https://www.home-assistant.io/integrations/vegehub",

--- a/homeassistant/components/vegehub/sensor.py
+++ b/homeassistant/components/vegehub/sensor.py
@@ -2,24 +2,41 @@
 
 from itertools import count
 
+from vegehub import therm200_transform, vh400_transform
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import UnitOfElectricPotential
+from homeassistant.const import PERCENTAGE, UnitOfElectricPotential, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import OPTION_DATA_TYPE_CHOICES
 from .coordinator import VegeHubConfigEntry, VegeHubCoordinator
 from .entity import VegeHubEntity
 
 SENSOR_TYPES: dict[str, SensorEntityDescription] = {
-    "analog_sensor": SensorEntityDescription(
+    OPTION_DATA_TYPE_CHOICES[0]: SensorEntityDescription(
         key="analog_sensor",
         translation_key="analog_sensor",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        suggested_display_precision=2,
+    ),
+    OPTION_DATA_TYPE_CHOICES[1]: SensorEntityDescription(
+        key="vh400_sensor",
+        translation_key="vh400_sensor",
+        device_class=SensorDeviceClass.MOISTURE,
+        native_unit_of_measurement=PERCENTAGE,
+        suggested_display_precision=2,
+    ),
+    OPTION_DATA_TYPE_CHOICES[2]: SensorEntityDescription(
+        key="therm200_sensor",
+        translation_key="therm200_sensor",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_display_precision=2,
     ),
     "battery_volts": SensorEntityDescription(
@@ -45,10 +62,14 @@ async def async_setup_entry(
 
     # Add each analog sensor input
     for _i in range(coordinator.vegehub.num_sensors):
+        index = next(sensor_index)
+        data_type = config_entry.options.get(
+            f"data_type_{index}", OPTION_DATA_TYPE_CHOICES[0]
+        )
         sensor = VegeHubSensor(
-            index=next(sensor_index),
+            index=index,
             coordinator=coordinator,
-            description=SENSOR_TYPES["analog_sensor"],
+            description=SENSOR_TYPES[data_type],
         )
         sensors.append(sensor)
 
@@ -91,4 +112,15 @@ class VegeHubSensor(VegeHubEntity, SensorEntity):
         """Return the sensor's current value."""
         if self.coordinator.data is None:
             return None
-        return self.coordinator.data.get(self.data_key)
+        val = self.coordinator.data.get(self.data_key)
+
+        if val is None:
+            return None
+
+        # Apply transformation based on sensor type
+        if self.entity_description.key == "vh400_sensor":
+            return vh400_transform(val)
+        if self.entity_description.key == "therm200_sensor":
+            return therm200_transform(val)
+
+        return val

--- a/homeassistant/components/vegehub/strings.json
+++ b/homeassistant/components/vegehub/strings.json
@@ -36,6 +36,12 @@
       "analog_sensor": {
         "name": "Input {index}"
       },
+      "vh400_sensor": {
+        "name": "Input {index} (moisture)"
+      },
+      "therm200_sensor": {
+        "name": "Input {index} (temperature)"
+      },
       "battery_volts": {
         "name": "Battery voltage"
       }

--- a/tests/components/vegehub/test_init.py
+++ b/tests/components/vegehub/test_init.py
@@ -1,0 +1,73 @@
+"""Tests for VegeHub integration setup and unload."""
+
+from http import HTTPStatus
+from unittest.mock import patch
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.core import HomeAssistant
+
+from . import init_integration
+from .conftest import TEST_WEBHOOK_ID
+
+from tests.common import MockConfigEntry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_unload_entry(
+    hass: HomeAssistant,
+    mocked_config_entry: MockConfigEntry,
+) -> None:
+    """Test unloading the config entry."""
+    with patch("homeassistant.components.vegehub.PLATFORMS", [Platform.SENSOR]):
+        await init_integration(hass, mocked_config_entry)
+
+    # Verify webhook is registered
+    assert TEST_WEBHOOK_ID in hass.data["webhook"]
+
+    # Unload the config entry
+    assert await hass.config_entries.async_unload(mocked_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify webhook is unregistered
+    assert TEST_WEBHOOK_ID not in hass.data["webhook"]
+
+
+async def test_homeassistant_stop_unregisters_webhook(
+    hass: HomeAssistant,
+    mocked_config_entry: MockConfigEntry,
+) -> None:
+    """Test that webhook is unregistered when Home Assistant stops."""
+    with patch("homeassistant.components.vegehub.PLATFORMS", [Platform.SENSOR]):
+        await init_integration(hass, mocked_config_entry)
+
+    # Verify webhook is registered
+    assert TEST_WEBHOOK_ID in hass.data["webhook"]
+
+    # Fire the stop event
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
+    # Verify webhook is unregistered
+    assert TEST_WEBHOOK_ID not in hass.data["webhook"]
+
+
+async def test_webhook_no_body(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    mocked_config_entry: MockConfigEntry,
+) -> None:
+    """Test webhook handler with no body."""
+    with patch("homeassistant.components.vegehub.PLATFORMS", [Platform.SENSOR]):
+        await init_integration(hass, mocked_config_entry)
+
+    assert TEST_WEBHOOK_ID in hass.data["webhook"], "Webhook was not registered"
+
+    client = await hass_client_no_auth()
+
+    # Send a POST request with no body
+    resp = await client.post(f"/api/webhook/{TEST_WEBHOOK_ID}")
+
+    # Should return BAD_REQUEST
+    assert resp.status == HTTPStatus.BAD_REQUEST
+    text = await resp.text()
+    assert "No Body" in text

--- a/tests/components/vegehub/test_sensor.py
+++ b/tests/components/vegehub/test_sensor.py
@@ -91,7 +91,6 @@ async def test_sensor_vh400_type(
     assert state.attributes["unit_of_measurement"] == "%"
 
     # The vh400_transform function should be applied to the raw voltage
-    # Raw voltage is 1.5V from UPDATE_DATA, expected output is ~24.615%
     assert float(state.state) == pytest.approx(24.615, rel=1e-3)
 
 
@@ -122,13 +121,6 @@ async def test_sensor_therm200_type(
     assert state.attributes["unit_of_measurement"] == "°C"
 
     # The therm200_transform function should be applied to the raw voltage
-    # Raw voltage is 1.45599997V from UPDATE_DATA
-    # Formula: (voltage - 0.4) * 41.67 = (1.45599997 - 0.4) * 41.67 ≈ 44.02°C
-    # However, looking at the library test, 1.0V gives 1.67°C
-    # So the formula appears to be: (voltage - 1) * 41.67 + 1.67
-    # For 1.45599997V: (1.45599997 - 1) * 41.67 + 1.67 ≈ 20.674°C
-    # Actually from the test: (v * 41.67) - 40 is the formula
-    # For 1.45599997V: (1.45599997 * 41.67) - 40 ≈ 20.669°C
     assert float(state.state) == pytest.approx(20.669, rel=1e-2)
 
 

--- a/tests/components/vegehub/test_sensor.py
+++ b/tests/components/vegehub/test_sensor.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
@@ -61,3 +62,233 @@ async def test_sensor_entities(
     await snapshot_platform(
         hass, entity_registry, snapshot, mocked_config_entry.entry_id
     )
+
+
+async def test_sensor_vh400_type(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    mocked_config_entry: MockConfigEntry,
+) -> None:
+    """Test VH400 moisture sensor with transformation."""
+    # Configure first sensor as VH400 moisture sensor
+    mocked_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mocked_config_entry, options={"data_type_0": "VH400"}
+    )
+
+    with patch("homeassistant.components.vegehub.PLATFORMS", [Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(mocked_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_client_no_auth()
+    await client.post(f"/api/webhook/{TEST_WEBHOOK_ID}", json=UPDATE_DATA)
+    await hass.async_block_till_done()
+
+    # Check that the VH400 sensor has the correct properties
+    state = hass.states.get("sensor.vegehub_input_1_moisture")
+    assert state is not None
+    assert state.attributes["device_class"] == "moisture"
+    assert state.attributes["unit_of_measurement"] == "%"
+
+    # The vh400_transform function should be applied to the raw voltage
+    # Raw voltage is 1.5V from UPDATE_DATA
+    # Verify the value is transformed (not the raw voltage)
+    assert state.state != "1.5"
+    assert float(state.state) != 1.5
+
+
+async def test_sensor_therm200_type(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    mocked_config_entry: MockConfigEntry,
+) -> None:
+    """Test THERM200 temperature sensor with transformation."""
+    # Configure second sensor as THERM200 temperature sensor
+    mocked_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mocked_config_entry, options={"data_type_1": "THERM200"}
+    )
+
+    with patch("homeassistant.components.vegehub.PLATFORMS", [Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(mocked_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_client_no_auth()
+    await client.post(f"/api/webhook/{TEST_WEBHOOK_ID}", json=UPDATE_DATA)
+    await hass.async_block_till_done()
+
+    # Check that the THERM200 sensor has the correct properties
+    state = hass.states.get("sensor.vegehub_input_2_temperature")
+    assert state is not None
+    assert state.attributes["device_class"] == "temperature"
+    assert state.attributes["unit_of_measurement"] == "°C"
+
+    # The therm200_transform function should be applied to the raw voltage
+    # Raw voltage is 1.45599997V from UPDATE_DATA
+    # Verify the value is transformed (not the raw voltage)
+    assert state.state != "1.45599997"
+    assert float(state.state) != 1.45599997
+
+
+async def test_sensor_mixed_types(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    hass_client_no_auth: ClientSessionGenerator,
+    entity_registry: er.EntityRegistry,
+    mocked_config_entry: MockConfigEntry,
+) -> None:
+    """Test mixed sensor types configuration."""
+    # Configure multiple sensors with different types
+    mocked_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mocked_config_entry,
+        options={
+            "data_type_0": "Raw Voltage",  # Default voltage sensor
+            "data_type_1": "VH400",  # Moisture sensor
+            "data_type_2": "THERM200",  # Temperature sensor
+            "data_type_3": "VH400",  # Another moisture sensor
+        },
+    )
+
+    with patch("homeassistant.components.vegehub.PLATFORMS", [Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(mocked_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_client_no_auth()
+    await client.post(f"/api/webhook/{TEST_WEBHOOK_ID}", json=UPDATE_DATA)
+    await hass.async_block_till_done()
+
+    # Verify sensor 1 (Raw Voltage) - should show raw voltage
+    state1 = hass.states.get("sensor.vegehub_input_1")
+    assert state1 is not None
+    assert state1.attributes["device_class"] == "voltage"
+    assert state1.state == "1.5"
+
+    # Verify sensor 2 (VH400) - should be transformed
+    state2 = hass.states.get("sensor.vegehub_input_2_moisture")
+    assert state2 is not None
+    assert state2.attributes["device_class"] == "moisture"
+    assert state2.state != "1.45599997"
+
+    # Verify sensor 3 (THERM200) - should be transformed
+    state3 = hass.states.get("sensor.vegehub_input_3_temperature")
+    assert state3 is not None
+    assert state3.attributes["device_class"] == "temperature"
+    assert state3.state != "1.330000043"
+
+    # Verify sensor 4 (VH400) - should be transformed
+    state4 = hass.states.get("sensor.vegehub_input_4_moisture")
+    assert state4 is not None
+    assert state4.attributes["device_class"] == "moisture"
+    assert state4.state != "0.075999998"
+
+
+async def test_sensor_default_type_when_no_options(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    mocked_config_entry: MockConfigEntry,
+) -> None:
+    """Test that sensors default to Raw Voltage when no options are set."""
+    # Don't set any options - should default to "Raw Voltage"
+    mocked_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(mocked_config_entry, options={})
+
+    with patch("homeassistant.components.vegehub.PLATFORMS", [Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(mocked_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_client_no_auth()
+    await client.post(f"/api/webhook/{TEST_WEBHOOK_ID}", json=UPDATE_DATA)
+    await hass.async_block_till_done()
+
+    # All sensors should be voltage sensors showing raw values
+    for i in range(1, 5):
+        state = hass.states.get(f"sensor.vegehub_input_{i}")
+        assert state is not None
+        assert state.attributes["device_class"] == "voltage"
+        assert state.attributes["unit_of_measurement"] == "V"
+
+
+@pytest.mark.parametrize(
+    ("sensor_type", "expected_device_class", "expected_unit"),
+    [
+        ("Raw Voltage", "voltage", "V"),
+        ("VH400", "moisture", "%"),
+        ("THERM200", "temperature", "°C"),
+    ],
+)
+async def test_sensor_type_configuration(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    mocked_config_entry: MockConfigEntry,
+    sensor_type: str,
+    expected_device_class: str,
+    expected_unit: str,
+) -> None:
+    """Test each sensor type configuration."""
+    mocked_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mocked_config_entry, options={"data_type_0": sensor_type}
+    )
+
+    with patch("homeassistant.components.vegehub.PLATFORMS", [Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(mocked_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_client_no_auth()
+    await client.post(f"/api/webhook/{TEST_WEBHOOK_ID}", json=UPDATE_DATA)
+    await hass.async_block_till_done()
+
+    # Find the sensor state - entity_id depends on sensor type
+    states = hass.states.async_all()
+    sensor_states = [s for s in states if "input_1" in s.entity_id]
+    assert len(sensor_states) == 1
+
+    state = sensor_states[0]
+    assert state.attributes["device_class"] == expected_device_class
+    assert state.attributes["unit_of_measurement"] == expected_unit
+
+
+async def test_sensor_transformation_with_none_value(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    mocked_config_entry: MockConfigEntry,
+) -> None:
+    """Test that sensors handle None values correctly."""
+    mocked_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mocked_config_entry,
+        options={
+            "data_type_0": "VH400",
+            "data_type_1": "THERM200",
+        },
+    )
+
+    with patch("homeassistant.components.vegehub.PLATFORMS", [Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(mocked_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Send update with missing sensor data
+    update_data_incomplete = {
+        "api_key": "",
+        "mac": TEST_SIMPLE_MAC,
+        "error_code": 0,
+        "sensors": [
+            # Missing slot 1 and 2 data
+            {"slot": 3, "samples": [{"v": 1.330000043, "t": "2025-01-15T16:51:23Z"}]},
+        ],
+        "send_time": 1736959883,
+        "wifi_str": -27,
+    }
+
+    client = await hass_client_no_auth()
+    await client.post(f"/api/webhook/{TEST_WEBHOOK_ID}", json=update_data_incomplete)
+    await hass.async_block_till_done()
+
+    # Sensors with missing data should have unavailable or None state
+    state1 = hass.states.get("sensor.vegehub_input_1_moisture")
+    state2 = hass.states.get("sensor.vegehub_input_2_temperature")
+
+    # These might be "unavailable" or "unknown" depending on entity availability logic
+    assert state1 is not None
+    assert state2 is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds infrastructure to support multiple sensor types (VH400 moisture sensors and THERM200 temperature sensors) in the sensor platform. It prepares the VegeHub integration for the future addition of an options flow that will allow the user to choose different sensor types for their VegeHub sensors.

Since only one platform can be modified in a PR, this PR will modify the sensor platform, and the next will modify the switch platform, and add the options flow.

The changes are backward compatible and maintain current behavior by defaulting to "Raw Voltage" sensors when no options are configured.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35639
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
