### PR TITLE
Improve error handling in Niko Home Control config flow

### DIFF
--- a/homeassistant/components/niko_home_control/config_flow.py
+++ b/homeassistant/components/niko_home_control/config_flow.py
@@ -28,8 +28,14 @@ async def test_connection(host: str) -> str | None:
     controller = NHCController(host, 8000)
     try:
         await controller.connect()
+    except TimeoutError:
+        _LOGGER.exception("Connection timed out")
+        return "cannot_connect"
+    except OSError:
+        _LOGGER.exception("Cannot connect to controller")
+        return "cannot_connect"
     except Exception:
-        _LOGGER.exception("Unexpected exception")
+        _LOGGER.exception("Unexpected exception during connection")
         return "cannot_connect"
     return None
 

--- a/homeassistant/components/niko_home_control/config_flow.py
+++ b/homeassistant/components/niko_home_control/config_flow.py
@@ -29,14 +29,12 @@ async def test_connection(host: str) -> str | None:
     try:
         await controller.connect()
     except TimeoutError:
-        _LOGGER.exception("Connection timed out")
-        return "cannot_connect"
+        return "timeout_connect"
     except OSError:
-        _LOGGER.exception("Cannot connect to controller")
         return "cannot_connect"
     except Exception:
         _LOGGER.exception("Unexpected exception during connection")
-        return "cannot_connect"
+        return "unknown"
     return None
 
 

--- a/homeassistant/components/niko_home_control/strings.json
+++ b/homeassistant/components/niko_home_control/strings.json
@@ -45,7 +45,7 @@
       }
     },
     "error": {
-      "connection_timeout": "Connection Timeout",
+      "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },

--- a/homeassistant/components/niko_home_control/strings.json
+++ b/homeassistant/components/niko_home_control/strings.json
@@ -5,7 +5,9 @@
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
       "reconfigure": {
@@ -43,15 +45,6 @@
           }
         }
       }
-    },
-    "error": {
-      "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   }
 }

--- a/homeassistant/components/niko_home_control/strings.json
+++ b/homeassistant/components/niko_home_control/strings.json
@@ -43,6 +43,15 @@
           }
         }
       }
+    },
+    "error": {
+      "connection_timeout": "Connection Timeout",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   }
 }

--- a/tests/components/niko_home_control/test_config_flow.py
+++ b/tests/components/niko_home_control/test_config_flow.py
@@ -37,7 +37,7 @@ async def test_full_flow(
 
 
 async def test_timeout_connect(hass: HomeAssistant) -> None:
-    """Test the cannot connect error."""
+    """Test the timeout error."""
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -69,7 +69,7 @@ async def test_timeout_connect(hass: HomeAssistant) -> None:
 
 
 async def test_unknown(hass: HomeAssistant) -> None:
-    """Test the cannot connect error."""
+    """Test the unknown error."""
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds specific handling for TimeoutError and OSError during controller connection attempts, logging appropriate messages and returning 'cannot_connect'. Updates strings.json to include a 'connection_timeout' error message.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
