### PR TITLE
Fix Yale integration to handle unavailable OAuth implementation at startup

### DIFF
--- a/homeassistant/components/yale/__init__.py
+++ b/homeassistant/components/yale/__init__.py
@@ -29,11 +29,14 @@ type YaleConfigEntry = ConfigEntry[YaleData]
 async def async_setup_entry(hass: HomeAssistant, entry: YaleConfigEntry) -> bool:
     """Set up yale from a config entry."""
     session = async_create_yale_clientsession(hass)
-    implementation = (
-        await config_entry_oauth2_flow.async_get_config_entry_implementation(
-            hass, entry
+    try:
+        implementation = (
+            await config_entry_oauth2_flow.async_get_config_entry_implementation(
+                hass, entry
+            )
         )
-    )
+    except ValueError as err:
+        raise ConfigEntryNotReady("OAuth implementation not available") from err
     oauth_session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
     yale_gateway = YaleGateway(Path(hass.config.config_dir), session, oauth_session)
     try:

--- a/homeassistant/components/yale/__init__.py
+++ b/homeassistant/components/yale/__init__.py
@@ -27,7 +27,7 @@ type YaleConfigEntry = ConfigEntry[YaleData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: YaleConfigEntry) -> bool:
-    """Set up yale from a config entry."""
+    """Set up Yale from a config entry."""
     session = async_create_yale_clientsession(hass)
     try:
         implementation = (

--- a/tests/components/yale/test_init.py
+++ b/tests/components/yale/test_init.py
@@ -1,6 +1,6 @@
 """The tests for the yale platform."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from aiohttp import ClientResponseError
 import pytest
@@ -28,6 +28,8 @@ from .mocks import (
     _mock_inoperative_yale_lock_detail,
     _mock_lock_with_offline_key,
     _mock_operative_yale_lock_detail,
+    mock_client_credentials,
+    mock_yale_config_entry,
 )
 
 from tests.typing import WebSocketGenerator
@@ -234,3 +236,18 @@ async def test_device_remove_devices(
     )
     response = await client.remove_device(dead_device_entry.id, config_entry.entry_id)
     assert response["success"]
+
+
+async def test_oauth_implementation_not_available(hass: HomeAssistant) -> None:
+    """Test that unavailable OAuth implementation raises ConfigEntryNotReady."""
+    await mock_client_credentials(hass)
+    entry = await mock_yale_config_entry(hass)
+
+    with patch(
+        "homeassistant.components.yale.config_entry_oauth2_flow.async_get_config_entry_implementation",
+        side_effect=ValueError("Implementation not available"),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes an issue in the Yale integration where a generic `ValueError` was raised when the OAuth implementation was not available during startup (e.g., due to network issues). The error message "Implementation not available" was not user-friendly and prevented proper retry logic from executing.

The fix catches the `ValueError` from `async_get_config_entry_implementation()` and converts it to `ConfigEntryNotReady` with a descriptive message. This allows Home Assistant to automatically retry the setup later when the network connection is restored and the OAuth implementation becomes available.

```
ERROR (MainThread) [homeassistant.config_entries] Error setting up entry for yale
Traceback (most recent call last):
  ...
  File "/usr/src/homeassistant/homeassistant/helpers/config_entry_oauth2_flow.py", line 581, in async_get_config_entry_implementation
    raise ValueError("Implementation not available")
ValueError: Implementation not available
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
