### PR TITLE
Moving all CONF_A* constants to MQTTConf(StrEnum) class

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -54,8 +54,6 @@ from homeassistant.util.unit_conversion import TemperatureConverter
 from . import subscription
 from .config import DEFAULT_RETAIN, MQTT_BASE_SCHEMA
 from .const import (
-    CONF_ACTION_TEMPLATE,
-    CONF_ACTION_TOPIC,
     CONF_CURRENT_HUMIDITY_TEMPLATE,
     CONF_CURRENT_HUMIDITY_TOPIC,
     CONF_CURRENT_TEMP_TEMPLATE,
@@ -114,6 +112,7 @@ from .const import (
     DEFAULT_CLIMATE_INITIAL_TEMPERATURE,
     DEFAULT_OPTIMISTIC,
     PAYLOAD_NONE,
+    MQTTConf,
 )
 from .entity import MqttEntity, async_setup_entity_entry_helper
 from .models import (
@@ -163,7 +162,7 @@ VALUE_TEMPLATE_KEYS = (
     CONF_FAN_MODE_STATE_TEMPLATE,
     CONF_HUMIDITY_STATE_TEMPLATE,
     CONF_MODE_STATE_TEMPLATE,
-    CONF_ACTION_TEMPLATE,
+    MQTTConf.ACTION_TEMPLATE,
     CONF_PRESET_MODE_VALUE_TEMPLATE,
     CONF_SWING_HORIZONTAL_MODE_STATE_TEMPLATE,
     CONF_SWING_MODE_STATE_TEMPLATE,
@@ -187,7 +186,7 @@ COMMAND_TEMPLATE_KEYS = {
 
 
 TOPIC_KEYS = (
-    CONF_ACTION_TOPIC,
+    MQTTConf.ACTION_TOPIC,
     CONF_CURRENT_HUMIDITY_TOPIC,
     CONF_CURRENT_TEMP_TOPIC,
     CONF_FAN_MODE_COMMAND_TOPIC,
@@ -297,8 +296,8 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
             vol.In([PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]),
         ),
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
-        vol.Optional(CONF_ACTION_TEMPLATE): cv.template,
-        vol.Optional(CONF_ACTION_TOPIC): valid_subscribe_topic,
+        vol.Optional(MQTTConf.ACTION_TEMPLATE.value): cv.template,
+        vol.Optional(MQTTConf.ACTION_TOPIC.value): valid_subscribe_topic,
         # CONF_PRESET_MODE_COMMAND_TOPIC and CONF_PRESET_MODES_LIST
         # must be used together
         vol.Inclusive(
@@ -669,7 +668,7 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
     @callback
     def _handle_action_received(self, msg: ReceiveMessage) -> None:
         """Handle receiving action via MQTT."""
-        payload = self.render_template(msg, CONF_ACTION_TEMPLATE)
+        payload = self.render_template(msg, MQTTConf.ACTION_TEMPLATE)
         if not payload:
             _LOGGER.debug(
                 "Invalid %s action: %s, ignoring",
@@ -729,7 +728,7 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
         """(Re)Subscribe to topics."""
         # add subscriptions for MqttClimate
         self.add_subscription(
-            CONF_ACTION_TOPIC,
+            MQTTConf.ACTION_TOPIC,
             self._handle_action_received,
             {"_attr_hvac_action"},
         )

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -146,10 +146,6 @@ from .const import (
     ATTR_QOS,
     ATTR_RETAIN,
     ATTR_TOPIC,
-    CONF_ACTION_TEMPLATE,
-    CONF_ACTION_TOPIC,
-    CONF_AVAILABILITY_TEMPLATE,
-    CONF_AVAILABILITY_TOPIC,
     CONF_BIRTH_MESSAGE,
     CONF_BLUE_TEMPLATE,
     CONF_BRIGHTNESS_COMMAND_TEMPLATE,
@@ -414,6 +410,7 @@ from .const import (
     TRANSPORT_TCP,
     TRANSPORT_WEBSOCKETS,
     VALUES_ON_COMMAND_TYPE,
+    MQTTConf,
     Platform,
 )
 from .models import MqttAvailabilityData, MqttDeviceData, MqttSubentryData
@@ -553,8 +550,8 @@ ENTITY_CATEGORY_SELECTOR = SelectSelector(
 )
 SUBENTRY_AVAILABILITY_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_AVAILABILITY_TOPIC): TEXT_SELECTOR,
-        vol.Optional(CONF_AVAILABILITY_TEMPLATE): TEMPLATE_SELECTOR,
+        vol.Optional(MQTTConf.AVAILABILITY_TOPIC.value): TEXT_SELECTOR,
+        vol.Optional(MQTTConf.AVAILABILITY_TEMPLATE.value): TEMPLATE_SELECTOR,
         vol.Optional(
             CONF_PAYLOAD_AVAILABLE, default=DEFAULT_PAYLOAD_AVAILABLE
         ): TEXT_SELECTOR,
@@ -1241,7 +1238,7 @@ PLATFORM_ENTITY_FIELDS: dict[str, dict[str, PlatformField]] = {
             selector=BOOLEAN_SELECTOR,
             required=False,
             exclude_from_config=True,
-            default=lambda config: bool(config.get(CONF_ACTION_TOPIC)),
+            default=lambda config: bool(config.get(MQTTConf.ACTION_TOPIC.value)),
         ),
         "climate_feature_target_temperature": PlatformField(
             selector=TARGET_TEMPERATURE_FEATURE_SELECTOR,
@@ -1588,7 +1585,7 @@ PLATFORM_MQTT_FIELDS: dict[str, dict[str, PlatformField]] = {
             selector=BOOLEAN_SELECTOR, required=False, validator=validate(bool)
         ),
         # current action settings
-        CONF_ACTION_TOPIC: PlatformField(
+        MQTTConf.ACTION_TOPIC.value: PlatformField(
             selector=TEXT_SELECTOR,
             required=True,
             validator=valid_subscribe_topic,
@@ -1596,7 +1593,7 @@ PLATFORM_MQTT_FIELDS: dict[str, dict[str, PlatformField]] = {
             section="climate_action_settings",
             conditions=({"climate_feature_action": True},),
         ),
-        CONF_ACTION_TEMPLATE: PlatformField(
+        MQTTConf.ACTION_TEMPLATE.value: PlatformField(
             selector=TEMPLATE_SELECTOR,
             required=False,
             validator=validate(cv.template),

--- a/homeassistant/components/mqtt/const.py
+++ b/homeassistant/components/mqtt/const.py
@@ -1,5 +1,6 @@
 """Constants used by multiple MQTT modules."""
 
+from enum import StrEnum
 import logging
 
 import jinja2
@@ -26,10 +27,18 @@ AVAILABILITY_MODES = [AVAILABILITY_ALL, AVAILABILITY_ANY, AVAILABILITY_LATEST]
 CONF_PAYLOAD_AVAILABLE = "payload_available"
 CONF_PAYLOAD_NOT_AVAILABLE = "payload_not_available"
 
-CONF_AVAILABILITY = "availability"
-CONF_AVAILABILITY_MODE = "availability_mode"
-CONF_AVAILABILITY_TEMPLATE = "availability_template"
-CONF_AVAILABILITY_TOPIC = "availability_topic"
+
+class MQTTConf(StrEnum):
+    """MQTT specific config values."""
+
+    ACTION_TEMPLATE = "action_template"
+    ACTION_TOPIC = "action_topic"
+    AVAILABILITY = "availability"
+    AVAILABILITY_MODE = "availability_mode"
+    AVAILABILITY_TEMPLATE = "availability_template"
+    AVAILABILITY_TOPIC = "availability_topic"
+
+
 CONF_BROKER = "broker"
 CONF_BIRTH_MESSAGE = "birth_message"
 CONF_CODE_ARM_REQUIRED = "code_arm_required"
@@ -61,8 +70,6 @@ CONF_WS_HEADERS = "ws_headers"
 CONF_WILL_MESSAGE = "will_message"
 CONF_PAYLOAD_RESET = "payload_reset"
 CONF_SUPPORTED_FEATURES = "supported_features"
-CONF_ACTION_TEMPLATE = "action_template"
-CONF_ACTION_TOPIC = "action_topic"
 CONF_BLUE_TEMPLATE = "blue_template"
 CONF_BRIGHTNESS_COMMAND_TEMPLATE = "brightness_command_template"
 CONF_BRIGHTNESS_COMMAND_TOPIC = "brightness_command_topic"

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -38,12 +38,12 @@ from .const import (
     ATTR_DISCOVERY_HASH,
     ATTR_DISCOVERY_PAYLOAD,
     ATTR_DISCOVERY_TOPIC,
-    CONF_AVAILABILITY,
     CONF_COMPONENTS,
     CONF_ORIGIN,
     CONF_TOPIC,
     DOMAIN,
     SUPPORTED_COMPONENTS,
+    MQTTConf,
 )
 from .models import DATA_MQTT, MqttComponentConfig, MqttOriginInfo, ReceiveMessage
 from .schemas import DEVICE_DISCOVERY_SCHEMA, MQTT_ORIGIN_INFO_SCHEMA, SHARED_OPTIONS
@@ -186,8 +186,10 @@ def _replace_all_abbreviations(
 
     _replace_abbreviations(discovery_payload, ABBREVIATIONS, ABBREVIATIONS_SET)
 
-    if CONF_AVAILABILITY in discovery_payload:
-        for availability_conf in cv.ensure_list(discovery_payload[CONF_AVAILABILITY]):
+    if MQTTConf.AVAILABILITY in discovery_payload:
+        for availability_conf in cv.ensure_list(
+            discovery_payload[MQTTConf.AVAILABILITY]
+        ):
             _replace_abbreviations(availability_conf, ABBREVIATIONS, ABBREVIATIONS_SET)
 
     if component_only:
@@ -224,8 +226,10 @@ def _replace_topic_base(discovery_payload: MQTTDiscoveryPayload) -> None:
                 discovery_payload[key] = f"{base}{value[1:]}"
             if value[-1] == TOPIC_BASE and key.endswith("topic"):
                 discovery_payload[key] = f"{value[:-1]}{base}"
-    if discovery_payload.get(CONF_AVAILABILITY):
-        for availability_conf in cv.ensure_list(discovery_payload[CONF_AVAILABILITY]):
+    if discovery_payload.get(MQTTConf.AVAILABILITY):
+        for availability_conf in cv.ensure_list(
+            discovery_payload[MQTTConf.AVAILABILITY]
+        ):
             if not isinstance(availability_conf, dict):
                 continue
             if topic := str(availability_conf.get(CONF_TOPIC)):
@@ -332,10 +336,10 @@ def _merge_common_device_options(
     """Merge common device options with the component config options.
 
     Common options are:
-        CONF_AVAILABILITY,
-        CONF_AVAILABILITY_MODE,
-        CONF_AVAILABILITY_TEMPLATE,
-        CONF_AVAILABILITY_TOPIC,
+        MQTTConf.AVAILABILITY,
+        MQTTConf.AVAILABILITY_MODE,
+        MQTTConf.AVAILABILITY_TEMPLATE,
+        MQTTConf.AVAILABILITY_TOPIC,
         CONF_COMMAND_TOPIC,
         CONF_PAYLOAD_AVAILABLE,
         CONF_PAYLOAD_NOT_AVAILABLE,

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -39,8 +39,6 @@ from homeassistant.helpers.typing import ConfigType, VolSchemaType
 from . import subscription
 from .config import MQTT_RW_SCHEMA
 from .const import (
-    CONF_ACTION_TEMPLATE,
-    CONF_ACTION_TOPIC,
     CONF_COMMAND_TEMPLATE,
     CONF_COMMAND_TOPIC,
     CONF_CURRENT_HUMIDITY_TEMPLATE,
@@ -48,6 +46,7 @@ from .const import (
     CONF_STATE_TOPIC,
     CONF_STATE_VALUE_TEMPLATE,
     PAYLOAD_NONE,
+    MQTTConf,
 )
 from .entity import MqttEntity, async_setup_entity_entry_helper
 from .models import (
@@ -117,9 +116,9 @@ def valid_humidity_range_configuration(config: ConfigType) -> ConfigType:
 
 _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
     {
-        vol.Optional(CONF_ACTION_TEMPLATE): cv.template,
-        vol.Optional(CONF_ACTION_TOPIC): valid_subscribe_topic,
-        # CONF_AVAIALABLE_MODES_LIST and CONF_MODE_COMMAND_TOPIC must be used together
+        vol.Optional(MQTTConf.ACTION_TEMPLATE.value): cv.template,
+        vol.Optional(MQTTConf.ACTION_TOPIC.value): valid_subscribe_topic,
+        # MQTTConf.AVAIALABLE_MODES_LIST and CONF_MODE_COMMAND_TOPIC must be used together
         vol.Inclusive(
             CONF_AVAILABLE_MODES_LIST, "available_modes", default=[]
         ): cv.ensure_list,
@@ -169,7 +168,7 @@ DISCOVERY_SCHEMA = vol.All(
 )
 
 TOPICS = (
-    CONF_ACTION_TOPIC,
+    MQTTConf.ACTION_TOPIC,
     CONF_STATE_TOPIC,
     CONF_COMMAND_TOPIC,
     CONF_CURRENT_HUMIDITY_TOPIC,
@@ -259,7 +258,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
         }
 
         value_templates: dict[str, Template | None] = {
-            ATTR_ACTION: config.get(CONF_ACTION_TEMPLATE),
+            ATTR_ACTION: config.get(MQTTConf.ACTION_TEMPLATE),
             ATTR_CURRENT_HUMIDITY: config.get(CONF_CURRENT_HUMIDITY_TEMPLATE),
             CONF_STATE: config.get(CONF_STATE_VALUE_TEMPLATE),
             ATTR_HUMIDITY: config.get(CONF_TARGET_HUMIDITY_STATE_TEMPLATE),
@@ -398,7 +397,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
         """(Re)Subscribe to topics."""
         self.add_subscription(CONF_STATE_TOPIC, self._state_received, {"_attr_is_on"})
         self.add_subscription(
-            CONF_ACTION_TOPIC, self._action_received, {"_attr_action"}
+            MQTTConf.ACTION_TOPIC, self._action_received, {"_attr_action"}
         )
         self.add_subscription(
             CONF_CURRENT_HUMIDITY_TOPIC,

--- a/homeassistant/components/mqtt/schemas.py
+++ b/homeassistant/components/mqtt/schemas.py
@@ -24,10 +24,6 @@ from homeassistant.helpers.typing import ConfigType
 from .const import (
     AVAILABILITY_LATEST,
     AVAILABILITY_MODES,
-    CONF_AVAILABILITY,
-    CONF_AVAILABILITY_MODE,
-    CONF_AVAILABILITY_TEMPLATE,
-    CONF_AVAILABILITY_TOPIC,
     CONF_COMMAND_TOPIC,
     CONF_COMPONENTS,
     CONF_CONFIGURATION_URL,
@@ -58,15 +54,16 @@ from .const import (
     DEFAULT_PAYLOAD_NOT_AVAILABLE,
     ENTITY_PLATFORMS,
     SUPPORTED_COMPONENTS,
+    MQTTConf,
 )
 from .util import valid_publish_topic, valid_qos_schema, valid_subscribe_topic
 
 # Device discovery options that are also available at entity component level
 SHARED_OPTIONS = [
-    CONF_AVAILABILITY,
-    CONF_AVAILABILITY_MODE,
-    CONF_AVAILABILITY_TEMPLATE,
-    CONF_AVAILABILITY_TOPIC,
+    MQTTConf.AVAILABILITY,
+    MQTTConf.AVAILABILITY_MODE,
+    MQTTConf.AVAILABILITY_TEMPLATE,
+    MQTTConf.AVAILABILITY_TOPIC,
     CONF_COMMAND_TOPIC,
     CONF_PAYLOAD_AVAILABLE,
     CONF_PAYLOAD_NOT_AVAILABLE,
@@ -85,8 +82,10 @@ MQTT_ORIGIN_INFO_SCHEMA = vol.All(
 
 _MQTT_AVAILABILITY_SINGLE_SCHEMA = vol.Schema(
     {
-        vol.Exclusive(CONF_AVAILABILITY_TOPIC, "availability"): valid_subscribe_topic,
-        vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
+        vol.Exclusive(
+            MQTTConf.AVAILABILITY_TOPIC.value, "availability"
+        ): valid_subscribe_topic,
+        vol.Optional(MQTTConf.AVAILABILITY_TEMPLATE.value): cv.template,
         vol.Optional(
             CONF_PAYLOAD_AVAILABLE, default=DEFAULT_PAYLOAD_AVAILABLE
         ): cv.string,
@@ -98,10 +97,10 @@ _MQTT_AVAILABILITY_SINGLE_SCHEMA = vol.Schema(
 
 _MQTT_AVAILABILITY_LIST_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_AVAILABILITY_MODE, default=AVAILABILITY_LATEST): vol.All(
-            cv.string, vol.In(AVAILABILITY_MODES)
-        ),
-        vol.Exclusive(CONF_AVAILABILITY, "availability"): vol.All(
+        vol.Optional(
+            MQTTConf.AVAILABILITY_MODE.value, default=AVAILABILITY_LATEST
+        ): vol.All(cv.string, vol.In(AVAILABILITY_MODES)),
+        vol.Exclusive(MQTTConf.AVAILABILITY.value, "availability"): vol.All(
             cv.ensure_list,
             [
                 {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
To separate the `mqtt.CONF_` from homeasistant builtins we could move them to StrEnum like this (it blew OOPP when I did all at the same time 🤣). There could be options here though, like splitting into integration type and a couple of other approaches. But I think we should be specific, its far better to type-check a `StrEnum` than a `str`.

As the component is HUGE the risk for cross-references is getting high and that could potentially be root-causes to bugs.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
