### PR TITLE
Automatically activate the preferred dataset in OTBR after hardware migration

### DIFF
--- a/tests/components/homeassistant_connect_zbt2/conftest.py
+++ b/tests/components/homeassistant_connect_zbt2/conftest.py
@@ -57,3 +57,14 @@ def mock_usb_path_exists() -> Generator[None]:
         return_value=True,
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_push_dataset_to_otbr() -> Generator[None]:
+    """Mock _push_dataset_to_otbr to avoid timeout waiting for OTBR discovery."""
+
+    with patch(
+        "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareInstallFlow._push_dataset_to_otbr",
+        new=AsyncMock(),
+    ):
+        yield

--- a/tests/components/homeassistant_hardware/conftest.py
+++ b/tests/components/homeassistant_hardware/conftest.py
@@ -1,10 +1,23 @@
 """Test fixtures for the Home Assistant Hardware integration."""
 
+import asyncio
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from homeassistant.components.hassio import hostname_from_addon_slug
+from homeassistant.components.otbr import OTBRData
+from homeassistant.config_entries import (
+    SIGNAL_CONFIG_ENTRY_CHANGED,
+    ConfigEntryChange,
+    ConfigEntryState,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
@@ -47,3 +60,45 @@ def mock_zha_get_last_network_settings() -> Generator[None]:
         AsyncMock(return_value=None),
     ):
         yield
+
+
+@pytest.fixture
+def start_addon_with_otbr_discovery(
+    hass: HomeAssistant, start_addon: AsyncMock
+) -> AsyncMock:
+    """Mock starting the OTBR addon and having hassio trigger OTBR discovery."""
+    orig_start_addon_side_effect = start_addon.side_effect
+
+    async def mock_addon_start(addon: str) -> None:
+        """Create an OTBR config entry with runtime_data for dataset push testing."""
+        await orig_start_addon_side_effect(addon)
+
+        async def mock_otbr_hassio_discovery() -> None:
+            # Discovery will happen a bit after the addon actually starts
+            await asyncio.sleep(0.1)
+
+            mock_otbr_data = MagicMock(spec=OTBRData)
+            mock_otbr_data.set_active_dataset_tlvs = AsyncMock()
+            mock_otbr_data.set_enabled = AsyncMock()
+
+            # Create the config entry
+            entry = MockConfigEntry(
+                domain="otbr",
+                data={"url": f"http://{hostname_from_addon_slug(addon)}:8081"},
+                title="Open Thread Border Router",
+                state=ConfigEntryState.LOADED,
+            )
+            entry.add_to_hass(hass)
+            entry.runtime_data = mock_otbr_data
+
+            # Manually trigger the signal that _push_dataset_to_otbr is waiting for
+            async_dispatcher_send(
+                hass, SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntryChange.ADDED, entry
+            )
+
+        # This runs asynchronously, after the addon has started
+        hass.async_create_task(mock_otbr_hassio_discovery())
+
+    start_addon.side_effect = mock_addon_start
+
+    return start_addon

--- a/tests/components/homeassistant_sky_connect/conftest.py
+++ b/tests/components/homeassistant_sky_connect/conftest.py
@@ -57,3 +57,14 @@ def mock_usb_path_exists() -> Generator[None]:
         return_value=True,
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_push_dataset_to_otbr() -> Generator[None]:
+    """Mock _push_dataset_to_otbr to avoid timeout waiting for OTBR discovery."""
+
+    with patch(
+        "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareInstallFlow._push_dataset_to_otbr",
+        new=AsyncMock(),
+    ):
+        yield

--- a/tests/components/homeassistant_yellow/conftest.py
+++ b/tests/components/homeassistant_yellow/conftest.py
@@ -47,3 +47,14 @@ def mock_zha_get_last_network_settings() -> Generator[None]:
         AsyncMock(return_value=None),
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_push_dataset_to_otbr() -> Generator[None]:
+    """Mock _push_dataset_to_otbr to avoid timeout waiting for OTBR discovery."""
+
+    with patch(
+        "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareInstallFlow._push_dataset_to_otbr",
+        new=AsyncMock(),
+    ):
+        yield


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current firmware config flow for ZBT adapters automatically points OTBR to the new device but it fails to actually migrate the Thread dataset over. This PR waits for hassio discovery to create the OTBR integration and uses its existing API to push and enable the active dataset in the OTBR addon.

Note that unlike Zigbee, this is not really a migration per se: this is effectively tearing down the old OTBR and spinning up a new one with the old dataset. The border router's IEEE address and other network information will change and other devices are expected to compensate. This can take time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
