### PR TITLE
Bump pydantic to 2.12.2

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -130,7 +130,7 @@ multidict>=6.0.2
 backoff>=2.0
 
 # ensure pydantic version does not float since it might have breaking changes
-pydantic==2.12.1
+pydantic==2.12.2
 
 # Required for Python 3.12.4 compatibility (#119223).
 mashumaro>=3.13.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -17,7 +17,7 @@ license-expression==30.4.3
 mock-open==1.4.0
 mypy-dev==1.19.0a4
 pre-commit==4.2.0
-pydantic==2.12.1
+pydantic==2.12.2
 pylint==4.0.0
 pylint-per-file-ignores==1.4.0
 pipdeptree==2.26.1

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -155,7 +155,7 @@ multidict>=6.0.2
 backoff>=2.0
 
 # ensure pydantic version does not float since it might have breaking changes
-pydantic==2.12.1
+pydantic==2.12.2
 
 # Required for Python 3.12.4 compatibility (#119223).
 mashumaro>=3.13.1


### PR DESCRIPTION
## Proposed change
Updates pydantic to [2.12.2](https://github.com/pydantic/pydantic/releases/tag/v2.12.2) to fix issues with missing wheels and broken CI.
This also causes pydantic-core to be updated to [2.41.4](https://github.com/pydantic/pydantic-core/releases/tag/v2.41.4).

Changelog and diff:
- https://github.com/pydantic/pydantic/releases/tag/v2.12.2
- https://github.com/pydantic/pydantic/compare/v2.12.1...v2.12.2

Previous PR (2.12.1 introduced corrupted wheels, which were later pulled, thus breaking HA CI entirely):
- https://github.com/home-assistant/core/pull/154424

Link to underlying issue in 2.12.1 / pydantic-core 2.41.3:
- https://github.com/pydantic/pydantic/issues/12395

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
