### PR TITLE
Add station selector dropdown to Environment Canada config flow

### DIFF
--- a/homeassistant/components/environment_canada/__init__.py
+++ b/homeassistant/components/environment_canada/__init__.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import logging
 
 from env_canada import ECAirQuality, ECRadar, ECWeather
+
 from homeassistant.const import CONF_LANGUAGE, CONF_LATITUDE, CONF_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-
 from env_canada import ECRadar
 import voluptuous as vol
 

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import voluptuous as vol
 
 from env_canada import ECRadar
+import voluptuous as vol
 
 from homeassistant.components.camera import Camera
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import voluptuous as vol
 
 from env_canada import ECRadar
+
 from homeassistant.components.camera import Camera
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import (

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from env_canada import ECRadar
 import voluptuous as vol
 
+from env_canada import ECRadar
 from homeassistant.components.camera import Camera
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import (
@@ -58,6 +58,14 @@ class ECCameraEntity(CoordinatorEntity[ECDataUpdateCoordinator[ECRadar]], Camera
         self._attr_device_info = coordinator.device_info
 
         self.content_type = "image/gif"
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        # Trigger coordinator refresh when entity is enabled
+        # since radar coordinator skips initial refresh during setup
+        if not self.coordinator.last_update_success:
+            await self.coordinator.async_request_refresh()
 
     def camera_image(
         self, width: int | None = None, height: int | None = None

--- a/homeassistant/components/environment_canada/config_flow.py
+++ b/homeassistant/components/environment_canada/config_flow.py
@@ -9,6 +9,7 @@ from env_canada.ec_weather import get_ec_sites_list
 import voluptuous as vol
 
 from env_canada import ECWeather, ec_exc
+
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_LANGUAGE, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.helpers import config_validation as cv

--- a/homeassistant/components/environment_canada/config_flow.py
+++ b/homeassistant/components/environment_canada/config_flow.py
@@ -5,12 +5,14 @@ from typing import Any
 import xml.etree.ElementTree as ET
 
 import aiohttp
-from env_canada import ECWeather, ec_exc
+from env_canada.ec_weather import get_ec_sites_list
 import voluptuous as vol
 
+from env_canada import ECWeather, ec_exc
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_LANGUAGE, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.selector import selector
 
 from .const import CONF_STATION, CONF_TITLE, DOMAIN
 
@@ -25,14 +27,16 @@ async def validate_input(data):
     lang = data.get(CONF_LANGUAGE).lower()
 
     if station:
+        # When station is provided, use it and get the coordinates from ECWeather
         weather_data = ECWeather(station_id=station, language=lang)
-    else:
-        weather_data = ECWeather(coordinates=(lat, lon), language=lang)
-    await weather_data.update()
-
-    if lat is None or lon is None:
+        await weather_data.update()
+        # Always use the station's coordinates, not the user-provided ones
         lat = weather_data.lat
         lon = weather_data.lon
+    else:
+        # When no station is provided, use coordinates to find nearest station
+        weather_data = ECWeather(coordinates=(lat, lon), language=lang)
+        await weather_data.update()
 
     return {
         CONF_TITLE: weather_data.metadata.location,
@@ -46,6 +50,13 @@ class EnvironmentCanadaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Environment Canada weather."""
 
     VERSION = 1
+    _station_codes: list[dict[str, str]] | None = None
+
+    async def _get_station_codes(self) -> list[dict[str, str]]:
+        """Get station codes, cached after first call."""
+        if self._station_codes is None:
+            self._station_codes = await get_ec_sites_list()
+        return self._station_codes
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -80,9 +91,18 @@ class EnvironmentCanadaConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(title=info[CONF_TITLE], data=user_input)
 
+        station_codes = await self._get_station_codes()
+
         data_schema = vol.Schema(
             {
-                vol.Optional(CONF_STATION): str,
+                vol.Optional(CONF_STATION): selector(
+                    {
+                        "select": {
+                            "options": station_codes,
+                            "mode": "dropdown",
+                        }
+                    }
+                ),
                 vol.Optional(
                     CONF_LATITUDE, default=self.hass.config.latitude
                 ): cv.latitude,

--- a/homeassistant/components/environment_canada/config_flow.py
+++ b/homeassistant/components/environment_canada/config_flow.py
@@ -5,10 +5,9 @@ from typing import Any
 import xml.etree.ElementTree as ET
 
 import aiohttp
+from env_canada import ECWeather, ec_exc
 from env_canada.ec_weather import get_ec_sites_list
 import voluptuous as vol
-
-from env_canada import ECWeather, ec_exc
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_LANGUAGE, CONF_LATITUDE, CONF_LONGITUDE

--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
   "iot_class": "cloud_polling",
   "loggers": ["env_canada"],
-  "requirements": ["env-canada==0.12.0"]
+  "requirements": ["env-canada==0.12.1"]
 }

--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
   "iot_class": "cloud_polling",
   "loggers": ["env_canada"],
-  "requirements": ["env-canada==0.11.3"]
+  "requirements": ["env-canada==0.12.0"]
 }

--- a/homeassistant/components/environment_canada/strings.json
+++ b/homeassistant/components/environment_canada/strings.json
@@ -3,11 +3,11 @@
     "step": {
       "user": {
         "title": "Environment Canada: weather location and language",
-        "description": "Either a station ID or latitude/longitude must be specified. The default latitude/longitude used are the values configured in your Home Assistant installation. The closest weather station to the coordinates will be used if specifying coordinates. If a station code is used it must follow the format: PP/code, where PP is the two-letter province and code is the station ID. The list of station IDs can be found here: https://dd.weather.gc.ca/citypage_weather/docs/site_list_towns_en.csv. Weather information can be retrieved in either English or French.",
+        "description": "Select a weather station from the dropdown, or specify coordinates to use the closest station. The default coordinates are from your Home Assistant installation. Weather information can be retrieved in English or French.",
         "data": {
           "latitude": "[%key:common::config_flow::data::latitude%]",
           "longitude": "[%key:common::config_flow::data::longitude%]",
-          "station": "Weather station ID",
+          "station": "Weather station",
           "language": "Weather information language"
         }
       }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -895,7 +895,7 @@ enocean==0.50
 enturclient==0.2.4
 
 # homeassistant.components.environment_canada
-env-canada==0.12.0
+env-canada==0.12.1
 
 # homeassistant.components.season
 ephem==4.1.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -895,7 +895,7 @@ enocean==0.50
 enturclient==0.2.4
 
 # homeassistant.components.environment_canada
-env-canada==0.11.3
+env-canada==0.12.0
 
 # homeassistant.components.season
 ephem==4.1.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -777,7 +777,7 @@ energyzero==2.1.1
 enocean==0.50
 
 # homeassistant.components.environment_canada
-env-canada==0.11.3
+env-canada==0.12.0
 
 # homeassistant.components.season
 ephem==4.1.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -777,7 +777,7 @@ energyzero==2.1.1
 enocean==0.50
 
 # homeassistant.components.environment_canada
-env-canada==0.12.0
+env-canada==0.12.1
 
 # homeassistant.components.season
 ephem==4.1.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enhance the configuration experience by adding a searchable dropdown selector for weather stations and fix several initialization issues.

Changes:
- Add station dropdown selector in config flow with city/province labels
- Update strings.json with simplified user-friendly instructions
- Bump env-canada dependency to 0.12.1 ([Changelog](https://github.com/michaeldavie/env_canada/blob/master/CHANGELOG.md))

Fixes:
- Radar image processing errors during initial setup

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
