### PR TITLE
Migrate Matter descriptions to be `kw_only`

### DIFF
--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.BINARY_SENSOR, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterBinarySensorEntityDescription(
     BinarySensorEntityDescription, MatterEntityDescription
 ):

--- a/homeassistant/components/matter/button.py
+++ b/homeassistant/components/matter/button.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.BUTTON, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterButtonEntityDescription(ButtonEntityDescription, MatterEntityDescription):
     """Describe Matter Button entities."""
 

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -183,7 +183,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.CLIMATE, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterClimateEntityDescription(ClimateEntityDescription, MatterEntityDescription):
     """Describe Matter Climate entities."""
 

--- a/homeassistant/components/matter/cover.py
+++ b/homeassistant/components/matter/cover.py
@@ -62,7 +62,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.COVER, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterCoverEntityDescription(CoverEntityDescription, MatterEntityDescription):
     """Describe Matter Cover entities."""
 

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -54,7 +54,7 @@ def catch_matter_error[_R, **P](
     return wrapper
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterEntityDescription(EntityDescription):
     """Describe the Matter entity."""
 

--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -47,7 +47,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.EVENT, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterEventEntityDescription(EventEntityDescription, MatterEntityDescription):
     """Describe Matter Event entities."""
 

--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -53,7 +53,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.FAN, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterFanEntityDescription(FanEntityDescription, MatterEntityDescription):
     """Describe Matter Fan entities."""
 

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -86,7 +86,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.LIGHT, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterLightEntityDescription(LightEntityDescription, MatterEntityDescription):
     """Describe Matter Light entities."""
 

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -53,7 +53,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.LOCK, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterLockEntityDescription(LockEntityDescription, MatterEntityDescription):
     """Describe Matter Lock entities."""
 

--- a/homeassistant/components/matter/number.py
+++ b/homeassistant/components/matter/number.py
@@ -44,7 +44,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.NUMBER, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterNumberEntityDescription(NumberEntityDescription, MatterEntityDescription):
     """Describe Matter Number Input entities."""
 

--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -62,7 +62,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.SELECT, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterSelectEntityDescription(SelectEntityDescription, MatterEntityDescription):
     """Describe Matter select entities."""
 

--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -166,7 +166,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.SENSOR, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterSensorEntityDescription(SensorEntityDescription, MatterEntityDescription):
     """Describe Matter sensor entities."""
 

--- a/homeassistant/components/matter/switch.py
+++ b/homeassistant/components/matter/switch.py
@@ -42,7 +42,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.SWITCH, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterSwitchEntityDescription(SwitchEntityDescription, MatterEntityDescription):
     """Describe Matter Switch entities."""
 
@@ -120,7 +120,7 @@ class MatterGenericCommandSwitch(MatterSwitch):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterGenericCommandSwitchEntityDescription(
     SwitchEntityDescription, MatterEntityDescription
 ):
@@ -132,7 +132,7 @@ class MatterGenericCommandSwitchEntityDescription(
     command_timeout: int | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterNumericSwitchEntityDescription(
     SwitchEntityDescription, MatterEntityDescription
 ):

--- a/homeassistant/components/matter/update.py
+++ b/homeassistant/components/matter/update.py
@@ -67,7 +67,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.UPDATE, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterUpdateEntityDescription(UpdateEntityDescription, MatterEntityDescription):
     """Describe Matter Update entities."""
 

--- a/homeassistant/components/matter/vacuum.py
+++ b/homeassistant/components/matter/vacuum.py
@@ -59,7 +59,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.VACUUM, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterStateVacuumEntityDescription(
     StateVacuumEntityDescription, MatterEntityDescription
 ):

--- a/homeassistant/components/matter/valve.py
+++ b/homeassistant/components/matter/valve.py
@@ -36,7 +36,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.VALVE, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterValveEntityDescription(ValveEntityDescription, MatterEntityDescription):
     """Describe Matter Valve entities."""
 

--- a/homeassistant/components/matter/water_heater.py
+++ b/homeassistant/components/matter/water_heater.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.WATER_HEATER, async_add_entities)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MatterWaterHeaterEntityDescription(
     WaterHeaterEntityDescription, MatterEntityDescription
 ):


### PR DESCRIPTION
## Proposed change

This migrates the Matter entity descriptions to also be `kw_only`.

Addresses:
- https://developers.home-assistant.io/blog/2023/12/11/entity-description-changes/
- https://github.com/home-assistant/core/pull/154173#discussion_r2426917742

Small follow-up to:
- https://github.com/home-assistant/core/pull/154083

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
