### PR TITLE
Make Shelly deprecated firmware issue more general

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -338,8 +338,10 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
         await hass.config_entries.async_forward_entry_setups(
             entry, runtime_data.platforms
         )
-        for model, min_firmware in DEPRECATED_FIRMWARES.items():
-            async_manage_deprecated_firmware_issue(hass, entry, model, min_firmware)
+        for model, data in DEPRECATED_FIRMWARES.items():
+            async_manage_deprecated_firmware_issue(
+                hass, entry, model, data["min_firmware"], data["ha_version"]
+            )
         async_manage_ble_scanner_firmware_unsupported_issue(
             hass,
             entry,

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -43,7 +43,6 @@ from .const import (
     BLOCK_WRONG_SLEEP_PERIOD,
     CONF_COAP_PORT,
     CONF_SLEEP_PERIOD,
-    DEPRECATED_FIRMWARES,
     DOMAIN,
     FIRMWARE_UNSUPPORTED_ISSUE_ID,
     LOGGER,
@@ -338,10 +337,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
         await hass.config_entries.async_forward_entry_setups(
             entry, runtime_data.platforms
         )
-        for model, data in DEPRECATED_FIRMWARES.items():
-            async_manage_deprecated_firmware_issue(
-                hass, entry, model, data["min_firmware"], data["ha_version"]
-            )
+        async_manage_deprecated_firmware_issue(hass, entry)
         async_manage_ble_scanner_firmware_unsupported_issue(
             hass,
             entry,

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -43,6 +43,7 @@ from .const import (
     BLOCK_WRONG_SLEEP_PERIOD,
     CONF_COAP_PORT,
     CONF_SLEEP_PERIOD,
+    DEPRECATED_FIRMWARES,
     DOMAIN,
     FIRMWARE_UNSUPPORTED_ISSUE_ID,
     LOGGER,
@@ -59,8 +60,8 @@ from .coordinator import (
 )
 from .repairs import (
     async_manage_ble_scanner_firmware_unsupported_issue,
+    async_manage_deprecated_firmware_issue,
     async_manage_outbound_websocket_incorrectly_enabled_issue,
-    async_manage_wall_display_firmware_unsupported_issue,
 )
 from .utils import (
     async_create_issue_unsupported_firmware,
@@ -337,7 +338,8 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
         await hass.config_entries.async_forward_entry_setups(
             entry, runtime_data.platforms
         )
-        async_manage_wall_display_firmware_unsupported_issue(hass, entry)
+        for model, min_firmware in DEPRECATED_FIRMWARES.items():
+            async_manage_deprecated_firmware_issue(hass, entry, model, min_firmware)
         async_manage_ble_scanner_firmware_unsupported_issue(
             hass,
             entry,

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -233,6 +233,19 @@ class BLEScannerMode(StrEnum):
 
 BLE_SCANNER_MIN_FIRMWARE = "1.5.1"
 
+MAX_PUSH_UPDATE_FAILURES = 5
+PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"
+
+NOT_CALIBRATED_ISSUE_ID = "not_calibrated_{unique}"
+
+FIRMWARE_UNSUPPORTED_ISSUE_ID = "firmware_unsupported_{unique}"
+
+BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID = "ble_scanner_firmware_unsupported_{unique}"
+OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID = (
+    "outbound_websocket_incorrectly_enabled_{unique}"
+)
+DEPRECATED_FIRMWARE_ISSUE_ID = "deprecated_firmware_{unique}"
+
 
 class DeprecatedFirmwareInfo(TypedDict):
     """TypedDict for Deprecated Firmware Info."""
@@ -253,19 +266,6 @@ class DeprecatedFirmwareInfo(TypedDict):
 #   ),
 # }
 DEPRECATED_FIRMWARES: dict[str, DeprecatedFirmwareInfo] = {}
-
-MAX_PUSH_UPDATE_FAILURES = 5
-PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"
-
-NOT_CALIBRATED_ISSUE_ID = "not_calibrated_{unique}"
-
-FIRMWARE_UNSUPPORTED_ISSUE_ID = "firmware_unsupported_{unique}"
-
-BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID = "ble_scanner_firmware_unsupported_{unique}"
-OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID = (
-    "outbound_websocket_incorrectly_enabled_{unique}"
-)
-DEPRECATED_FIRMWARE_ISSUE_ID = "deprecated_firmware_{unique}"
 
 GAS_VALVE_OPEN_STATES = ("opening", "opened")
 

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -232,7 +232,9 @@ class BLEScannerMode(StrEnum):
 
 
 BLE_SCANNER_MIN_FIRMWARE = "1.5.1"
-WALL_DISPLAY_MIN_FIRMWARE = "2.3.0"
+DEPRECATED_FIRMWARES = {
+    MODEL_WALL_DISPLAY: "2.3.0",
+}
 
 MAX_PUSH_UPDATE_FAILURES = 5
 PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"
@@ -245,9 +247,7 @@ BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID = "ble_scanner_firmware_unsupported_{u
 OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID = (
     "outbound_websocket_incorrectly_enabled_{unique}"
 )
-WALL_DISPLAY_FIRMWARE_UNSUPPORTED_ISSUE_ID = (
-    "wall_display_firmware_unsupported_{unique}"
-)
+DEPRECATED_FIRMWARE_ISSUE_ID = "deprecated_firmware_{unique}"
 
 GAS_VALVE_OPEN_STATES = ("opening", "opened")
 

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import StrEnum
 from logging import Logger, getLogger
 import re
-from typing import Final
+from typing import Final, TypedDict
 
 from aioshelly.const import (
     MODEL_BULB,
@@ -233,18 +233,26 @@ class BLEScannerMode(StrEnum):
 
 BLE_SCANNER_MIN_FIRMWARE = "1.5.1"
 
+
+class DeprecatedFirmwareInfo(TypedDict):
+    """TypedDict for Deprecated Firmware Info."""
+
+    min_firmware: str
+    ha_version: str
+
+
 # Provide firmware deprecation data:
 # key: device model
 # value: dict with:
 #   min_firmware: minimum supported firmware version
 #   ha_version: Home Assistant version when older firmware will be deprecated
 # Example:
-# DEPRECATED_FIRMWARES = {
-#   MODEL_WALL_DISPLAY: {
-#   "min_firmware": "2.3.0", "ha_version": "2025.10.0"
-#   }
+# DEPRECATED_FIRMWARES: dict[str, DeprecatedFirmwareInfo] = {
+#   MODEL_WALL_DISPLAY: DeprecatedFirmwareInfo(
+#     {"min_firmware": "2.3.0", "ha_version": "2025.10.0"}
+#   ),
 # }
-DEPRECATED_FIRMWARES: dict[str, dict[str, str]] = {}
+DEPRECATED_FIRMWARES: dict[str, DeprecatedFirmwareInfo] = {}
 
 MAX_PUSH_UPDATE_FAILURES = 5
 PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -232,9 +232,19 @@ class BLEScannerMode(StrEnum):
 
 
 BLE_SCANNER_MIN_FIRMWARE = "1.5.1"
-DEPRECATED_FIRMWARES = {
-    MODEL_WALL_DISPLAY: {"min_firmware": "2.3.0", "ha_version": "2025.10.0"},
-}
+
+# Provide firmware deprecation data:
+# key: device model
+# value: dict with:
+#   min_firmware: minimum supported firmware version
+#   ha_version: Home Assistant version when older firmware will be deprecated
+# Example:
+# DEPRECATED_FIRMWARES = {
+#   MODEL_WALL_DISPLAY: {
+#   "min_firmware": "2.3.0", "ha_version": "2025.10.0"
+#   }
+# }
+DEPRECATED_FIRMWARES: dict[str, dict[str, str]] = {}
 
 MAX_PUSH_UPDATE_FAILURES = 5
 PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -233,7 +233,7 @@ class BLEScannerMode(StrEnum):
 
 BLE_SCANNER_MIN_FIRMWARE = "1.5.1"
 DEPRECATED_FIRMWARES = {
-    MODEL_WALL_DISPLAY: "2.3.0",
+    MODEL_WALL_DISPLAY: {"min_firmware": "2.3.0", "ha_version": "2025.10.0"},
 }
 
 MAX_PUSH_UPDATE_FAILURES = 5

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -20,6 +20,7 @@ from .const import (
     BLE_SCANNER_MIN_FIRMWARE,
     CONF_BLE_SCANNER_MODE,
     DEPRECATED_FIRMWARE_ISSUE_ID,
+    DEPRECATED_FIRMWARES,
     DOMAIN,
     OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID,
     BLEScannerMode,
@@ -72,9 +73,6 @@ def async_manage_ble_scanner_firmware_unsupported_issue(
 def async_manage_deprecated_firmware_issue(
     hass: HomeAssistant,
     entry: ShellyConfigEntry,
-    model: str,
-    min_firmware: str,
-    ha_version: str,
 ) -> None:
     """Manage deprecated firmware issue."""
     issue_id = DEPRECATED_FIRMWARE_ISSUE_ID.format(unique=entry.unique_id)
@@ -83,8 +81,12 @@ def async_manage_deprecated_firmware_issue(
         assert entry.runtime_data.rpc is not None
 
     device = entry.runtime_data.rpc.device
+    model = entry.data["model"]
 
-    if entry.data["model"] == model:
+    if model in DEPRECATED_FIRMWARES:
+        min_firmware = DEPRECATED_FIRMWARES[model]["min_firmware"]
+        ha_version = DEPRECATED_FIRMWARES[model]["ha_version"]
+
         firmware = AwesomeVersion(device.shelly["ver"])
         if firmware < min_firmware:
             ir.async_create_issue(

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -74,6 +74,7 @@ def async_manage_deprecated_firmware_issue(
     entry: ShellyConfigEntry,
     model: str,
     min_firmware: str,
+    ha_version: str,
 ) -> None:
     """Manage deprecated firmware issue."""
     issue_id = DEPRECATED_FIRMWARE_ISSUE_ID.format(unique=entry.unique_id)
@@ -98,6 +99,7 @@ def async_manage_deprecated_firmware_issue(
                     "device_name": device.name,
                     "ip_address": device.ip_address,
                     "firmware": firmware,
+                    "ha_version": ha_version,
                 },
                 data={"entry_id": entry.entry_id},
             )

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -312,13 +312,13 @@
         }
       }
     },
-    "wall_display_firmware_unsupported": {
+    "deprecated_firmware": {
       "title": "{device_name} is running outdated firmware",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "{device_name} is running outdated firmware",
-            "description": "Your Shelly device {device_name} with IP address {ip_address} is running firmware {firmware}. This firmware version will not be supported by Shelly integration starting from Home Assistant 2025.11.0.\n\nSelect **Submit** button to start the OTA update to the latest stable firmware version."
+            "description": "Your Shelly device {device_name} with IP address {ip_address} is running firmware {firmware}. This firmware version will not be supported by Shelly integration starting from next month Home Assistant release.\n\nSelect **Submit** button to start the OTA update to the latest stable firmware version."
           }
         },
         "abort": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -318,7 +318,7 @@
         "step": {
           "confirm": {
             "title": "{device_name} is running outdated firmware",
-            "description": "Your Shelly device {device_name} with IP address {ip_address} is running firmware {firmware}. This firmware version will no longer be supported by the Shelly integration starting with next month’s Home Assistant release.\n\nSelect **Submit** button to start the OTA update to the latest stable firmware version."
+            "description": "Your Shelly device {device_name} with IP address {ip_address} is running firmware {firmware}. This firmware version will not be supported by Shelly integration starting from Home Assistant {ha_version}.\n\nSelect **Submit** button to start the OTA update to the latest stable firmware version."
           }
         },
         "abort": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -318,7 +318,7 @@
         "step": {
           "confirm": {
             "title": "{device_name} is running outdated firmware",
-            "description": "Your Shelly device {device_name} with IP address {ip_address} is running firmware {firmware}. This firmware version will not be supported by Shelly integration starting from next month Home Assistant release.\n\nSelect **Submit** button to start the OTA update to the latest stable firmware version."
+            "description": "Your Shelly device {device_name} with IP address {ip_address} is running firmware {firmware}. This firmware version will no longer be supported by the Shelly integration starting with next month’s Home Assistant release.\n\nSelect **Submit** button to start the OTA update to the latest stable firmware version."
           }
         },
         "abort": {

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -1,6 +1,6 @@
 """Test repairs handling for Shelly."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from aioshelly.const import MODEL_WALL_DISPLAY
 from aioshelly.exceptions import DeviceConnectionError, RpcCallError
@@ -225,7 +225,11 @@ async def test_deprecated_firmware_issue(
     issue_id = DEPRECATED_FIRMWARE_ISSUE_ID.format(unique=MOCK_MAC)
     assert await async_setup_component(hass, "repairs", {})
     await hass.async_block_till_done()
-    await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
+    with patch(
+        "homeassistant.components.shelly.DEPRECATED_FIRMWARES",
+        {MODEL_WALL_DISPLAY: {"min_firmware": "2.3.0", "ha_version": "2025.10.0"}},
+    ):
+        await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
     # The default fw version in tests is 1.0.0, the repair issue should be created.
     assert issue_registry.async_get_issue(DOMAIN, issue_id)

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -13,6 +13,7 @@ from homeassistant.components.shelly.const import (
     DOMAIN,
     OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID,
     BLEScannerMode,
+    DeprecatedFirmwareInfo,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
@@ -227,7 +228,11 @@ async def test_deprecated_firmware_issue(
     await hass.async_block_till_done()
     with patch(
         "homeassistant.components.shelly.repairs.DEPRECATED_FIRMWARES",
-        {MODEL_WALL_DISPLAY: {"min_firmware": "2.3.0", "ha_version": "2025.10.0"}},
+        {
+            MODEL_WALL_DISPLAY: DeprecatedFirmwareInfo(
+                {"min_firmware": "2.3.0", "ha_version": "2025.10.0"}
+            )
+        },
     ):
         await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -9,9 +9,9 @@ import pytest
 from homeassistant.components.shelly.const import (
     BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID,
     CONF_BLE_SCANNER_MODE,
+    DEPRECATED_FIRMWARE_ISSUE_ID,
     DOMAIN,
     OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID,
-    WALL_DISPLAY_FIRMWARE_UNSUPPORTED_ISSUE_ID,
     BLEScannerMode,
 )
 from homeassistant.core import HomeAssistant
@@ -215,14 +215,14 @@ async def test_outbound_websocket_incorrectly_enabled_issue_exc(
     assert len(issue_registry.issues) == 1
 
 
-async def test_wall_display_unsupported_firmware_issue(
+async def test_deprecated_firmware_issue(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     mock_rpc_device: Mock,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test repair issues handling for Wall Display with unsupported firmware."""
-    issue_id = WALL_DISPLAY_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(unique=MOCK_MAC)
+    """Test repair issues handling deprecated firmware."""
+    issue_id = DEPRECATED_FIRMWARE_ISSUE_ID.format(unique=MOCK_MAC)
     assert await async_setup_component(hass, "repairs", {})
     await hass.async_block_till_done()
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -226,7 +226,7 @@ async def test_deprecated_firmware_issue(
     assert await async_setup_component(hass, "repairs", {})
     await hass.async_block_till_done()
     with patch(
-        "homeassistant.components.shelly.DEPRECATED_FIRMWARES",
+        "homeassistant.components.shelly.repairs.DEPRECATED_FIRMWARES",
         {MODEL_WALL_DISPLAY: {"min_firmware": "2.3.0", "ha_version": "2025.10.0"}},
     ):
         await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We needed to notify users about the need to update the Shelly Wall Display firmware.

Now, we want to preserve this code for future use, so this repair issue has been made more general.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
