### PR TITLE
Move translatable URL out of strings.json for airnow integration

### DIFF
--- a/homeassistant/components/airnow/config_flow.py
+++ b/homeassistant/components/airnow/config_flow.py
@@ -26,6 +26,10 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
+# Documentation URL for API key generation
+_API_KEY_URL = "https://docs.airnowapi.org/account/request/"
+
+
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> bool:
     """Validate the user input allows us to connect.
 
@@ -114,6 +118,7 @@ class AirNowConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                 }
             ),
+            description_placeholders={"api_key_url": _API_KEY_URL},
             errors=errors,
         )
 

--- a/homeassistant/components/airnow/const.py
+++ b/homeassistant/components/airnow/const.py
@@ -43,6 +43,3 @@ US_TZ_OFFSETS = {
     "AST": -4 * SECONDS_PER_HOUR,
     "ADT": -3 * SECONDS_PER_HOUR,
 }
-
-# Documentation URL for API key generation
-API_KEY_URL = "https://docs.airnowapi.org/account/request/"

--- a/homeassistant/components/airnow/const.py
+++ b/homeassistant/components/airnow/const.py
@@ -43,3 +43,6 @@ US_TZ_OFFSETS = {
     "AST": -4 * SECONDS_PER_HOUR,
     "ADT": -3 * SECONDS_PER_HOUR,
 }
+
+# Documentation URL for API key generation
+API_KEY_URL = "https://docs.airnowapi.org/account/request/"

--- a/homeassistant/components/airnow/strings.json
+++ b/homeassistant/components/airnow/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "To generate API key go to https://docs.airnowapi.org/account/request/",
+        "description": "To generate API key go to {api_key_url}",
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "latitude": "[%key:common::config_flow::data::latitude%]",

--- a/tests/components/airnow/test_config_flow.py
+++ b/tests/components/airnow/test_config_flow.py
@@ -25,6 +25,9 @@ async def test_form(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
+    assert result["description_placeholders"] == {
+        "api_key_url": "https://docs.airnowapi.org/account/request/"
+    }
 
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], config)
     assert result2["type"] is FlowResultType.CREATE_ENTRY


### PR DESCRIPTION
## Proposed change

Moved the AirNow API key generation URL from `strings.json`.  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/154226
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist.
