### PR TITLE
Simplify generic camera tests

### DIFF
--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -32,7 +32,6 @@ from homeassistant.components.stream import (
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import (
     CONF_AUTHENTICATION,
-    CONF_NAME,
     CONF_PASSWORD,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
@@ -56,13 +55,14 @@ TESTDATA = {
     CONF_VERIFY_SSL: False,
 }
 
+TESTDATA_ONLYSTILL = TESTDATA.copy()
+TESTDATA_ONLYSTILL.pop(CONF_STREAM_SOURCE)
+
+TESTDATA_ONLYSTREAM = TESTDATA.copy()
+TESTDATA_ONLYSTREAM.pop(CONF_STILL_IMAGE_URL)
+
 TESTDATA_OPTIONS = {
     CONF_LIMIT_REFETCH_TO_URL_CHANGE: False,
-    **TESTDATA,
-}
-
-TESTDATA_YAML = {
-    CONF_NAME: "Yaml Defined Name",
     **TESTDATA,
 }
 
@@ -135,11 +135,9 @@ async def test_form_only_stillimage(
     mock_setup_entry: _patch[MagicMock],
 ) -> None:
     """Test we complete ok if the user wants still images only."""
-    data = TESTDATA.copy()
-    data.pop(CONF_STREAM_SOURCE)
     result1 = await hass.config_entries.flow.async_configure(
         user_flow["flow_id"],
-        data,
+        TESTDATA_ONLYSTILL,
     )
     await hass.async_block_till_done()
     assert result1["type"] is FlowResultType.FORM
@@ -235,11 +233,9 @@ async def test_form_only_stillimage_gif(
     mock_setup_entry: _patch[MagicMock],
 ) -> None:
     """Test we complete ok if the user wants a gif."""
-    data = TESTDATA.copy()
-    data.pop(CONF_STREAM_SOURCE)
     result1 = await hass.config_entries.flow.async_configure(
         user_flow["flow_id"],
-        data,
+        TESTDATA_ONLYSTILL,
     )
     assert result1["type"] is FlowResultType.FORM
     assert result1["step_id"] == "user_confirm"
@@ -262,11 +258,9 @@ async def test_form_only_svg_whitespace(
     """Test we complete ok if svg starts with whitespace, issue #68889."""
     fakeimgbytes_wspace_svg = bytes("  \n ", encoding="utf-8") + fakeimgbytes_svg
     respx.get("http://127.0.0.1/testurl/1").respond(stream=fakeimgbytes_wspace_svg)
-    data = TESTDATA.copy()
-    data.pop(CONF_STREAM_SOURCE)
     result1 = await hass.config_entries.flow.async_configure(
         user_flow["flow_id"],
-        data,
+        TESTDATA_ONLYSTILL,
     )
     assert result1["type"] is FlowResultType.FORM
     assert result1["step_id"] == "user_confirm"
@@ -296,11 +290,9 @@ async def test_form_only_still_sample(
     image_path = os.path.join(os.path.dirname(__file__), image_file)
     image_bytes = await hass.async_add_executor_job(Path(image_path).read_bytes)
     respx.get("http://127.0.0.1/testurl/1").respond(stream=image_bytes)
-    data = TESTDATA.copy()
-    data.pop(CONF_STREAM_SOURCE)
     result1 = await hass.config_entries.flow.async_configure(
         user_flow["flow_id"],
-        data,
+        TESTDATA_ONLYSTILL,
     )
     assert result1["type"] is FlowResultType.FORM
     assert result1["step_id"] == "user_confirm"
@@ -364,8 +356,7 @@ async def test_form_still_template(
         # There is no need to mock the request if its an
         # invalid url because we will never make the request
         respx.get(url).respond(stream=fakeimgbytes_png)
-    data = TESTDATA.copy()
-    data.pop(CONF_STREAM_SOURCE)
+    data = TESTDATA_ONLYSTILL.copy()
     data[CONF_STILL_IMAGE_URL] = template
     result2 = await hass.config_entries.flow.async_configure(
         user_flow["flow_id"],
@@ -417,8 +408,7 @@ async def test_form_only_stream(
     mock_create_stream: _patch[MagicMock],
 ) -> None:
     """Test we complete ok if the user wants stream only."""
-    data = TESTDATA.copy()
-    data.pop(CONF_STILL_IMAGE_URL)
+    data = TESTDATA_ONLYSTREAM.copy()
     data[CONF_STREAM_SOURCE] = "rtsp://user:pass@127.0.0.1/testurl/2"
     result1 = await hass.config_entries.flow.async_configure(
         user_flow["flow_id"],
@@ -592,8 +582,6 @@ async def test_form_stream_timeout(
 @respx.mock
 async def test_form_stream_not_set_up(hass: HomeAssistant, user_flow) -> None:
     """Test we handle if stream has not been set up."""
-    TESTDATA_ONLY_STREAM = TESTDATA.copy()
-    TESTDATA_ONLY_STREAM.pop(CONF_STILL_IMAGE_URL)
 
     with patch(
         "homeassistant.components.generic.config_flow.create_stream",
@@ -601,7 +589,7 @@ async def test_form_stream_not_set_up(hass: HomeAssistant, user_flow) -> None:
     ):
         result1 = await hass.config_entries.flow.async_configure(
             user_flow["flow_id"],
-            TESTDATA_ONLY_STREAM,
+            TESTDATA_ONLYSTREAM,
         )
     await hass.async_block_till_done()
 
@@ -612,8 +600,6 @@ async def test_form_stream_not_set_up(hass: HomeAssistant, user_flow) -> None:
 @respx.mock
 async def test_form_stream_other_error(hass: HomeAssistant, user_flow) -> None:
     """Test the unknown error for streams."""
-    TESTDATA_ONLY_STREAM = TESTDATA.copy()
-    TESTDATA_ONLY_STREAM.pop(CONF_STILL_IMAGE_URL)
 
     with (
         patch(
@@ -624,7 +610,7 @@ async def test_form_stream_other_error(hass: HomeAssistant, user_flow) -> None:
     ):
         await hass.config_entries.flow.async_configure(
             user_flow["flow_id"],
-            TESTDATA_ONLY_STREAM,
+            TESTDATA_ONLYSTREAM,
         )
     await hass.async_block_till_done()
 
@@ -794,14 +780,12 @@ async def test_options_only_stream(
     mock_create_stream: _patch[MagicMock],
 ) -> None:
     """Test the options flow without a still_image_url."""
-    data = TESTDATA.copy()
-    data.pop(CONF_STILL_IMAGE_URL)
 
     mock_entry = MockConfigEntry(
         title="Test Camera",
         domain=DOMAIN,
         data={},
-        options=data,
+        options=TESTDATA_ONLYSTREAM,
     )
     mock_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -813,7 +797,7 @@ async def test_options_only_stream(
     # try updating the config options
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input=data,
+        user_input=TESTDATA_ONLYSTREAM,
     )
     assert result2["type"] is FlowResultType.FORM
     assert result2["step_id"] == "user_confirm"
@@ -830,7 +814,8 @@ async def test_options_still_and_stream_not_provided(
     mock_setup_entry: _patch[MagicMock],
 ) -> None:
     """Test we show a suitable error if neither still or stream URL are provided."""
-    data = TESTDATA.copy()
+    data = TESTDATA_ONLYSTILL.copy()
+    data.pop(CONF_STILL_IMAGE_URL)
 
     mock_entry = MockConfigEntry(
         title="Test Camera",
@@ -845,8 +830,6 @@ async def test_options_still_and_stream_not_provided(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
 
-    data.pop(CONF_STILL_IMAGE_URL)
-    data.pop(CONF_STREAM_SOURCE)
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input=data,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Several data structures are reused throughout the tests, so this PR makes them common constants.

Also deleted some constants that were not longer used.

There should be no functional change in this PR

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
