### PR TITLE
Deprecate has_mean in favor of mean_type in recorder statistic API

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -78,13 +78,7 @@ from .db_schema import (
     StatisticsShortTerm,
 )
 from .executor import DBInterruptibleThreadPoolExecutor
-from .models import (
-    DatabaseEngine,
-    StatisticData,
-    StatisticMeanType,
-    StatisticMetaData,
-    UnsupportedDialect,
-)
+from .models import DatabaseEngine, StatisticData, StatisticMetaData, UnsupportedDialect
 from .pool import POOL_SIZE, MutexPool, RecorderPool
 from .table_managers.event_data import EventDataManager
 from .table_managers.event_types import EventTypeManager
@@ -621,17 +615,6 @@ class Recorder(threading.Thread):
         table: type[Statistics | StatisticsShortTerm],
     ) -> None:
         """Schedule import of statistics."""
-        if "mean_type" not in metadata:
-            # Backwards compatibility for old metadata format
-            # Can be removed after 2026.4
-            metadata["mean_type"] = (  # type: ignore[unreachable]
-                StatisticMeanType.ARITHMETIC
-                if metadata.get("has_mean")
-                else StatisticMeanType.NONE
-            )
-        # Remove deprecated has_mean as it's not needed anymore in core
-        metadata.pop("has_mean", None)
-
         self.queue_task(ImportStatisticsTask(metadata, stats, table))
 
     @callback

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -2592,6 +2592,15 @@ def _async_import_statistics(
     statistics: Iterable[StatisticData],
 ) -> None:
     """Validate timestamps and insert an import_statistics job in the queue."""
+    if "has_mean" not in metadata and "mean_type" not in metadata:
+        raise HomeAssistantError("mean_type must be specified in metadata")
+    if "mean_type" not in metadata:
+        metadata["mean_type"] = (  # type: ignore[unreachable]
+            StatisticMeanType.ARITHMETIC
+            if metadata.pop("has_mean")
+            else StatisticMeanType.NONE
+        )
+
     # If unit class is not set, we try to set it based on the unit of measurement
     # Note: This can't happen from the type checker's perspective, but we need
     # to guard against custom integrations that have not been updated to set
@@ -2658,6 +2667,12 @@ def async_import_statistics(
     if not metadata["source"] or metadata["source"] != DOMAIN:
         raise HomeAssistantError("Invalid source")
 
+    if "mean_type" not in metadata and not _called_from_ws_api:  # type: ignore[unreachable]
+        report_usage(  # type: ignore[unreachable]
+            "doesn't specify mean_type when calling async_import_statistics",
+            breaks_in_ha_version="2026.11",
+            exclude_integrations={DOMAIN},
+        )
     if "unit_class" not in metadata and not _called_from_ws_api:  # type: ignore[unreachable]
         report_usage(  # type: ignore[unreachable]
             "doesn't specify unit_class when calling async_import_statistics",
@@ -2689,6 +2704,12 @@ def async_add_external_statistics(
     if not metadata["source"] or metadata["source"] != domain:
         raise HomeAssistantError("Invalid source")
 
+    if "mean_type" not in metadata and not _called_from_ws_api:  # type: ignore[unreachable]
+        report_usage(  # type: ignore[unreachable]
+            "doesn't specify mean_type when calling async_import_statistics",
+            breaks_in_ha_version="2026.11",
+            exclude_integrations={DOMAIN},
+        )
     if "unit_class" not in metadata and not _called_from_ws_api:  # type: ignore[unreachable]
         report_usage(  # type: ignore[unreachable]
             "doesn't specify unit_class when calling async_add_external_statistics",

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -2592,12 +2592,10 @@ def _async_import_statistics(
     statistics: Iterable[StatisticData],
 ) -> None:
     """Validate timestamps and insert an import_statistics job in the queue."""
-    if "has_mean" not in metadata and "mean_type" not in metadata:
-        raise HomeAssistantError("mean_type must be specified in metadata")
     if "mean_type" not in metadata:
         metadata["mean_type"] = (  # type: ignore[unreachable]
             StatisticMeanType.ARITHMETIC
-            if metadata.pop("has_mean")
+            if metadata.pop("has_mean", False)
             else StatisticMeanType.NONE
         )
 

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -540,7 +540,11 @@ async def ws_adjust_sum_statistics(
     {
         vol.Required("type"): "recorder/import_statistics",
         vol.Required("metadata"): {
-            vol.Required("has_mean"): bool,
+            vol.Optional("has_mean"): bool,
+            vol.Optional("mean_type"): vol.All(
+                vol.In(StatisticMeanType.__members__.values()),
+                vol.Coerce(StatisticMeanType),
+            ),
             vol.Required("has_sum"): bool,
             vol.Required("name"): vol.Any(str, None),
             vol.Required("source"): str,
@@ -570,10 +574,12 @@ def ws_import_statistics(
     The unit_class specifies which unit conversion class to use, if applicable.
     """
     metadata = msg["metadata"]
-    # The WS command will be changed in a follow up PR
-    metadata["mean_type"] = (
-        StatisticMeanType.ARITHMETIC if metadata["has_mean"] else StatisticMeanType.NONE
-    )
+    if "mean_type" not in metadata:
+        _LOGGER.warning(
+            "WS command recorder/import_statistics called without specifying "
+            "mean_type in metadata, this is deprecated and will stop working "
+            "in HA Core 2026.11"
+        )
     if "unit_class" not in metadata:
         _LOGGER.warning(
             "WS command recorder/import_statistics called without specifying "

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.components.energy import data, is_configured
 from homeassistant.components.recorder import Recorder
+from homeassistant.components.recorder.models import StatisticMeanType
 from homeassistant.components.recorder.statistics import async_add_external_statistics
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -365,8 +366,8 @@ async def test_fossil_energy_consumption_no_co2(
         },
     )
     external_energy_metadata_1 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import_tariff_1",
@@ -400,8 +401,8 @@ async def test_fossil_energy_consumption_no_co2(
         },
     )
     external_energy_metadata_2 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import_tariff_2",
@@ -532,8 +533,8 @@ async def test_fossil_energy_consumption_hole(
         },
     )
     external_energy_metadata_1 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import_tariff_1",
@@ -567,8 +568,8 @@ async def test_fossil_energy_consumption_hole(
         },
     )
     external_energy_metadata_2 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import_tariff_2",
@@ -697,8 +698,8 @@ async def test_fossil_energy_consumption_no_data(
         },
     )
     external_energy_metadata_1 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import_tariff_1",
@@ -732,8 +733,8 @@ async def test_fossil_energy_consumption_no_data(
         },
     )
     external_energy_metadata_2 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import_tariff_2",
@@ -851,8 +852,8 @@ async def test_fossil_energy_consumption(
         },
     )
     external_energy_metadata_1 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import_tariff_1",
@@ -886,8 +887,8 @@ async def test_fossil_energy_consumption(
         },
     )
     external_energy_metadata_2 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import_tariff_2",
@@ -917,8 +918,8 @@ async def test_fossil_energy_consumption(
         },
     )
     external_co2_metadata = {
-        "has_mean": True,
         "has_sum": False,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": "Fossil percentage",
         "source": "test",
         "statistic_id": "test:fossil_percentage",
@@ -1105,8 +1106,8 @@ async def test_fossil_energy_consumption_check_missing_hour(
         },
     )
     energy_metadata_1 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import",
@@ -1140,8 +1141,8 @@ async def test_fossil_energy_consumption_check_missing_hour(
         },
     )
     co2_metadata = {
-        "has_mean": True,
         "has_sum": False,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": "Fossil percentage",
         "source": "test",
         "statistic_id": "test:fossil_percentage",
@@ -1202,8 +1203,8 @@ async def test_fossil_energy_consumption_missing_sum(
         {"start": period4, "last_reset": None, "state": 3, "mean": 5},
     )
     external_energy_metadata_1 = {
-        "has_mean": True,
         "has_sum": False,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": "Mean imported energy",
         "source": "test",
         "statistic_id": "test:mean_energy_import_tariff",

--- a/tests/components/kitchen_sink/test_init.py
+++ b/tests/components/kitchen_sink/test_init.py
@@ -83,7 +83,7 @@ async def test_demo_statistics_growth(hass: HomeAssistant) -> None:
         "statistic_id": statistic_id,
         "unit_class": "volume",
         "unit_of_measurement": "m³",
-        "has_mean": False,
+        "mean_type": StatisticMeanType.NONE,
         "has_sum": True,
     }
     statistics = [

--- a/tests/components/opower/test_coordinator.py
+++ b/tests/components/opower/test_coordinator.py
@@ -10,7 +10,11 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.opower.const import DOMAIN
 from homeassistant.components.opower.coordinator import OpowerCoordinator
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
+from homeassistant.components.recorder.models import (
+    StatisticData,
+    StatisticMeanType,
+    StatisticMetaData,
+)
 from homeassistant.components.recorder.statistics import (
     async_add_external_statistics,
     get_last_statistics,
@@ -186,6 +190,7 @@ async def test_coordinator_migration(
     statistic_id = "opower:pge_elec_111111_energy_consumption"
     metadata = StatisticMetaData(
         has_sum=True,
+        mean_type=StatisticMeanType.NONE,
         name="Opower pge elec 111111 consumption",
         source=DOMAIN,
         statistic_id=statistic_id,

--- a/tests/components/recorder/auto_repairs/statistics/test_duplicates.py
+++ b/tests/components/recorder/auto_repairs/statistics/test_duplicates.py
@@ -14,6 +14,7 @@ from homeassistant.components.recorder.auto_repairs.statistics.duplicates import
     delete_statistics_duplicates,
     delete_statistics_meta_duplicates,
 )
+from homeassistant.components.recorder.models import StatisticMeanType
 from homeassistant.components.recorder.statistics import async_add_external_statistics
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.core import HomeAssistant
@@ -59,8 +60,8 @@ async def test_duplicate_statistics_handle_integrity_error(
     period2 = dt_util.as_utc(dt_util.parse_datetime("2021-09-30 23:00:00"))
 
     external_energy_metadata_1 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import_tariff_1",

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -401,8 +401,8 @@ def mock_sensor_statistics():
         """Generate fake statistics."""
         return {
             "meta": {
-                "has_mean": True,
                 "has_sum": False,
+                "mean_type": StatisticMeanType.ARITHMETIC,
                 "name": None,
                 "statistic_id": entity_id,
                 "unit_class": None,
@@ -668,8 +668,8 @@ async def test_rename_entity_collision(
 
     # Insert metadata for sensor.test99
     metadata_1 = {
-        "has_mean": True,
         "has_sum": False,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "sensor.test99",
@@ -775,8 +775,8 @@ async def test_rename_entity_collision_states_meta_check_disabled(
 
     # Insert metadata for sensor.test99
     metadata_1 = {
-        "has_mean": True,
         "has_sum": False,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "sensor.test99",
@@ -861,6 +861,13 @@ async def test_statistics_duplicated(
     ],
 )
 @pytest.mark.parametrize(
+    ("external_metadata_extra_2"),
+    [
+        {"has_mean": False},
+        {"mean_type": StatisticMeanType.NONE},
+    ],
+)
+@pytest.mark.parametrize(
     ("source", "statistic_id", "import_fn"),
     [
         ("test", "test:total_energy_import", async_add_external_statistics),
@@ -873,6 +880,7 @@ async def test_import_statistics(
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
     external_metadata_extra: dict[str, str],
+    external_metadata_extra_2: dict[str, Any],
     source,
     statistic_id,
     import_fn,
@@ -903,14 +911,17 @@ async def test_import_statistics(
         "sum": 3,
     }
 
-    external_metadata = {
-        "has_mean": False,
-        "has_sum": True,
-        "name": "Total imported energy",
-        "source": source,
-        "statistic_id": statistic_id,
-        "unit_of_measurement": "kWh",
-    } | external_metadata_extra
+    external_metadata = (
+        {
+            "has_sum": True,
+            "name": "Total imported energy",
+            "source": source,
+            "statistic_id": statistic_id,
+            "unit_of_measurement": "kWh",
+        }
+        | external_metadata_extra
+        | external_metadata_extra_2
+    )
 
     import_fn(hass, external_metadata, (external_statistics1, external_statistics2))
     await async_wait_recording_done(hass)
@@ -1137,8 +1148,8 @@ async def test_external_statistics_errors(
     }
 
     _external_metadata = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import",
@@ -1226,8 +1237,8 @@ async def test_import_statistics_errors(
     }
 
     _external_metadata = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "recorder",
         "statistic_id": "sensor.total_energy_import",
@@ -1564,8 +1575,8 @@ async def test_daily_statistics_sum(
         },
     )
     external_metadata = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import",
@@ -1746,8 +1757,8 @@ async def test_multiple_daily_statistics_sum(
         },
     )
     external_metadata1 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy 1",
         "source": "test",
         "statistic_id": "test:total_energy_import2",
@@ -1755,8 +1766,8 @@ async def test_multiple_daily_statistics_sum(
         "unit_of_measurement": "kWh",
     }
     external_metadata2 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy 2",
         "source": "test",
         "statistic_id": "test:total_energy_import1",
@@ -1946,8 +1957,8 @@ async def test_weekly_statistics_mean(
         },
     )
     external_metadata = {
-        "has_mean": True,
         "has_sum": False,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import",
@@ -2093,8 +2104,8 @@ async def test_weekly_statistics_sum(
         },
     )
     external_metadata = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import",
@@ -2275,8 +2286,8 @@ async def test_monthly_statistics_sum(
         },
     )
     external_metadata = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import",
@@ -2605,8 +2616,8 @@ async def test_change(
         },
     )
     external_metadata = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "recorder",
         "statistic_id": "sensor.total_energy_import",
@@ -2942,8 +2953,8 @@ async def test_change_multiple(
         },
     )
     external_metadata1 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "recorder",
         "statistic_id": "sensor.total_energy_import1",
@@ -2951,8 +2962,8 @@ async def test_change_multiple(
         "unit_of_measurement": "kWh",
     }
     external_metadata2 = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "recorder",
         "statistic_id": "sensor.total_energy_import2",
@@ -3333,8 +3344,8 @@ async def test_change_with_none(
         },
     )
     external_metadata = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import",
@@ -3888,8 +3899,8 @@ async def test_get_statistics_service(
         },
     )
     external_metadata1 = {
-        "has_mean": True,
         "has_sum": True,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": "Total imported energy",
         "source": "recorder",
         "statistic_id": "sensor.total_energy_import1",
@@ -3897,8 +3908,8 @@ async def test_get_statistics_service(
         "unit_of_measurement": "kWh",
     }
     external_metadata2 = {
-        "has_mean": True,
         "has_sum": True,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": "Total imported energy",
         "source": "recorder",
         "statistic_id": "sensor.total_energy_import2",

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import math
 from statistics import fmean
 import sys
+from typing import Any
 from unittest.mock import ANY, patch
 
 from _pytest.python_api import ApproxBase
@@ -319,8 +320,8 @@ async def test_statistic_during_period(
         )
 
     imported_metadata = {
-        "has_mean": True,
         "has_sum": True,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": "Total imported energy",
         "source": "recorder",
         "statistic_id": "sensor.test",
@@ -1095,8 +1096,8 @@ async def test_statistic_during_period_hole(
     ]
 
     imported_metadata = {
-        "has_mean": True,
         "has_sum": True,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": "Total imported energy",
         "source": "recorder",
         "statistic_id": "sensor.test",
@@ -1440,8 +1441,8 @@ async def test_statistic_during_period_partial_overlap(
 
     statId = "sensor.test_overlapping"
     imported_metadata = {
-        "has_mean": True,
         "has_sum": True,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": "Total imported energy overlapping",
         "source": "recorder",
         "statistic_id": statId,
@@ -3550,8 +3551,8 @@ async def test_get_statistics_metadata(
         },
     )
     external_energy_metadata_1 = {
-        "has_mean": has_mean,
         "has_sum": has_sum,
+        "mean_type": mean_type,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_gas",
@@ -3648,6 +3649,15 @@ async def test_get_statistics_metadata(
 
 
 @pytest.mark.parametrize(
+    ("external_metadata_extra_2"),
+    [
+        {"has_mean": False},
+        {
+            "mean_type": int(StatisticMeanType.NONE)
+        },  # The WS API accepts integer, not enum
+    ],
+)
+@pytest.mark.parametrize(
     ("external_metadata_extra", "unit_1", "unit_2", "unit_3", "expected_unit_class"),
     [
         ({}, "kWh", "kWh", "kWh", "energy"),
@@ -3675,6 +3685,7 @@ async def test_import_statistics(
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
     external_metadata_extra: dict[str, str],
+    external_metadata_extra_2: dict[str, Any],
     unit_1: str,
     unit_2: str,
     unit_3: str,
@@ -3705,14 +3716,17 @@ async def test_import_statistics(
         "sum": 3,
     }
 
-    imported_metadata = {
-        "has_mean": False,
-        "has_sum": True,
-        "name": "Total imported energy",
-        "source": source,
-        "statistic_id": statistic_id,
-        "unit_of_measurement": unit_1,
-    } | external_metadata_extra
+    imported_metadata = (
+        {
+            "has_sum": True,
+            "name": "Total imported energy",
+            "source": source,
+            "statistic_id": statistic_id,
+            "unit_of_measurement": unit_1,
+        }
+        | external_metadata_extra
+        | external_metadata_extra_2
+    )
 
     await client.send_json_auto_id(
         {
@@ -3997,8 +4011,8 @@ async def test_import_statistics_with_error(
     }
 
     imported_metadata = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": int(StatisticMeanType.NONE),
         "name": "Total imported energy",
         "source": source,
         "statistic_id": statistic_id,
@@ -4047,6 +4061,15 @@ async def test_import_statistics_with_error(
     ],
 )
 @pytest.mark.parametrize(
+    ("external_metadata_extra_2"),
+    [
+        {"has_mean": False},
+        {
+            "mean_type": int(StatisticMeanType.NONE)
+        },  # The WS API accepts integer, not enum
+    ],
+)
+@pytest.mark.parametrize(
     ("source", "statistic_id"),
     [
         ("test", "test:total_energy_import"),
@@ -4059,6 +4082,7 @@ async def test_adjust_sum_statistics_energy(
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
     external_metadata_extra: dict[str, str],
+    external_metadata_extra_2: dict[str, Any],
     source,
     statistic_id,
 ) -> None:
@@ -4085,14 +4109,17 @@ async def test_adjust_sum_statistics_energy(
         "sum": 3,
     }
 
-    imported_metadata = {
-        "has_mean": False,
-        "has_sum": True,
-        "name": "Total imported energy",
-        "source": source,
-        "statistic_id": statistic_id,
-        "unit_of_measurement": "kWh",
-    } | external_metadata_extra
+    imported_metadata = (
+        {
+            "has_sum": True,
+            "name": "Total imported energy",
+            "source": source,
+            "statistic_id": statistic_id,
+            "unit_of_measurement": "kWh",
+        }
+        | external_metadata_extra
+        | external_metadata_extra_2
+    )
 
     await client.send_json_auto_id(
         {
@@ -4251,6 +4278,15 @@ async def test_adjust_sum_statistics_energy(
     ],
 )
 @pytest.mark.parametrize(
+    ("external_metadata_extra_2"),
+    [
+        {"has_mean": False},
+        {
+            "mean_type": int(StatisticMeanType.NONE)
+        },  # The WS API accepts integer, not enum
+    ],
+)
+@pytest.mark.parametrize(
     ("source", "statistic_id"),
     [
         ("test", "test:total_gas"),
@@ -4263,6 +4299,7 @@ async def test_adjust_sum_statistics_gas(
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
     external_metadata_extra: dict[str, str],
+    external_metadata_extra_2: dict[str, Any],
     source,
     statistic_id,
 ) -> None:
@@ -4289,14 +4326,17 @@ async def test_adjust_sum_statistics_gas(
         "sum": 3,
     }
 
-    imported_metadata = {
-        "has_mean": False,
-        "has_sum": True,
-        "name": "Total imported energy",
-        "source": source,
-        "statistic_id": statistic_id,
-        "unit_of_measurement": "m³",
-    } | external_metadata_extra
+    imported_metadata = (
+        {
+            "has_sum": True,
+            "name": "Total imported energy",
+            "source": source,
+            "statistic_id": statistic_id,
+            "unit_of_measurement": "m³",
+        }
+        | external_metadata_extra
+        | external_metadata_extra_2
+    )
 
     await client.send_json_auto_id(
         {
@@ -4503,8 +4543,8 @@ async def test_adjust_sum_statistics_errors(
     }
 
     imported_metadata = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": int(StatisticMeanType.NONE),
         "name": "Total imported energy",
         "source": source,
         "statistic_id": statistic_id,
@@ -4667,8 +4707,8 @@ async def test_import_statistics_with_last_reset(
     }
 
     external_metadata = {
-        "has_mean": False,
         "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
         "name": "Total imported energy",
         "source": "test",
         "statistic_id": "test:total_energy_import",

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -3651,10 +3651,11 @@ async def test_get_statistics_metadata(
 @pytest.mark.parametrize(
     ("external_metadata_extra_2"),
     [
+        # Neither has_mean nor mean_type interpreted as False/None
+        {},
         {"has_mean": False},
-        {
-            "mean_type": int(StatisticMeanType.NONE)
-        },  # The WS API accepts integer, not enum
+        # The WS API accepts integer, not enum
+        {"mean_type": int(StatisticMeanType.NONE)},
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -5964,8 +5964,8 @@ async def test_validate_statistics_other_domain(
 
     # Create statistics for another domain
     metadata: StatisticMetaData = {
-        "has_mean": True,
         "has_sum": True,
+        "mean_type": StatisticMeanType.ARITHMETIC,
         "name": None,
         "source": RECORDER_DOMAIN,
         "statistic_id": "number.test",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate has_mean in favor of mean_type in recorder statistic API

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2824
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
