### PR TITLE
Add config flow title placeholder update infrastructure

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2860,6 +2860,27 @@ class ConfigFlow(ConfigEntryBaseFlow):
         return {}
 
     @callback
+    def async_update_title_placeholders(
+        self, title_placeholders: Mapping[str, str]
+    ) -> None:
+        """Update title placeholders for the discovery notification and notify listeners.
+
+        This updates the flow context title_placeholders and notifies listeners
+        (such as the frontend) to reload the flow state, updating the discovery
+        notification title.
+
+        Only call this method when the flow is not progressing to a new step
+        (e.g., from a callback that receives updated data). If the flow is
+        progressing to a new step, set title_placeholders directly in context
+        before returning the step result, as the step change will trigger
+        listener notification automatically.
+        """
+        # Context is typed as TypedDict but is mutable dict at runtime
+        current_placeholders = self.context.setdefault("title_placeholders", {})
+        current_placeholders.update(title_placeholders)  # type: ignore[attr-defined]
+        self.async_notify_flow_changed()
+
+    @callback
     def _async_abort_entries_match(
         self, match_dict: dict[str, Any] | None = None
     ) -> None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2876,8 +2876,10 @@ class ConfigFlow(ConfigEntryBaseFlow):
         listener notification automatically.
         """
         # Context is typed as TypedDict but is mutable dict at runtime
-        current_placeholders = self.context.setdefault("title_placeholders", {})
-        current_placeholders.update(title_placeholders)  # type: ignore[attr-defined]
+        current_placeholders = cast(
+            dict[str, str], self.context.setdefault("title_placeholders", {})
+        )
+        current_placeholders.update(title_placeholders)
         self.async_notify_flow_changed()
 
     @callback

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -432,11 +432,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
                     != result.get("description_placeholders")
                 )
             ):
-                # Tell frontend to reload the flow state.
-                self.hass.bus.async_fire_internal(
-                    EVENT_DATA_ENTRY_FLOW_PROGRESSED,
-                    {"handler": flow.handler, "flow_id": flow_id, "refresh": True},
-                )
+                flow.async_notify_flow_changed()
 
         return result
 
@@ -884,6 +880,17 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         self.hass.bus.async_fire_internal(
             EVENT_DATA_ENTRY_FLOW_PROGRESS_UPDATE,
             {"handler": self.handler, "flow_id": self.flow_id, "progress": progress},
+        )
+
+    @callback
+    def async_notify_flow_changed(self) -> None:
+        """Notify listeners that the flow has changed.
+
+        This notifies listeners (such as the frontend) to reload the flow state.
+        """
+        self.hass.bus.async_fire_internal(
+            EVENT_DATA_ENTRY_FLOW_PROGRESSED,
+            {"handler": self.handler, "flow_id": self.flow_id, "refresh": True},
         )
 
     @callback

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -9434,3 +9434,74 @@ async def test_create_entry_existing_unique_id(
         "working in Home Assistant 2026.3, please create a bug report at https:"
     )
     assert (log_text in caplog.text) == expected_log
+
+
+async def test_async_update_title_placeholders(hass: HomeAssistant) -> None:
+    """Test async_update_title_placeholders updates context and notifies listeners."""
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        VERSION = 1
+
+        async def async_step_user(self, user_input=None):
+            """Test user step."""
+            self.context["title_placeholders"] = {"initial": "value"}
+            return self.async_show_form(step_id="user")
+
+    mock_integration(hass, MockModule("comp"))
+    mock_platform(hass, "comp.config_flow", None)
+
+    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
+        result = await hass.config_entries.flow.async_init(
+            "comp", context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] is FlowResultType.FORM
+
+        # Get the flow to check initial title_placeholders
+        flow = hass.config_entries.flow.async_get(result["flow_id"])
+        assert flow["context"]["title_placeholders"] == {"initial": "value"}
+
+        # Get the flow instance to call methods
+        flow_instance = hass.config_entries.flow._progress[result["flow_id"]]
+
+        # Capture events to verify frontend notification
+        events = async_capture_events(
+            hass, data_entry_flow.EVENT_DATA_ENTRY_FLOW_PROGRESSED
+        )
+
+        # Update title placeholders
+        flow_instance.async_update_title_placeholders({"name": "updated"})
+        await hass.async_block_till_done()
+
+        # Verify placeholders were updated (preserving existing values)
+        flow = hass.config_entries.flow.async_get(result["flow_id"])
+        assert flow["context"]["title_placeholders"] == {
+            "initial": "value",
+            "name": "updated",
+        }
+
+        # Verify frontend was notified
+        assert len(events) == 1
+        assert events[0].data == {
+            "handler": "comp",
+            "flow_id": result["flow_id"],
+            "refresh": True,
+        }
+
+        # Update again with overlapping key
+        flow_instance.async_update_title_placeholders(
+            {"initial": "new_value", "another": "key"}
+        )
+        await hass.async_block_till_done()
+
+        # Verify placeholders were updated correctly
+        flow = hass.config_entries.flow.async_get(result["flow_id"])
+        assert flow["context"]["title_placeholders"] == {
+            "initial": "new_value",
+            "name": "updated",
+            "another": "key",
+        }
+
+        # Verify frontend was notified again
+        assert len(events) == 2


### PR DESCRIPTION
supports https://github.com/home-assistant/core/pull/154352

## Proposed change

This PR adds infrastructure to allow config flows to update their title placeholders and notify the frontend to refresh the flow display during an active configuration flow.

**New methods added:**

1. **`FlowHandler.async_notify_flow_changed()`** - Generic method in the base `FlowHandler` class to notify listeners (primarily the frontend) that a flow has changed by firing an `EVENT_DATA_ENTRY_FLOW_PROGRESSED` event with `refresh: True`.

2. **`ConfigFlow.async_update_title_placeholders()`** - Config-flow-specific method to update title placeholders while preserving existing values, then trigger frontend notification via `async_notify_flow_changed()`.

**Additional improvement:**

Refactored `FlowManager._async_configure()` to use the new `async_notify_flow_changed()` method, eliminating code duplication where the same event firing logic was previously duplicated.

**Use case:**

This infrastructure enables config flows to update discovery notification titles when receiving updated information during the flow (e.g., via callbacks that receive updated discovery data). The method should only be called when the flow is not progressing to a new step, as step changes already trigger listener notifications automatically.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
