### PR TITLE
Add clamp/wrap/remap to template math functions

### DIFF
--- a/homeassistant/helpers/template/extensions/math.py
+++ b/homeassistant/helpers/template/extensions/math.py
@@ -431,8 +431,7 @@ class MathExtension(BaseTemplateExtension):
             value_num = in_min_num + position_in_period
         # Unknown "edges" values are left as-is; no use throwing an error.
 
-        if steps < 0:  # noqa: PLR1730 (we don't want a function call here)
-            steps = 0
+        steps = max(steps, 0)
 
         if not steps and (in_min_num == out_min_num and in_max_num == out_max_num):
             return value_num  # No remapping needed. Save some cycles and floating-point precision.

--- a/homeassistant/helpers/template/extensions/math.py
+++ b/homeassistant/helpers/template/extensions/math.py
@@ -338,14 +338,16 @@ class MathExtension(BaseTemplateExtension):
 
         Constrains value to the range [min_value, max_value] (inclusive).
         """
-        return MathExtension.remap(
-            value,
-            in_min=min_value,
-            in_max=max_value,
-            out_min=min_value,
-            out_max=max_value,
-            edges="clamp",
-        )
+        try:
+            value_num = float(value)
+            min_value_num = float(min_value)
+            max_value_num = float(max_value)
+        except (ValueError, TypeError) as err:
+            raise ValueError(
+                f"function requires numeric arguments, "
+                f"got {value=}, {min_value=}, {max_value=}"
+            ) from err
+        return max(min_value_num, min(max_value_num, value_num))
 
     @staticmethod
     def wrap(value: Any, min_value: Any, max_value: Any) -> Any:
@@ -353,14 +355,20 @@ class MathExtension(BaseTemplateExtension):
 
         Wraps value cyclically within [min_value, max_value) (inclusive min, exclusive max).
         """
-        return MathExtension.remap(
-            value,
-            in_min=min_value,
-            in_max=max_value,
-            out_min=min_value,
-            out_max=max_value,
-            edges="wrap",
-        )
+        try:
+            value_num = float(value)
+            min_value_num = float(min_value)
+            max_value_num = float(max_value)
+        except (ValueError, TypeError) as err:
+            raise ValueError(
+                f"function requires numeric arguments, "
+                f"got {value=}, {min_value=}, {max_value=}"
+            ) from err
+        try:
+            range_size = max_value_num - min_value_num
+            return ((value_num - min_value_num) % range_size) + min_value_num
+        except ZeroDivisionError:  # be lenient: if the range is empty, just clamp
+            return min_value_num
 
     @staticmethod
     def remap(

--- a/homeassistant/helpers/template/extensions/math.py
+++ b/homeassistant/helpers/template/extensions/math.py
@@ -398,16 +398,19 @@ class MathExtension(BaseTemplateExtension):
                 f"got {value=}, {in_min=}, {in_max=}, {out_min=}, {out_max=}"
             ) from err
 
-        if in_min_num == in_max_num:
-            raise ValueError(f"{in_min=} must not equal {in_max=}")
-
         # Apply edge behavior in original space for accuracy.
         if edges == "clamp":
             value_num = max(in_min_num, min(in_max_num, value_num))
         elif edges == "wrap":
+            if in_min_num == in_max_num:
+                raise ValueError(f"{in_min=} must not equal {in_max=}")
+
             range_size = in_max_num - in_min_num  # Validated against div0 above.
             value_num = ((value_num - in_min_num) % range_size) + in_min_num
         elif edges == "mirror":
+            if in_min_num == in_max_num:
+                raise ValueError(f"{in_min=} must not equal {in_max=}")
+
             range_size = in_max_num - in_min_num  # Validated against div0 above.
             # Determine which period we're in and whether it should be mirrored
             offset = value_num - in_min_num

--- a/homeassistant/helpers/template/extensions/math.py
+++ b/homeassistant/helpers/template/extensions/math.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from functools import wraps
 import math
 import statistics
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import jinja2
 from jinja2 import pass_environment
@@ -77,6 +77,10 @@ class MathExtension(BaseTemplateExtension):
                 TemplateFunction(
                     "bitwise_xor", self.bitwise_xor, as_global=True, as_filter=True
                 ),
+                # Value constraint functions (as globals and filters)
+                TemplateFunction("clamp", self.clamp, as_global=True, as_filter=True),
+                TemplateFunction("wrap", self.wrap, as_global=True, as_filter=True),
+                TemplateFunction("remap", self.remap, as_global=True, as_filter=True),
             ],
         )
 
@@ -327,3 +331,104 @@ class MathExtension(BaseTemplateExtension):
     def bitwise_xor(first_value: Any, second_value: Any) -> Any:
         """Perform a bitwise xor operation."""
         return first_value ^ second_value
+
+    @staticmethod
+    def clamp(value: Any, min_value: Any, max_value: Any) -> Any:
+        """Filter and function to clamp a value between min and max bounds.
+
+        Constrains value to the range [min_value, max_value] (inclusive).
+        """
+        return MathExtension.remap(
+            value,
+            in_min=min_value,
+            in_max=max_value,
+            out_min=min_value,
+            out_max=max_value,
+            edges="clamp",
+        )
+
+    @staticmethod
+    def wrap(value: Any, min_value: Any, max_value: Any) -> Any:
+        """Filter and function to wrap a value within a range.
+
+        Wraps value cyclically within [min_value, max_value) (inclusive min, exclusive max).
+        """
+        return MathExtension.remap(
+            value,
+            in_min=min_value,
+            in_max=max_value,
+            out_min=min_value,
+            out_max=max_value,
+            edges="wrap",
+        )
+
+    @staticmethod
+    def remap(
+        value: Any,
+        in_min: Any,
+        in_max: Any,
+        out_min: Any,
+        out_max: Any,
+        *,
+        steps: int | None = None,
+        edges: Literal["none", "clamp", "wrap", "mirror"] = "none",
+    ) -> Any:
+        """Filter and function to remap a value from one range to another.
+
+        Maps value from input range [in_min, in_max] to output range [out_min, out_max].
+
+        The optional steps parameter, if provided and greater than 0, quantizes the output into
+        the specified number of discrete steps.
+
+        The edges parameter controls how out-of-bounds input values are handled:
+        - "none": No special handling; values outside the input range are extrapolated into the output range.
+        - "clamp": Values outside the input range are clamped to the nearest boundary.
+        - "wrap": Values outside the input range are wrapped around cyclically.
+        - "mirror": Values outside the input range are mirrored back into the range.
+        """
+        try:
+            value_num = float(value)
+            in_min_num = float(in_min)
+            in_max_num = float(in_max)
+            out_min_num = float(out_min)
+            out_max_num = float(out_max)
+        except (ValueError, TypeError) as err:
+            raise ValueError(
+                f"function requires numeric arguments, "
+                f"got {value=}, {in_min=}, {in_max=}, {out_min=}, {out_max=}"
+            ) from err
+
+        if in_min_num == in_max_num:
+            raise ValueError(f"{in_min=} must not equal {in_max=}")
+
+        # Apply edge behavior in original space for accuracy.
+        if edges == "clamp":
+            value_num = max(in_min_num, min(in_max_num, value_num))
+        elif edges == "wrap":
+            range_size = in_max_num - in_min_num  # Validated against div0 above.
+            value_num = ((value_num - in_min_num) % range_size) + in_min_num
+        elif edges == "mirror":
+            range_size = in_max_num - in_min_num  # Validated against div0 above.
+            # Determine which period we're in and whether it should be mirrored
+            offset = value_num - in_min_num
+            period = math.floor(offset / range_size)
+            position_in_period = offset - (period * range_size)
+
+            if (period < 0) or (period % 2 != 0):
+                position_in_period = range_size - position_in_period
+
+            value_num = in_min_num + position_in_period
+        # Unknown "edges" values are left as-is; no use throwing an error.
+
+        if steps and steps < 0:
+            steps = None
+
+        if not steps and (in_min_num == out_min_num and in_max_num == out_max_num):
+            return value_num  # No remapping needed. Save some cycles and floating-point precision.
+
+        normalized = (value_num - in_min_num) / (in_max_num - in_min_num)
+
+        if steps:
+            normalized = round(normalized * steps) / steps
+
+        return out_min_num + (normalized * (out_max_num - out_min_num))

--- a/homeassistant/helpers/template/extensions/math.py
+++ b/homeassistant/helpers/template/extensions/math.py
@@ -378,14 +378,14 @@ class MathExtension(BaseTemplateExtension):
         out_min: Any,
         out_max: Any,
         *,
-        steps: int | None = None,
+        steps: int = 0,
         edges: Literal["none", "clamp", "wrap", "mirror"] = "none",
     ) -> Any:
         """Filter and function to remap a value from one range to another.
 
         Maps value from input range [in_min, in_max] to output range [out_min, out_max].
 
-        The optional steps parameter, if provided and greater than 0, quantizes the output into
+        The steps parameter, if greater than 0, quantizes the output into
         the specified number of discrete steps.
 
         The edges parameter controls how out-of-bounds input values are handled:
@@ -431,8 +431,8 @@ class MathExtension(BaseTemplateExtension):
             value_num = in_min_num + position_in_period
         # Unknown "edges" values are left as-is; no use throwing an error.
 
-        if steps and steps < 0:
-            steps = None
+        if steps < 0:  # noqa: PLR1730 (we don't want a function call here)
+            steps = 0
 
         if not steps and (in_min_num == out_min_num and in_max_num == out_max_num):
             return value_num  # No remapping needed. Save some cycles and floating-point precision.

--- a/tests/helpers/template/extensions/test_math.py
+++ b/tests/helpers/template/extensions/test_math.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
+from homeassistant.helpers.template.extensions import MathExtension
 
 from tests.helpers.template.helpers import render
 
@@ -340,3 +341,200 @@ def test_min_max_attribute(hass: HomeAssistant, attribute) -> None:
         )
         == 3
     )
+
+
+def test_clamp(hass: HomeAssistant) -> None:
+    """Test clamp function."""
+    # Test function and filter usage in templates.
+    assert render(hass, "{{ clamp(15, 0, 10) }}") == 10.0
+    assert render(hass, "{{ -5 | clamp(0, 10) }}") == 0.0
+
+    # Test basic clamping behavior
+    assert MathExtension.clamp(5, 0, 10) == 5.0
+    assert MathExtension.clamp(-5, 0, 10) == 0.0
+    assert MathExtension.clamp(15, 0, 10) == 10.0
+    assert MathExtension.clamp(0, 0, 10) == 0.0
+    assert MathExtension.clamp(10, 0, 10) == 10.0
+
+    # Test with float values
+    assert MathExtension.clamp(5.5, 0, 10) == 5.5
+    assert MathExtension.clamp(5.5, 0.5, 10.5) == 5.5
+    assert MathExtension.clamp(0.25, 0.5, 10.5) == 0.5
+    assert MathExtension.clamp(11.0, 0.5, 10.5) == 10.5
+
+    # Test with negative ranges
+    assert MathExtension.clamp(-5, -10, -1) == -5.0
+    assert MathExtension.clamp(-15, -10, -1) == -10.0
+    assert MathExtension.clamp(0, -10, -1) == -1.0
+
+    # Test error handling - invalid input types
+    for case in (
+        "{{ clamp('invalid', 0, 10) }}",
+        "{{ clamp(5, 'invalid', 10) }}",
+        "{{ clamp(5, 0, 'invalid') }}",
+    ):
+        with pytest.raises(TemplateError):
+            render(hass, case)
+
+
+def test_wrap(hass: HomeAssistant) -> None:
+    """Test wrap function."""
+    # Test function and filter usage in templates.
+    assert render(hass, "{{ wrap(15, 0, 10) }}") == 5.0
+    assert render(hass, "{{ -5 | wrap(0, 10) }}") == 5.0
+
+    # Test basic wrapping behavior
+    assert MathExtension.wrap(5, 0, 10) == 5.0
+    assert MathExtension.wrap(10, 0, 10) == 0.0  # max wraps to min
+    assert MathExtension.wrap(15, 0, 10) == 5.0
+    assert MathExtension.wrap(25, 0, 10) == 5.0
+    assert MathExtension.wrap(-5, 0, 10) == 5.0
+    assert MathExtension.wrap(-10, 0, 10) == 0.0
+
+    # Test angle wrapping (common use case)
+    assert MathExtension.wrap(370, 0, 360) == 10.0
+    assert MathExtension.wrap(-10, 0, 360) == 350.0
+    assert MathExtension.wrap(720, 0, 360) == 0.0
+    assert MathExtension.wrap(361, 0, 360) == 1.0
+
+    # Test with float values
+    assert MathExtension.wrap(10.5, 0, 10) == 0.5
+    assert MathExtension.wrap(370.5, 0, 360) == 10.5
+
+    # Test with negative ranges
+    assert MathExtension.wrap(-15, -10, 0) == -5.0
+    assert MathExtension.wrap(5, -10, 0) == -5.0
+
+    # Test with arbitrary ranges
+    assert MathExtension.wrap(25, 10, 20) == 15.0
+    assert MathExtension.wrap(5, 10, 20) == 15.0
+
+    # Test error handling - invalid input types
+    for case in (
+        "{{ wrap('invalid', 0, 10) }}",
+        "{{ wrap(5, 'invalid', 10) }}",
+        "{{ wrap(5, 0, 'invalid') }}",
+    ):
+        with pytest.raises(TemplateError):
+            render(hass, case)
+
+
+def test_remap(hass: HomeAssistant) -> None:
+    """Test remap function."""
+    # Test function and filter usage in templates, with kitchen sink parameters.
+    # We don't check the return value; that's covered by the unit tests below.
+    assert render(hass, "{{ remap(5, 0, 6, 0, 740, steps=10) }}")
+    assert render(hass, "{{ 50 | remap(0, 100, 0, 10, steps=8) }}")
+
+    # Test basic remapping - scale from 0-10 to 0-100
+    assert MathExtension.remap(0, 0, 10, 0, 100) == 0.0
+    assert MathExtension.remap(5, 0, 10, 0, 100) == 50.0
+    assert MathExtension.remap(10, 0, 10, 0, 100) == 100.0
+
+    # Test with different input and output ranges
+    assert MathExtension.remap(50, 0, 100, 0, 10) == 5.0
+    assert MathExtension.remap(25, 0, 100, 0, 10) == 2.5
+
+    # Test with negative ranges
+    assert MathExtension.remap(0, -10, 10, 0, 100) == 50.0
+    assert MathExtension.remap(-10, -10, 10, 0, 100) == 0.0
+    assert MathExtension.remap(10, -10, 10, 0, 100) == 100.0
+
+    # Test inverted output range
+    assert MathExtension.remap(0, 0, 10, 100, 0) == 100.0
+    assert MathExtension.remap(5, 0, 10, 100, 0) == 50.0
+    assert MathExtension.remap(10, 0, 10, 100, 0) == 0.0
+
+    # Test values outside input range, and edge modes
+    assert MathExtension.remap(15, 0, 10, 0, 100, edges="none") == 150.0
+    assert MathExtension.remap(-4, 0, 10, 0, 100, edges="none") == -40.0
+    assert MathExtension.remap(15, 0, 10, 0, 80, edges="clamp") == 80.0
+    assert MathExtension.remap(-5, 0, 10, -1, 1, edges="clamp") == -1
+    assert MathExtension.remap(15, 0, 10, 0, 100, edges="wrap") == 50.0
+    assert MathExtension.remap(-5, 0, 10, 0, 100, edges="wrap") == 50.0
+
+    # Test sensor conversion use case: Celsius to Fahrenheit: 0-100°C to 32-212°F
+    assert MathExtension.remap(0, 0, 100, 32, 212) == 32.0
+    assert MathExtension.remap(100, 0, 100, 32, 212) == 212.0
+    assert MathExtension.remap(50, 0, 100, 32, 212) == 122.0
+
+    # Test time conversion use case: 0-60 minutes to 0-360 degrees, with wrap
+    assert MathExtension.remap(80, 0, 60, 0, 360, edges="wrap") == 120.0
+
+    # Test percentage to byte conversion (0-100% to 0-255)
+    assert MathExtension.remap(0, 0, 100, 0, 255) == 0.0
+    assert MathExtension.remap(50, 0, 100, 0, 255) == 127.5
+    assert MathExtension.remap(100, 0, 100, 0, 255) == 255.0
+
+    # Test with float precision
+    assert MathExtension.remap(2.5, 0, 10, 0, 100) == 25.0
+    assert MathExtension.remap(7.5, 0, 10, 0, 100) == 75.0
+
+    # Test error handling
+    for case in (
+        "{{ remap(5, 10, 10, 0, 100) }}",
+        "{{ remap('invalid', 0, 10, 0, 100) }}",
+        "{{ remap(5, 'invalid', 10, 0, 100) }}",
+        "{{ remap(5, 0, 'invalid', 0, 100) }}",
+        "{{ remap(5, 0, 10, 'invalid', 100) }}",
+        "{{ remap(5, 0, 10, 0, 'invalid') }}",
+    ):
+        with pytest.raises(TemplateError):
+            render(hass, case)
+
+
+def test_remap_with_steps(hass: HomeAssistant) -> None:
+    """Test remap function with steps parameter."""
+    # Test basic stepping - quantize to 10 steps
+    assert MathExtension.remap(0.2, 0, 10, 0, 100, steps=10) == 0.0
+    assert MathExtension.remap(5.3, 0, 10, 0, 100, steps=10) == 50.0
+    assert MathExtension.remap(10, 0, 10, 0, 100, steps=10) == 100.0
+
+    # Test stepping with intermediate values - should snap to nearest step
+    # With 10 steps, normalized values are rounded: 0.0, 0.1, 0.2, ..., 1.0
+    assert MathExtension.remap(2.4, 0, 10, 0, 100, steps=10) == 20.0
+    assert MathExtension.remap(2.5, 0, 10, 0, 100, steps=10) == 20.0
+    assert MathExtension.remap(2.6, 0, 10, 0, 100, steps=10) == 30.0
+
+    # Test with 4 steps (0%, 25%, 50%, 75%, 100%)
+    assert MathExtension.remap(0, 0, 10, 0, 100, steps=4) == 0.0
+    assert MathExtension.remap(2.5, 0, 10, 0, 100, steps=4) == 25.0
+    assert MathExtension.remap(5, 0, 10, 0, 100, steps=4) == 50.0
+    assert MathExtension.remap(7.5, 0, 10, 0, 100, steps=4) == 75.0
+    assert MathExtension.remap(10, 0, 10, 0, 100, steps=4) == 100.0
+
+    # Test with 2 steps (0%, 50%, 100%)
+    assert MathExtension.remap(2, 0, 10, 0, 100, steps=2) == 0.0
+    assert MathExtension.remap(6, 0, 10, 0, 100, steps=2) == 50.0
+    assert MathExtension.remap(8, 0, 10, 0, 100, steps=2) == 100.0
+
+    # Test with 1 step (0%, 100%)
+    assert MathExtension.remap(0, 0, 10, 0, 100, steps=1) == 0.0
+    assert MathExtension.remap(5, 0, 10, 0, 100, steps=1) == 0.0
+    assert MathExtension.remap(6, 0, 10, 0, 100, steps=1) == 100.0
+    assert MathExtension.remap(10, 0, 10, 0, 100, steps=1) == 100.0
+
+    # Test with inverted output range and steps
+    assert MathExtension.remap(4.8, 0, 10, 100, 0, steps=4) == 50.0
+
+    # Test with 0 or negative steps (should be ignored/no quantization)
+    assert MathExtension.remap(5, 0, 10, 0, 100, steps=0) == 50.0
+    assert MathExtension.remap(2.7, 0, 10, 0, 100, steps=0) == 27.0
+    assert MathExtension.remap(5, 0, 10, 0, 100, steps=-1) == 50.0
+
+
+def test_remap_with_mirror(hass: HomeAssistant) -> None:
+    """Test the mirror edge mode of the remap function."""
+
+    assert [
+        MathExtension.remap(i, 0, 4, 0, 1, edges="mirror") for i in range(-4, 9)
+    ] == [1.0, 0.75, 0.5, 0.25, 0.0, 0.25, 0.5, 0.75, 1.0, 0.75, 0.5, 0.25, 0.0]
+
+    # Test with different output range
+    assert MathExtension.remap(15, 0, 10, 50, 150, edges="mirror") == 100.0
+    assert MathExtension.remap(25, 0, 10, 50, 150, edges="mirror") == 100.0
+    # Test with inverted output range
+    assert MathExtension.remap(15, 0, 10, 100, 0, edges="mirror") == 50.0
+    assert MathExtension.remap(12, 0, 10, 100, 0, edges="mirror") == 20.0
+    # Test without remapping
+    assert MathExtension.remap(-0.1, 0, 1, 0, 1, edges="mirror") == pytest.approx(0.1)

--- a/tests/helpers/template/extensions/test_math.py
+++ b/tests/helpers/template/extensions/test_math.py
@@ -367,6 +367,9 @@ def test_clamp(hass: HomeAssistant) -> None:
     assert MathExtension.clamp(-15, -10, -1) == -10.0
     assert MathExtension.clamp(0, -10, -1) == -1.0
 
+    # Test with non-range
+    assert MathExtension.clamp(5, 10, 10) == 10.0
+
     # Test error handling - invalid input types
     for case in (
         "{{ clamp('invalid', 0, 10) }}",
@@ -408,6 +411,9 @@ def test_wrap(hass: HomeAssistant) -> None:
     # Test with arbitrary ranges
     assert MathExtension.wrap(25, 10, 20) == 15.0
     assert MathExtension.wrap(5, 10, 20) == 15.0
+
+    # Test with non-range
+    assert MathExtension.wrap(5, 10, 10) == 10.0
 
     # Test error handling - invalid input types
     for case in (


### PR DESCRIPTION
## Proposed change

This PR introduces three new math functions, `clamp`, `wrap`, and the powerful `remap`, inspired by my very own struggles this Monday writing an automation that lets me correctly use an Ikea Styrbar remote that doesn't want to bind with our new Ikea Jetström ceiling panel. It's still not done, because I started implementing this instead.

* `clamp(v, min, max)` limits the value `v` to be between `min` and `max`, [clamping at the edges](https://en.wikipedia.org/wiki/Clamp_(function)). Same as `max(..., min(..., v))`, but easier to read and understand.
* `wrap(v, min, max)` limits the value to be between `min` and `max`, wrapping the value at the edges; in math speak, [modular arithmetic](https://en.wikipedia.org/wiki/Modular_arithmetic), but in common terms, "clock face math". `wrap(15, 0, 12)` is 3 (as 15:00 would point to "3" on a 12-hour clock face). This can also be expressed as a somewhat convoluted modulo expression in a template, but it gets extra hairy when you would like to `wrap(15, 7, 12)` instead. Or, say, in an automation, `wrap(current_mireds + 50, min_mireds, max_mireds)`...
* `remap(v, in_min, in_max, out_min, out_max, *, [steps], [edges])` is the powerhouse function. If you've used Processing, you may know this as [`map`](https://processing.org/reference/map_.html), but this a bit has more power. At its simplest, it remaps a value from an input range to an output range. Let's say you...
  * wanted to take the current clock hour, and turn it into a color temperature for your light, but you want to invert the output scale – IOW, the smaller the hour, the warmer the light? `remap(hour, 0, 24, 454, 250)`. 
  * have a distance sensor measuring in centimeters (10-200) and want to trigger actions based on "closeness" as a discrete 0-10 scale? `remap(distance, 200, 10, 0, 10, steps=10)` – note the _input_ range is inverted this time.
  * want to create a "breathing" light effect that oscillates brightness (0-255) based on a continuously incrementing counter? `remap(counter, 0, 100, 0, 255, edges='mirror')` will bounce the brightness back down when it hits the max, then back up again.
  * are trying to map an outdoor lux sensor (0-100000 lux) to an indoor blind position (0..100), but never want to go fully closed? `remap(lux, 1000, 50000, 0, 80, edges='clamp')` to prevent values outside that range from going negative or above 80.

As with the other `MathExtension` functions, these work as filters as well as loose functions.

I also started adding [easings](https://easings.net/) into this (because it's easier (ha!) to do that in normalized space, which remap uses), but figured it could be added in a follow-up PR instead...

### Practical example

A part of the automation would become as succinct as

```yaml
sequence:
  - variables:
      curr_temp: "{{ state_attr('light.bedroom_ceiling_panel', 'color_temp') }}"
      min_temp: "{{ state_attr('light.bedroom_ceiling_panel', 'min_mireds') }}"
      max_temp: "{{ state_attr('light.bedroom_ceiling_panel', 'max_mireds') }}"
      delta: "{% if action == 'arrow_left_click' %}-{% endif %}20"
      new_temp: "{{ remap(curr_temp + delta, min_temp, max_temp, min_temp, max_temp, edges='wrap') }}"
  - target:
      device_id: light.bedroom_ceiling_panel
    data:
      color_temp: "{{ new_temp }}"
      transition: 0.5
    action: light.turn_on
```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41986
- Link to developer documentation pull request: No developer docs need changing.
- Link to frontend pull request: No frontend changes.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
  - There's more test than functional code here...
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.
  - Claude helped me along a bit, especially with the test cases, but this is mostly human-written. 

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
  - https://github.com/home-assistant/home-assistant.io/pull/41986

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
