### PR TITLE
Add model name to Lunatone devices

### DIFF
--- a/homeassistant/components/lunatone/__init__.py
+++ b/homeassistant/components/lunatone/__init__.py
@@ -45,6 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LunatoneConfigEntry) -> 
         hw_version=info_api.data.device.pcb,
         configuration_url=entry.data[CONF_URL],
         serial_number=str(info_api.serial_number),
+        model=info_api.product_name,
         model_id=(
             f"{info_api.data.device.article_number}{info_api.data.device.article_info}"
         ),

--- a/homeassistant/components/lunatone/manifest.json
+++ b/homeassistant/components/lunatone/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "quality_scale": "silver",
-  "requirements": ["lunatone-rest-api-client==0.4.8"]
+  "requirements": ["lunatone-rest-api-client==0.5.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1397,7 +1397,7 @@ loqedAPI==2.1.10
 luftdaten==0.7.4
 
 # homeassistant.components.lunatone
-lunatone-rest-api-client==0.4.8
+lunatone-rest-api-client==0.5.3
 
 # homeassistant.components.lupusec
 lupupy==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1201,7 +1201,7 @@ loqedAPI==2.1.10
 luftdaten==0.7.4
 
 # homeassistant.components.lunatone
-lunatone-rest-api-client==0.4.8
+lunatone-rest-api-client==0.5.3
 
 # homeassistant.components.lupusec
 lupupy==0.3.2

--- a/tests/components/lunatone/__init__.py
+++ b/tests/components/lunatone/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 BASE_URL: Final = "http://10.0.0.131"
+PRODUCT_NAME: Final = "Test Product"
 SERIAL_NUMBER: Final = 12345
 VERSION: Final = "v1.14.1/1.4.3"
 

--- a/tests/components/lunatone/conftest.py
+++ b/tests/components/lunatone/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.components.lunatone.const import DOMAIN
 from homeassistant.const import CONF_URL
 
-from . import BASE_URL, DEVICES_DATA, INFO_DATA, SERIAL_NUMBER
+from . import BASE_URL, DEVICES_DATA, INFO_DATA, PRODUCT_NAME, SERIAL_NUMBER
 
 from tests.common import MockConfigEntry
 
@@ -68,6 +68,7 @@ def mock_lunatone_info() -> Generator[AsyncMock]:
         info.name = info.data.name
         info.version = info.data.version
         info.serial_number = info.data.device.serial
+        info.product_name = PRODUCT_NAME
         yield info
 
 

--- a/tests/components/lunatone/test_init.py
+++ b/tests/components/lunatone/test_init.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from . import BASE_URL, VERSION, setup_integration
+from . import BASE_URL, PRODUCT_NAME, VERSION, setup_integration
 
 from tests.common import MockConfigEntry
 
@@ -33,6 +33,7 @@ async def test_load_unload_config_entry(
     assert device_entry.manufacturer == "Lunatone"
     assert device_entry.sw_version == VERSION
     assert device_entry.configuration_url == BASE_URL
+    assert device_entry.model == PRODUCT_NAME
 
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR extends the main device information with the model name.
lunatone-rest-api-client v0.5.3 changelog: https://gitlab.com/lunatone-public/lunatone-rest-api-client/-/blob/v0.5.3/CHANGELOG.md

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
