### PR TITLE
Simplify onewire entity descriptions

### DIFF
--- a/homeassistant/components/onewire/binary_sensor.py
+++ b/homeassistant/components/onewire/binary_sensor.py
@@ -153,6 +153,6 @@ class OneWireBinarySensorEntity(OneWireEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if sensor is on."""
-        if (raw_value := self._raw_value) is None:
+        if (raw_value := self._state) is None:
             return None
         return raw_value == "1"

--- a/homeassistant/components/onewire/binary_sensor.py
+++ b/homeassistant/components/onewire/binary_sensor.py
@@ -153,6 +153,6 @@ class OneWireBinarySensorEntity(OneWireEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if sensor is on."""
-        if (raw_value := self._state) is None:
+        if (state := self._state) is None:
             return None
-        return raw_value == "1"
+        return state == "1"

--- a/homeassistant/components/onewire/binary_sensor.py
+++ b/homeassistant/components/onewire/binary_sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import timedelta
 import os
 
@@ -16,8 +15,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DEVICE_KEYS_0_3, DEVICE_KEYS_0_7, DEVICE_KEYS_A_B, READ_MODE_INT
-from .entity import OneWireEntity, OneWireEntityDescription
+from .const import DEVICE_KEYS_0_3, DEVICE_KEYS_0_7, DEVICE_KEYS_A_B
+from .entity import OneWireEntity
 from .onewirehub import (
     SIGNAL_NEW_DEVICE_CONNECTED,
     OneWireConfigEntry,
@@ -31,25 +30,16 @@ PARALLEL_UPDATES = 0
 SCAN_INTERVAL = timedelta(seconds=30)
 
 
-@dataclass(frozen=True)
-class OneWireBinarySensorEntityDescription(
-    OneWireEntityDescription, BinarySensorEntityDescription
-):
-    """Class describing OneWire binary sensor entities."""
-
-    read_mode = READ_MODE_INT
-
-
-DEVICE_BINARY_SENSORS: dict[str, tuple[OneWireBinarySensorEntityDescription, ...]] = {
+DEVICE_BINARY_SENSORS: dict[str, tuple[BinarySensorEntityDescription, ...]] = {
     "05": (
-        OneWireBinarySensorEntityDescription(
+        BinarySensorEntityDescription(
             key="sensed",
             entity_registry_enabled_default=False,
             translation_key="sensed",
         ),
     ),
     "12": tuple(
-        OneWireBinarySensorEntityDescription(
+        BinarySensorEntityDescription(
             key=f"sensed.{device_key}",
             entity_registry_enabled_default=False,
             translation_key="sensed_id",
@@ -58,7 +48,7 @@ DEVICE_BINARY_SENSORS: dict[str, tuple[OneWireBinarySensorEntityDescription, ...
         for device_key in DEVICE_KEYS_A_B
     ),
     "29": tuple(
-        OneWireBinarySensorEntityDescription(
+        BinarySensorEntityDescription(
             key=f"sensed.{device_key}",
             entity_registry_enabled_default=False,
             translation_key="sensed_id",
@@ -67,7 +57,7 @@ DEVICE_BINARY_SENSORS: dict[str, tuple[OneWireBinarySensorEntityDescription, ...
         for device_key in DEVICE_KEYS_0_7
     ),
     "3A": tuple(
-        OneWireBinarySensorEntityDescription(
+        BinarySensorEntityDescription(
             key=f"sensed.{device_key}",
             entity_registry_enabled_default=False,
             translation_key="sensed_id",
@@ -79,9 +69,9 @@ DEVICE_BINARY_SENSORS: dict[str, tuple[OneWireBinarySensorEntityDescription, ...
 }
 
 # EF sensors are usually hobbyboards specialized sensors.
-HOBBYBOARD_EF: dict[str, tuple[OneWireBinarySensorEntityDescription, ...]] = {
+HOBBYBOARD_EF: dict[str, tuple[BinarySensorEntityDescription, ...]] = {
     "HB_HUB": tuple(
-        OneWireBinarySensorEntityDescription(
+        BinarySensorEntityDescription(
             key=f"hub/short.{device_key}",
             entity_registry_enabled_default=False,
             entity_category=EntityCategory.DIAGNOSTIC,
@@ -96,7 +86,7 @@ HOBBYBOARD_EF: dict[str, tuple[OneWireBinarySensorEntityDescription, ...]] = {
 
 def get_sensor_types(
     device_sub_type: str,
-) -> dict[str, tuple[OneWireBinarySensorEntityDescription, ...]]:
+) -> dict[str, tuple[BinarySensorEntityDescription, ...]]:
     """Return the proper info array for the device type."""
     if "HobbyBoard" in device_sub_type:
         return HOBBYBOARD_EF
@@ -160,11 +150,9 @@ def get_entities(
 class OneWireBinarySensorEntity(OneWireEntity, BinarySensorEntity):
     """Implementation of a 1-Wire binary sensor."""
 
-    entity_description: OneWireBinarySensorEntityDescription
-
     @property
     def is_on(self) -> bool | None:
         """Return true if sensor is on."""
-        if self._state is None:
+        if (raw_value := self._raw_value) is None:
             return None
-        return self._state == 1
+        return raw_value == "1"

--- a/homeassistant/components/onewire/const.py
+++ b/homeassistant/components/onewire/const.py
@@ -50,6 +50,3 @@ INPUT_ENTRY_DEVICE_SELECTION = "device_selection"
 MANUFACTURER_MAXIM = "Maxim Integrated"
 MANUFACTURER_HOBBYBOARDS = "Hobby Boards"
 MANUFACTURER_EDS = "Embedded Data Systems"
-
-READ_MODE_FLOAT = "float"
-READ_MODE_INT = "int"

--- a/homeassistant/components/onewire/entity.py
+++ b/homeassistant/components/onewire/entity.py
@@ -33,7 +33,7 @@ class OneWireEntity(Entity):
         self._attr_unique_id = f"/{device_id}/{description.key}"
         self._attr_device_info = device_info
         self._device_file = device_file
-        self._raw_value: str | None = None
+        self._state: str | None = None
         self._owproxy = owproxy
 
     @property
@@ -50,14 +50,14 @@ class OneWireEntity(Entity):
     async def async_update(self) -> None:
         """Get the latest data from the device."""
         try:
-            value = await self._owproxy.read(self._device_file)
+            state = await self._owproxy.read(self._device_file)
         except OWServerError as exc:
             if self._last_update_success:
                 _LOGGER.error("Error fetching %s data: %s", self.name, exc)
                 self._last_update_success = False
-            self._raw_value = None
+            self._state = None
         else:
             if not self._last_update_success:
                 self._last_update_success = True
                 _LOGGER.debug("Fetching %s data recovered", self.name)
-            self._raw_value = value.decode("ascii").strip()
+            self._state = state.decode("ascii").strip()

--- a/homeassistant/components/onewire/select.py
+++ b/homeassistant/components/onewire/select.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import timedelta
 import os
 
@@ -12,8 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import READ_MODE_INT
-from .entity import OneWireEntity, OneWireEntityDescription
+from .entity import OneWireEntity
 from .onewirehub import (
     SIGNAL_NEW_DEVICE_CONNECTED,
     OneWireConfigEntry,
@@ -27,17 +25,11 @@ PARALLEL_UPDATES = 0
 SCAN_INTERVAL = timedelta(seconds=30)
 
 
-@dataclass(frozen=True)
-class OneWireSelectEntityDescription(OneWireEntityDescription, SelectEntityDescription):
-    """Class describing OneWire select entities."""
-
-
-ENTITY_DESCRIPTIONS: dict[str, tuple[OneWireEntityDescription, ...]] = {
+ENTITY_DESCRIPTIONS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "28": (
-        OneWireSelectEntityDescription(
+        SelectEntityDescription(
             key="tempres",
             entity_category=EntityCategory.CONFIG,
-            read_mode=READ_MODE_INT,
             options=["9", "10", "11", "12"],
             translation_key="tempres",
         ),
@@ -98,12 +90,10 @@ def get_entities(
 class OneWireSelectEntity(OneWireEntity, SelectEntity):
     """Implementation of a 1-Wire switch."""
 
-    entity_description: OneWireSelectEntityDescription
-
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return str(self._state)
+        return self._raw_value
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/homeassistant/components/onewire/select.py
+++ b/homeassistant/components/onewire/select.py
@@ -93,7 +93,7 @@ class OneWireSelectEntity(OneWireEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return self._raw_value
+        return self._state
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -454,6 +454,6 @@ class OneWireSensorEntity(OneWireEntity, SensorEntity):
     @property
     def native_value(self) -> float | int | None:
         """Return the state of the entity."""
-        if (raw_value := self._state) is None:
+        if (state := self._state) is None:
             return None
-        return float(raw_value) if "." in raw_value else int(raw_value)
+        return float(state) if "." in state else int(state)

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -452,7 +452,7 @@ class OneWireSensorEntity(OneWireEntity, SensorEntity):
     """Implementation of a 1-Wire sensor."""
 
     @property
-    def native_value(self) -> float | None:
+    def native_value(self) -> float | int | None:
         """Return the state of the entity."""
         if (raw_value := self._state) is None:
             return None

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -27,7 +27,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.typing import StateType
 
 from .const import (
     DEVICE_KEYS_0_3,
@@ -36,10 +35,8 @@ from .const import (
     OPTION_ENTRY_DEVICE_OPTIONS,
     OPTION_ENTRY_SENSOR_PRECISION,
     PRECISION_MAPPING_FAMILY_28,
-    READ_MODE_FLOAT,
-    READ_MODE_INT,
 )
-from .entity import OneWireEntity, OneWireEntityDescription
+from .entity import OneWireEntity
 from .onewirehub import (
     SIGNAL_NEW_DEVICE_CONNECTED,
     OneWireConfigEntry,
@@ -54,7 +51,7 @@ SCAN_INTERVAL = timedelta(seconds=30)
 
 
 @dataclasses.dataclass(frozen=True)
-class OneWireSensorEntityDescription(OneWireEntityDescription, SensorEntityDescription):
+class OneWireSensorEntityDescription(SensorEntityDescription):
     """Class describing OneWire sensor entities."""
 
     override_key: Callable[[str, Mapping[str, Any]], str] | None = None
@@ -81,7 +78,6 @@ SIMPLE_TEMPERATURE_SENSOR_DESCRIPTION = OneWireSensorEntityDescription(
     key="temperature",
     device_class=SensorDeviceClass.TEMPERATURE,
     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-    read_mode=READ_MODE_FLOAT,
     state_class=SensorStateClass.MEASUREMENT,
 )
 
@@ -96,7 +92,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.TEMPERATURE,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         OneWireSensorEntityDescription(
@@ -104,7 +99,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.PRESSURE,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=UnitOfPressure.MBAR,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
     ),
@@ -115,7 +109,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
                 device_class=SensorDeviceClass.VOLTAGE,
                 entity_registry_enabled_default=False,
                 native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-                read_mode=READ_MODE_FLOAT,
                 state_class=SensorStateClass.MEASUREMENT,
                 translation_key="latest_voltage_id",
                 translation_placeholders={"id": str(device_key)},
@@ -127,7 +120,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
                 key=f"volt.{device_key}",
                 device_class=SensorDeviceClass.VOLTAGE,
                 native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-                read_mode=READ_MODE_FLOAT,
                 state_class=SensorStateClass.MEASUREMENT,
                 translation_key="voltage_id",
                 translation_placeholders={"id": str(device_key)},
@@ -143,7 +135,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.HUMIDITY,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=PERCENTAGE,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         OneWireSensorEntityDescription(
@@ -151,7 +142,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.HUMIDITY,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=PERCENTAGE,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="humidity_hih3600",
         ),
@@ -160,7 +150,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.HUMIDITY,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=PERCENTAGE,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="humidity_hih4000",
         ),
@@ -169,7 +158,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.HUMIDITY,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=PERCENTAGE,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="humidity_hih5030",
         ),
@@ -178,7 +166,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.HUMIDITY,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=PERCENTAGE,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="humidity_htm1735",
         ),
@@ -187,7 +174,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.PRESSURE,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=UnitOfPressure.MBAR,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         OneWireSensorEntityDescription(
@@ -195,7 +181,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.ILLUMINANCE,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=LIGHT_LUX,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         OneWireSensorEntityDescription(
@@ -203,7 +188,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.VOLTAGE,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="voltage_vad",
         ),
@@ -212,7 +196,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.VOLTAGE,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="voltage_vdd",
         ),
@@ -221,7 +204,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.VOLTAGE,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="voltage_vis",
         ),
@@ -232,7 +214,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.TEMPERATURE,
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             override_key=_get_sensor_precision_family_28,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
     ),
@@ -243,7 +224,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.TEMPERATURE,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-            read_mode=READ_MODE_FLOAT,
             override_key=lambda d, o: "typeK/temperature",
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="thermocouple_temperature_k",
@@ -253,7 +233,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.VOLTAGE,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         OneWireSensorEntityDescription(
@@ -261,7 +240,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.VOLTAGE,
             entity_registry_enabled_default=False,
             native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="voltage_vis_gradient",
         ),
@@ -271,7 +249,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
     "1D": tuple(
         OneWireSensorEntityDescription(
             key=f"counter.{device_key}",
-            read_mode=READ_MODE_INT,
             state_class=SensorStateClass.TOTAL_INCREASING,
             translation_key="counter_id",
             translation_placeholders={"id": str(device_key)},
@@ -288,14 +265,12 @@ HOBBYBOARD_EF: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             key="humidity/humidity_corrected",
             device_class=SensorDeviceClass.HUMIDITY,
             native_unit_of_measurement=PERCENTAGE,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         OneWireSensorEntityDescription(
             key="humidity/humidity_raw",
             device_class=SensorDeviceClass.HUMIDITY,
             native_unit_of_measurement=PERCENTAGE,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="humidity_raw",
         ),
@@ -303,7 +278,6 @@ HOBBYBOARD_EF: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             key="humidity/temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
     ),
@@ -312,7 +286,6 @@ HOBBYBOARD_EF: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             key=f"moisture/sensor.{device_key}",
             device_class=SensorDeviceClass.PRESSURE,
             native_unit_of_measurement=UnitOfPressure.CBAR,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="moisture_id",
             translation_placeholders={"id": str(device_key)},
@@ -329,14 +302,12 @@ EDS_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             key="EDS0066/temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         OneWireSensorEntityDescription(
             key="EDS0066/pressure",
             device_class=SensorDeviceClass.PRESSURE,
             native_unit_of_measurement=UnitOfPressure.MBAR,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
     ),
@@ -345,28 +316,24 @@ EDS_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
             key="EDS0068/temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         OneWireSensorEntityDescription(
             key="EDS0068/pressure",
             device_class=SensorDeviceClass.PRESSURE,
             native_unit_of_measurement=UnitOfPressure.MBAR,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         OneWireSensorEntityDescription(
             key="EDS0068/light",
             device_class=SensorDeviceClass.ILLUMINANCE,
             native_unit_of_measurement=LIGHT_LUX,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         OneWireSensorEntityDescription(
             key="EDS0068/humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             native_unit_of_measurement=PERCENTAGE,
-            read_mode=READ_MODE_FLOAT,
             state_class=SensorStateClass.MEASUREMENT,
         ),
     ),
@@ -484,9 +451,9 @@ async def get_entities(
 class OneWireSensorEntity(OneWireEntity, SensorEntity):
     """Implementation of a 1-Wire sensor."""
 
-    entity_description: OneWireSensorEntityDescription
-
     @property
-    def native_value(self) -> StateType:
+    def native_value(self) -> float | None:
         """Return the state of the entity."""
-        return self._state
+        if (raw_value := self._raw_value) is None:
+            return None
+        return float(raw_value) if "." in raw_value else int(raw_value)

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -454,6 +454,6 @@ class OneWireSensorEntity(OneWireEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the state of the entity."""
-        if (raw_value := self._raw_value) is None:
+        if (raw_value := self._state) is None:
             return None
         return float(raw_value) if "." in raw_value else int(raw_value)

--- a/homeassistant/components/onewire/switch.py
+++ b/homeassistant/components/onewire/switch.py
@@ -206,7 +206,7 @@ class OneWireSwitchEntity(OneWireEntity, SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
-        if (raw_value := self._raw_value) is None:
+        if (raw_value := self._state) is None:
             return None
         return raw_value == "1"
 

--- a/homeassistant/components/onewire/switch.py
+++ b/homeassistant/components/onewire/switch.py
@@ -206,9 +206,9 @@ class OneWireSwitchEntity(OneWireEntity, SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
-        if (raw_value := self._state) is None:
+        if (state := self._state) is None:
             return None
-        return raw_value == "1"
+        return state == "1"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/onewire/switch.py
+++ b/homeassistant/components/onewire/switch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import timedelta
 import os
 from typing import Any
@@ -13,8 +12,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DEVICE_KEYS_0_3, DEVICE_KEYS_0_7, DEVICE_KEYS_A_B, READ_MODE_INT
-from .entity import OneWireEntity, OneWireEntityDescription
+from .const import DEVICE_KEYS_0_3, DEVICE_KEYS_0_7, DEVICE_KEYS_A_B
+from .entity import OneWireEntity
 from .onewirehub import (
     SIGNAL_NEW_DEVICE_CONNECTED,
     OneWireConfigEntry,
@@ -28,16 +27,9 @@ PARALLEL_UPDATES = 0
 SCAN_INTERVAL = timedelta(seconds=30)
 
 
-@dataclass(frozen=True)
-class OneWireSwitchEntityDescription(OneWireEntityDescription, SwitchEntityDescription):
-    """Class describing OneWire switch entities."""
-
-    read_mode = READ_MODE_INT
-
-
-DEVICE_SWITCHES: dict[str, tuple[OneWireEntityDescription, ...]] = {
+DEVICE_SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "05": (
-        OneWireSwitchEntityDescription(
+        SwitchEntityDescription(
             key="PIO",
             entity_registry_enabled_default=False,
             translation_key="pio",
@@ -45,7 +37,7 @@ DEVICE_SWITCHES: dict[str, tuple[OneWireEntityDescription, ...]] = {
     ),
     "12": tuple(
         [
-            OneWireSwitchEntityDescription(
+            SwitchEntityDescription(
                 key=f"PIO.{device_key}",
                 entity_registry_enabled_default=False,
                 translation_key="pio_id",
@@ -54,7 +46,7 @@ DEVICE_SWITCHES: dict[str, tuple[OneWireEntityDescription, ...]] = {
             for device_key in DEVICE_KEYS_A_B
         ]
         + [
-            OneWireSwitchEntityDescription(
+            SwitchEntityDescription(
                 key=f"latch.{device_key}",
                 entity_registry_enabled_default=False,
                 translation_key="latch_id",
@@ -64,7 +56,7 @@ DEVICE_SWITCHES: dict[str, tuple[OneWireEntityDescription, ...]] = {
         ]
     ),
     "26": (
-        OneWireSwitchEntityDescription(
+        SwitchEntityDescription(
             key="IAD",
             entity_registry_enabled_default=False,
             entity_category=EntityCategory.CONFIG,
@@ -73,7 +65,7 @@ DEVICE_SWITCHES: dict[str, tuple[OneWireEntityDescription, ...]] = {
     ),
     "29": tuple(
         [
-            OneWireSwitchEntityDescription(
+            SwitchEntityDescription(
                 key=f"PIO.{device_key}",
                 entity_registry_enabled_default=False,
                 translation_key="pio_id",
@@ -82,7 +74,7 @@ DEVICE_SWITCHES: dict[str, tuple[OneWireEntityDescription, ...]] = {
             for device_key in DEVICE_KEYS_0_7
         ]
         + [
-            OneWireSwitchEntityDescription(
+            SwitchEntityDescription(
                 key=f"latch.{device_key}",
                 entity_registry_enabled_default=False,
                 translation_key="latch_id",
@@ -92,7 +84,7 @@ DEVICE_SWITCHES: dict[str, tuple[OneWireEntityDescription, ...]] = {
         ]
     ),
     "3A": tuple(
-        OneWireSwitchEntityDescription(
+        SwitchEntityDescription(
             key=f"PIO.{device_key}",
             entity_registry_enabled_default=False,
             translation_key="pio_id",
@@ -105,9 +97,9 @@ DEVICE_SWITCHES: dict[str, tuple[OneWireEntityDescription, ...]] = {
 
 # EF sensors are usually hobbyboards specialized sensors.
 
-HOBBYBOARD_EF: dict[str, tuple[OneWireEntityDescription, ...]] = {
+HOBBYBOARD_EF: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "HB_HUB": tuple(
-        OneWireSwitchEntityDescription(
+        SwitchEntityDescription(
             key=f"hub/branch.{device_key}",
             entity_registry_enabled_default=False,
             entity_category=EntityCategory.CONFIG,
@@ -118,7 +110,7 @@ HOBBYBOARD_EF: dict[str, tuple[OneWireEntityDescription, ...]] = {
     ),
     "HB_MOISTURE_METER": tuple(
         [
-            OneWireSwitchEntityDescription(
+            SwitchEntityDescription(
                 key=f"moisture/is_leaf.{device_key}",
                 entity_registry_enabled_default=False,
                 entity_category=EntityCategory.CONFIG,
@@ -128,7 +120,7 @@ HOBBYBOARD_EF: dict[str, tuple[OneWireEntityDescription, ...]] = {
             for device_key in DEVICE_KEYS_0_3
         ]
         + [
-            OneWireSwitchEntityDescription(
+            SwitchEntityDescription(
                 key=f"moisture/is_moisture.{device_key}",
                 entity_registry_enabled_default=False,
                 entity_category=EntityCategory.CONFIG,
@@ -143,7 +135,7 @@ HOBBYBOARD_EF: dict[str, tuple[OneWireEntityDescription, ...]] = {
 
 def get_sensor_types(
     device_sub_type: str,
-) -> dict[str, tuple[OneWireEntityDescription, ...]]:
+) -> dict[str, tuple[SwitchEntityDescription, ...]]:
     """Return the proper info array for the device type."""
     if "HobbyBoard" in device_sub_type:
         return HOBBYBOARD_EF
@@ -211,14 +203,12 @@ def get_entities(
 class OneWireSwitchEntity(OneWireEntity, SwitchEntity):
     """Implementation of a 1-Wire switch."""
 
-    entity_description: OneWireSwitchEntityDescription
-
     @property
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
-        if self._state is None:
+        if (raw_value := self._raw_value) is None:
             return None
-        return self._state == 1
+        return raw_value == "1"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`owserver` passes all values as ascii-encoded strings
We can remove `read_mode` from the entity descriptions, and just store the raw string in the base entity.
We can then convert to `bool`/`int`/`float` in the relevant place

This greatly simplifies the code as we can drop custom EntityDescription


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
