### PR TITLE
Set assumed state to group if at least one child has assumed state

### DIFF
--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -19,7 +19,6 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
@@ -283,12 +282,10 @@ class CoverGroup(GroupEntity, CoverEntity):
         self._attr_is_closed = True
         self._attr_is_closing = False
         self._attr_is_opening = False
-        self._attr_assumed_state = False
+        self._update_assumed_state_from_members()
         for entity_id in self._entity_ids:
             if not (state := self.hass.states.get(entity_id)):
                 continue
-            if state.attributes.get(ATTR_ASSUMED_STATE):
-                self._attr_assumed_state = True
             if state.state == CoverState.OPEN:
                 self._attr_is_closed = False
                 continue

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -19,6 +19,7 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
@@ -282,9 +283,12 @@ class CoverGroup(GroupEntity, CoverEntity):
         self._attr_is_closed = True
         self._attr_is_closing = False
         self._attr_is_opening = False
+        self._attr_assumed_state = False
         for entity_id in self._entity_ids:
             if not (state := self.hass.states.get(entity_id)):
                 continue
+            if state.attributes.get(ATTR_ASSUMED_STATE):
+                self._attr_assumed_state = True
             if state.state == CoverState.OPEN:
                 self._attr_is_closed = False
                 continue

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -116,6 +116,17 @@ class GroupEntity(Entity):
         """Abstract method to update the entity."""
 
     @callback
+    def _update_assumed_state_from_members(self) -> None:
+        """Update assumed_state based on member entities."""
+        self._attr_assumed_state = False
+        for entity_id in self._entity_ids:
+            if (state := self.hass.states.get(entity_id)) is None:
+                continue
+            if state.attributes.get(ATTR_ASSUMED_STATE):
+                self._attr_assumed_state = True
+                return
+
+    @callback
     def async_update_supported_features(
         self,
         entity_id: str,

--- a/homeassistant/components/group/fan.py
+++ b/homeassistant/components/group/fan.py
@@ -252,6 +252,7 @@ class FanGroup(GroupEntity, FanEntity):
     @callback
     def async_update_group_state(self) -> None:
         """Update state and attributes."""
+        self._update_assumed_state_from_members()
 
         states = [
             state

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -205,6 +205,8 @@ class LightGroup(GroupEntity, LightEntity):
     @callback
     def async_update_group_state(self) -> None:
         """Query all members and determine the light group state."""
+        self._update_assumed_state_from_members()
+
         states = [
             state
             for entity_id in self._entity_ids

--- a/homeassistant/components/group/switch.py
+++ b/homeassistant/components/group/switch.py
@@ -156,6 +156,8 @@ class SwitchGroup(GroupEntity, SwitchEntity):
     @callback
     def async_update_group_state(self) -> None:
         """Query all members and determine the switch group state."""
+        self._update_assumed_state_from_members()
+
         states = [
             state.state
             for entity_id in self._entity_ids

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -30,6 +30,7 @@ from homeassistant.components.light import (
     ColorMode,
 )
 from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     EVENT_CALL_SERVICE,
@@ -1647,3 +1648,72 @@ async def test_nested_group(hass: HomeAssistant) -> None:
     assert hass.states.get("light.kitchen_lights").state == STATE_OFF
     assert hass.states.get("light.bedroom_group").state == STATE_OFF
     assert hass.states.get("light.nested_group").state == STATE_OFF
+
+
+async def test_assumed_state(hass: HomeAssistant) -> None:
+    """Test assumed_state attribute behavior."""
+    await async_setup_component(
+        hass,
+        LIGHT_DOMAIN,
+        {
+            LIGHT_DOMAIN: {
+                "platform": DOMAIN,
+                "entities": ["light.kitchen", "light.bedroom", "light.living_room"],
+                "name": "Light Group",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    # No members with assumed_state -> group doesn't have assumed_state in attributes
+    hass.states.async_set("light.kitchen", STATE_ON, {})
+    hass.states.async_set("light.bedroom", STATE_ON, {})
+    hass.states.async_set("light.living_room", STATE_OFF, {})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.light_group")
+    assert ATTR_ASSUMED_STATE not in state.attributes
+
+    # One member with assumed_state=True -> group has assumed_state=True
+    hass.states.async_set("light.kitchen", STATE_ON, {ATTR_ASSUMED_STATE: True})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.light_group")
+    assert state.attributes.get(ATTR_ASSUMED_STATE) is True
+
+    # Multiple members with assumed_state=True -> group has assumed_state=True
+    hass.states.async_set("light.bedroom", STATE_OFF, {ATTR_ASSUMED_STATE: True})
+    hass.states.async_set("light.living_room", STATE_OFF, {ATTR_ASSUMED_STATE: True})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.light_group")
+    assert state.attributes.get(ATTR_ASSUMED_STATE) is True
+
+    # Unavailable member with assumed_state=True -> group has assumed_state=True
+    hass.states.async_set("light.kitchen", STATE_ON, {})
+    hass.states.async_set("light.bedroom", STATE_OFF, {})
+    hass.states.async_set(
+        "light.living_room", STATE_UNAVAILABLE, {ATTR_ASSUMED_STATE: True}
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.light_group")
+    assert state.attributes.get(ATTR_ASSUMED_STATE) is True
+
+    # Unknown member with assumed_state=True -> group has assumed_state=True
+    hass.states.async_set(
+        "light.living_room", STATE_UNKNOWN, {ATTR_ASSUMED_STATE: True}
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.light_group")
+    assert state.attributes.get(ATTR_ASSUMED_STATE) is True
+
+    # All members without assumed_state -> group doesn't have assumed_state in attributes
+    hass.states.async_set("light.living_room", STATE_OFF, {})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.light_group")
+    assert ATTR_ASSUMED_STATE not in state.attributes


### PR DESCRIPTION
## Proposed change

Previously, the group’s assumed state was always false, regardless of the state of its child entities.

This PR changes that behavior so that:
- The group will now have an assumed state of true if at least one child entity has an assumed state.
- This makes the group’s assumed state reflect the uncertainty of its children more accurately.

These domains have been added : switch, fan, light and cover.

Related front-end issue : https://github.com/home-assistant/frontend/issues/18563

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
