### PR TITLE
Enable pylint consider-math-not-float check

### DIFF
--- a/homeassistant/components/habitica/todo.py
+++ b/homeassistant/components/habitica/todo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 import logging
+import math
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -281,7 +282,7 @@ class HabiticaTodosListEntity(BaseHabiticaListEntity):
         return sorted(
             tasks,
             key=lambda task: (
-                float("inf")
+                math.inf
                 if (uid := UUID(task.uid))
                 not in (tasks_order := self.coordinator.data.user.tasksOrder.todos)
                 else tasks_order.index(uid)
@@ -367,7 +368,7 @@ class HabiticaDailiesListEntity(BaseHabiticaListEntity):
         return sorted(
             tasks,
             key=lambda task: (
-                float("inf")
+                math.inf
                 if (uid := UUID(task.uid))
                 not in (tasks_order := self.coordinator.data.user.tasksOrder.dailys)
                 else tasks_order.index(uid)

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections import OrderedDict
+import math
 from typing import ClassVar, Final
 
 import voluptuous as vol
@@ -86,7 +87,7 @@ def number_limit_sub_validator(entity_config: OrderedDict) -> OrderedDict:
         raise vol.Invalid(f"'type: {value_type}' is not a valid numeric sensor type.")
     # Infinity is not supported by Home Assistant frontend so user defined
     # config is required if if xknx DPTNumeric subclass defines it as limit.
-    if min_config is None and dpt_class.value_min == float("-inf"):
+    if min_config is None and dpt_class.value_min == -math.inf:
         raise vol.Invalid(f"'min' key required for value type '{value_type}'")
     if min_config is not None and min_config < dpt_class.value_min:
         raise vol.Invalid(
@@ -94,7 +95,7 @@ def number_limit_sub_validator(entity_config: OrderedDict) -> OrderedDict:
             f" of value type '{value_type}': {dpt_class.value_min}"
         )
 
-    if max_config is None and dpt_class.value_max == float("inf"):
+    if max_config is None and dpt_class.value_max == math.inf:
         raise vol.Invalid(f"'max' key required for value type '{value_type}'")
     if max_config is not None and max_config > dpt_class.value_max:
         raise vol.Invalid(

--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import deque
 from io import DEFAULT_BUFFER_SIZE, BytesIO
 import logging
+import math
 import os
 from typing import TYPE_CHECKING
 
@@ -76,7 +77,7 @@ class RecorderOutput(StreamOutput):
         # units which seem to be defined inversely to how stream time_bases are defined
         running_duration = 0
 
-        last_sequence = float("-inf")
+        last_sequence = -math.inf
 
         def write_segment(segment: Segment) -> None:
             """Write a segment to output."""

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -9,6 +9,7 @@ from dataclasses import fields
 import datetime
 from io import SEEK_END, BytesIO
 import logging
+import math
 from threading import Event
 from typing import Any, Self, cast
 
@@ -46,7 +47,7 @@ from .fmp4utils import read_init
 from .hls import HlsStreamOutput
 
 _LOGGER = logging.getLogger(__name__)
-NEGATIVE_INF = float("-inf")
+NEGATIVE_INF = -math.inf
 
 
 def redact_av_error_string(err: av.FFmpegError) -> str:

--- a/homeassistant/helpers/significant_change.py
+++ b/homeassistant/helpers/significant_change.py
@@ -30,6 +30,7 @@ The following cases will never be passed to your function:
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+import math
 from types import MappingProxyType
 from typing import Any, Protocol
 
@@ -161,7 +162,7 @@ def check_percentage_change(
         try:
             return (abs(new_state - old_state) / old_state) * 100.0
         except ZeroDivisionError:
-            return float("inf")
+            return math.inf
 
     return _check_numeric_change(old_state, new_state, change, percentage_change)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,6 @@ class-const-naming-style = "any"
 # possibly-used-before-assignment - too many errors / not necessarily issues
 # ---
 # Pylint CodeStyle plugin
-# consider-math-not-float
 # consider-using-namedtuple-or-dataclass - too opinionated
 # consider-using-assignment-expr - decision to use := better left to devs
 disable = [
@@ -182,7 +181,6 @@ disable = [
   "too-many-boolean-expressions",
   "too-many-positional-arguments",
   "wrong-import-order",
-  "consider-math-not-float",
   "consider-using-namedtuple-or-dataclass",
   "consider-using-assignment-expr",
   "possibly-used-before-assignment",

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -3,6 +3,7 @@
 from decimal import Decimal
 from http import HTTPStatus
 import json
+import math
 from unittest.mock import AsyncMock, Mock
 
 from aiohttp.web_exceptions import (
@@ -46,7 +47,7 @@ async def test_invalid_json(caplog: pytest.LogCaptureFixture) -> None:
 
 async def test_nan_serialized_to_null() -> None:
     """Test nan serialized to null JSON."""
-    response = HomeAssistantView.json(float("NaN"))
+    response = HomeAssistantView.json(math.nan)
     assert json.loads(response.body.decode("utf-8")) is None
 
 

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -1,5 +1,6 @@
 """The tests for the Modbus sensor component."""
 
+import math
 import struct
 
 import pytest
@@ -738,8 +739,8 @@ async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
             [
                 0x5102,
                 0x0304,
-                int.from_bytes(struct.pack(">f", float("nan"))[0:2]),
-                int.from_bytes(struct.pack(">f", float("nan"))[2:4]),
+                int.from_bytes(struct.pack(">f", math.nan)[0:2]),
+                int.from_bytes(struct.pack(">f", math.nan)[2:4]),
             ],
             False,
             ["34899771392.0", STATE_UNKNOWN],
@@ -753,8 +754,8 @@ async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
             [
                 0x5102,
                 0x0304,
-                int.from_bytes(struct.pack(">f", float("nan"))[0:2]),
-                int.from_bytes(struct.pack(">f", float("nan"))[2:4]),
+                int.from_bytes(struct.pack(">f", math.nan)[0:2]),
+                int.from_bytes(struct.pack(">f", math.nan)[2:4]),
             ],
             False,
             ["34899771392.0", STATE_UNKNOWN],
@@ -1160,8 +1161,8 @@ async def test_wrong_unpack(hass: HomeAssistant, mock_do_cycle) -> None:
                 CONF_DATA_TYPE: DataType.FLOAT32,
             },
             [
-                int.from_bytes(struct.pack(">f", float("nan"))[0:2]),
-                int.from_bytes(struct.pack(">f", float("nan"))[2:4]),
+                int.from_bytes(struct.pack(">f", math.nan)[0:2]),
+                int.from_bytes(struct.pack(">f", math.nan)[2:4]),
             ],
             STATE_UNKNOWN,
         ),
@@ -1224,8 +1225,8 @@ async def test_unpack_ok(hass: HomeAssistant, mock_do_cycle, expected) -> None:
             # floats: nan, 10.600000381469727,
             #         1.000879611487865e-28, 10.566553115844727
             [
-                int.from_bytes(struct.pack(">f", float("nan"))[0:2]),
-                int.from_bytes(struct.pack(">f", float("nan"))[2:4]),
+                int.from_bytes(struct.pack(">f", math.nan)[0:2]),
+                int.from_bytes(struct.pack(">f", math.nan)[2:4]),
                 0x4129,
                 0x999A,
                 0x10FD,

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Generator
 from datetime import UTC, date, datetime
 from decimal import Decimal
+import math
 from typing import Any
 from unittest.mock import patch
 
@@ -2313,9 +2314,9 @@ async def test_state_classes_with_invalid_unit_of_measurement(
         (datetime(2012, 11, 10, 7, 35, 1), "non-numeric"),
         (date(2012, 11, 10), "non-numeric"),
         ("inf", "non-finite"),
-        (float("inf"), "non-finite"),
+        (math.inf, "non-finite"),
         ("nan", "non-finite"),
-        (float("nan"), "non-finite"),
+        (math.nan, "non-finite"),
     ],
 )
 async def test_non_numeric_validation_error(

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -2315,8 +2315,10 @@ async def test_state_classes_with_invalid_unit_of_measurement(
         (date(2012, 11, 10), "non-numeric"),
         ("inf", "non-finite"),
         (math.inf, "non-finite"),
+        (float("inf"), "non-finite"),  # pylint: disable=consider-math-not-float
         ("nan", "non-finite"),
         (math.nan, "non-finite"),
+        (float("nan"), "non-finite"),  # pylint: disable=consider-math-not-float
     ],
 )
 async def test_non_numeric_validation_error(

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -4,6 +4,7 @@ import asyncio
 from copy import deepcopy
 import io
 import logging
+import math
 from typing import Any
 from unittest.mock import ANY, AsyncMock, Mock, patch
 
@@ -1061,7 +1062,7 @@ async def test_get_states_not_allows_nan(
 ) -> None:
     """Test get_states command converts NaN to None."""
     hass.states.async_set("greeting.hello", "world")
-    hass.states.async_set("greeting.bad", "data", {"hello": float("NaN")})
+    hass.states.async_set("greeting.bad", "data", {"hello": math.nan})
     hass.states.async_set("greeting.bye", "universe")
 
     await websocket_client.send_json_auto_id({"type": "get_states"})

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -306,7 +306,7 @@ def test_find_unserializable_data() -> None:
     assert find_paths_unserializable_data({("A",): 1}) == {"$<key: ('A',)>": ("A",)}
     assert math.isnan(
         find_paths_unserializable_data(
-            float("nan"), dump=partial(json.dumps, allow_nan=False)
+            math.nan, dump=partial(json.dumps, allow_nan=False)
         )["$"]
     )
 


### PR DESCRIPTION
## Proposed change
The latest pylint released added the optional `consider-math-not-float` check.
https://pylint.readthedocs.io/en/stable/user_guide/messages/refactor/consider-math-not-float.html

It detects calls to `float("inf")` and `float("nan")` and suggests to use `math.inf` and `math.nan` instead.

**Reasoning**
- After the initial import of `math`, `math.inf` and `math.nan` are faster than the corresponding `float` calls. _The import time doesn't really matter as `math` is used in a lot of modules already. So it's likely already imported._
- As an added benefit, it's less likely to accidentally introduce a typo. If `math.inf` or `math.nan` were spelled wrong, mypy would also catch it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
