### PR TITLE
Move template-rendering test helpers to separate module

### DIFF
--- a/tests/helpers/template/extensions/test_math.py
+++ b/tests/helpers/template/extensions/test_math.py
@@ -10,10 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template
 
-
-def render(hass: HomeAssistant, template_str: str) -> str:
-    """Render template and return result."""
-    return template.Template(template_str, hass).async_render()
+from tests.helpers.template.helpers import render
 
 
 def test_math_constants(hass: HomeAssistant) -> None:

--- a/tests/helpers/template/helpers.py
+++ b/tests/helpers/template/helpers.py
@@ -15,7 +15,7 @@ def render(
     template_str: str,
     variables: TemplateVarsType | None = None,
     **render_kwargs: Any,
-) -> str:
+) -> Any:
     """Render template and return result."""
     return template.Template(template_str, hass).async_render(
         variables, **render_kwargs

--- a/tests/helpers/template/helpers.py
+++ b/tests/helpers/template/helpers.py
@@ -1,0 +1,56 @@
+"""Helpers for tests around template rendering."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import template
+from homeassistant.helpers.typing import TemplateVarsType
+
+
+def render(
+    hass: HomeAssistant, template_str: str, variables: TemplateVarsType | None = None
+) -> str:
+    """Render template and return result."""
+    return template.Template(template_str, hass).async_render(variables)
+
+
+def render_to_info(
+    hass: HomeAssistant, template_str: str, variables: TemplateVarsType | None = None
+) -> template.RenderInfo:
+    """Create render info from template."""
+    return template.Template(template_str, hass).async_render_to_info(variables)
+
+
+def extract_entities(
+    hass: HomeAssistant, template_str: str, variables: TemplateVarsType | None = None
+) -> set[str]:
+    """Extract entities from a template."""
+    return render_to_info(hass, template_str, variables).entities
+
+
+def assert_result_info(
+    info: template.RenderInfo,
+    result: Any,
+    entities: Iterable[str] | None = None,
+    domains: Iterable[str] | None = None,
+    all_states: bool = False,
+) -> None:
+    """Check result info."""
+    assert info.result() == result
+    assert info.all_states == all_states
+    assert info.filter("invalid_entity_name.somewhere") == all_states
+    if entities is not None:
+        assert info.entities == frozenset(entities)
+        assert all(info.filter(entity) for entity in entities)
+        if not all_states:
+            assert not info.filter("invalid_entity_name.somewhere")
+    else:
+        assert not info.entities
+    if domains is not None:
+        assert info.domains == frozenset(domains)
+        assert all(info.filter(domain + ".entity") for domain in domains)
+    else:
+        assert not hasattr(info, "_domains")

--- a/tests/helpers/template/helpers.py
+++ b/tests/helpers/template/helpers.py
@@ -11,10 +11,15 @@ from homeassistant.helpers.typing import TemplateVarsType
 
 
 def render(
-    hass: HomeAssistant, template_str: str, variables: TemplateVarsType | None = None
+    hass: HomeAssistant,
+    template_str: str,
+    variables: TemplateVarsType | None = None,
+    **render_kwargs: Any,
 ) -> str:
     """Render template and return result."""
-    return template.Template(template_str, hass).async_render(variables)
+    return template.Template(template_str, hass).async_render(
+        variables, **render_kwargs
+    )
 
 
 def render_to_info(

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -52,11 +52,12 @@ from homeassistant.helpers.template.render_info import (
     ALL_STATES_RATE_LIMIT,
     DOMAIN_STATES_RATE_LIMIT,
 )
-from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.read_only_dict import ReadOnlyDict
 from homeassistant.util.unit_system import UnitSystem
+
+from .helpers import assert_result_info, render, render_to_info
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -75,55 +76,6 @@ def _set_up_units(hass: HomeAssistant) -> None:
         volume=UnitOfVolume.LITERS,
         wind_speed=UnitOfSpeed.KILOMETERS_PER_HOUR,
     )
-
-
-def render(
-    hass: HomeAssistant, template_str: str, variables: TemplateVarsType | None = None
-) -> Any:
-    """Create render info from template."""
-    tmp = template.Template(template_str, hass)
-    return tmp.async_render(variables)
-
-
-def render_to_info(
-    hass: HomeAssistant, template_str: str, variables: TemplateVarsType | None = None
-) -> template.RenderInfo:
-    """Create render info from template."""
-    tmp = template.Template(template_str, hass)
-    return tmp.async_render_to_info(variables)
-
-
-def extract_entities(
-    hass: HomeAssistant, template_str: str, variables: TemplateVarsType | None = None
-) -> set[str]:
-    """Extract entities from a template."""
-    info = render_to_info(hass, template_str, variables)
-    return info.entities
-
-
-def assert_result_info(
-    info: template.RenderInfo,
-    result: Any,
-    entities: Iterable[str] | None = None,
-    domains: Iterable[str] | None = None,
-    all_states: bool = False,
-) -> None:
-    """Check result info."""
-    assert info.result() == result
-    assert info.all_states == all_states
-    assert info.filter("invalid_entity_name.somewhere") == all_states
-    if entities is not None:
-        assert info.entities == frozenset(entities)
-        assert all(info.filter(entity) for entity in entities)
-        if not all_states:
-            assert not info.filter("invalid_entity_name.somewhere")
-    else:
-        assert not info.entities
-    if domains is not None:
-        assert info.domains == frozenset(domains)
-        assert all(info.filter(domain + ".entity") for domain in domains)
-    else:
-        assert not hasattr(info, "_domains")
 
 
 async def test_template_render_missing_hass(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

#152266 added a new `render()` helper function that was practically a duplicate of the `render()` added in #56453 in `test_init`.

This PR moves all of those helper functions from `test_init` to a common helper module and deduplicates the new `render()` helper out.

A follow-up PR can mechanically change all of the manual uses of the pattern `tmpl = (x, hass); assert tmpl.async_render() == ...` to `assert render(hass, x) == ...`.

I noticed this while working on other template-related things (#154537).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: #152266
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
