### PR TITLE
Restore KNX sensor entity states

### DIFF
--- a/homeassistant/components/knx/binary_sensor.py
+++ b/homeassistant/components/knx/binary_sensor.py
@@ -84,11 +84,11 @@ class _KnxBinarySensor(BinarySensorEntity, RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         """Restore last state."""
-        await super().async_added_to_hass()
         if (
             last_state := await self.async_get_last_state()
         ) and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             self._device.remote_value.update_value(last_state.state == STATE_ON)
+        await super().async_added_to_hass()
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -6,15 +6,15 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import partial
-from typing import Any
 
 from xknx import XKNX
 from xknx.core.connection_state import XknxConnectionState, XknxConnectionType
-from xknx.devices import Sensor as XknxSensor
+from xknx.devices import Device as XknxDevice, Sensor as XknxSensor
 
 from homeassistant import config_entries
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -25,6 +25,8 @@ from homeassistant.const import (
     CONF_ENTITY_CATEGORY,
     CONF_NAME,
     CONF_TYPE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     EntityCategory,
     Platform,
 )
@@ -141,7 +143,7 @@ def _create_sensor(xknx: XKNX, config: ConfigType) -> XknxSensor:
     )
 
 
-class KNXSensor(KnxYamlEntity, SensorEntity):
+class KNXSensor(KnxYamlEntity, RestoreSensor):
     """Representation of a KNX sensor."""
 
     _device: XknxSensor
@@ -164,20 +166,25 @@ class KNXSensor(KnxYamlEntity, SensorEntity):
         self._attr_unique_id = str(self._device.sensor_value.group_address_state)
         self._attr_native_unit_of_measurement = self._device.unit_of_measurement()
         self._attr_state_class = config.get(CONF_STATE_CLASS)
+        self._attr_extra_state_attributes = {}
 
-    @property
-    def native_value(self) -> StateType:
-        """Return the state of the sensor."""
-        return self._device.resolve_state()
+    async def async_added_to_hass(self) -> None:
+        """Restore last state."""
+        if (
+            last_state := await self.async_get_last_state()
+        ) and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            self._attr_native_value = last_state.state
+            self._attr_extra_state_attributes.update(last_state.attributes)
+        await super().async_added_to_hass()
 
-    @property
-    def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Return device specific state attributes."""
-        attr: dict[str, Any] = {}
-
-        if self._device.last_telegram is not None:
-            attr[ATTR_SOURCE] = str(self._device.last_telegram.source_address)
-        return attr
+    def after_update_callback(self, device: XknxDevice) -> None:
+        """Call after device was updated."""
+        self._attr_native_value = self._device.resolve_state()
+        if telegram := self._device.last_telegram:
+            self._attr_extra_state_attributes[ATTR_SOURCE] = str(
+                telegram.source_address
+            )
+        super().after_update_callback(device)
 
 
 class KNXSystemSensor(SensorEntity):

--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -171,9 +171,14 @@ class KNXSensor(KnxYamlEntity, RestoreSensor):
     async def async_added_to_hass(self) -> None:
         """Restore last state."""
         if (
-            last_state := await self.async_get_last_state()
-        ) and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-            self._attr_native_value = last_state.state
+            (last_state := await self.async_get_last_state())
+            and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+            and (
+                (last_sensor_data := await self.async_get_last_sensor_data())
+                is not None
+            )
+        ):
+            self._attr_native_value = last_sensor_data.native_value
             self._attr_extra_state_attributes.update(last_state.attributes)
         await super().async_added_to_hass()
 

--- a/tests/components/knx/test_binary_sensor.py
+++ b/tests/components/knx/test_binary_sensor.py
@@ -284,8 +284,8 @@ async def test_binary_sensor_reset(
     assert state.state is STATE_OFF
 
 
-async def test_binary_sensor_restore_and_respond(hass: HomeAssistant, knx) -> None:
-    """Test restoring KNX binary sensor state and respond to read."""
+async def test_binary_sensor_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test restoring KNX binary sensor state."""
     _ADDRESS = "2/2/2"
     fake_state = State("binary_sensor.test", STATE_ON)
     mock_restore_cache(hass, (fake_state,))
@@ -312,7 +312,9 @@ async def test_binary_sensor_restore_and_respond(hass: HomeAssistant, knx) -> No
     assert state.state is STATE_OFF
 
 
-async def test_binary_sensor_restore_invert(hass: HomeAssistant, knx) -> None:
+async def test_binary_sensor_restore_invert(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
     """Test restoring KNX binary sensor state with invert."""
     _ADDRESS = "2/2/2"
     fake_state = State("binary_sensor.test", STATE_ON)

--- a/tests/components/knx/test_sensor.py
+++ b/tests/components/knx/test_sensor.py
@@ -16,7 +16,7 @@ from .conftest import KNXTestKit
 from tests.common import (
     async_capture_events,
     async_fire_time_changed,
-    mock_restore_cache,
+    mock_restore_cache_with_extra_data,
 )
 
 
@@ -57,8 +57,11 @@ async def test_sensor_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
     RAW_FLOAT_21_0 = (0x0C, 0x1A)
     RESTORED_STATE = "21.0"
     RESTORED_STATE_ATTRIBUTES = {ATTR_SOURCE: knx.INDIVIDUAL_ADDRESS}
-    fake_state = State("sensor.test", RESTORED_STATE, RESTORED_STATE_ATTRIBUTES)
-    mock_restore_cache(hass, (fake_state,))
+    fake_state = State(
+        "sensor.test", "ignored in favour of native_value", RESTORED_STATE_ATTRIBUTES
+    )
+    extra_data = {"native_value": RESTORED_STATE, "native_unit_of_measurement": "°C"}
+    mock_restore_cache_with_extra_data(hass, [(fake_state, extra_data)])
 
     await knx.setup_integration(
         {

--- a/tests/components/knx/test_sensor.py
+++ b/tests/components/knx/test_sensor.py
@@ -2,14 +2,22 @@
 
 from freezegun.api import FrozenDateTimeFactory
 
-from homeassistant.components.knx.const import CONF_STATE_ADDRESS, CONF_SYNC_STATE
+from homeassistant.components.knx.const import (
+    ATTR_SOURCE,
+    CONF_STATE_ADDRESS,
+    CONF_SYNC_STATE,
+)
 from homeassistant.components.knx.schema import SensorSchema
 from homeassistant.const import CONF_NAME, CONF_TYPE, STATE_UNKNOWN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 
 from .conftest import KNXTestKit
 
-from tests.common import async_capture_events, async_fire_time_changed
+from tests.common import (
+    async_capture_events,
+    async_fire_time_changed,
+    mock_restore_cache,
+)
 
 
 async def test_sensor(hass: HomeAssistant, knx: KNXTestKit) -> None:
@@ -41,6 +49,38 @@ async def test_sensor(hass: HomeAssistant, knx: KNXTestKit) -> None:
     # don't answer to GroupValueRead requests
     await knx.receive_read("1/1/1")
     await knx.assert_no_telegram()
+
+
+async def test_sensor_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test restoring KNX sensor state."""
+    ADDRESS = "2/2/2"
+    RAW_FLOAT_21_0 = (0x0C, 0x1A)
+    RESTORED_STATE = "21.0"
+    RESTORED_STATE_ATTRIBUTES = {ATTR_SOURCE: knx.INDIVIDUAL_ADDRESS}
+    fake_state = State("sensor.test", RESTORED_STATE, RESTORED_STATE_ATTRIBUTES)
+    mock_restore_cache(hass, (fake_state,))
+
+    await knx.setup_integration(
+        {
+            SensorSchema.PLATFORM: [
+                {
+                    CONF_NAME: "test",
+                    CONF_STATE_ADDRESS: ADDRESS,
+                    CONF_TYPE: "temperature",  # 2 byte float
+                    CONF_SYNC_STATE: False,
+                },
+            ]
+        }
+    )
+
+    # restored state - no read-response due to sync_state False
+    knx.assert_state("sensor.test", RESTORED_STATE, **RESTORED_STATE_ATTRIBUTES)
+    await knx.assert_telegram_count(0)
+
+    # receiving the restored value from restored source does not trigger state_changed event
+    events = async_capture_events(hass, "state_changed")
+    await knx.receive_write(ADDRESS, RAW_FLOAT_21_0)
+    assert not events
 
 
 async def test_last_reported(

--- a/tests/components/knx/test_switch.py
+++ b/tests/components/knx/test_switch.py
@@ -111,7 +111,7 @@ async def test_switch_state(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await knx.assert_telegram_count(0)
 
 
-async def test_switch_restore_and_respond(hass: HomeAssistant, knx) -> None:
+async def test_switch_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test restoring KNX switch state and respond to read."""
     _ADDRESS = "1/1/1"
     fake_state = State("switch.test", "on")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Restore KNX sensor entity states

Store state in HAs internal `_attr_native_value` to avoid having to convert the state string to int / float / str for the xknx Sensor's `_device.sensor_value.value`. This also allows to use `_attr_extra_state_attributes` to restore "source" - which avoids double state-change events when the same value was received.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
