### PR TITLE
Add attachments support to OpenRouter AI task

### DIFF
--- a/homeassistant/components/open_router/ai_task.py
+++ b/homeassistant/components/open_router/ai_task.py
@@ -40,7 +40,10 @@ class OpenRouterAITaskEntity(
     """OpenRouter AI Task entity."""
 
     _attr_name = None
-    _attr_supported_features = ai_task.AITaskEntityFeature.GENERATE_DATA
+    _attr_supported_features = (
+        ai_task.AITaskEntityFeature.GENERATE_DATA
+        | ai_task.AITaskEntityFeature.SUPPORT_ATTACHMENTS
+    )
 
     async def _async_generate_data(
         self,

--- a/homeassistant/components/open_router/entity.py
+++ b/homeassistant/components/open_router/entity.py
@@ -190,7 +190,7 @@ async def async_prepare_files_for_prompt(
 
             if not mime_type or not mime_type.startswith(("image/", "application/pdf")):
                 raise HomeAssistantError(
-                    "Only images and PDF are supported by the OpenRouter API,"
+                    "Only images and PDF are supported by the OpenRouter API, "
                     f"`{file_path}` is not an image file or PDF"
                 )
 
@@ -266,8 +266,6 @@ class OpenRouterEntity(Entity):
             assert last_message["role"] == "user" and isinstance(
                 last_message["content"], str
             )
-            LOGGER.warning("Last content: %s", last_content)
-            LOGGER.warning("Last message: %s", last_message)
             # Encode files with base64 and append them to the text prompt
             files = await async_prepare_files_for_prompt(
                 self.hass,

--- a/tests/components/open_router/snapshots/test_ai_task.ambr
+++ b/tests/components/open_router/snapshots/test_ai_task.ambr
@@ -31,7 +31,7 @@
     'platform': 'open_router',
     'previous_unique_id': None,
     'suggested_object_id': None,
-    'supported_features': <AITaskEntityFeature: 1>,
+    'supported_features': <AITaskEntityFeature: 3>,
     'translation_key': None,
     'unique_id': 'ABCDEG',
     'unit_of_measurement': None,
@@ -41,7 +41,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Gemini 1.5 Pro',
-      'supported_features': <AITaskEntityFeature: 1>,
+      'supported_features': <AITaskEntityFeature: 3>,
     }),
     'context': <ANY>,
     'entity_id': 'ai_task.gemini_1_5_pro',

--- a/tests/components/open_router/test_ai_task.py
+++ b/tests/components/open_router/test_ai_task.py
@@ -1,5 +1,6 @@
 """Test AI Task structured data generation."""
 
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from openai.types import CompletionUsage
@@ -9,7 +10,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 import voluptuous as vol
 
-from homeassistant.components import ai_task
+from homeassistant.components import ai_task, media_source
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -208,3 +209,102 @@ async def test_generate_invalid_structured_data(
                 },
             ),
         )
+
+
+async def test_generate_data_with_attachments(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openai_client: AsyncMock,
+) -> None:
+    """Test AI Task data generation with attachments."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = "ai_task.gemini_1_5_pro"
+
+    mock_openai_client.chat.completions.create = AsyncMock(
+        return_value=ChatCompletion(
+            id="chatcmpl-1234567890ABCDEFGHIJKLMNOPQRS",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(
+                        content="Hi there!",
+                        role="assistant",
+                        function_call=None,
+                        tool_calls=None,
+                    ),
+                )
+            ],
+            created=1700000000,
+            model="x-ai/grok-3",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=CompletionUsage(
+                completion_tokens=9, prompt_tokens=8, total_tokens=17
+            ),
+        )
+    )
+
+    # Test with attachments
+    with (
+        patch(
+            "homeassistant.components.media_source.async_resolve_media",
+            side_effect=[
+                media_source.PlayMedia(
+                    url="http://example.com/doorbell_snapshot.jpg",
+                    mime_type="image/jpeg",
+                    path=Path("doorbell_snapshot.jpg"),
+                ),
+                media_source.PlayMedia(
+                    url="http://example.com/context.pdf",
+                    mime_type="application/pdf",
+                    path=Path("context.pdf"),
+                ),
+            ],
+        ),
+        patch("pathlib.Path.exists", return_value=True),
+        patch(
+            "homeassistant.components.open_router.entity.guess_file_type",
+            return_value=("image/jpeg", None),
+        ),
+        patch("pathlib.Path.read_bytes", return_value=b"fake_image_data"),
+    ):
+        result = await ai_task.async_generate_data(
+            hass,
+            task_name="Test Task",
+            entity_id=entity_id,
+            instructions="Test prompt",
+            attachments=[
+                {"media_content_id": "media-source://media/doorbell_snapshot.jpg"},
+                {"media_content_id": "media-source://media/context.pdf"},
+            ],
+        )
+
+    assert result.data == "Hi there!"
+
+    # Verify that the create was called with the correct parameters
+    # The last call should have the user message with attachments
+    call_args = mock_openai_client.chat.completions.create.call_args
+    assert call_args is not None
+
+    # Check that the input includes the attachments
+    input_messages = call_args[1]["messages"]
+    assert len(input_messages) > 0
+
+    # Find the user message with attachments
+    user_message_with_attachments = input_messages[-2]
+
+    assert user_message_with_attachments is not None
+    assert len(user_message_with_attachments["content"]) == 3  # Text + attachments
+    assert user_message_with_attachments["content"] == [
+        {"type": "text", "text": "Test prompt"},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh"},
+        },
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:application/pdf;base64,ZmFrZV9pbWFnZV9kYXRh"},
+        },
+    ]


### PR DESCRIPTION
## Proposed change

Unlike all the remaining AI task integrations, OpenRouter didn't support adding attachments. However, the API and some models still support it, so add handling of the attachments to this integration too. This PR basically mirrors OpenAI implementation added in #148676, just adjusting the message structure to use Chat Completions API instead of Responses API (which is still in alpha on OpenRouter).

There is no checking that the model used actually supports multi-modal input, using a model that doesn't support it would lead to runtime errors.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #150473
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] N/A (no mention on attachment support in docs)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
