### PR TITLE
Allow following of 302 redirects in generic camera

### DIFF
--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -191,7 +191,9 @@ async def async_test_still(
     try:
         async_client = get_async_client(hass, verify_ssl=verify_ssl)
         async with asyncio.timeout(GET_IMAGE_TIMEOUT):
-            response = await async_client.get(url, auth=auth, timeout=GET_IMAGE_TIMEOUT)
+            response = await async_client.get(
+                url, auth=auth, timeout=GET_IMAGE_TIMEOUT, follow_redirects=True
+            )
             response.raise_for_status()
             image = response.content
     except (

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -516,6 +516,29 @@ async def test_form_image_http_exceptions(
 
 
 @respx.mock
+@pytest.mark.usefixtures("fakeimg_png")
+async def test_form_image_http_302(
+    hass: HomeAssistant,
+    user_flow: ConfigFlowResult,
+    mock_create_stream: _patch[MagicMock],
+    fakeimgbytes_png: bytes,
+) -> None:
+    """Test we handle image http 302 (temporary redirect)."""
+    respx.get("http://127.0.0.1/testurl/1").side_effect = [
+        httpx.Response(
+            status_code=302, headers={"Location": "http://127.0.0.1/testurl/2"}
+        )
+    ]
+    result2 = await hass.config_entries.flow.async_configure(
+        user_flow["flow_id"],
+        TESTDATA,
+    )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "user_confirm"
+
+
+@respx.mock
 async def test_form_stream_invalidimage(
     hass: HomeAssistant,
     user_flow: ConfigFlowResult,

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -516,7 +516,6 @@ async def test_form_image_http_exceptions(
 
 
 @respx.mock
-@pytest.mark.usefixtures("fakeimg_png")
 async def test_form_image_http_302(
     hass: HomeAssistant,
     user_flow: ConfigFlowResult,
@@ -526,9 +525,12 @@ async def test_form_image_http_302(
     """Test we handle image http 302 (temporary redirect)."""
     respx.get("http://127.0.0.1/testurl/1").side_effect = [
         httpx.Response(
-            status_code=302, headers={"Location": "http://127.0.0.1/testurl/2"}
+            status_code=302, headers={"Location": "http://127.0.0.1/testurl2/1"}
         )
     ]
+    respx.get("http://127.0.0.1/testurl2/1", name="fake_img2").respond(
+        stream=fakeimgbytes_png
+    )
     result2 = await hass.config_entries.flow.async_configure(
         user_flow["flow_id"],
         TESTDATA,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As reported in #154185, the generic camera didn't follow HTTP 302 redirects. HTTP 302 is a temporary redirect, i.e. the resource has moved, but could come back. Previously, HTTP302 was treated as an error.

This PR adds the 'allow_redirect' parameter and adds a test to make sure setup works as expected in this condition.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #154185 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
