### PR TITLE
Add [K11+] support to Switchbot Cloud

### DIFF
--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -158,6 +158,7 @@ async def make_device_data(
         "Robot Vacuum Cleaner K10+ Pro Combo",
         "Robot Vacuum Cleaner S10",
         "S20",
+        "Robot Vacuum Cleaner K11 Plus",
     ]:
         coordinator = await coordinator_for_device(
             hass, entry, api, device, coordinators_by_id, True

--- a/homeassistant/components/switchbot_cloud/vacuum.py
+++ b/homeassistant/components/switchbot_cloud/vacuum.py
@@ -241,11 +241,10 @@ def _async_make_entity(
     | SwitchBotCloudVacuumK10PlusProCombo
 ):
     """Make a SwitchBotCloudVacuum."""
-    if device.device_type in VacuumCleanerV2Commands.get_supported_devices():
-        if device.device_type == "K20+ Pro":
-            return SwitchBotCloudVacuumK20PlusPro(api, device, coordinator)
+    if device.device_type in ["K20+ Pro", "Robot Vacuum Cleaner K11 Plus"]:
+        return SwitchBotCloudVacuumK20PlusPro(api, device, coordinator)
+    if device.device_type == "Robot Vacuum Cleaner K10+ Pro Combo":
         return SwitchBotCloudVacuumK10PlusProCombo(api, device, coordinator)
-
     if device.device_type in VacuumCleanerV3Commands.get_supported_devices():
         return SwitchBotCloudVacuumV3(api, device, coordinator)
     return SwitchBotCloudVacuum(api, device, coordinator)

--- a/homeassistant/components/switchbot_cloud/vacuum.py
+++ b/homeassistant/components/switchbot_cloud/vacuum.py
@@ -130,7 +130,7 @@ class SwitchBotCloudVacuum(SwitchBotCloudEntity, StateVacuumEntity):
 
 
 class SwitchBotCloudVacuumV2(SwitchBotCloudVacuum):
-    """Representation of a SwitchBot K20+ Pro."""
+    """Representation of a SwitchBot K20+ Pro & Robot Vacuum Cleaner K11 Plus."""
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set fan speed."""

--- a/homeassistant/components/switchbot_cloud/vacuum.py
+++ b/homeassistant/components/switchbot_cloud/vacuum.py
@@ -129,7 +129,7 @@ class SwitchBotCloudVacuum(SwitchBotCloudEntity, StateVacuumEntity):
             self._attr_fan_speed = VACUUM_FAN_SPEED_QUIET
 
 
-class SwitchBotCloudVacuumK20PlusPro(SwitchBotCloudVacuum):
+class SwitchBotCloudVacuumV2(SwitchBotCloudVacuum):
     """Representation of a SwitchBot K20+ Pro."""
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
@@ -176,7 +176,7 @@ class SwitchBotCloudVacuumK20PlusPro(SwitchBotCloudVacuum):
         await self.coordinator.async_request_refresh()
 
 
-class SwitchBotCloudVacuumK10PlusProCombo(SwitchBotCloudVacuumK20PlusPro):
+class SwitchBotCloudVacuumK10PlusProCombo(SwitchBotCloudVacuumV2):
     """Representation of a SwitchBot vacuum K10+ Pro Combo."""
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
@@ -194,7 +194,7 @@ class SwitchBotCloudVacuumK10PlusProCombo(SwitchBotCloudVacuumK20PlusPro):
         await self.coordinator.async_request_refresh()
 
 
-class SwitchBotCloudVacuumV3(SwitchBotCloudVacuumK20PlusPro):
+class SwitchBotCloudVacuumV3(SwitchBotCloudVacuumV2):
     """Representation of a SwitchBot vacuum Robot Vacuum Cleaner S10 & S20."""
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
@@ -236,13 +236,13 @@ def _async_make_entity(
     api: SwitchBotAPI, device: Device | Remote, coordinator: SwitchBotCoordinator
 ) -> (
     SwitchBotCloudVacuum
-    | SwitchBotCloudVacuumK20PlusPro
+    | SwitchBotCloudVacuumV2
     | SwitchBotCloudVacuumV3
     | SwitchBotCloudVacuumK10PlusProCombo
 ):
     """Make a SwitchBotCloudVacuum."""
     if device.device_type in ["K20+ Pro", "Robot Vacuum Cleaner K11 Plus"]:
-        return SwitchBotCloudVacuumK20PlusPro(api, device, coordinator)
+        return SwitchBotCloudVacuumV2(api, device, coordinator)
     if device.device_type == "Robot Vacuum Cleaner K10+ Pro Combo":
         return SwitchBotCloudVacuumK10PlusProCombo(api, device, coordinator)
     if device.device_type in VacuumCleanerV3Commands.get_supported_devices():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add new support device k11+ as vacuum


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41304
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
