### PR TITLE
Abort user step in HA hardware config flow with error message

### DIFF
--- a/homeassistant/components/homeassistant_connect_zbt2/strings.json
+++ b/homeassistant/components/homeassistant_connect_zbt2/strings.json
@@ -220,7 +220,8 @@
       "otbr_still_using_stick": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::otbr_still_using_stick%]",
       "unsupported_firmware": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::unsupported_firmware%]",
       "fw_download_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_download_failed%]",
-      "fw_install_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_install_failed%]"
+      "fw_install_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_install_failed%]",
+      "not_user_configurable": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::not_user_configurable%]"
     },
     "progress": {
       "install_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::install_addon%]",

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -577,6 +577,12 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
 class BaseFirmwareConfigFlow(BaseFirmwareInstallFlow, ConfigFlow):
     """Base config flow for installing firmware."""
 
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Setup started by user."""
+        return self.async_abort(reason="not_user_configurable")
+
     @staticmethod
     @callback
     @abstractmethod

--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -73,7 +73,8 @@
         "otbr_still_using_stick": "This {model} is in use by the OpenThread Border Router add-on. If you use the Thread network, make sure you have alternative border routers. Uninstall the add-on and try again.",
         "unsupported_firmware": "The radio firmware on your {model} could not be determined. Make sure that no other integration or add-on is currently trying to communicate with the device. If you are running Home Assistant OS in a virtual machine or in Docker, please make sure that permissions are set correctly for the device.",
         "fw_download_failed": "{firmware_name} firmware for your {model} failed to download. Make sure Home Assistant has internet access and try again.",
-        "fw_install_failed": "{firmware_name} firmware failed to install, check Home Assistant logs for more information."
+        "fw_install_failed": "{firmware_name} firmware failed to install, check Home Assistant logs for more information.",
+        "not_user_configurable": "This integration is not user configurable. Please plug in supported Home Assistant hardware and configure it using the discovered device."
       },
       "progress": {
         "install_firmware": "Installing {firmware_name} firmware.\n\nDo not make any changes to your hardware or software until this finishes.",

--- a/homeassistant/components/homeassistant_sky_connect/strings.json
+++ b/homeassistant/components/homeassistant_sky_connect/strings.json
@@ -220,7 +220,8 @@
       "otbr_still_using_stick": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::otbr_still_using_stick%]",
       "unsupported_firmware": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::unsupported_firmware%]",
       "fw_download_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_download_failed%]",
-      "fw_install_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_install_failed%]"
+      "fw_install_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_install_failed%]",
+      "not_user_configurable": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::not_user_configurable%]"
     },
     "progress": {
       "install_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::install_addon%]",

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -154,7 +154,8 @@
       "otbr_still_using_stick": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::otbr_still_using_stick%]",
       "unsupported_firmware": "The radio firmware on your {model} could not be determined. Make sure that no other integration or add-on is currently trying to communicate with the device.",
       "fw_download_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_download_failed%]",
-      "fw_install_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_install_failed%]"
+      "fw_install_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_install_failed%]",
+      "not_user_configurable": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::not_user_configurable%]"
     },
     "progress": {
       "install_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::install_addon%]",

--- a/tests/components/homeassistant_hardware/test_config_flow_failures.py
+++ b/tests/components/homeassistant_hardware/test_config_flow_failures.py
@@ -442,3 +442,17 @@ async def test_options_flow_thread_to_zigbee_otbr_configured(
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "otbr_still_using_stick"
+
+
+@pytest.mark.parametrize(
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
+)
+async def test_config_flow_user(hass: HomeAssistant) -> None:
+    """Test config flow manually initiated by user aborts with error message."""
+    init_result = await hass.config_entries.flow.async_init(
+        TEST_DOMAIN, context={"source": "user"}
+    )
+
+    assert init_result["type"] is FlowResultType.ABORT
+    assert init_result["reason"] == "not_user_configurable"


### PR DESCRIPTION
## Proposed change

In the user step for the `BaseFirmwareConfigFlow` used by ZBT-1, ZBT-2, and Yellow, we now abort with a helpful error message, instead of showing "not_implemented".

You can initiate the user step by pressing the "Add hardware" button when a ZBT-1/ZBT-2/Yellow is configured. See the screenshots below for reference.

### Frontend

It looks like the "Add hardware" button cannot be hidden from the frontend right now (and maybe we don't want to?):
[home-assistant/frontend/src/panels/config/integrations/ha-config-integration-page.ts#L531-L541](https://github.com/home-assistant/frontend/blob/e35b155c66452919c5d6f60ea0b3bcd59467eb19/src/panels/config/integrations/ha-config-integration-page.ts#L531-L541)

### Screenshots

<details><summary>Pictures of how to achieve this and old & new error messages (click to open)</summary>
<p>

<img width="929" height="319" alt="image" src="https://github.com/user-attachments/assets/3e0c643c-fe42-4931-8c0c-83f370c75bff" />

Instead of this:
<img width="592" height="236" alt="image" src="https://github.com/user-attachments/assets/f286c1fa-bc4b-462a-8b73-cb3c42221b20" />

We now get this:

<img width="643" height="258" alt="image" src="https://github.com/user-attachments/assets/dde86e82-4c02-4320-84c7-b27c805f2f76" />

</p>
</details> 


### Notes

If we want to move this user step with an immediate abort to the individual config flows (ZBT-1/ZBT-2/Yellow), we can also do that, though I don't see much reason for doing that.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #154570
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
