### PR TITLE
Fix Bluetooth discovery for devices with alternating advertisement names

### DIFF
--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -68,12 +68,17 @@ class IntegrationMatchHistory:
     manufacturer_data: bool
     service_data: set[str]
     service_uuids: set[str]
+    name: str
 
 
 def seen_all_fields(
-    previous_match: IntegrationMatchHistory, advertisement_data: AdvertisementData
+    previous_match: IntegrationMatchHistory,
+    advertisement_data: AdvertisementData,
+    name: str,
 ) -> bool:
     """Return if we have seen all fields."""
+    if previous_match.name != name:
+        return False
     if not previous_match.manufacturer_data and advertisement_data.manufacturer_data:
         return False
     if advertisement_data.service_data and (
@@ -122,10 +127,11 @@ class IntegrationMatcher:
         device = service_info.device
         advertisement_data = service_info.advertisement
         connectable = service_info.connectable
+        name = service_info.name
         matched = self._matched_connectable if connectable else self._matched
         matched_domains: set[str] = set()
         if (previous_match := matched.get(device.address)) and seen_all_fields(
-            previous_match, advertisement_data
+            previous_match, advertisement_data, name
         ):
             # We have seen all fields so we can skip the rest of the matchers
             return matched_domains
@@ -140,11 +146,13 @@ class IntegrationMatcher:
             )
             previous_match.service_data |= set(advertisement_data.service_data)
             previous_match.service_uuids |= set(advertisement_data.service_uuids)
+            previous_match.name = name
         else:
             matched[device.address] = IntegrationMatchHistory(
                 manufacturer_data=bool(advertisement_data.manufacturer_data),
                 service_data=set(advertisement_data.service_data),
                 service_uuids=set(advertisement_data.service_uuids),
+                name=name,
             )
         return matched_domains
 

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -703,6 +703,67 @@ async def test_discovery_match_by_local_name(
         assert mock_config_flow.mock_calls[0][1][0] == "switchbot"
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_discovery_match_by_service_uuid_when_name_changes_from_mac(
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
+) -> None:
+    """Test bluetooth discovery still matches when name changes from MAC address to real name."""
+    mock_bt = [
+        {
+            "domain": "improv_ble",
+            "service_uuid": "00467768-6228-2272-4663-277478268000",
+        }
+    ]
+    with (
+        patch(
+            "homeassistant.components.bluetooth.async_get_bluetooth",
+            return_value=mock_bt,
+        ),
+        patch.object(hass.config_entries.flow, "async_init") as mock_config_flow,
+    ):
+        await async_setup_with_default_adapter(hass)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        # First advertisement: name is MAC address, with service UUID
+        # This should trigger discovery
+        device_mac_name = generate_ble_device("64:E8:33:7E:0D:9E", "64:E8:33:7E:0D:9E")
+        adv_mac_name = generate_advertisement_data(
+            local_name="64:E8:33:7E:0D:9E",
+            service_uuids=["00467768-6228-2272-4663-277478268000"],
+            service_data={
+                "00004677-0000-1000-8000-00805f9b34fb": b"\x02\x00\x00\x00\x00\x00"
+            },
+        )
+
+        inject_advertisement(hass, device_mac_name, adv_mac_name)
+        await hass.async_block_till_done()
+
+        assert len(mock_config_flow.mock_calls) == 1
+        assert mock_config_flow.mock_calls[0][1][0] == "improv_ble"
+        mock_config_flow.reset_mock()
+
+        # Second advertisement: name changes to real name, same service UUID
+        # This should trigger discovery again because the name changed
+        device_real_name = generate_ble_device("64:E8:33:7E:0D:9E", "improvtest")
+        adv_real_name = generate_advertisement_data(
+            local_name="improvtest",
+            service_uuids=["00467768-6228-2272-4663-277478268000"],
+            service_data={
+                "00004677-0000-1000-8000-00805f9b34fb": b"\x02\x00\x00\x00\x00\x00"
+            },
+        )
+
+        inject_advertisement(hass, device_real_name, adv_real_name)
+        await hass.async_block_till_done()
+
+        # Should still match improv_ble even though name changed
+        assert len(mock_config_flow.mock_calls) == 1
+        assert mock_config_flow.mock_calls[0][1][0] == "improv_ble"
+
+
 @pytest.mark.usefixtures("macos_adapter")
 async def test_discovery_match_by_manufacturer_id_and_manufacturer_data_start(
     hass: HomeAssistant, mock_bleak_scanner_start: MagicMock


### PR DESCRIPTION
## Proposed change

Fixes Bluetooth device discovery for devices that alternate advertisement names to work within the 31-byte BLE advertisement size limit.

This PR fixes a bug where Bluetooth devices that alternate their advertised name would not trigger re-discovery. This critically affects devices that must alternate between short names (with sensor data) and full names (with minimal data) due to the 31-byte BLE advertisement constraint.

**User impact**: Many integrations discover devices by matching `local_name` patterns (e.g., `Govee*`, `SensorPush*`, `Inkbird*`, `Ruuvi *`, etc.). Bluetooth LE advertisements are limited to 31 bytes, so devices often alternate between different advertisement packets - some with a short name and sensor data, others with a full name but less data. When the matcher only sees the short name advertisement first, re-discovery does not fire when the full name advertisement is later received, so these devices are **never discovered at all** if the short name doesn't match the pattern.

**Example**: A SensorPush device alternates advertisements:
- Advertisement 1: name=`s` + temperature/humidity data (fits in 31 bytes)
- Advertisement 2: name=`SensorPush HT.w 12345` + minimal data (fits in 31 bytes)

Without this fix, if the matcher sees advertisement 1 first, the `sensorpush` integration (which matches `local_name: "SensorPush*"`) never discovers the device because re-discovery doesn't fire when advertisement 2 with the full name arrives.

This is standard BLE behavior where devices alternate advertisement content to work within the 31-byte limit.

**Root cause**: The `IntegrationMatchHistory` class tracked which advertisement fields (manufacturer_data, service_data, service_uuids) had been seen for each device to optimize matcher performance. However, it did not track the device name. When a device's name changed but other fields remained the same, `seen_all_fields()` would incorrectly return `True`, causing an early return with an empty match set instead of re-evaluating the device against matchers.

**Fix**: Added `name` field to `IntegrationMatchHistory` and updated `seen_all_fields()` to check if the name has changed. When the name changes, the device is now re-evaluated against all matchers, triggering a second discovery that allows integrations to update the device information.

**Example scenario**:

SensorPush device alternating advertisements:
1. Advertisement 1: name=`s` + sensor data → no match (doesn't match `SensorPush*` pattern)
2. Advertisement 2: name=`SensorPush HT.w 12345` + minimal data → previously returned empty match, **device never discovered**
3. With this fix → matches `sensorpush` by name pattern, device is discovered

This same issue affects many other integrations that match by `local_name` pattern including Govee, Inkbird, Ruuvi, and dozens of others listed in bluetooth.py.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
