### PR TITLE
Suppress FutureWarning in Xiaomi Miio integration

### DIFF
--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -11,6 +11,7 @@ from typing import Any
 import warnings
 
 # Suppress FutureWarning from miio library about functools.partial
+# This must be done before importing miio to be effective
 warnings.filterwarnings(
     "ignore",
     message="functools.partial will be a method descriptor",
@@ -18,7 +19,7 @@ warnings.filterwarnings(
     module="miio.miot_device",
 )
 
-from miio import (
+from miio import (  # noqa: E402
     AirFresh,
     AirFreshA1,
     AirFreshT2017,
@@ -42,15 +43,15 @@ from miio import (
     Timer,
     VacuumStatus,
 )
-from miio.gateway.gateway import GatewayException
+from miio.gateway.gateway import GatewayException  # noqa: E402
 
-from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_MODEL, CONF_TOKEN, Platform
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_MODEL, CONF_TOKEN, Platform  # noqa: E402
+from homeassistant.core import HomeAssistant, callback  # noqa: E402
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady  # noqa: E402
+from homeassistant.helpers import device_registry as dr, entity_registry as er  # noqa: E402
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed  # noqa: E402
 
-from .const import (
+from .const import (  # noqa: E402
     ATTR_AVAILABLE,
     CONF_FLOW_TYPE,
     CONF_GATEWAY,
@@ -80,8 +81,8 @@ from .const import (
     AuthException,
     SetupException,
 )
-from .gateway import ConnectXiaomiGateway
-from .typing import XiaomiMiioConfigEntry, XiaomiMiioRuntimeData
+from .gateway import ConnectXiaomiGateway  # noqa: E402
+from .typing import XiaomiMiioConfigEntry, XiaomiMiioRuntimeData  # noqa: E402
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -8,6 +8,15 @@ from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from typing import Any
+import warnings
+
+# Suppress FutureWarning from miio library about functools.partial
+warnings.filterwarnings(
+    "ignore",
+    message="functools.partial will be a method descriptor",
+    category=FutureWarning,
+    module="miio.miot_device",
+)
 
 from miio import (
     AirFresh,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
This PR suppresses a FutureWarning from the python-miio library that appears when the Xiaomi Miio integration is loaded.

Problem
When the integration starts, users see the following warning in their logs:

Code
Logger: py.warnings
Source: components/xiaomi_miio/init.py:12
/usr/local/lib/python3.13/site-packages/miio/miot_device.py:23: FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in enum.member() if you want to preserve the old behavior Bool = partial(_str2bool)
This warning originates from the external python-miio library (specifically miio/miot_device.py), not from Home Assistant code itself.

Solution
Added a warning filter in init.py to suppress this specific FutureWarning from the miio.miot_device module. This is a temporary workaround until the issue is fixed upstream in the python-miio library.

The filter is narrowly scoped to only suppress this specific warning:

Category: FutureWarning
Message: "functools.partial will be a method descriptor"
Module: miio.miot_device


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #132902
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
