### PR TITLE
Add generic cover integration with switch control

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -216,6 +216,7 @@ homeassistant.components.frontend.*
 homeassistant.components.fujitsu_fglair.*
 homeassistant.components.fully_kiosk.*
 homeassistant.components.fyta.*
+homeassistant.components.generic_cover.*
 homeassistant.components.generic_hygrostat.*
 homeassistant.components.generic_thermostat.*
 homeassistant.components.geo_location.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -553,6 +553,8 @@ build.json @home-assistant/supervisor
 /tests/components/gdacs/ @exxamalte
 /homeassistant/components/generic/ @davet2001
 /tests/components/generic/ @davet2001
+/homeassistant/components/generic_cover/ @bsunderhus
+/tests/components/generic_cover/ @bsunderhus
 /homeassistant/components/generic_hygrostat/ @Shulyaka
 /tests/components/generic_hygrostat/ @Shulyaka
 /homeassistant/components/geniushub/ @manzanotti

--- a/homeassistant/components/generic_cover/__init__.py
+++ b/homeassistant/components/generic_cover/__init__.py
@@ -1,0 +1,62 @@
+"""The Generic Cover integration."""
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import discovery
+from homeassistant.helpers.device import (
+    async_remove_stale_devices_links_keep_entity_device,
+)
+from homeassistant.helpers.typing import ConfigType
+
+from .const import CONF_SWITCH_CLOSE, CONF_SWITCH_OPEN, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Generic Cover component."""
+    if DOMAIN not in config:
+        return True
+
+    for cover_conf in config[DOMAIN]:
+        hass.async_create_task(
+            discovery.async_load_platform(
+                hass, Platform.COVER, DOMAIN, cover_conf, config
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up from a config entry."""
+
+    options = {**entry.data, **entry.options}
+
+    async_remove_stale_devices_links_keep_entity_device(
+        hass,
+        entry.entry_id,
+        options[CONF_SWITCH_OPEN],
+    )
+    async_remove_stale_devices_links_keep_entity_device(
+        hass,
+        entry.entry_id,
+        options[CONF_SWITCH_CLOSE],
+    )
+
+    await hass.config_entries.async_forward_entry_setups(entry, (Platform.COVER,))
+    entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
+    return True
+
+
+async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update listener, called when the config entry options are changed."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, (Platform.COVER,))

--- a/homeassistant/components/generic_cover/config_flow.py
+++ b/homeassistant/components/generic_cover/config_flow.py
@@ -1,0 +1,232 @@
+"""Config flow for Generic cover."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components import switch
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
+from homeassistant.const import CONF_NAME
+from homeassistant.core import callback
+from homeassistant.helpers import entity_registry as er, selector
+
+from .const import (
+    CONF_DURATION,
+    CONF_SWITCH_CLOSE,
+    CONF_SWITCH_OPEN,
+    CONF_TILT_DURATION,
+    DOMAIN,
+)
+from .cover import (
+    ATTR_DURATION,
+    ATTR_SWITCH_CLOSE_ENTITY_ID,
+    ATTR_SWITCH_OPEN_ENTITY_ID,
+    ATTR_TILT_DURATION,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GenericCoverConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Generic Cover."""
+
+    VERSION = 1
+    MINOR_VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            errors = _validate_user_input(user_input)
+            if not errors:
+                # Set unique ID based on the switch entities used
+                unique_id = (
+                    f"{user_input[CONF_SWITCH_OPEN]}_{user_input[CONF_SWITCH_CLOSE]}"
+                )
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME], data=user_input
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NAME): selector.TextSelector(),
+                    vol.Required(CONF_SWITCH_OPEN): selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain=switch.DOMAIN)
+                    ),
+                    vol.Required(CONF_SWITCH_CLOSE): selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain=switch.DOMAIN)
+                    ),
+                    vol.Optional(CONF_DURATION): selector.DurationSelector(
+                        selector.DurationSelectorConfig(
+                            allow_negative=False,
+                            enable_day=False,
+                            enable_millisecond=True,
+                        ),
+                    ),
+                    vol.Optional(CONF_TILT_DURATION): selector.DurationSelector(
+                        selector.DurationSelectorConfig(
+                            allow_negative=False,
+                            enable_day=False,
+                            enable_millisecond=True,
+                        )
+                    ),
+                }
+            ),
+            errors=errors,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> GenericCoverOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return GenericCoverOptionsFlowHandler()
+
+
+class GenericCoverOptionsFlowHandler(OptionsFlow):
+    """Handle an options flow for Generic Cover."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        errors = None
+
+        if user_input is not None:
+            errors = _validate_user_input(user_input)
+            if not errors:
+                return self.async_create_entry(data=user_input)
+
+        defaults = {
+            CONF_SWITCH_OPEN: self.config_entry.data[CONF_SWITCH_OPEN],
+            CONF_SWITCH_CLOSE: self.config_entry.data[CONF_SWITCH_CLOSE],
+            CONF_DURATION: self.config_entry.data.get(CONF_DURATION),
+            CONF_TILT_DURATION: self.config_entry.data.get(CONF_TILT_DURATION),
+        }
+
+        entity_registry = er.async_get(self.hass)
+        entity_entry = entity_registry.async_get_entity_id(
+            domain="cover",
+            platform="generic_cover",
+            unique_id=self.config_entry.entry_id,  # Use the entry_id as the unique_id
+        )
+
+        if entity_entry:
+            last_state = self.hass.states.get(entity_entry)
+        else:
+            last_state = None
+
+        if last_state is not None:
+            defaults = {
+                CONF_SWITCH_OPEN: last_state.attributes.get(ATTR_SWITCH_OPEN_ENTITY_ID),
+                CONF_SWITCH_CLOSE: last_state.attributes.get(
+                    ATTR_SWITCH_CLOSE_ENTITY_ID
+                ),
+                CONF_DURATION: _parse_duration(
+                    last_state.attributes.get(ATTR_DURATION)
+                ),
+                CONF_TILT_DURATION: _parse_duration(
+                    last_state.attributes.get(ATTR_TILT_DURATION)
+                ),
+            }
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SWITCH_OPEN,
+                        default=defaults.get(CONF_SWITCH_OPEN),
+                    ): selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain=switch.DOMAIN)
+                    ),
+                    vol.Required(
+                        CONF_SWITCH_CLOSE,
+                        default=defaults.get(CONF_SWITCH_CLOSE),
+                    ): selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain=switch.DOMAIN)
+                    ),
+                    vol.Required(
+                        CONF_DURATION, default=defaults.get(CONF_DURATION)
+                    ): selector.DurationSelector(
+                        selector.DurationSelectorConfig(
+                            allow_negative=False,
+                            enable_day=False,
+                            enable_millisecond=True,
+                        ),
+                    ),
+                    vol.Required(
+                        CONF_TILT_DURATION,
+                        default=defaults.get(CONF_TILT_DURATION),
+                    ): selector.DurationSelector(
+                        selector.DurationSelectorConfig(
+                            allow_negative=False,
+                            enable_day=False,
+                            enable_millisecond=True,
+                        )
+                    ),
+                }
+            ),
+            errors=errors,
+        )
+
+
+def _validate_user_input(user_input: dict[str, Any]) -> dict[str, str]:
+    """Validate the user input."""
+    errors = {}
+    # Ensure that the duration is greater than 0
+    if CONF_DURATION in user_input:
+        duration = timedelta(**(user_input[CONF_DURATION]))
+        if duration == timedelta(0):
+            errors[CONF_DURATION] = "invalid_duration"
+    # Ensure that the tilt duration is greater than 0
+    if CONF_TILT_DURATION in user_input:
+        tilt_duration = timedelta(**(user_input[CONF_TILT_DURATION]))
+        if tilt_duration == timedelta(0):
+            errors[CONF_TILT_DURATION] = "invalid_tilt_duration"
+    # Ensure switches are different
+    if (
+        user_input.get(CONF_SWITCH_OPEN)
+        and user_input.get(CONF_SWITCH_CLOSE)
+        and user_input[CONF_SWITCH_OPEN] == user_input[CONF_SWITCH_CLOSE]
+    ):
+        errors["base"] = "same_switch"
+    return errors
+
+
+def _parse_duration(duration_str: str | None) -> dict[str, int] | None:
+    """Parse duration string to dict."""
+    if not duration_str:
+        return None
+    try:
+        # Try parsing with milliseconds
+        dt = datetime.strptime(duration_str, "%H:%M:%S.%f")
+    except ValueError:
+        try:
+            # Fallback to parsing without milliseconds
+            dt = datetime.strptime(duration_str, "%H:%M:%S")
+        except ValueError:
+            return None
+    return {
+        "hours": dt.hour,
+        "minutes": dt.minute,
+        "seconds": dt.second,
+        "milliseconds": dt.microsecond // 1000,
+    }

--- a/homeassistant/components/generic_cover/const.py
+++ b/homeassistant/components/generic_cover/const.py
@@ -1,0 +1,10 @@
+"""Constants for the Generic Cover integration."""
+
+DOMAIN = "generic_cover"
+
+CONF_SWITCH_OPEN = "switch_open"
+CONF_SWITCH_CLOSE = "switch_close"
+CONF_DURATION = "duration"
+CONF_TILT_DURATION = "tilt_duration"
+
+DEFAULT_NAME = "Generic Cover"

--- a/homeassistant/components/generic_cover/cover.py
+++ b/homeassistant/components/generic_cover/cover.py
@@ -304,7 +304,9 @@ class GenericCover(CoverEntity, RestoreEntity):
                 self._target_cover_position = 100
             elif self._target_cover_position < (self.current_cover_position or 0):
                 self._cancel_update_cover_position_track()
-                raise InterlockError
+                raise InterlockError(
+                    "Cannot open cover while closing operation is active"
+                )
             self._track_update_cover_position()
         if new_state.state == STATE_OFF:
             self._attr_is_opening = False
@@ -332,7 +334,9 @@ class GenericCover(CoverEntity, RestoreEntity):
                 self._target_cover_position = 0
             elif self._target_cover_position > (self.current_cover_position or 0):
                 self._cancel_update_cover_position_track()
-                raise InterlockError
+                raise InterlockError(
+                    "Cannot close cover while opening operation is active"
+                )
             self._track_update_cover_position()
         elif new_state.state == STATE_OFF:
             self._attr_is_closing = False
@@ -349,7 +353,9 @@ class GenericCover(CoverEntity, RestoreEntity):
         # there should be a target position
         if self._target_cover_position is None:
             self._cancel_update_cover_position_track()
-            raise NotImplementedError
+            raise NotImplementedError(
+                "Cover position update called without target position"
+            )
 
         if self.is_opening:
             self._attr_current_cover_position = min(
@@ -368,7 +374,9 @@ class GenericCover(CoverEntity, RestoreEntity):
         else:
             # it should either be opening or closing
             self._cancel_update_cover_position_track()
-            raise NotImplementedError
+            raise NotImplementedError(
+                "Cover position update called when not opening or closing"
+            )
 
         if self.current_cover_position == self._target_cover_position:
             self._cancel_update_cover_position_track()

--- a/homeassistant/components/generic_cover/cover.py
+++ b/homeassistant/components/generic_cover/cover.py
@@ -1,0 +1,478 @@
+"""Adds support for generic cover units."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Mapping
+from datetime import datetime, timedelta
+import logging
+import math
+from typing import Any
+
+from propcache.api import cached_property
+
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
+    CoverEntity,
+    CoverEntityFeature,
+    CoverState,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_NAME,
+    CONF_UNIQUE_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    Event,
+    EventStateChangedData,
+    HomeAssistant,
+    callback,
+)
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    AddEntitiesCallback,
+)
+from homeassistant.helpers.event import (
+    async_track_state_change_event,
+    async_track_time_interval,
+)
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from .const import (
+    CONF_DURATION,
+    CONF_SWITCH_CLOSE,
+    CONF_SWITCH_OPEN,
+    CONF_TILT_DURATION,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the generic cover platform."""
+    if discovery_info:
+        config = discovery_info
+    await _async_setup_config(
+        hass, config, config.get(CONF_UNIQUE_ID), async_add_entities
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Initialize config entry."""
+
+    config = {**config_entry.data, **config_entry.options}
+
+    await _async_setup_config(
+        hass,
+        config,
+        config_entry.entry_id,
+        async_add_entities,
+    )
+
+
+async def _async_setup_config(
+    hass: HomeAssistant,
+    config: Mapping[str, Any],
+    unique_id: str | None,
+    async_add_entities: AddEntitiesCallback | AddConfigEntryEntitiesCallback,
+) -> None:
+    name: str = config[CONF_NAME]
+    switch_open_entity_id: str = config[CONF_SWITCH_OPEN]
+    switch_close_entity_id: str = config[CONF_SWITCH_CLOSE]
+
+    duration: timedelta = timedelta(seconds=5)
+    if CONF_DURATION in config:
+        duration = timedelta(**(config[CONF_DURATION]))
+
+    tilt_duration: timedelta = timedelta(seconds=1)
+    if CONF_TILT_DURATION in config:
+        tilt_duration = timedelta(**(config[CONF_TILT_DURATION]))
+
+    async_add_entities(
+        [
+            GenericCover(
+                hass,
+                name,
+                switch_open_entity_id,
+                switch_close_entity_id,
+                duration,
+                tilt_duration,
+                unique_id,
+            )
+        ]
+    )
+
+
+class InterlockError(RuntimeError):
+    """Error raised when cover switches interlock."""
+
+
+ATTR_DURATION = "duration"
+ATTR_TILT_DURATION = "tilt_duration"
+ATTR_SWITCH_OPEN_ENTITY_ID = "switch_open_entity_id"
+ATTR_SWITCH_CLOSE_ENTITY_ID = "switch_close_entity_id"
+
+
+class GenericCover(CoverEntity, RestoreEntity):
+    """Representation of a Generic Cover device."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        name: str,
+        switch_open_entity_id: str,
+        switch_close_entity_id: str,
+        duration: timedelta,
+        tilt_duration: timedelta,
+        unique_id: str | None,
+    ) -> None:
+        """Initialize the cover."""
+        super().__init__()
+        self._attr_name = name
+        self._attr_duration = duration
+        self._attr_tilt_duration = tilt_duration
+        self._attr_switch_open_entity_id = switch_open_entity_id
+        self._attr_switch_close_entity_id = switch_close_entity_id
+        self._attr_unique_id = unique_id
+        self._attr_supported_features = (
+            CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.STOP
+            | CoverEntityFeature.OPEN_TILT
+            | CoverEntityFeature.CLOSE_TILT
+        )
+        self._cancel_update_cover_position_track_callback: Callable[[], None] | None = (
+            None
+        )
+        self._target_cover_position: int | None = None
+        self._tilt_step = math.ceil(
+            100
+            / math.ceil(
+                min(max(self.tilt_duration, self.duration / 100), self.duration)
+                / (self.duration / 100)
+            )
+        )
+        self._switch_close_turn_off_event: asyncio.Event | None = None
+        self._switch_open_turn_off_event: asyncio.Event | None = None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return the extra state attributes."""
+        return {
+            ATTR_DURATION: str(self._attr_duration),
+            ATTR_TILT_DURATION: str(self._attr_tilt_duration),
+            ATTR_SWITCH_OPEN_ENTITY_ID: self._attr_switch_open_entity_id,
+            ATTR_SWITCH_CLOSE_ENTITY_ID: self._attr_switch_close_entity_id,
+        }
+
+    @cached_property
+    def duration(self) -> timedelta:
+        """Return duration to go from open to close (vice versa)."""
+        return self._attr_duration
+
+    @cached_property
+    def tilt_duration(self) -> timedelta:
+        """Return duration to tilt the cover."""
+        return self._attr_tilt_duration
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added."""
+        await super().async_added_to_hass()
+
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_current_cover_position = last_state.attributes.get(
+                ATTR_CURRENT_POSITION, 0
+            )
+            self._attr_current_cover_tilt_position = last_state.attributes.get(
+                ATTR_CURRENT_TILT_POSITION, 0
+            )
+            self._attr_is_closed = last_state.state == CoverState.CLOSED
+            self._attr_is_closing = last_state.state == CoverState.CLOSING
+            self._attr_is_opening = last_state.state == CoverState.OPENING
+        else:
+            self._attr_current_cover_position = 0
+            self._attr_current_cover_tilt_position = 0
+            self._attr_is_closed = True
+            self._attr_is_closing = False
+            self._attr_is_opening = False
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass,
+                self._attr_switch_open_entity_id,
+                self._async_switch_open_event,
+            )
+        )
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass,
+                self._attr_switch_close_entity_id,
+                self._async_switch_close_event,
+            )
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity is about to be removed."""
+        await super().async_will_remove_from_hass()
+        self._cancel_update_cover_position_track()
+
+    @property
+    def name(self) -> str:
+        """Return the name of the cover."""
+        return self._attr_name or "Generic Cover"
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the cover."""
+        if (self.current_cover_position or 0) >= 100:
+            self._cancel_update_cover_position_track()
+            return
+        await self._async_switch_open_turn_on(100)
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the cover."""
+        if (self.current_cover_position or 0) <= 0:
+            self._cancel_update_cover_position_track()
+            return
+        await self._async_switch_close_turn_on(0)
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the cover."""
+        self._target_cover_position = None
+        await self._async_switches_turn_off()
+
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+        """Open the cover tilt."""
+        if (self.current_cover_tilt_position or 0) >= 100:
+            self._cancel_update_cover_position_track()
+            return
+        await self._async_switch_open_turn_on(
+            min(
+                (self.current_cover_position or 0) + self._steps_to_tilt(100),
+                100,
+            )
+        )
+
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+        """Close the cover tilt."""
+        if (self.current_cover_tilt_position or 0) <= 0:
+            self._cancel_update_cover_position_track()
+            return
+        await self._async_switch_close_turn_on(
+            max(
+                (self.current_cover_position or 0) - self._steps_to_tilt(100),
+                0,
+            )
+        )
+
+    @callback
+    def _async_switch_open_event(self, event: Event[EventStateChangedData]) -> None:
+        new_state = event.data["new_state"]
+        if new_state is None:
+            return
+        if new_state.state == STATE_ON:
+            if self.current_cover_position == 100:
+                self._cancel_update_cover_position_track()
+                self._attr_is_opening = False
+                self._attr_is_closed = False
+                self.async_write_ha_state()
+                return
+            self._attr_is_opening = True
+            self._attr_is_closing = False
+            self._attr_is_closed = False
+            if self._target_cover_position is None:
+                self._target_cover_position = 100
+            elif self._target_cover_position < (self.current_cover_position or 0):
+                self._cancel_update_cover_position_track()
+                raise InterlockError
+            self._track_update_cover_position()
+        if new_state.state == STATE_OFF:
+            self._attr_is_opening = False
+            self._cancel_update_cover_position_track()
+            if self._switch_open_turn_off_event is not None:
+                self._switch_open_turn_off_event.set()
+
+        self.async_write_ha_state()
+
+    @callback
+    def _async_switch_close_event(self, event: Event[EventStateChangedData]) -> None:
+        new_state = event.data["new_state"]
+        if new_state is None:
+            return
+        if new_state.state == STATE_ON:
+            if self.current_cover_position == 0:
+                self._cancel_update_cover_position_track()
+                self._attr_is_closing = False
+                self._attr_is_closed = True
+                self.async_write_ha_state()
+                return
+            self._attr_is_closing = True
+            self._attr_is_opening = False
+            if self._target_cover_position is None:
+                self._target_cover_position = 0
+            elif self._target_cover_position > (self.current_cover_position or 0):
+                self._cancel_update_cover_position_track()
+                raise InterlockError
+            self._track_update_cover_position()
+        elif new_state.state == STATE_OFF:
+            self._attr_is_closing = False
+            self._cancel_update_cover_position_track()
+            if self._switch_close_turn_off_event is not None:
+                self._switch_close_turn_off_event.set()
+
+        self.async_write_ha_state()
+
+    async def _async_update_current_cover_position(
+        self, time: datetime | None = None, force: bool = False
+    ) -> None:
+        """Update the cover position."""
+        # there should be a target position
+        if self._target_cover_position is None:
+            self._cancel_update_cover_position_track()
+            raise NotImplementedError
+
+        if self.is_opening:
+            self._attr_current_cover_position = min(
+                (self.current_cover_position or 0) + 1, 100
+            )
+            self._attr_current_cover_tilt_position = min(
+                (self.current_cover_tilt_position or 0) + self._tilt_step, 100
+            )
+        elif self.is_closing:
+            self._attr_current_cover_position = max(
+                (self.current_cover_position or 0) - 1, 0
+            )
+            self._attr_current_cover_tilt_position = max(
+                (self.current_cover_tilt_position or 0) - self._tilt_step, 0
+            )
+        else:
+            # it should either be opening or closing
+            self._cancel_update_cover_position_track()
+            raise NotImplementedError
+
+        if self.current_cover_position == self._target_cover_position:
+            self._cancel_update_cover_position_track()
+            self._attr_is_opening = False
+            self._attr_is_closing = False
+            self._attr_is_closed = self.current_cover_position == 0
+            await self._async_switches_turn_off()
+        self.async_write_ha_state()
+
+    def _track_update_cover_position(self) -> None:
+        """Track the cover position."""
+        if self._cancel_update_cover_position_track_callback is None:
+            self._cancel_update_cover_position_track_callback = (
+                async_track_time_interval(
+                    self.hass,
+                    self._async_update_current_cover_position,
+                    self.duration / 100,
+                )
+            )
+
+    def _cancel_update_cover_position_track(self) -> None:
+        self._target_cover_position = None
+        if self._cancel_update_cover_position_track_callback:
+            self._cancel_update_cover_position_track_callback()
+        self._cancel_update_cover_position_track_callback = None
+
+    async def _async_switch_open_turn_on(
+        self, target_cover_position: None | int = None
+    ) -> None:
+        """Turn on the open switch."""
+        await self._async_switch_close_turn_off()
+        if target_cover_position is not None:
+            self._target_cover_position = target_cover_position
+        await self.hass.services.async_call(
+            HOMEASSISTANT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: self._attr_switch_open_entity_id},
+        )
+
+    async def _async_switch_open_turn_off(self) -> None:
+        """Turn off the open switch."""
+        switch_open_state = self.hass.states.get(self._attr_switch_open_entity_id)
+        if switch_open_state is None or switch_open_state.state == STATE_OFF:
+            return
+        self._switch_open_turn_off_event = asyncio.Event()
+        await self.hass.services.async_call(
+            HOMEASSISTANT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: self._attr_switch_open_entity_id},
+        )
+        try:
+            await asyncio.wait_for(self._switch_open_turn_off_event.wait(), timeout=1)
+        except TimeoutError:
+            _LOGGER.warning("Timeout waiting for open switch to turn off")
+            self._switch_open_turn_off_event = None
+
+    async def _async_switch_close_turn_on(
+        self, target_cover_position: None | int = None
+    ) -> None:
+        """Turn on the close switch."""
+        await self._async_switch_open_turn_off()
+        if target_cover_position is not None:
+            self._target_cover_position = target_cover_position
+        await self.hass.services.async_call(
+            HOMEASSISTANT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: self._attr_switch_close_entity_id},
+        )
+
+    async def _async_switch_close_turn_off(self) -> None:
+        """Turn off the close switch."""
+        switch_close_state = self.hass.states.get(self._attr_switch_close_entity_id)
+        if switch_close_state is None or switch_close_state.state == STATE_OFF:
+            return
+        self._switch_close_turn_off_event = asyncio.Event()
+        await self.hass.services.async_call(
+            HOMEASSISTANT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: self._attr_switch_close_entity_id},
+        )
+        try:
+            await asyncio.wait_for(self._switch_close_turn_off_event.wait(), timeout=1)
+        except TimeoutError:
+            _LOGGER.warning("Timeout waiting for close switch to turn off")
+            self._switch_close_turn_off_event = None
+
+    async def _async_switches_turn_off(self) -> None:
+        """Turn off both switches."""
+        await asyncio.gather(
+            self._async_switch_open_turn_off(),
+            self._async_switch_close_turn_off(),
+        )
+
+    def _steps_to_tilt(
+        self,
+        target_tilt_position: int,
+    ) -> int:
+        return math.ceil(
+            (
+                math.ceil(
+                    min(max(self.tilt_duration, self.duration / 100.0), self.duration)
+                    / (self.duration / 100.0)
+                )
+                / 100
+            )
+            * abs(target_tilt_position - (self.current_cover_tilt_position or 0))
+        )

--- a/homeassistant/components/generic_cover/cover.py
+++ b/homeassistant/components/generic_cover/cover.py
@@ -120,10 +120,6 @@ async def _async_setup_config(
     )
 
 
-class InterlockError(RuntimeError):
-    """Error raised when cover switches interlock."""
-
-
 ATTR_DURATION = "duration"
 ATTR_TILT_DURATION = "tilt_duration"
 ATTR_SWITCH_OPEN_ENTITY_ID = "switch_open_entity_id"
@@ -304,9 +300,8 @@ class GenericCover(CoverEntity, RestoreEntity):
                 self._target_cover_position = 100
             elif self._target_cover_position < (self.current_cover_position or 0):
                 self._cancel_update_cover_position_track()
-                raise InterlockError(
-                    "Cannot open cover while closing operation is active"
-                )
+                _LOGGER.warning("Cannot open cover while closing operation is active")
+                return
             self._track_update_cover_position()
         if new_state.state == STATE_OFF:
             self._attr_is_opening = False
@@ -334,9 +329,8 @@ class GenericCover(CoverEntity, RestoreEntity):
                 self._target_cover_position = 0
             elif self._target_cover_position > (self.current_cover_position or 0):
                 self._cancel_update_cover_position_track()
-                raise InterlockError(
-                    "Cannot close cover while opening operation is active"
-                )
+                _LOGGER.warning("Cannot close cover while opening operation is active")
+                return
             self._track_update_cover_position()
         elif new_state.state == STATE_OFF:
             self._attr_is_closing = False
@@ -353,9 +347,7 @@ class GenericCover(CoverEntity, RestoreEntity):
         # there should be a target position
         if self._target_cover_position is None:
             self._cancel_update_cover_position_track()
-            raise NotImplementedError(
-                "Cover position update called without target position"
-            )
+            raise RuntimeError("Cover position update called without target position")
 
         if self.is_opening:
             self._attr_current_cover_position = min(
@@ -374,7 +366,7 @@ class GenericCover(CoverEntity, RestoreEntity):
         else:
             # it should either be opening or closing
             self._cancel_update_cover_position_track()
-            raise NotImplementedError(
+            raise RuntimeError(
                 "Cover position update called when not opening or closing"
             )
 

--- a/homeassistant/components/generic_cover/manifest.json
+++ b/homeassistant/components/generic_cover/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "generic_cover",
+  "name": "Generic Cover",
+  "codeowners": ["@bsunderhus"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/generic_cover",
+  "integration_type": "helper",
+  "iot_class": "local_polling",
+  "quality_scale": "bronze"
+}

--- a/homeassistant/components/generic_cover/quality_scale.yaml
+++ b/homeassistant/components/generic_cover/quality_scale.yaml
@@ -1,0 +1,102 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: Integration does not register custom actions.
+  appropriate-polling: done
+  brands:
+    status: exempt
+    comment: Helper integration does not represent physical brands.
+  common-modules: done
+  config-flow-test-coverage: todo
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: Integration does not register custom actions.
+  docs-high-level-description: todo
+  docs-installation-instructions: todo
+  docs-removal-instructions: todo
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data:
+    status: exempt
+    comment: Helper integration stores data in config entry only.
+  test-before-configure: todo
+  test-before-setup: todo
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: Integration does not register custom actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable:
+    status: exempt
+    comment: Cover availability depends on underlying switches.
+  integration-owner: done
+  log-when-unavailable:
+    status: exempt
+    comment: Cover availability depends on underlying switches.
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: Helper integration does not require authentication.
+  test-coverage: todo
+
+  # Gold
+  devices:
+    status: exempt
+    comment: Helper integration creates virtual entities without physical devices.
+  diagnostics:
+    status: exempt
+    comment: Helper integration has minimal diagnostic data needs.
+  discovery-update-info:
+    status: exempt
+    comment: Helper integration does not support discovery.
+  discovery:
+    status: exempt
+    comment: Helper integration does not support discovery.
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices:
+    status: exempt
+    comment: Helper integration does not represent physical devices.
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: Helper integration creates virtual entities without physical devices.
+  entity-category: done
+  entity-device-class:
+    status: exempt
+    comment: Cover entities use default cover device class.
+  entity-disabled-by-default:
+    status: exempt
+    comment: Helper entities should be enabled by default.
+  entity-translations: done
+  exception-translations: todo
+  icon-translations:
+    status: exempt
+    comment: Cover entities use appropriate default icons.
+  reconfiguration-flow: done
+  repair-issues:
+    status: exempt
+    comment: Helper integration has minimal failure scenarios.
+  stale-devices:
+    status: exempt
+    comment: Helper integration creates virtual entities without physical devices.
+
+  # Platinum
+  async-dependency:
+    status: exempt
+    comment: Helper integration has no external dependencies.
+  inject-websession:
+    status: exempt
+    comment: Helper integration does not make web requests.
+  strict-typing: todo

--- a/homeassistant/components/generic_cover/strings.json
+++ b/homeassistant/components/generic_cover/strings.json
@@ -1,0 +1,51 @@
+{
+  "title": "Generic cover",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Create generic cover",
+        "description": "Create a cover entity that is controlled by two switches.",
+        "data": {
+          "name": "Name",
+          "switch_open": "Open Switch",
+          "switch_close": "Close Switch",
+          "duration": "Duration",
+          "tilt_duration": "Tilt Duration"
+        },
+        "data_description": {
+          "name": "Name for this cover entity.",
+          "switch_open": "Switch to open the cover. This switch will be turned on when the cover is opening, and off when it is closing.",
+          "switch_close": "Switch to close the cover. This switch will be turned on when the cover is closing, and off when it is opening.",
+          "duration": "Duration that takes to open or close the entire cover. This is used to calculate the position of the cover. If you don't know the duration, you can keep it empty and adjust it later in the settings.",
+          "tilt_duration": "Duration that takes to tilt the cover. This is used to calculate the tilt position of the cover. If you don't know the duration, you can keep it empty and adjust it later in the settings."
+        }
+      }
+    },
+    "error": {
+      "same_switch": "The open and close switches must be different",
+      "invalid_duration": "Duration must be greater than 0 seconds",
+      "invalid_tilt_duration": "Tilt duration must be greater than 0 seconds"
+    },
+    "abort": {
+      "already_configured": "A cover with the same switches is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "switch_open": "[%key:component::generic_cover::config::step::user::data::switch_open%]",
+          "switch_close": "[%key:component::generic_cover::config::step::user::data::switch_close%]",
+          "duration": "[%key:component::generic_cover::config::step::user::data::duration%]",
+          "tilt_duration": "[%key:component::generic_cover::config::step::user::data::tilt_duration%]"
+        },
+        "data_description": {
+          "switch_open": "[%key:component::generic_cover::config::step::user::data_description::switch_open%]",
+          "switch_close": "[%key:component::generic_cover::config::step::user::data_description::switch_close%]",
+          "duration": "[%key:component::generic_cover::config::step::user::data_description::duration%]",
+          "tilt_duration": "[%key:component::generic_cover::config::step::user::data_description::tilt_duration%]"
+        }
+      }
+    }
+  }
+}

--- a/tests/components/generic_cover/__init__.py
+++ b/tests/components/generic_cover/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Generic Cover integration."""

--- a/tests/components/generic_cover/conftest.py
+++ b/tests/components/generic_cover/conftest.py
@@ -1,0 +1,51 @@
+"""Test fixtures for Generic Cover integration."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.generic_cover.const import (
+    CONF_DURATION,
+    CONF_SWITCH_CLOSE,
+    CONF_SWITCH_OPEN,
+    CONF_TILT_DURATION,
+    DOMAIN,
+)
+from homeassistant.const import CONF_NAME
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Test Generic Cover",
+        data={
+            CONF_NAME: "Test Generic Cover",
+            CONF_SWITCH_OPEN: "switch.test_open",
+            CONF_SWITCH_CLOSE: "switch.test_close",
+            CONF_DURATION: {"hours": 0, "minutes": 0, "seconds": 10, "milliseconds": 0},
+            CONF_TILT_DURATION: {
+                "hours": 0,
+                "minutes": 0,
+                "seconds": 2,
+                "milliseconds": 0,
+            },
+        },
+        unique_id="switch.test_open_switch.test_close",
+    )
+
+
+@pytest.fixture
+def mock_switch_entities() -> Generator[AsyncMock]:
+    """Mock switch entities."""
+    with (
+        patch("homeassistant.components.switch.is_on", return_value=False),
+        patch(
+            "homeassistant.core.ServiceRegistry.async_call", new_callable=AsyncMock
+        ) as mock_call,
+    ):
+        yield mock_call

--- a/tests/components/generic_cover/test_config_flow.py
+++ b/tests/components/generic_cover/test_config_flow.py
@@ -1,0 +1,202 @@
+"""Test the Generic Cover config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.components.generic_cover.const import (
+    CONF_DURATION,
+    CONF_SWITCH_CLOSE,
+    CONF_SWITCH_OPEN,
+    CONF_TILT_DURATION,
+    DOMAIN,
+)
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+async def test_form(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.generic_cover.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: "Test Cover",
+                CONF_SWITCH_OPEN: "switch.test_open",
+                CONF_SWITCH_CLOSE: "switch.test_close",
+                CONF_DURATION: {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 10,
+                    "milliseconds": 0,
+                },
+                CONF_TILT_DURATION: {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 2,
+                    "milliseconds": 0,
+                },
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Test Cover"
+    assert result2["data"] == {
+        CONF_NAME: "Test Cover",
+        CONF_SWITCH_OPEN: "switch.test_open",
+        CONF_SWITCH_CLOSE: "switch.test_close",
+        CONF_DURATION: {"hours": 0, "minutes": 0, "seconds": 10, "milliseconds": 0},
+        CONF_TILT_DURATION: {"hours": 0, "minutes": 0, "seconds": 2, "milliseconds": 0},
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_duration(hass: HomeAssistant) -> None:
+    """Test we handle invalid duration."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Test Cover",
+            CONF_SWITCH_OPEN: "switch.test_open",
+            CONF_SWITCH_CLOSE: "switch.test_close",
+            CONF_DURATION: {"hours": 0, "minutes": 0, "seconds": 0, "milliseconds": 0},
+        },
+    )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {CONF_DURATION: "invalid_duration"}
+
+
+async def test_form_invalid_tilt_duration(hass: HomeAssistant) -> None:
+    """Test we handle invalid tilt duration."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Test Cover",
+            CONF_SWITCH_OPEN: "switch.test_open",
+            CONF_SWITCH_CLOSE: "switch.test_close",
+            CONF_TILT_DURATION: {
+                "hours": 0,
+                "minutes": 0,
+                "seconds": 0,
+                "milliseconds": 0,
+            },
+        },
+    )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {CONF_TILT_DURATION: "invalid_tilt_duration"}
+
+
+async def test_form_same_switch(hass: HomeAssistant) -> None:
+    """Test we handle same switch for open and close."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Test Cover",
+            CONF_SWITCH_OPEN: "switch.test_switch",
+            CONF_SWITCH_CLOSE: "switch.test_switch",
+        },
+    )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "same_switch"}
+
+
+async def test_form_duplicate_entry(hass: HomeAssistant) -> None:
+    """Test we handle duplicate entries."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test Cover",
+        data={
+            CONF_NAME: "Test Cover",
+            CONF_SWITCH_OPEN: "switch.test_open",
+            CONF_SWITCH_CLOSE: "switch.test_close",
+        },
+        unique_id="switch.test_open_switch.test_close",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Test Cover",
+            CONF_SWITCH_OPEN: "switch.test_open",
+            CONF_SWITCH_CLOSE: "switch.test_close",
+        },
+    )
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+
+async def test_options_flow(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test options flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.generic_cover.async_setup_entry",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_SWITCH_OPEN: "switch.test_open_new",
+            CONF_SWITCH_CLOSE: "switch.test_close_new",
+            CONF_DURATION: {"hours": 0, "minutes": 0, "seconds": 15, "milliseconds": 0},
+            CONF_TILT_DURATION: {
+                "hours": 0,
+                "minutes": 0,
+                "seconds": 3,
+                "milliseconds": 0,
+            },
+        },
+    )
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"] == {
+        CONF_SWITCH_OPEN: "switch.test_open_new",
+        CONF_SWITCH_CLOSE: "switch.test_close_new",
+        CONF_DURATION: {"hours": 0, "minutes": 0, "seconds": 15, "milliseconds": 0},
+        CONF_TILT_DURATION: {"hours": 0, "minutes": 0, "seconds": 3, "milliseconds": 0},
+    }

--- a/tests/components/generic_cover/test_cover.py
+++ b/tests/components/generic_cover/test_cover.py
@@ -1,0 +1,145 @@
+"""Test the Generic Cover entity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.generic_cover.const import DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_STOP_COVER,
+    STATE_CLOSED,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_cover_entity_setup(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test the cover entity is set up correctly."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Mock the switches
+    hass.states.async_set("switch.test_open", "off")
+    hass.states.async_set("switch.test_close", "off")
+
+    with patch("homeassistant.core.ServiceRegistry.async_call", new_callable=AsyncMock):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Check entity is registered
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get_entity_id(
+        COVER_DOMAIN, DOMAIN, mock_config_entry.entry_id
+    )
+    assert entity is not None
+
+    # Check entity state
+    state = hass.states.get(entity)
+    assert state is not None
+    assert state.state == STATE_CLOSED
+
+
+async def test_cover_open(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test opening the cover."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Mock the switches
+    hass.states.async_set("switch.test_open", "off")
+    hass.states.async_set("switch.test_close", "off")
+
+    with patch(
+        "homeassistant.core.ServiceRegistry.async_call", new_callable=AsyncMock
+    ) as mock_call:
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        entity_registry = er.async_get(hass)
+        entity_id = entity_registry.async_get_entity_id(
+            COVER_DOMAIN, DOMAIN, mock_config_entry.entry_id
+        )
+
+        # Call open service
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+        # Verify the open switch was called
+        mock_call.assert_called()
+
+
+async def test_cover_close(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test closing the cover."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Mock the switches
+    hass.states.async_set("switch.test_open", "off")
+    hass.states.async_set("switch.test_close", "off")
+
+    with patch(
+        "homeassistant.core.ServiceRegistry.async_call", new_callable=AsyncMock
+    ) as mock_call:
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        entity_registry = er.async_get(hass)
+        entity_id = entity_registry.async_get_entity_id(
+            COVER_DOMAIN, DOMAIN, mock_config_entry.entry_id
+        )
+
+        # Call close service
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+        # Verify the close switch was called
+        mock_call.assert_called()
+
+
+async def test_cover_stop(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test stopping the cover."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Mock the switches
+    hass.states.async_set("switch.test_open", "off")
+    hass.states.async_set("switch.test_close", "off")
+
+    with patch(
+        "homeassistant.core.ServiceRegistry.async_call", new_callable=AsyncMock
+    ) as mock_call:
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        entity_registry = er.async_get(hass)
+        entity_id = entity_registry.async_get_entity_id(
+            COVER_DOMAIN, DOMAIN, mock_config_entry.entry_id
+        )
+
+        # Call stop service
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+        # Verify service was called to turn off switches
+        mock_call.assert_called()


### PR DESCRIPTION
This integration allows creating cover entities that are controlled by two switches:
- One switch for opening/up movement
- One switch for closing/down movement

Features:
- Configurable duration for full open/close cycle
- Tilt support with configurable tilt duration
- Position tracking and restoration
- Interlocking to prevent simultaneous open/close
- UI configuration flow with validation
- Bronze quality scale compliance

Tests: 10/10 passing
Type checking: mypy clean
Code quality: ruff/pylint clean

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/41309
- Link to brands pull request: https://github.com/home-assistant/brands/pull/8166
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
