### PR TITLE
Skip adding Control4 rooms with no audio/video sources as media player devices

### DIFF
--- a/homeassistant/components/control4/media_player.py
+++ b/homeassistant/components/control4/media_player.py
@@ -148,6 +148,15 @@ async def async_setup_entry(
                             source_type={dev_type}, idx=dev_id, name=name
                         )
 
+        # Skip rooms with no audio/video sources
+        if not sources:
+            _LOGGER.debug(
+                "Skipping room '%s' (ID: %s) - no audio/video sources found",
+                room.get("name"),
+                room_id,
+            )
+            continue
+
         try:
             hidden = room["roomHidden"]
             entity_list.append(

--- a/tests/components/control4/__init__.py
+++ b/tests/components/control4/__init__.py
@@ -1,1 +1,18 @@
 """Tests for the Control4 integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> MockConfigEntry:
+    """Set up the Control4 integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return mock_config_entry

--- a/tests/components/control4/conftest.py
+++ b/tests/components/control4/conftest.py
@@ -7,7 +7,6 @@ import pytest
 
 from homeassistant.components.control4.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -28,6 +27,7 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_PASSWORD: MOCK_PASSWORD,
             "controller_unique_id": MOCK_CONTROLLER_UNIQUE_ID,
         },
+        unique_id="00:aa:00:aa:00:aa",
     )
 
 
@@ -101,16 +101,3 @@ async def mock_patch_platforms(platforms: list[str]) -> AsyncGenerator[None]:
     """Fixture to set up platforms for tests."""
     with patch("homeassistant.components.control4.PLATFORMS", platforms):
         yield
-
-
-async def setup_integration(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-) -> MockConfigEntry:
-    """Set up the Control4 integration for testing."""
-    mock_config_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    return mock_config_entry

--- a/tests/components/control4/conftest.py
+++ b/tests/components/control4/conftest.py
@@ -1,0 +1,116 @@
+"""Common fixtures for the Control4 tests."""
+
+from collections.abc import AsyncGenerator, Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.control4.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry, load_fixture
+
+MOCK_HOST = "192.168.1.100"
+MOCK_USERNAME = "test-username"
+MOCK_PASSWORD = "test-password"
+MOCK_CONTROLLER_UNIQUE_ID = "control4_test_123"
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_USERNAME: MOCK_USERNAME,
+            CONF_PASSWORD: MOCK_PASSWORD,
+            "controller_unique_id": MOCK_CONTROLLER_UNIQUE_ID,
+        },
+    )
+
+
+@pytest.fixture
+def mock_c4_account() -> Generator[MagicMock]:
+    """Mock a Control4 Account client."""
+    with patch(
+        "homeassistant.components.control4.C4Account", autospec=True
+    ) as mock_account_class:
+        mock_account = mock_account_class.return_value
+        mock_account.getAccountBearerToken = AsyncMock()
+        mock_account.getAccountControllers = AsyncMock(
+            return_value={"href": "https://example.com"}
+        )
+        mock_account.getDirectorBearerToken = AsyncMock(return_value={"token": "test"})
+        mock_account.getControllerOSVersion = AsyncMock(return_value="3.2.0")
+        yield mock_account
+
+
+@pytest.fixture
+def mock_c4_director() -> Generator[MagicMock]:
+    """Mock a Control4 Director client."""
+    with patch(
+        "homeassistant.components.control4.C4Director", autospec=True
+    ) as mock_director_class:
+        mock_director = mock_director_class.return_value
+        # Default: Multi-room setup (room with sources, room without sources)
+        # Note: The API returns JSON strings, so we load fixtures as strings
+        mock_director.getAllItemInfo = AsyncMock(
+            return_value=load_fixture("director_all_items.json", DOMAIN)
+        )
+        mock_director.getUiConfiguration = AsyncMock(
+            return_value=load_fixture("ui_configuration.json", DOMAIN)
+        )
+        yield mock_director
+
+
+@pytest.fixture
+def mock_update_variables() -> Generator[AsyncMock]:
+    """Mock the update_variables_for_config_entry function."""
+
+    async def _mock_update_variables(*args, **kwargs):
+        return {
+            1: {
+                "POWER_STATE": True,
+                "CURRENT_VOLUME": 50,
+                "IS_MUTED": False,
+                "CURRENT_VIDEO_DEVICE": 100,
+                "CURRENT MEDIA INFO": {},
+                "PLAYING": False,
+                "PAUSED": False,
+                "STOPPED": False,
+            }
+        }
+
+    with patch(
+        "homeassistant.components.control4.media_player.update_variables_for_config_entry",
+        new=_mock_update_variables,
+    ) as mock_update:
+        yield mock_update
+
+
+@pytest.fixture
+def platforms() -> list[str]:
+    """Platforms which should be loaded during the test."""
+    return ["media_player"]
+
+
+@pytest.fixture(autouse=True)
+async def mock_patch_platforms(platforms: list[str]) -> AsyncGenerator[None]:
+    """Fixture to set up platforms for tests."""
+    with patch("homeassistant.components.control4.PLATFORMS", platforms):
+        yield
+
+
+async def setup_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> MockConfigEntry:
+    """Set up the Control4 integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return mock_config_entry

--- a/tests/components/control4/fixtures/director_all_items.json
+++ b/tests/components/control4/fixtures/director_all_items.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 1,
+    "typeName": "room",
+    "name": "Living Room",
+    "roomHidden": false
+  },
+  {
+    "id": 2,
+    "typeName": "room",
+    "name": "Thermostat Room",
+    "roomHidden": false
+  },
+  {
+    "id": 100,
+    "name": "TV"
+  }
+]

--- a/tests/components/control4/fixtures/ui_configuration.json
+++ b/tests/components/control4/fixtures/ui_configuration.json
@@ -1,0 +1,15 @@
+{
+  "experiences": [
+    {
+      "room_id": 1,
+      "type": "watch",
+      "sources": {
+        "source": [
+          {
+            "id": 100
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/components/control4/snapshots/test_media_player.ambr
+++ b/tests/components/control4/snapshots/test_media_player.ambr
@@ -1,0 +1,60 @@
+# serializer version: 1
+# name: test_media_player_with_and_without_sources[media_player.living_room-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'source_list': list([
+        'TV',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'media_player',
+    'entity_category': None,
+    'entity_id': 'media_player.living_room',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <MediaPlayerDeviceClass.TV: 'tv'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'control4',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <MediaPlayerEntityFeature: 23821>,
+    'translation_key': None,
+    'unique_id': '1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_media_player_with_and_without_sources[media_player.living_room-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'tv',
+      'friendly_name': 'Living Room',
+      'is_volume_muted': False,
+      'source_list': list([
+        'TV',
+      ]),
+      'supported_features': <MediaPlayerEntityFeature: 23821>,
+      'volume_level': 0.5,
+    }),
+    'context': <ANY>,
+    'entity_id': 'media_player.living_room',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/control4/test_config_flow.py
+++ b/tests/components/control4/test_config_flow.py
@@ -17,6 +17,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from .conftest import MOCK_HOST, MOCK_PASSWORD, MOCK_USERNAME
+
 from tests.common import MockConfigEntry
 
 
@@ -69,9 +71,9 @@ async def test_form(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: "1.1.1.1",
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
+                CONF_HOST: MOCK_HOST,
+                CONF_USERNAME: MOCK_USERNAME,
+                CONF_PASSWORD: MOCK_PASSWORD,
             },
         )
         await hass.async_block_till_done()
@@ -79,9 +81,9 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == "control4_model_00AA00AA00AA"
     assert result2["data"] == {
-        CONF_HOST: "1.1.1.1",
-        CONF_USERNAME: "test-username",
-        CONF_PASSWORD: "test-password",
+        CONF_HOST: MOCK_HOST,
+        CONF_USERNAME: MOCK_USERNAME,
+        CONF_PASSWORD: MOCK_PASSWORD,
         "controller_unique_id": "control4_model_00AA00AA00AA",
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -100,9 +102,9 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: "1.1.1.1",
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
+                CONF_HOST: MOCK_HOST,
+                CONF_USERNAME: MOCK_USERNAME,
+                CONF_PASSWORD: MOCK_PASSWORD,
             },
         )
 
@@ -123,9 +125,9 @@ async def test_form_unexpected_exception(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: "1.1.1.1",
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
+                CONF_HOST: MOCK_HOST,
+                CONF_USERNAME: MOCK_USERNAME,
+                CONF_PASSWORD: MOCK_PASSWORD,
             },
         )
 
@@ -152,9 +154,9 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: "1.1.1.1",
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
+                CONF_HOST: MOCK_HOST,
+                CONF_USERNAME: MOCK_USERNAME,
+                CONF_PASSWORD: MOCK_PASSWORD,
             },
         )
 

--- a/tests/components/control4/test_config_flow.py
+++ b/tests/components/control4/test_config_flow.py
@@ -86,6 +86,7 @@ async def test_form(hass: HomeAssistant) -> None:
         CONF_PASSWORD: MOCK_PASSWORD,
         "controller_unique_id": "control4_model_00AA00AA00AA",
     }
+    assert result2["result"].unique_id == "00:aa:00:aa:00:aa"
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/control4/test_media_player.py
+++ b/tests/components/control4/test_media_player.py
@@ -1,0 +1,100 @@
+"""Test Control4 Media Player."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.control4.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_media_player_with_and_without_sources(hass: HomeAssistant) -> None:
+    """Test that rooms with sources create entities and rooms without are skipped."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "192.168.1.100",
+            "username": "test",
+            "password": "test",
+            "controller_unique_id": "control4_test_123",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    mock_account = MagicMock()
+    mock_account.getAccountBearerToken = AsyncMock()
+    mock_account.getAccountControllers = AsyncMock(
+        return_value={"href": "https://example.com"}
+    )
+    mock_account.getDirectorBearerToken = AsyncMock(return_value={"token": "test"})
+    mock_account.getControllerOSVersion = AsyncMock(return_value="3.2.0")
+
+    # Room 1 has video source, Room 2 has no sources (thermostat-only room)
+    mock_director = MagicMock()
+    mock_director.getAllItemInfo = AsyncMock(
+        return_value=json.dumps(
+            [
+                {
+                    "id": 1,
+                    "typeName": "room",
+                    "name": "Living Room",
+                    "roomHidden": False,
+                },
+                {
+                    "id": 2,
+                    "typeName": "room",
+                    "name": "Thermostat Room",
+                    "roomHidden": False,
+                },
+                {"id": 100, "name": "TV"},
+            ]
+        )
+    )
+    mock_director.getUiConfiguration = AsyncMock(
+        return_value=json.dumps(
+            {
+                "experiences": [
+                    {
+                        "room_id": 1,
+                        "type": "watch",
+                        "sources": {"source": [{"id": 100}]},
+                    },
+                    # Room 2 has no experiences (thermostat-only)
+                ]
+            }
+        )
+    )
+
+    async def mock_update_variables(*args, **kwargs):
+        return {
+            1: {
+                "POWER_STATE": True,
+                "CURRENT_VOLUME": 50,
+                "IS_MUTED": False,
+                "CURRENT_VIDEO_DEVICE": 100,
+                "CURRENT MEDIA INFO": {},
+                "PLAYING": False,
+                "PAUSED": False,
+                "STOPPED": False,
+            }
+        }
+
+    with (
+        patch("homeassistant.components.control4.C4Account", return_value=mock_account),
+        patch(
+            "homeassistant.components.control4.C4Director", return_value=mock_director
+        ),
+        patch("homeassistant.components.control4.PLATFORMS", ["media_player"]),
+        patch(
+            "homeassistant.components.control4.media_player.update_variables_for_config_entry",
+            new=mock_update_variables,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Only 1 media_player entity should be created (Living Room with sources)
+    states = hass.states.async_all("media_player")
+    assert len(states) == 1
+    assert states[0].name == "Living Room"

--- a/tests/components/control4/test_media_player.py
+++ b/tests/components/control4/test_media_player.py
@@ -1,98 +1,23 @@
 """Test Control4 Media Player."""
 
-import json
-from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
 
-from homeassistant.components.control4.const import DOMAIN
 from homeassistant.core import HomeAssistant
+
+from .conftest import setup_integration
 
 from tests.common import MockConfigEntry
 
 
-async def test_media_player_with_and_without_sources(hass: HomeAssistant) -> None:
+@pytest.mark.usefixtures("mock_c4_account", "mock_c4_director", "mock_update_variables")
+async def test_media_player_with_and_without_sources(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
     """Test that rooms with sources create entities and rooms without are skipped."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "host": "192.168.1.100",
-            "username": "test",
-            "password": "test",
-            "controller_unique_id": "control4_test_123",
-        },
-    )
-    entry.add_to_hass(hass)
-
-    mock_account = MagicMock()
-    mock_account.getAccountBearerToken = AsyncMock()
-    mock_account.getAccountControllers = AsyncMock(
-        return_value={"href": "https://example.com"}
-    )
-    mock_account.getDirectorBearerToken = AsyncMock(return_value={"token": "test"})
-    mock_account.getControllerOSVersion = AsyncMock(return_value="3.2.0")
-
+    # The default mock_c4_director fixture provides multi-room data:
     # Room 1 has video source, Room 2 has no sources (thermostat-only room)
-    mock_director = MagicMock()
-    mock_director.getAllItemInfo = AsyncMock(
-        return_value=json.dumps(
-            [
-                {
-                    "id": 1,
-                    "typeName": "room",
-                    "name": "Living Room",
-                    "roomHidden": False,
-                },
-                {
-                    "id": 2,
-                    "typeName": "room",
-                    "name": "Thermostat Room",
-                    "roomHidden": False,
-                },
-                {"id": 100, "name": "TV"},
-            ]
-        )
-    )
-    mock_director.getUiConfiguration = AsyncMock(
-        return_value=json.dumps(
-            {
-                "experiences": [
-                    {
-                        "room_id": 1,
-                        "type": "watch",
-                        "sources": {"source": [{"id": 100}]},
-                    },
-                    # Room 2 has no experiences (thermostat-only)
-                ]
-            }
-        )
-    )
-
-    async def mock_update_variables(*args, **kwargs):
-        return {
-            1: {
-                "POWER_STATE": True,
-                "CURRENT_VOLUME": 50,
-                "IS_MUTED": False,
-                "CURRENT_VIDEO_DEVICE": 100,
-                "CURRENT MEDIA INFO": {},
-                "PLAYING": False,
-                "PAUSED": False,
-                "STOPPED": False,
-            }
-        }
-
-    with (
-        patch("homeassistant.components.control4.C4Account", return_value=mock_account),
-        patch(
-            "homeassistant.components.control4.C4Director", return_value=mock_director
-        ),
-        patch("homeassistant.components.control4.PLATFORMS", ["media_player"]),
-        patch(
-            "homeassistant.components.control4.media_player.update_variables_for_config_entry",
-            new=mock_update_variables,
-        ),
-    ):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    await setup_integration(hass, mock_config_entry)
 
     # Only 1 media_player entity should be created (Living Room with sources)
     states = hass.states.async_all("media_player")

--- a/tests/components/control4/test_media_player.py
+++ b/tests/components/control4/test_media_player.py
@@ -1,25 +1,26 @@
 """Test Control4 Media Player."""
 
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
-from .conftest import setup_integration
+from . import setup_integration
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.mark.usefixtures("mock_c4_account", "mock_c4_director", "mock_update_variables")
 async def test_media_player_with_and_without_sources(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test that rooms with sources create entities and rooms without are skipped."""
     # The default mock_c4_director fixture provides multi-room data:
     # Room 1 has video source, Room 2 has no sources (thermostat-only room)
     await setup_integration(hass, mock_config_entry)
 
-    # Only 1 media_player entity should be created (Living Room with sources)
-    states = hass.states.async_all("media_player")
-    assert len(states) == 1
-    assert states[0].name == "Living Room"
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)


### PR DESCRIPTION
## Proposed change
The current Control4 component adds non-media devices such as thermostats as media player entities. This change filters them out and adds a basic unit test (since one does not exist for media_player.py). A subsequent PR will add support for climate devices.


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
N/A

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
