### PR TITLE
Add services to set thresholds on a threshold helper

### DIFF
--- a/homeassistant/components/threshold/const.py
+++ b/homeassistant/components/threshold/const.py
@@ -22,6 +22,9 @@ POSITION_BELOW: Final = "below"
 POSITION_IN_RANGE: Final = "in_range"
 POSITION_UNKNOWN: Final = "unknown"
 
+SERVICE_SET_LOWER_THRESHOLD: Final = "set_lower_threshold"
+SERVICE_SET_UPPER_THRESHOLD: Final = "set_upper_threshold"
+
 TYPE_LOWER: Final = "lower"
 TYPE_RANGE: Final = "range"
 TYPE_UPPER: Final = "upper"

--- a/homeassistant/components/threshold/icons.json
+++ b/homeassistant/components/threshold/icons.json
@@ -1,0 +1,10 @@
+{
+  "services": {
+    "set_lower_threshold": {
+      "service": "mdi:arrow-down-bold"
+    },
+    "set_upper_threshold": {
+      "service": "mdi:arrow-up-bold"
+    }
+  }
+}

--- a/homeassistant/components/threshold/services.yaml
+++ b/homeassistant/components/threshold/services.yaml
@@ -1,0 +1,27 @@
+set_lower_threshold:
+  target:
+    entity:
+      integration: threshold
+      domain: binary_sensor
+  fields:
+    value:
+      required: true
+      example: 20.5
+      selector:
+        number:
+          mode: box
+          step: any
+
+set_upper_threshold:
+  target:
+    entity:
+      integration: threshold
+      domain: binary_sensor
+  fields:
+    value:
+      required: true
+      example: 80.5
+      selector:
+        number:
+          mode: box
+          step: any

--- a/homeassistant/components/threshold/strings.json
+++ b/homeassistant/components/threshold/strings.json
@@ -34,5 +34,27 @@
     "error": {
       "need_lower_upper": "[%key:component::threshold::config::error::need_lower_upper%]"
     }
+  },
+  "services": {
+    "set_lower_threshold": {
+      "name": "Set lower threshold",
+      "description": "Sets the lower threshold value and updates the helper state immediately.",
+      "fields": {
+        "value": {
+          "name": "Value",
+          "description": "The new lower threshold value."
+        }
+      }
+    },
+    "set_upper_threshold": {
+      "name": "Set upper threshold",
+      "description": "Sets the upper threshold value and updates the helper state immediately.",
+      "fields": {
+        "value": {
+          "name": "Value",
+          "description": "The new upper threshold value."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Proposed change

This PR adds two services to the Threshold helper, one to set the lower
threshold and another to set the upper threshold. In both cases calling
this will immediately recalculate the Threshold's state, it ignores the
hysteresis value when doing so on the basis this recalculation has been
explicitly requested.

The intent behind this is to provide a more intuitive interface for updating
thresholds, I'm specifically intending to use this for lighting thresholds,
where I want to have a physical button I push which toggles the lights and
at the same time updates the threshold to the current lux level.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41292
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
