### PR TITLE
Always run install of packages with same python as script

### DIFF
--- a/script/install_integration_requirements.py
+++ b/script/install_integration_requirements.py
@@ -46,6 +46,8 @@ def main() -> int | None:
             "-c",
             "homeassistant/package_constraints.txt",
             "-U",
+            "--python",
+            sys.executable,
             *sorted(all_requirements),  # Sort for consistent output
         ]
         print(" ".join(cmd))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ensure uv use the same python as the one that started the script to install integration requirements. This fixes the issues with vscode not able to run the installation of integration requirements with errors like attached. vscode will start the selected python executable, but will not set up the venv variables. 

```
uv pip install -c homeassistant/package_constraints.txt -U aiousbwatcher==1.1.1 bleak-retry-connector==4.4.3 bleak==1.0.1 bluetooth-adapters==2.1.0 bluetooth-auto-recovery==1.5.3 bluetooth-data-tools==1.28.3 dbus-fast==2.44.5 habluetooth==5.7.0 pyserial==3.5 togrill-bluetooth==0.8.0
error: Failed to inspect Python interpreter from virtual environment at `bin/python3`
  Caused by: Python interpreter not found at `/Users/joakim/src/hass/home-assistant/bin/python3`
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/joakim/src/hass/home-assistant/script/install_integration_requirements.py", line 62, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/joakim/src/hass/home-assistant/script/install_integration_requirements.py", line 52, in main
    subprocess.run(
    ~~~~~~~~~~~~~~^
        cmd,
        ^^^^
        check=True,
        ^^^^^^^^^^^
    )
    ^
  File "/usr/local/Cellar/python@3.13/3.13.3/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['uv', 'pip', 'install', '-c', 'homeassistant/package_constraints.txt', '-U', 'aiousbwatcher==1.1.1', 'bleak-retry-connector==4.4.3', 'bleak==1.0.1', 'bluetooth-adapters==2.1.0', 'bluetooth-auto-recovery==1.5.3', 'bluetooth-data-tools==1.28.3', 'dbus-fast==2.44.5', 'habluetooth==5.7.0', 'pyserial==3.5', 'togrill-bluetooth==0.8.0']' returned non-zero exit status 2.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
