### PR TITLE
Add configuration for the Mailgun EU domain

### DIFF
--- a/homeassistant/components/mailgun/__init__.py
+++ b/homeassistant/components/mailgun/__init__.py
@@ -20,8 +20,10 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 CONF_SANDBOX = "sandbox"
+CONF_EU_DOMAIN = "eu_domain"
 
 DEFAULT_SANDBOX = False
+DEFAULT_EU_DOMAIN = False
 
 MESSAGE_RECEIVED = f"{DOMAIN}_message_received"
 
@@ -31,6 +33,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_API_KEY): cv.string,
                 vol.Required(CONF_DOMAIN): cv.string,
+                vol.Optional(CONF_EU_DOMAIN, default=DEFAULT_EU_DOMAIN): cv.boolean,
                 vol.Optional(CONF_SANDBOX, default=DEFAULT_SANDBOX): cv.boolean,
             }
         )

--- a/homeassistant/components/mailgun/manifest.json
+++ b/homeassistant/components/mailgun/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/mailgun",
   "iot_class": "cloud_push",
   "loggers": ["pymailgunner"],
-  "requirements": ["pymailgunner==1.4"]
+  "requirements": ["pymailgunner==1.5"]
 }

--- a/homeassistant/components/mailgun/notify.py
+++ b/homeassistant/components/mailgun/notify.py
@@ -23,7 +23,7 @@ from homeassistant.const import CONF_API_KEY, CONF_DOMAIN, CONF_RECIPIENT, CONF_
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import CONF_SANDBOX, DOMAIN
+from . import CONF_SANDBOX, DOMAIN, CONF_EU_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +48,7 @@ def get_service(
         data.get(CONF_DOMAIN),
         data.get(CONF_SANDBOX),
         data.get(CONF_API_KEY),
+        data.get(CONF_EU_DOMAIN),
         config.get(CONF_SENDER),
         config.get(CONF_RECIPIENT),
     )
@@ -60,19 +61,20 @@ def get_service(
 class MailgunNotificationService(BaseNotificationService):
     """Implement a notification service for the Mailgun mail service."""
 
-    def __init__(self, domain, sandbox, api_key, sender, recipient):
+    def __init__(self, domain, sandbox, api_key, eu_domain, sender, recipient):
         """Initialize the service."""
         self._client = None  # Mailgun API client
         self._domain = domain
         self._sandbox = sandbox
         self._api_key = api_key
+        self._eu_domain = eu_domain
         self._sender = sender
         self._recipient = recipient
 
     def initialize_client(self):
         """Initialize the connection to Mailgun."""
 
-        self._client = Client(self._api_key, self._domain, self._sandbox)
+        self._client = Client(self._api_key, self._domain, self._sandbox, self._eu_domain)
         _LOGGER.debug("Mailgun domain: %s", self._client.domain)
         self._domain = self._client.domain
         if not self._sender:


### PR DESCRIPTION
This change add the "eu_domain" property for the mailgun integration. It defaults to false, but if set to true allows to switch to the EU Mailgun servers

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #143346
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X ] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
