### PR TITLE
Use Entity Description in Shelly BLU TRV button

### DIFF
--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -97,36 +97,6 @@ BUTTONS: Final[list[ShellyButtonDescription[Any]]] = [
     ),
 ]
 
-BLU_TRV_BUTTONS: Final[list[ShellyButtonDescription]] = [
-    ShellyButtonDescription[ShellyRpcCoordinator](
-        key="calibrate",
-        name="Calibrate",
-        translation_key="calibrate",
-        entity_category=EntityCategory.CONFIG,
-        press_action="trigger_blu_trv_calibration",
-        supported=lambda coordinator: coordinator.model == MODEL_BLU_GATEWAY_G3,
-    ),
-]
-
-RPC_VIRTUAL_BUTTONS = {
-    "button_generic": RpcButtonDescription(
-        key="button",
-        role="generic",
-    ),
-    "button_open": RpcButtonDescription(
-        key="button",
-        entity_registry_enabled_default=False,
-        role="open",
-        models={MODEL_FRANKEVER_WATER_VALVE},
-    ),
-    "button_close": RpcButtonDescription(
-        key="button",
-        entity_registry_enabled_default=False,
-        role="close",
-        models={MODEL_FRANKEVER_WATER_VALVE},
-    ),
-}
-
 
 @callback
 def async_migrate_unique_ids(
@@ -218,7 +188,7 @@ async def async_setup_entry(
         hass, config_entry.entry_id, partial(async_migrate_unique_ids, coordinator)
     )
 
-    entities: list[ShellyButton | ShellyBluTrvButton] = []
+    entities: list[ShellyButton] = []
 
     entities.extend(
         ShellyButton(coordinator, button)
@@ -226,25 +196,15 @@ async def async_setup_entry(
         if button.supported(coordinator)
     )
 
+    async_add_entities(entities)
+
     if not isinstance(coordinator, ShellyRpcCoordinator):
-        async_add_entities(entities)
         return
 
-    # add virtual buttons
+    # add RPC buttons
     async_setup_entry_rpc(
-        hass, config_entry, async_add_entities, RPC_VIRTUAL_BUTTONS, RpcVirtualButton
+        hass, config_entry, async_add_entities, RPC_BUTTONS, RpcVirtualButton
     )
-
-    # add BLU TRV buttons
-    if blutrv_key_ids := get_rpc_key_ids(coordinator.device.status, BLU_TRV_IDENTIFIER):
-        entities.extend(
-            ShellyBluTrvButton(coordinator, button, id_)
-            for id_ in blutrv_key_ids
-            for button in BLU_TRV_BUTTONS
-            if button.supported(coordinator)
-        )
-
-    async_add_entities(entities)
 
     # the user can remove virtual components from the device configuration, so
     # we need to remove orphaned entities
@@ -342,37 +302,35 @@ class ShellyButton(ShellyBaseButton):
         await method()
 
 
-class ShellyBluTrvButton(ShellyBaseButton):
+class ShellyBluTrvButton(ShellyRpcAttributeEntity, ButtonEntity):
     """Represent a Shelly BLU TRV button."""
+
+    entity_description: RpcButtonDescription
+    _id: int
 
     def __init__(
         self,
         coordinator: ShellyRpcCoordinator,
-        description: ShellyButtonDescription,
-        id_: int,
+        key: str,
+        attribute: str,
+        description: RpcEntityDescription,
     ) -> None:
-        """Initialize."""
-        super().__init__(coordinator, description)
+        """Initialize button."""
+        super().__init__(coordinator, key, attribute, description)
 
-        key = f"{BLU_TRV_IDENTIFIER}:{id_}"
         config = coordinator.device.config[key]
         ble_addr: str = config["addr"]
         fw_ver = coordinator.device.status[key].get("fw_ver")
 
-        self._attr_unique_id = f"{format_ble_addr(ble_addr)}-{key}-{description.key}"
+        self._attr_unique_id = f"{format_ble_addr(ble_addr)}-{key}-{attribute}"
         self._attr_device_info = get_blu_trv_device_info(
             config, ble_addr, coordinator.mac, fw_ver
         )
-        self._id = id_
 
-    async def _press_method(self) -> None:
-        """Press method."""
-        method = getattr(self.coordinator.device, self.entity_description.press_action)
-
-        if TYPE_CHECKING:
-            assert method is not None
-
-        await method(self._id)
+    @rpc_call
+    async def async_press(self) -> None:
+        """Triggers the Shelly button press service."""
+        await self.coordinator.device.trigger_blu_trv_calibration(self._id)
 
 
 class RpcVirtualButton(ShellyRpcAttributeEntity, ButtonEntity):
@@ -388,3 +346,31 @@ class RpcVirtualButton(ShellyRpcAttributeEntity, ButtonEntity):
             assert isinstance(self.coordinator, ShellyRpcCoordinator)
 
         await self.coordinator.device.button_trigger(self._id, "single_push")
+
+
+RPC_BUTTONS = {
+    "button_generic": RpcButtonDescription(
+        key="button",
+        role="generic",
+    ),
+    "button_open": RpcButtonDescription(
+        key="button",
+        entity_registry_enabled_default=False,
+        role="open",
+        models={MODEL_FRANKEVER_WATER_VALVE},
+    ),
+    "button_close": RpcButtonDescription(
+        key="button",
+        entity_registry_enabled_default=False,
+        role="close",
+        models={MODEL_FRANKEVER_WATER_VALVE},
+    ),
+    "calibrate": RpcButtonDescription(
+        key="blutrv",
+        name="Calibrate",
+        translation_key="calibrate",
+        entity_category=EntityCategory.CONFIG,
+        entity_class=ShellyBluTrvButton,
+        models={MODEL_BLU_GATEWAY_G3},
+    ),
+}

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -219,7 +219,7 @@ async def test_rpc_blu_trv_button(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert mock_blu_trv.trigger_blu_trv_calibration.call_count == 1
+    mock_blu_trv.trigger_blu_trv_calibration.assert_called_once_with(200)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use Entity Description in Shelly BLU TRV button

I am splitting converting this platform to entity description into multiple PRs since it requires refactoring and moving code so it is easier to review in smaller PRs.

Changes already covered by tests and snapshot that also validate the entity unique ID.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
