### PR TITLE
Streamline template tests

### DIFF
--- a/tests/helpers/template/extensions/test_base64.py
+++ b/tests/helpers/template/extensions/test_base64.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import pytest
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import template
+
+from tests.helpers.template.helpers import render
 
 
 @pytest.mark.parametrize(
@@ -18,26 +19,19 @@ from homeassistant.helpers import template
 )
 def test_base64_encode(hass: HomeAssistant, value_template: str, expected: str) -> None:
     """Test the base64_encode filter."""
-    assert template.Template(value_template, hass).async_render() == expected
+    assert render(hass, value_template) == expected
 
 
 def test_base64_decode(hass: HomeAssistant) -> None:
     """Test the base64_decode filter."""
     assert (
-        template.Template(
-            '{{ "aG9tZWFzc2lzdGFudA==" | base64_decode }}', hass
-        ).async_render()
-        == "homeassistant"
+        render(hass, '{{ "aG9tZWFzc2lzdGFudA==" | base64_decode }}') == "homeassistant"
     )
     assert (
-        template.Template(
-            '{{ "aG9tZWFzc2lzdGFudA==" | base64_decode(None) }}', hass
-        ).async_render()
+        render(hass, '{{ "aG9tZWFzc2lzdGFudA==" | base64_decode(None) }}')
         == b"homeassistant"
     )
     assert (
-        template.Template(
-            '{{ "aG9tZWFzc2lzdGFudA==" | base64_decode("ascii") }}', hass
-        ).async_render()
+        render(hass, '{{ "aG9tZWFzc2lzdGFudA==" | base64_decode("ascii") }}')
         == "homeassistant"
     )

--- a/tests/helpers/template/extensions/test_collection.py
+++ b/tests/helpers/template/extensions/test_collection.py
@@ -122,18 +122,11 @@ def test_tuple(hass: HomeAssistant, value: Any, expected: bool) -> None:
 )
 def test_zip(hass: HomeAssistant, cola, colb, expected) -> None:
     """Test zip."""
-    assert (
-        render(hass, "{{ zip(cola, colb) | list }}", {"cola": cola, "colb": colb})
-        == expected
-    )
-    assert (
-        render(
-            hass,
-            "[{% for a, b in zip(cola, colb) %}({{a}}, {{b}}), {% endfor %}]",
-            {"cola": cola, "colb": colb},
-        )
-        == expected
-    )
+    for tpl in (
+        "{{ zip(cola, colb) | list }}",
+        "[{% for a, b in zip(cola, colb) %}({{a}}, {{b}}), {% endfor %}]",
+    ):
+        assert render(hass, tpl, {"cola": cola, "colb": colb}) == expected
 
 
 @pytest.mark.parametrize(
@@ -145,11 +138,11 @@ def test_zip(hass: HomeAssistant, cola, colb, expected) -> None:
 )
 def test_unzip(hass: HomeAssistant, col, expected) -> None:
     """Test unzipping using zip."""
-    assert render(hass, "{{ zip(*col) | list }}", {"col": col}) == expected
-    assert (
-        render(hass, "{% set a, b = zip(*col) %}[{{a}}, {{b}}]", {"col": col})
-        == expected
-    )
+    for tpl in (
+        "{{ zip(*col) | list }}",
+        "{% set a, b = zip(*col) %}[{{a}}, {{b}}]",
+    ):
+        assert render(hass, tpl, {"col": col}) == expected
 
 
 def test_shuffle(hass: HomeAssistant) -> None:
@@ -178,16 +171,10 @@ def test_flatten(hass: HomeAssistant) -> None:
     assert render(hass, "{{ flatten([[1, 2], [3, 4]]) }}") == [1, 2, 3, 4]
 
     # Test nested flattening
-    assert render(hass, "{{ flatten([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]) }}") == [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-    ]
+    expected = [1, 2, 3, 4, 5, 6, 7, 8]
+    assert (
+        render(hass, "{{ flatten([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]) }}") == expected
+    )
 
     # Test flattening with levels
     assert render(
@@ -201,11 +188,7 @@ def test_flatten(hass: HomeAssistant) -> None:
     assert render(hass, "{{ flatten([]) }}") == []
 
     # Test single level
-    assert render(hass, "{{ flatten([1, 2, 3]) }}") == [
-        1,
-        2,
-        3,
-    ]
+    assert render(hass, "{{ flatten([1, 2, 3]) }}") == [1, 2, 3]
 
 
 def test_intersect(hass: HomeAssistant) -> None:

--- a/tests/helpers/template/extensions/test_crypto.py
+++ b/tests/helpers/template/extensions/test_crypto.py
@@ -3,18 +3,19 @@
 from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import template
+
+from tests.helpers.template.helpers import render
 
 
 def test_md5(hass: HomeAssistant) -> None:
     """Test the md5 function and filter."""
     assert (
-        template.Template("{{ md5('Home Assistant') }}", hass).async_render()
+        render(hass, "{{ md5('Home Assistant') }}")
         == "3d15e5c102c3413d0337393c3287e006"
     )
 
     assert (
-        template.Template("{{ 'Home Assistant' | md5 }}", hass).async_render()
+        render(hass, "{{ 'Home Assistant' | md5 }}")
         == "3d15e5c102c3413d0337393c3287e006"
     )
 
@@ -22,12 +23,12 @@ def test_md5(hass: HomeAssistant) -> None:
 def test_sha1(hass: HomeAssistant) -> None:
     """Test the sha1 function and filter."""
     assert (
-        template.Template("{{ sha1('Home Assistant') }}", hass).async_render()
+        render(hass, "{{ sha1('Home Assistant') }}")
         == "c8fd3bb19b94312664faa619af7729bdbf6e9f8a"
     )
 
     assert (
-        template.Template("{{ 'Home Assistant' | sha1 }}", hass).async_render()
+        render(hass, "{{ 'Home Assistant' | sha1 }}")
         == "c8fd3bb19b94312664faa619af7729bdbf6e9f8a"
     )
 
@@ -35,12 +36,12 @@ def test_sha1(hass: HomeAssistant) -> None:
 def test_sha256(hass: HomeAssistant) -> None:
     """Test the sha256 function and filter."""
     assert (
-        template.Template("{{ sha256('Home Assistant') }}", hass).async_render()
+        render(hass, "{{ sha256('Home Assistant') }}")
         == "2a366abb0cd47f51f3725bf0fb7ebcb4fefa6e20f4971e25fe2bb8da8145ce2b"
     )
 
     assert (
-        template.Template("{{ 'Home Assistant' | sha256 }}", hass).async_render()
+        render(hass, "{{ 'Home Assistant' | sha256 }}")
         == "2a366abb0cd47f51f3725bf0fb7ebcb4fefa6e20f4971e25fe2bb8da8145ce2b"
     )
 
@@ -48,11 +49,11 @@ def test_sha256(hass: HomeAssistant) -> None:
 def test_sha512(hass: HomeAssistant) -> None:
     """Test the sha512 function and filter."""
     assert (
-        template.Template("{{ sha512('Home Assistant') }}", hass).async_render()
+        render(hass, "{{ sha512('Home Assistant') }}")
         == "9e3c2cdd1fbab0037378d37e1baf8a3a4bf92c54b56ad1d459deee30ccbb2acbebd7a3614552ea08992ad27dedeb7b4c5473525ba90cb73dbe8b9ec5f69295bb"
     )
 
     assert (
-        template.Template("{{ 'Home Assistant' | sha512 }}", hass).async_render()
+        render(hass, "{{ 'Home Assistant' | sha512 }}")
         == "9e3c2cdd1fbab0037378d37e1baf8a3a4bf92c54b56ad1d459deee30ccbb2acbebd7a3614552ea08992ad27dedeb7b4c5473525ba90cb73dbe8b9ec5f69295bb"
     )

--- a/tests/helpers/template/extensions/test_crypto.py
+++ b/tests/helpers/template/extensions/test_crypto.py
@@ -9,51 +9,27 @@ from tests.helpers.template.helpers import render
 
 def test_md5(hass: HomeAssistant) -> None:
     """Test the md5 function and filter."""
-    assert (
-        render(hass, "{{ md5('Home Assistant') }}")
-        == "3d15e5c102c3413d0337393c3287e006"
-    )
-
-    assert (
-        render(hass, "{{ 'Home Assistant' | md5 }}")
-        == "3d15e5c102c3413d0337393c3287e006"
-    )
+    ha_md5 = "3d15e5c102c3413d0337393c3287e006"
+    assert render(hass, "{{ md5('Home Assistant') }}") == ha_md5
+    assert render(hass, "{{ 'Home Assistant' | md5 }}") == ha_md5
 
 
 def test_sha1(hass: HomeAssistant) -> None:
     """Test the sha1 function and filter."""
-    assert (
-        render(hass, "{{ sha1('Home Assistant') }}")
-        == "c8fd3bb19b94312664faa619af7729bdbf6e9f8a"
-    )
-
-    assert (
-        render(hass, "{{ 'Home Assistant' | sha1 }}")
-        == "c8fd3bb19b94312664faa619af7729bdbf6e9f8a"
-    )
+    ha_sha1 = "c8fd3bb19b94312664faa619af7729bdbf6e9f8a"
+    assert render(hass, "{{ sha1('Home Assistant') }}") == ha_sha1
+    assert render(hass, "{{ 'Home Assistant' | sha1 }}") == ha_sha1
 
 
 def test_sha256(hass: HomeAssistant) -> None:
     """Test the sha256 function and filter."""
-    assert (
-        render(hass, "{{ sha256('Home Assistant') }}")
-        == "2a366abb0cd47f51f3725bf0fb7ebcb4fefa6e20f4971e25fe2bb8da8145ce2b"
-    )
-
-    assert (
-        render(hass, "{{ 'Home Assistant' | sha256 }}")
-        == "2a366abb0cd47f51f3725bf0fb7ebcb4fefa6e20f4971e25fe2bb8da8145ce2b"
-    )
+    ha_sha256 = "2a366abb0cd47f51f3725bf0fb7ebcb4fefa6e20f4971e25fe2bb8da8145ce2b"
+    assert render(hass, "{{ sha256('Home Assistant') }}") == ha_sha256
+    assert render(hass, "{{ 'Home Assistant' | sha256 }}") == ha_sha256
 
 
 def test_sha512(hass: HomeAssistant) -> None:
     """Test the sha512 function and filter."""
-    assert (
-        render(hass, "{{ sha512('Home Assistant') }}")
-        == "9e3c2cdd1fbab0037378d37e1baf8a3a4bf92c54b56ad1d459deee30ccbb2acbebd7a3614552ea08992ad27dedeb7b4c5473525ba90cb73dbe8b9ec5f69295bb"
-    )
-
-    assert (
-        render(hass, "{{ 'Home Assistant' | sha512 }}")
-        == "9e3c2cdd1fbab0037378d37e1baf8a3a4bf92c54b56ad1d459deee30ccbb2acbebd7a3614552ea08992ad27dedeb7b4c5473525ba90cb73dbe8b9ec5f69295bb"
-    )
+    ha_sha512 = "9e3c2cdd1fbab0037378d37e1baf8a3a4bf92c54b56ad1d459deee30ccbb2acbebd7a3614552ea08992ad27dedeb7b4c5473525ba90cb73dbe8b9ec5f69295bb"
+    assert render(hass, "{{ sha512('Home Assistant') }}") == ha_sha512
+    assert render(hass, "{{ 'Home Assistant' | sha512 }}") == ha_sha512

--- a/tests/helpers/template/extensions/test_math.py
+++ b/tests/helpers/template/extensions/test_math.py
@@ -8,7 +8,6 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template
 
 from tests.helpers.template.helpers import render
 
@@ -29,29 +28,19 @@ def test_logarithm(hass: HomeAssistant) -> None:
     ]
 
     for value, base, expected in tests:
-        assert (
-            template.Template(
-                f"{{{{ {value} | log({base}) | round(1) }}}}", hass
-            ).async_render()
-            == expected
-        )
+        assert render(hass, f"{{{{ {value} | log({base}) | round(1) }}}}") == expected
 
-        assert (
-            template.Template(
-                f"{{{{ log({value}, {base}) | round(1) }}}}", hass
-            ).async_render()
-            == expected
-        )
+        assert render(hass, f"{{{{ log({value}, {base}) | round(1) }}}}") == expected
 
     # Test handling of invalid input
     with pytest.raises(TemplateError):
-        template.Template("{{ invalid | log(_) }}", hass).async_render()
+        render(hass, "{{ invalid | log(_) }}")
     with pytest.raises(TemplateError):
-        template.Template("{{ log(invalid, _) }}", hass).async_render()
+        render(hass, "{{ log(invalid, _) }}")
     with pytest.raises(TemplateError):
-        template.Template("{{ 10 | log(invalid) }}", hass).async_render()
+        render(hass, "{{ 10 | log(invalid) }}")
     with pytest.raises(TemplateError):
-        template.Template("{{ log(10, invalid) }}", hass).async_render()
+        render(hass, "{{ log(10, invalid) }}")
 
     # Test handling of default return value
     assert render(hass, "{{ 'no_number' | log(10, 1) }}") == 1
@@ -73,19 +62,14 @@ def test_sine(hass: HomeAssistant) -> None:
     ]
 
     for value, expected in tests:
-        assert (
-            template.Template(
-                f"{{{{ {value} | sin | round(3) }}}}", hass
-            ).async_render()
-            == expected
-        )
+        assert render(hass, f"{{{{ {value} | sin | round(3) }}}}") == expected
         assert render(hass, f"{{{{ sin({value}) | round(3) }}}}") == expected
 
     # Test handling of invalid input
     with pytest.raises(TemplateError):
-        template.Template("{{ 'duck' | sin }}", hass).async_render()
+        render(hass, "{{ 'duck' | sin }}")
     with pytest.raises(TemplateError):
-        template.Template("{{ invalid | sin('duck') }}", hass).async_render()
+        render(hass, "{{ invalid | sin('duck') }}")
 
     # Test handling of default return value
     assert render(hass, "{{ 'no_number' | sin(1) }}") == 1
@@ -105,17 +89,12 @@ def test_cosine(hass: HomeAssistant) -> None:
     ]
 
     for value, expected in tests:
-        assert (
-            template.Template(
-                f"{{{{ {value} | cos | round(3) }}}}", hass
-            ).async_render()
-            == expected
-        )
+        assert render(hass, f"{{{{ {value} | cos | round(3) }}}}") == expected
         assert render(hass, f"{{{{ cos({value}) | round(3) }}}}") == expected
 
     # Test handling of invalid input
     with pytest.raises(TemplateError):
-        template.Template("{{ 'duck' | cos }}", hass).async_render()
+        render(hass, "{{ 'duck' | cos }}")
 
     # Test handling of default return value
     assert render(hass, "{{ 'no_number' | cos(1) }}") == 1
@@ -134,17 +113,12 @@ def test_tangent(hass: HomeAssistant) -> None:
     ]
 
     for value, expected in tests:
-        assert (
-            template.Template(
-                f"{{{{ {value} | tan | round(3) }}}}", hass
-            ).async_render()
-            == expected
-        )
+        assert render(hass, f"{{{{ {value} | tan | round(3) }}}}") == expected
         assert render(hass, f"{{{{ tan({value}) | round(3) }}}}") == expected
 
     # Test handling of invalid input
     with pytest.raises(TemplateError):
-        template.Template("{{ 'duck' | tan }}", hass).async_render()
+        render(hass, "{{ 'duck' | tan }}")
 
     # Test handling of default return value
     assert render(hass, "{{ 'no_number' | tan(1) }}") == 1
@@ -165,17 +139,14 @@ def test_square_root(hass: HomeAssistant) -> None:
     ]
 
     for value, expected in tests:
-        assert (
-            template.Template(f"{{{{ {value} | sqrt }}}}", hass).async_render()
-            == expected
-        )
+        assert render(hass, f"{{{{ {value} | sqrt }}}}") == expected
         assert render(hass, f"{{{{ sqrt({value}) }}}}") == expected
 
     # Test handling of invalid input
     with pytest.raises(TemplateError):
-        template.Template("{{ 'duck' | sqrt }}", hass).async_render()
+        render(hass, "{{ 'duck' | sqrt }}")
     with pytest.raises(TemplateError):
-        template.Template("{{ -1 | sqrt }}", hass).async_render()
+        render(hass, "{{ -1 | sqrt }}")
 
     # Test handling of default return value
     assert render(hass, "{{ 'no_number' | sqrt(1) }}") == 1
@@ -217,114 +188,95 @@ def test_arc_functions(hass: HomeAssistant) -> None:
 
 def test_average(hass: HomeAssistant) -> None:
     """Test the average function."""
-    assert template.Template("{{ average([1, 2, 3]) }}", hass).async_render() == 2
-    assert template.Template("{{ average(1, 2, 3) }}", hass).async_render() == 2
+    assert render(hass, "{{ average([1, 2, 3]) }}") == 2
+    assert render(hass, "{{ average(1, 2, 3) }}") == 2
 
     # Testing of default values
-    assert template.Template("{{ average([1, 2, 3], -1) }}", hass).async_render() == 2
-    assert template.Template("{{ average([], -1) }}", hass).async_render() == -1
-    assert template.Template("{{ average([], default=-1) }}", hass).async_render() == -1
-    assert (
-        template.Template("{{ average([], 5, default=-1) }}", hass).async_render() == -1
-    )
-    assert (
-        template.Template("{{ average(1, 'a', 3, default=-1) }}", hass).async_render()
-        == -1
-    )
+    assert render(hass, "{{ average([1, 2, 3], -1) }}") == 2
+    assert render(hass, "{{ average([], -1) }}") == -1
+    assert render(hass, "{{ average([], default=-1) }}") == -1
+    assert render(hass, "{{ average([], 5, default=-1) }}") == -1
+    assert render(hass, "{{ average(1, 'a', 3, default=-1) }}") == -1
 
     with pytest.raises(TemplateError):
-        template.Template("{{ average() }}", hass).async_render()
+        render(hass, "{{ average() }}")
 
     with pytest.raises(TemplateError):
-        template.Template("{{ average([]) }}", hass).async_render()
+        render(hass, "{{ average([]) }}")
 
 
 def test_median(hass: HomeAssistant) -> None:
     """Test the median function."""
-    assert template.Template("{{ median([1, 2, 3]) }}", hass).async_render() == 2
-    assert template.Template("{{ median([1, 2, 3, 4]) }}", hass).async_render() == 2.5
-    assert template.Template("{{ median(1, 2, 3) }}", hass).async_render() == 2
+    assert render(hass, "{{ median([1, 2, 3]) }}") == 2
+    assert render(hass, "{{ median([1, 2, 3, 4]) }}") == 2.5
+    assert render(hass, "{{ median(1, 2, 3) }}") == 2
 
     # Testing of default values
-    assert template.Template("{{ median([1, 2, 3], -1) }}", hass).async_render() == 2
-    assert template.Template("{{ median([], -1) }}", hass).async_render() == -1
-    assert template.Template("{{ median([], default=-1) }}", hass).async_render() == -1
+    assert render(hass, "{{ median([1, 2, 3], -1) }}") == 2
+    assert render(hass, "{{ median([], -1) }}") == -1
+    assert render(hass, "{{ median([], default=-1) }}") == -1
 
     with pytest.raises(TemplateError):
-        template.Template("{{ median() }}", hass).async_render()
+        render(hass, "{{ median() }}")
 
     with pytest.raises(TemplateError):
-        template.Template("{{ median([]) }}", hass).async_render()
+        render(hass, "{{ median([]) }}")
 
 
 def test_statistical_mode(hass: HomeAssistant) -> None:
     """Test the statistical mode function."""
-    assert (
-        template.Template("{{ statistical_mode([1, 1, 2, 3]) }}", hass).async_render()
-        == 1
-    )
-    assert (
-        template.Template("{{ statistical_mode(1, 1, 2, 3) }}", hass).async_render()
-        == 1
-    )
+    assert render(hass, "{{ statistical_mode([1, 1, 2, 3]) }}") == 1
+    assert render(hass, "{{ statistical_mode(1, 1, 2, 3) }}") == 1
 
     # Testing of default values
-    assert (
-        template.Template("{{ statistical_mode([1, 1, 2], -1) }}", hass).async_render()
-        == 1
-    )
-    assert (
-        template.Template("{{ statistical_mode([], -1) }}", hass).async_render() == -1
-    )
-    assert (
-        template.Template("{{ statistical_mode([], default=-1) }}", hass).async_render()
-        == -1
-    )
+    assert render(hass, "{{ statistical_mode([1, 1, 2], -1) }}") == 1
+    assert render(hass, "{{ statistical_mode([], -1) }}") == -1
+    assert render(hass, "{{ statistical_mode([], default=-1) }}") == -1
 
     with pytest.raises(TemplateError):
-        template.Template("{{ statistical_mode() }}", hass).async_render()
+        render(hass, "{{ statistical_mode() }}")
 
     with pytest.raises(TemplateError):
-        template.Template("{{ statistical_mode([]) }}", hass).async_render()
+        render(hass, "{{ statistical_mode([]) }}")
 
 
 def test_min_max_functions(hass: HomeAssistant) -> None:
     """Test min and max functions."""
     # Test min function
-    assert template.Template("{{ min([1, 2, 3]) }}", hass).async_render() == 1
-    assert template.Template("{{ min(1, 2, 3) }}", hass).async_render() == 1
+    assert render(hass, "{{ min([1, 2, 3]) }}") == 1
+    assert render(hass, "{{ min(1, 2, 3) }}") == 1
 
     # Test max function
-    assert template.Template("{{ max([1, 2, 3]) }}", hass).async_render() == 3
-    assert template.Template("{{ max(1, 2, 3) }}", hass).async_render() == 3
+    assert render(hass, "{{ max([1, 2, 3]) }}") == 3
+    assert render(hass, "{{ max(1, 2, 3) }}") == 3
 
     # Test error handling
     with pytest.raises(TemplateError):
-        template.Template("{{ min() }}", hass).async_render()
+        render(hass, "{{ min() }}")
 
     with pytest.raises(TemplateError):
-        template.Template("{{ max() }}", hass).async_render()
+        render(hass, "{{ max() }}")
 
 
 def test_bitwise_and(hass: HomeAssistant) -> None:
     """Test bitwise and."""
-    assert template.Template("{{ bitwise_and(8, 2) }}", hass).async_render() == 0
-    assert template.Template("{{ bitwise_and(10, 2) }}", hass).async_render() == 2
-    assert template.Template("{{ bitwise_and(8, 8) }}", hass).async_render() == 8
+    assert render(hass, "{{ bitwise_and(8, 2) }}") == 0
+    assert render(hass, "{{ bitwise_and(10, 2) }}") == 2
+    assert render(hass, "{{ bitwise_and(8, 8) }}") == 8
 
 
 def test_bitwise_or(hass: HomeAssistant) -> None:
     """Test bitwise or."""
-    assert template.Template("{{ bitwise_or(8, 2) }}", hass).async_render() == 10
-    assert template.Template("{{ bitwise_or(8, 8) }}", hass).async_render() == 8
-    assert template.Template("{{ bitwise_or(10, 2) }}", hass).async_render() == 10
+    assert render(hass, "{{ bitwise_or(8, 2) }}") == 10
+    assert render(hass, "{{ bitwise_or(8, 8) }}") == 8
+    assert render(hass, "{{ bitwise_or(10, 2) }}") == 10
 
 
 def test_bitwise_xor(hass: HomeAssistant) -> None:
     """Test bitwise xor."""
-    assert template.Template("{{ bitwise_xor(8, 2) }}", hass).async_render() == 10
-    assert template.Template("{{ bitwise_xor(8, 8) }}", hass).async_render() == 0
-    assert template.Template("{{ bitwise_xor(10, 2) }}", hass).async_render() == 8
+    assert render(hass, "{{ bitwise_xor(8, 2) }}") == 10
+    assert render(hass, "{{ bitwise_xor(8, 8) }}") == 0
+    assert render(hass, "{{ bitwise_xor(10, 2) }}") == 8
 
 
 @pytest.mark.parametrize(
@@ -361,30 +313,30 @@ def test_min_max_attribute(hass: HomeAssistant, attribute) -> None:
         },
     )
     assert (
-        template.Template(
+        render(
+            hass,
             f"{{{{ (state_attr('test.object', 'objects') | min(attribute='{attribute}'))['{attribute}']}}}}",
-            hass,
-        ).async_render()
+        )
         == 1
     )
     assert (
-        template.Template(
+        render(
+            hass,
             f"{{{{ (min(state_attr('test.object', 'objects'), attribute='{attribute}'))['{attribute}']}}}}",
-            hass,
-        ).async_render()
+        )
         == 1
     )
     assert (
-        template.Template(
-            f"{{{{ (state_attr('test.object', 'objects') | max(attribute='{attribute}'))['{attribute}']}}}}",
+        render(
             hass,
-        ).async_render()
+            f"{{{{ (state_attr('test.object', 'objects') | max(attribute='{attribute}'))['{attribute}']}}}}",
+        )
         == 3
     )
     assert (
-        template.Template(
-            f"{{{{ (max(state_attr('test.object', 'objects'), attribute='{attribute}'))['{attribute}']}}}}",
+        render(
             hass,
-        ).async_render()
+            f"{{{{ (max(state_attr('test.object', 'objects'), attribute='{attribute}'))['{attribute}']}}}}",
+        )
         == 3
     )

--- a/tests/helpers/template/extensions/test_regex.py
+++ b/tests/helpers/template/extensions/test_regex.py
@@ -12,33 +12,25 @@ from homeassistant.helpers import template
 def test_regex_match(hass: HomeAssistant) -> None:
     """Test regex_match method."""
     tpl = template.Template(
-        r"""
-{{ '123-456-7890' | regex_match('(\\d{3})-(\\d{3})-(\\d{4})') }}
-            """,
+        r"""{{ '123-456-7890' | regex_match('(\\d{3})-(\\d{3})-(\\d{4})') }}""",
         hass,
     )
     assert tpl.async_render() is True
 
     tpl = template.Template(
-        """
-{{ 'Home Assistant test' | regex_match('home', True) }}
-            """,
+        """{{ 'Home Assistant test' | regex_match('home', True) }}""",
         hass,
     )
     assert tpl.async_render() is True
 
     tpl = template.Template(
-        """
-    {{ 'Another Home Assistant test' | regex_match('Home') }}
-                    """,
+        """    {{ 'Another Home Assistant test' | regex_match('Home') }}""",
         hass,
     )
     assert tpl.async_render() is False
 
     tpl = template.Template(
-        """
-{{ ['Home Assistant test'] | regex_match('.*Assist') }}
-            """,
+        """{{ ['Home Assistant test'] | regex_match('.*Assist') }}""",
         hass,
     )
     assert tpl.async_render() is True
@@ -47,9 +39,7 @@ def test_regex_match(hass: HomeAssistant) -> None:
 def test_match_test(hass: HomeAssistant) -> None:
     """Test match test."""
     tpl = template.Template(
-        r"""
-{{ '123-456-7890' is match('(\\d{3})-(\\d{3})-(\\d{4})') }}
-            """,
+        r"""{{ '123-456-7890' is match('(\\d{3})-(\\d{3})-(\\d{4})') }}""",
         hass,
     )
     assert tpl.async_render() is True
@@ -58,33 +48,25 @@ def test_match_test(hass: HomeAssistant) -> None:
 def test_regex_search(hass: HomeAssistant) -> None:
     """Test regex_search method."""
     tpl = template.Template(
-        r"""
-{{ '123-456-7890' | regex_search('(\\d{3})-(\\d{3})-(\\d{4})') }}
-            """,
+        r"""{{ '123-456-7890' | regex_search('(\\d{3})-(\\d{3})-(\\d{4})') }}""",
         hass,
     )
     assert tpl.async_render() is True
 
     tpl = template.Template(
-        """
-{{ 'Home Assistant test' | regex_search('home', True) }}
-            """,
+        """{{ 'Home Assistant test' | regex_search('home', True) }}""",
         hass,
     )
     assert tpl.async_render() is True
 
     tpl = template.Template(
-        """
-    {{ 'Another Home Assistant test' | regex_search('Home') }}
-                    """,
+        """    {{ 'Another Home Assistant test' | regex_search('Home') }}""",
         hass,
     )
     assert tpl.async_render() is True
 
     tpl = template.Template(
-        """
-{{ ['Home Assistant test'] | regex_search('Assist') }}
-            """,
+        """{{ ['Home Assistant test'] | regex_search('Assist') }}""",
         hass,
     )
     assert tpl.async_render() is True
@@ -93,9 +75,7 @@ def test_regex_search(hass: HomeAssistant) -> None:
 def test_search_test(hass: HomeAssistant) -> None:
     """Test search test."""
     tpl = template.Template(
-        r"""
-{{ '123-456-7890' is search('(\\d{3})-(\\d{3})-(\\d{4})') }}
-            """,
+        r"""{{ '123-456-7890' is search('(\\d{3})-(\\d{3})-(\\d{4})') }}""",
         hass,
     )
     assert tpl.async_render() is True
@@ -104,17 +84,13 @@ def test_search_test(hass: HomeAssistant) -> None:
 def test_regex_replace(hass: HomeAssistant) -> None:
     """Test regex_replace method."""
     tpl = template.Template(
-        r"""
-{{ 'Hello World' | regex_replace('(Hello\\s)',) }}
-            """,
+        r"""{{ 'Hello World' | regex_replace('(Hello\\s)',) }}""",
         hass,
     )
     assert tpl.async_render() == "World"
 
     tpl = template.Template(
-        """
-{{ ['Home hinderant test'] | regex_replace('hinder', 'Assist') }}
-            """,
+        """{{ ['Home hinderant test'] | regex_replace('hinder', 'Assist') }}""",
         hass,
     )
     assert tpl.async_render() == ["Home Assistant test"]
@@ -123,9 +99,7 @@ def test_regex_replace(hass: HomeAssistant) -> None:
 def test_regex_findall(hass: HomeAssistant) -> None:
     """Test regex_findall method."""
     tpl = template.Template(
-        """
-{{ 'Flight from JFK to LHR' | regex_findall('([A-Z]{3})') }}
-            """,
+        """{{ 'Flight from JFK to LHR' | regex_findall('([A-Z]{3})') }}""",
         hass,
     )
     assert tpl.async_render() == ["JFK", "LHR"]
@@ -134,17 +108,13 @@ def test_regex_findall(hass: HomeAssistant) -> None:
 def test_regex_findall_index(hass: HomeAssistant) -> None:
     """Test regex_findall_index method."""
     tpl = template.Template(
-        """
-{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 0) }}
-            """,
+        """{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 0) }}""",
         hass,
     )
     assert tpl.async_render() == "JFK"
 
     tpl = template.Template(
-        """
-{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 1) }}
-            """,
+        """{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 1) }}""",
         hass,
     )
     assert tpl.async_render() == "LHR"
@@ -154,36 +124,28 @@ def test_regex_ignorecase_parameter(hass: HomeAssistant) -> None:
     """Test ignorecase parameter across all regex functions."""
     # Test regex_match with ignorecase
     tpl = template.Template(
-        """
-{{ 'TEST' | regex_match('test', True) }}
-            """,
+        """{{ 'TEST' | regex_match('test', True) }}""",
         hass,
     )
     assert tpl.async_render() is True
 
     # Test regex_search with ignorecase
     tpl = template.Template(
-        """
-{{ 'TEST STRING' | regex_search('test', True) }}
-            """,
+        """{{ 'TEST STRING' | regex_search('test', True) }}""",
         hass,
     )
     assert tpl.async_render() is True
 
     # Test regex_replace with ignorecase
     tpl = template.Template(
-        """
-{{ 'TEST' | regex_replace('test', 'replaced', True) }}
-            """,
+        """{{ 'TEST' | regex_replace('test', 'replaced', True) }}""",
         hass,
     )
     assert tpl.async_render() == "replaced"
 
     # Test regex_findall with ignorecase
     tpl = template.Template(
-        """
-{{ 'TEST test Test' | regex_findall('test', True) }}
-            """,
+        """{{ 'TEST test Test' | regex_findall('test', True) }}""",
         hass,
     )
     assert tpl.async_render() == ["TEST", "test", "Test"]
@@ -193,18 +155,14 @@ def test_regex_with_non_string_input(hass: HomeAssistant) -> None:
     """Test regex functions with non-string input (automatic conversion)."""
     # Test with integer
     tpl = template.Template(
-        r"""
-{{ 12345 | regex_match('\\d+') }}
-            """,
+        r"""{{ 12345 | regex_match('\\d+') }}""",
         hass,
     )
     assert tpl.async_render() is True
 
     # Test with list (string conversion)
     tpl = template.Template(
-        r"""
-{{ [1, 2, 3] | regex_search('\\d') }}
-            """,
+        r"""{{ [1, 2, 3] | regex_search('\\d') }}""",
         hass,
     )
     assert tpl.async_render() is True
@@ -214,18 +172,14 @@ def test_regex_edge_cases(hass: HomeAssistant) -> None:
     """Test regex functions with edge cases."""
     # Test with empty string
     tpl = template.Template(
-        """
-{{ '' | regex_match('.*') }}
-            """,
+        """{{ '' | regex_match('.*') }}""",
         hass,
     )
     assert tpl.async_render() is True
 
     # Test regex_findall_index with out of bounds index
     tpl = template.Template(
-        """
-{{ 'test' | regex_findall_index('t', 5) }}
-            """,
+        """{{ 'test' | regex_findall_index('t', 5) }}""",
         hass,
     )
     with pytest.raises(TemplateError):
@@ -233,9 +187,7 @@ def test_regex_edge_cases(hass: HomeAssistant) -> None:
 
     # Test with invalid regex pattern
     tpl = template.Template(
-        """
-{{ 'test' | regex_match('[') }}
-            """,
+        """{{ 'test' | regex_match('[') }}""",
         hass,
     )
     with pytest.raises(TemplateError):  # re.error wrapped in TemplateError
@@ -246,18 +198,14 @@ def test_regex_groups_and_replacement_patterns(hass: HomeAssistant) -> None:
     """Test regex with groups and replacement patterns."""
     # Test replacement with groups
     tpl = template.Template(
-        r"""
-{{ 'John Doe' | regex_replace('(\\w+) (\\w+)', '\\2, \\1') }}
-            """,
+        r"""{{ 'John Doe' | regex_replace('(\\w+) (\\w+)', '\\2, \\1') }}""",
         hass,
     )
     assert tpl.async_render() == "Doe, John"
 
     # Test findall with groups
     tpl = template.Template(
-        r"""
-{{ 'Email: test@example.com, Phone: 123-456-7890' | regex_findall('(\\w+@\\w+\\.\\w+)|(\\d{3}-\\d{3}-\\d{4})') }}
-            """,
+        r"""{{ 'Email: test@example.com, Phone: 123-456-7890' | regex_findall('(\\w+@\\w+\\.\\w+)|(\\d{3}-\\d{3}-\\d{4})') }}""",
         hass,
     )
     result = tpl.async_render()

--- a/tests/helpers/template/extensions/test_regex.py
+++ b/tests/helpers/template/extensions/test_regex.py
@@ -11,171 +11,143 @@ from homeassistant.helpers import template
 
 def test_regex_match(hass: HomeAssistant) -> None:
     """Test regex_match method."""
-    tpl = template.Template(
-        r"""{{ '123-456-7890' | regex_match('(\\d{3})-(\\d{3})-(\\d{4})') }}""",
-        hass,
-    )
-    assert tpl.async_render() is True
 
-    tpl = template.Template(
-        """{{ 'Home Assistant test' | regex_match('home', True) }}""",
-        hass,
+    result = render(
+        hass, r"""{{ '123-456-7890' | regex_match('(\\d{3})-(\\d{3})-(\\d{4})') }}"""
     )
-    assert tpl.async_render() is True
+    assert result is True
 
-    tpl = template.Template(
-        """    {{ 'Another Home Assistant test' | regex_match('Home') }}""",
-        hass,
-    )
-    assert tpl.async_render() is False
+    result = render(hass, """{{ 'Home Assistant test' | regex_match('home', True) }}""")
+    assert result is True
 
-    tpl = template.Template(
-        """{{ ['Home Assistant test'] | regex_match('.*Assist') }}""",
-        hass,
+    result = render(
+        hass, """    {{ 'Another Home Assistant test' | regex_match('Home') }}"""
     )
-    assert tpl.async_render() is True
+    assert result is False
+
+    result = render(hass, """{{ ['Home Assistant test'] | regex_match('.*Assist') }}""")
+    assert result is True
 
 
 def test_match_test(hass: HomeAssistant) -> None:
     """Test match test."""
-    tpl = template.Template(
-        r"""{{ '123-456-7890' is match('(\\d{3})-(\\d{3})-(\\d{4})') }}""",
-        hass,
+
+    result = render(
+        hass, r"""{{ '123-456-7890' is match('(\\d{3})-(\\d{3})-(\\d{4})') }}"""
     )
-    assert tpl.async_render() is True
+    assert result is True
 
 
 def test_regex_search(hass: HomeAssistant) -> None:
     """Test regex_search method."""
-    tpl = template.Template(
-        r"""{{ '123-456-7890' | regex_search('(\\d{3})-(\\d{3})-(\\d{4})') }}""",
-        hass,
-    )
-    assert tpl.async_render() is True
 
-    tpl = template.Template(
-        """{{ 'Home Assistant test' | regex_search('home', True) }}""",
-        hass,
+    result = render(
+        hass, r"""{{ '123-456-7890' | regex_search('(\\d{3})-(\\d{3})-(\\d{4})') }}"""
     )
-    assert tpl.async_render() is True
+    assert result is True
 
-    tpl = template.Template(
-        """    {{ 'Another Home Assistant test' | regex_search('Home') }}""",
-        hass,
+    result = render(
+        hass, """{{ 'Home Assistant test' | regex_search('home', True) }}"""
     )
-    assert tpl.async_render() is True
+    assert result is True
 
-    tpl = template.Template(
-        """{{ ['Home Assistant test'] | regex_search('Assist') }}""",
-        hass,
+    result = render(
+        hass, """    {{ 'Another Home Assistant test' | regex_search('Home') }}"""
     )
-    assert tpl.async_render() is True
+    assert result is True
+
+    result = render(hass, """{{ ['Home Assistant test'] | regex_search('Assist') }}""")
+    assert result is True
 
 
 def test_search_test(hass: HomeAssistant) -> None:
     """Test search test."""
-    tpl = template.Template(
-        r"""{{ '123-456-7890' is search('(\\d{3})-(\\d{3})-(\\d{4})') }}""",
-        hass,
+
+    result = render(
+        hass, r"""{{ '123-456-7890' is search('(\\d{3})-(\\d{3})-(\\d{4})') }}"""
     )
-    assert tpl.async_render() is True
+    assert result is True
 
 
 def test_regex_replace(hass: HomeAssistant) -> None:
     """Test regex_replace method."""
-    tpl = template.Template(
-        r"""{{ 'Hello World' | regex_replace('(Hello\\s)',) }}""",
-        hass,
-    )
-    assert tpl.async_render() == "World"
 
-    tpl = template.Template(
-        """{{ ['Home hinderant test'] | regex_replace('hinder', 'Assist') }}""",
-        hass,
+    result = render(hass, r"""{{ 'Hello World' | regex_replace('(Hello\\s)',) }}""")
+    assert result == "World"
+
+    result = render(
+        hass, """{{ ['Home hinderant test'] | regex_replace('hinder', 'Assist') }}"""
     )
-    assert tpl.async_render() == ["Home Assistant test"]
+    assert result == ["Home Assistant test"]
 
 
 def test_regex_findall(hass: HomeAssistant) -> None:
     """Test regex_findall method."""
-    tpl = template.Template(
-        """{{ 'Flight from JFK to LHR' | regex_findall('([A-Z]{3})') }}""",
-        hass,
+
+    result = render(
+        hass, """{{ 'Flight from JFK to LHR' | regex_findall('([A-Z]{3})') }}"""
     )
-    assert tpl.async_render() == ["JFK", "LHR"]
+    assert result == ["JFK", "LHR"]
 
 
 def test_regex_findall_index(hass: HomeAssistant) -> None:
     """Test regex_findall_index method."""
-    tpl = template.Template(
-        """{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 0) }}""",
-        hass,
-    )
-    assert tpl.async_render() == "JFK"
 
-    tpl = template.Template(
-        """{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 1) }}""",
+    result = render(
         hass,
+        """{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 0) }}""",
     )
-    assert tpl.async_render() == "LHR"
+    assert result == "JFK"
+
+    result = render(
+        hass,
+        """{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 1) }}""",
+    )
+    assert result == "LHR"
 
 
 def test_regex_ignorecase_parameter(hass: HomeAssistant) -> None:
     """Test ignorecase parameter across all regex functions."""
     # Test regex_match with ignorecase
-    tpl = template.Template(
-        """{{ 'TEST' | regex_match('test', True) }}""",
-        hass,
-    )
-    assert tpl.async_render() is True
+
+    result = render(hass, """{{ 'TEST' | regex_match('test', True) }}""")
+    assert result is True
 
     # Test regex_search with ignorecase
-    tpl = template.Template(
-        """{{ 'TEST STRING' | regex_search('test', True) }}""",
-        hass,
-    )
-    assert tpl.async_render() is True
+
+    result = render(hass, """{{ 'TEST STRING' | regex_search('test', True) }}""")
+    assert result is True
 
     # Test regex_replace with ignorecase
-    tpl = template.Template(
-        """{{ 'TEST' | regex_replace('test', 'replaced', True) }}""",
-        hass,
-    )
-    assert tpl.async_render() == "replaced"
+
+    result = render(hass, """{{ 'TEST' | regex_replace('test', 'replaced', True) }}""")
+    assert result == "replaced"
 
     # Test regex_findall with ignorecase
-    tpl = template.Template(
-        """{{ 'TEST test Test' | regex_findall('test', True) }}""",
-        hass,
-    )
-    assert tpl.async_render() == ["TEST", "test", "Test"]
+
+    result = render(hass, """{{ 'TEST test Test' | regex_findall('test', True) }}""")
+    assert result == ["TEST", "test", "Test"]
 
 
 def test_regex_with_non_string_input(hass: HomeAssistant) -> None:
     """Test regex functions with non-string input (automatic conversion)."""
     # Test with integer
-    tpl = template.Template(
-        r"""{{ 12345 | regex_match('\\d+') }}""",
-        hass,
-    )
-    assert tpl.async_render() is True
+
+    result = render(hass, r"""{{ 12345 | regex_match('\\d+') }}""")
+    assert result is True
 
     # Test with list (string conversion)
-    tpl = template.Template(
-        r"""{{ [1, 2, 3] | regex_search('\\d') }}""",
-        hass,
-    )
-    assert tpl.async_render() is True
+
+    result = render(hass, r"""{{ [1, 2, 3] | regex_search('\\d') }}""")
+    assert result is True
 
 
 def test_regex_edge_cases(hass: HomeAssistant) -> None:
     """Test regex functions with edge cases."""
     # Test with empty string
-    tpl = template.Template(
-        """{{ '' | regex_match('.*') }}""",
-        hass,
-    )
-    assert tpl.async_render() is True
+
+    result = render(hass, """{{ '' | regex_match('.*') }}""")
+    assert result is True
 
     # Test regex_findall_index with out of bounds index
     tpl = template.Template(
@@ -197,11 +169,11 @@ def test_regex_edge_cases(hass: HomeAssistant) -> None:
 def test_regex_groups_and_replacement_patterns(hass: HomeAssistant) -> None:
     """Test regex with groups and replacement patterns."""
     # Test replacement with groups
-    tpl = template.Template(
-        r"""{{ 'John Doe' | regex_replace('(\\w+) (\\w+)', '\\2, \\1') }}""",
-        hass,
+
+    result = render(
+        hass, r"""{{ 'John Doe' | regex_replace('(\\w+) (\\w+)', '\\2, \\1') }}"""
     )
-    assert tpl.async_render() == "Doe, John"
+    assert result == "Doe, John"
 
     # Test findall with groups
     tpl = template.Template(

--- a/tests/helpers/template/extensions/test_regex.py
+++ b/tests/helpers/template/extensions/test_regex.py
@@ -6,7 +6,8 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template
+
+from tests.helpers.template.helpers import render
 
 
 def test_regex_match(hass: HomeAssistant) -> None:
@@ -20,9 +21,7 @@ def test_regex_match(hass: HomeAssistant) -> None:
     result = render(hass, """{{ 'Home Assistant test' | regex_match('home', True) }}""")
     assert result is True
 
-    result = render(
-        hass, """    {{ 'Another Home Assistant test' | regex_match('Home') }}"""
-    )
+    result = render(hass, """{{ 'Another Home Assistant test'|regex_match('Home') }}""")
     assert result is False
 
     result = render(hass, """{{ ['Home Assistant test'] | regex_match('.*Assist') }}""")
@@ -146,24 +145,15 @@ def test_regex_edge_cases(hass: HomeAssistant) -> None:
     """Test regex functions with edge cases."""
     # Test with empty string
 
-    result = render(hass, """{{ '' | regex_match('.*') }}""")
-    assert result is True
+    assert render(hass, """{{ '' | regex_match('.*') }}""") is True
 
     # Test regex_findall_index with out of bounds index
-    tpl = template.Template(
-        """{{ 'test' | regex_findall_index('t', 5) }}""",
-        hass,
-    )
     with pytest.raises(TemplateError):
-        tpl.async_render()
+        render(hass, """{{ 'test' | regex_findall_index('t', 5) }}""")
 
     # Test with invalid regex pattern
-    tpl = template.Template(
-        """{{ 'test' | regex_match('[') }}""",
-        hass,
-    )
     with pytest.raises(TemplateError):  # re.error wrapped in TemplateError
-        tpl.async_render()
+        render(hass, """{{ 'test' | regex_match('[') }}""")
 
 
 def test_regex_groups_and_replacement_patterns(hass: HomeAssistant) -> None:
@@ -176,10 +166,9 @@ def test_regex_groups_and_replacement_patterns(hass: HomeAssistant) -> None:
     assert result == "Doe, John"
 
     # Test findall with groups
-    tpl = template.Template(
-        r"""{{ 'Email: test@example.com, Phone: 123-456-7890' | regex_findall('(\\w+@\\w+\\.\\w+)|(\\d{3}-\\d{3}-\\d{4})') }}""",
+    result = render(
         hass,
+        r"""{{ 'Email: test@example.com, Phone: 123-456-7890' | regex_findall('(\\w+@\\w+\\.\\w+)|(\\d{3}-\\d{3}-\\d{4})') }}""",
     )
-    result = tpl.async_render()
     # The result will contain tuples with empty strings for non-matching groups
     assert len(result) == 2

--- a/tests/helpers/template/extensions/test_string.py
+++ b/tests/helpers/template/extensions/test_string.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import template
 
 from tests.helpers.template.helpers import render
 
@@ -117,11 +116,10 @@ def test_slugify_various_separators(hass: HomeAssistant) -> None:
 def test_urlencode_various_types(hass: HomeAssistant) -> None:
     """Test urlencode with various data types."""
     # Test with nested dictionary values
-    tpl = template.Template(
-        "{% set data = {'key': 'value with spaces', 'num': 123} %}{{ data | urlencode }}",
+    result = render(
         hass,
+        "{% set data = {'key': 'value with spaces', 'num': 123} %}{{ data | urlencode }}",
     )
-    result = tpl.async_render()
     # URL encoding can have different order, so check both parts are present
     # Note: urllib.parse.urlencode uses + for spaces in form data
     assert "key=value+with+spaces" in result

--- a/tests/helpers/template/extensions/test_string.py
+++ b/tests/helpers/template/extensions/test_string.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import template
 
+from tests.helpers.template.helpers import render
+
 
 def test_ordinal(hass: HomeAssistant) -> None:
     """Test the ordinal filter."""
@@ -20,37 +22,22 @@ def test_ordinal(hass: HomeAssistant) -> None:
     ]
 
     for value, expected in tests:
-        assert (
-            template.Template(f"{{{{ {value} | ordinal }}}}", hass).async_render()
-            == expected
-        )
+        assert render(hass, f"{{{{ {value} | ordinal }}}}") == expected
 
 
 def test_slugify(hass: HomeAssistant) -> None:
     """Test the slugify filter."""
     # Test as global function
-    assert (
-        template.Template('{{ slugify("Home Assistant") }}', hass).async_render()
-        == "home_assistant"
-    )
+    assert render(hass, '{{ slugify("Home Assistant") }}') == "home_assistant"
 
     # Test as filter
-    assert (
-        template.Template('{{ "Home Assistant" | slugify }}', hass).async_render()
-        == "home_assistant"
-    )
+    assert render(hass, '{{ "Home Assistant" | slugify }}') == "home_assistant"
 
     # Test with custom separator as global
-    assert (
-        template.Template('{{ slugify("Home Assistant", "-") }}', hass).async_render()
-        == "home-assistant"
-    )
+    assert render(hass, '{{ slugify("Home Assistant", "-") }}') == "home-assistant"
 
     # Test with custom separator as filter
-    assert (
-        template.Template('{{ "Home Assistant" | slugify("-") }}', hass).async_render()
-        == "home-assistant"
-    )
+    assert render(hass, '{{ "Home Assistant" | slugify("-") }}') == "home-assistant"
 
 
 def test_urlencode(hass: HomeAssistant) -> None:
@@ -73,10 +60,10 @@ def test_urlencode(hass: HomeAssistant) -> None:
 def test_string_functions_with_non_string_input(hass: HomeAssistant) -> None:
     """Test string functions with non-string input (automatic conversion)."""
     # Test ordinal with integer
-    assert template.Template("{{ 42 | ordinal }}", hass).async_render() == "42nd"
+    assert render(hass, "{{ 42 | ordinal }}") == "42nd"
 
     # Test slugify with integer - Note: Jinja2 may return integer for simple cases
-    result = template.Template("{{ 123 | slugify }}", hass).async_render()
+    result = render(hass, "{{ 123 | slugify }}")
     # Accept either string or integer result for simple numeric cases
     assert result in ["123", 123]
 
@@ -94,10 +81,7 @@ def test_ordinal_edge_cases(hass: HomeAssistant) -> None:
     ]
 
     for value, expected in teens_tests:
-        assert (
-            template.Template(f"{{{{ {value} | ordinal }}}}", hass).async_render()
-            == expected
-        )
+        assert render(hass, f"{{{{ {value} | ordinal }}}}") == expected
 
     # Test other numbers ending in 1, 2, 3
     other_tests = [
@@ -110,10 +94,7 @@ def test_ordinal_edge_cases(hass: HomeAssistant) -> None:
     ]
 
     for value, expected in other_tests:
-        assert (
-            template.Template(f"{{{{ {value} | ordinal }}}}", hass).async_render()
-            == expected
-        )
+        assert render(hass, f"{{{{ {value} | ordinal }}}}") == expected
 
 
 def test_slugify_various_separators(hass: HomeAssistant) -> None:
@@ -127,20 +108,10 @@ def test_slugify_various_separators(hass: HomeAssistant) -> None:
 
     for text, separator, expected in test_cases:
         # Test as global function
-        assert (
-            template.Template(
-                f'{{{{ slugify("{text}", "{separator}") }}}}', hass
-            ).async_render()
-            == expected
-        )
+        assert render(hass, f'{{{{ slugify("{text}", "{separator}") }}}}') == expected
 
         # Test as filter
-        assert (
-            template.Template(
-                f'{{{{ "{text}" | slugify("{separator}") }}}}', hass
-            ).async_render()
-            == expected
-        )
+        assert render(hass, f'{{{{ "{text}" | slugify("{separator}") }}}}') == expected
 
 
 def test_urlencode_various_types(hass: HomeAssistant) -> None:

--- a/tests/helpers/template/extensions/test_string.py
+++ b/tests/helpers/template/extensions/test_string.py
@@ -43,18 +43,18 @@ def test_slugify(hass: HomeAssistant) -> None:
 def test_urlencode(hass: HomeAssistant) -> None:
     """Test the urlencode method."""
     # Test with dictionary
-    tpl = template.Template(
-        "{% set dict = {'foo': 'x&y', 'bar': 42} %}{{ dict | urlencode }}",
-        hass,
+
+    result = render(
+        hass, "{% set dict = {'foo': 'x&y', 'bar': 42} %}{{ dict | urlencode }}"
     )
-    assert tpl.async_render() == "foo=x%26y&bar=42"
+    assert result == "foo=x%26y&bar=42"
 
     # Test with string
-    tpl = template.Template(
-        "{% set string = 'the quick brown fox = true' %}{{ string | urlencode }}",
-        hass,
+
+    result = render(
+        hass, "{% set string = 'the quick brown fox = true' %}{{ string | urlencode }}"
     )
-    assert tpl.async_render() == "the%20quick%20brown%20fox%20%3D%20true"
+    assert result == "the%20quick%20brown%20fox%20%3D%20true"
 
 
 def test_string_functions_with_non_string_input(hass: HomeAssistant) -> None:
@@ -128,8 +128,8 @@ def test_urlencode_various_types(hass: HomeAssistant) -> None:
     assert "num=123" in result
 
     # Test with special characters
-    tpl = template.Template(
-        "{% set data = {'special': 'a+b=c&d'} %}{{ data | urlencode }}",
-        hass,
+
+    result = render(
+        hass, "{% set data = {'special': 'a+b=c&d'} %}{{ data | urlencode }}"
     )
-    assert tpl.async_render() == "special=a%2Bb%3Dc%26d"
+    assert result == "special=a%2Bb%3Dc%26d"

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -531,15 +531,13 @@ def test_add(hass: HomeAssistant) -> None:
 
 def test_apply(hass: HomeAssistant) -> None:
     """Test apply."""
-    assert render(
-        hass,
-        """
+    tpl = """
     {%- macro add_foo(arg) -%}
     {{arg}}foo
     {%- endmacro -%}
     {{ ["a", "b", "c"] | map('apply', add_foo) | list }}
-    """,
-    ) == ["afoo", "bfoo", "cfoo"]
+    """
+    assert render(hass, tpl) == ["afoo", "bfoo", "cfoo"]
 
     assert render(
         hass, "{{ ['1', '2', '3', '4', '5'] | map('apply', int) | list }}"
@@ -549,80 +547,55 @@ def test_apply(hass: HomeAssistant) -> None:
 def test_apply_macro_with_arguments(hass: HomeAssistant) -> None:
     """Test apply macro with positional, named, and mixed arguments."""
     # Test macro with positional arguments
-    assert (
-        render(
-            hass,
-            """
+    tpl = """
                 {%- macro add_numbers(a, b, c) -%}
                 {{ a + b + c }}
                 {%- endmacro -%}
                 {{ apply(5, add_numbers, 10, 15) }}
-                """,
-        )
-        == 30
-    )
+                """
+    assert render(hass, tpl) == 30
 
     # Test macro with named arguments
-    assert (
-        render(
-            hass,
-            """
+    tpl = """
                 {%- macro greet(name, greeting="Hello") -%}
                 {{ greeting }}, {{ name }}!
                 {%- endmacro -%}
                 {{ apply("World", greet, greeting="Hi") }}
-                """,
-        )
-        == "Hi, World!"
-    )
+                """
+    assert render(hass, tpl) == "Hi, World!"
 
     # Test macro with mixed arguments
-    assert (
-        render(
-            hass,
-            """
+    tpl = """
                 {%- macro format_message(prefix, name, suffix="!") -%}
                 {{ prefix }} {{ name }}{{ suffix }}
                 {%- endmacro -%}
                 {{ apply("Welcome", format_message, "John", suffix="...") }}
-                """,
-        )
-        == "Welcome John..."
-    )
+                """
+    assert render(hass, tpl) == "Welcome John..."
 
 
 def test_as_function(hass: HomeAssistant) -> None:
     """Test as_function."""
-    assert (
-        render(
-            hass,
-            """
+    tpl = """
         {%- macro macro_double(num, returns) -%}
         {%- do returns(num * 2) -%}
         {%- endmacro -%}
         {%- set double = macro_double | as_function -%}
         {{ double(5) }}
-        """,
-        )
-        == 10
-    )
+        """
+    assert render(hass, tpl) == 10
 
 
 def test_as_function_no_arguments(hass: HomeAssistant) -> None:
     """Test as_function with no arguments."""
-    assert (
-        render(
-            hass,
-            """
+    tpl = """
         {%- macro macro_get_hello(returns) -%}
         {%- do returns("Hello") -%}
         {%- endmacro -%}
         {%- set get_hello = macro_get_hello | as_function -%}
         {{ get_hello() }}
-        """,
-        )
-        == "Hello"
-    )
+        """
+    assert render(hass, tpl) == "Hello"
 
 
 def test_strptime(hass: HomeAssistant) -> None:
@@ -999,29 +972,20 @@ def test_passing_vars_as_list(hass: HomeAssistant) -> None:
 
 def test_passing_vars_as_list_element(hass: HomeAssistant) -> None:
     """Test passing variables as list."""
-    assert (
-        template.render_complex(
-            template.Template("{{ hello[1] }}", hass), {"hello": ["foo", "bar"]}
-        )
-        == "bar"
-    )
+    tpl = template.Template("{{ hello[1] }}", hass)
+    assert template.render_complex(tpl, {"hello": ["foo", "bar"]}) == "bar"
 
 
 def test_passing_vars_as_dict_element(hass: HomeAssistant) -> None:
     """Test passing variables as list."""
-    assert (
-        template.render_complex(
-            template.Template("{{ hello.foo }}", hass), {"hello": {"foo": "bar"}}
-        )
-        == "bar"
-    )
+    tpl = template.Template("{{ hello.foo }}", hass)
+    assert template.render_complex(tpl, {"hello": {"foo": "bar"}}) == "bar"
 
 
 def test_passing_vars_as_dict(hass: HomeAssistant) -> None:
     """Test passing variables as list."""
-    assert template.render_complex(
-        template.Template("{{ hello }}", hass), {"hello": {"foo": "bar"}}
-    ) == {"foo": "bar"}
+    tpl = template.Template("{{ hello }}", hass)
+    assert template.render_complex(tpl, {"hello": {"foo": "bar"}}) == {"foo": "bar"}
 
 
 def test_render_with_possible_json_value_with_valid_json(hass: HomeAssistant) -> None:
@@ -4302,11 +4266,10 @@ async def test_undefined_symbol_warnings(
 ) -> None:
     """Test a warning is logged on undefined variables."""
 
-    result = render(hass, template_string)
-    assert result == ""
+    assert render(hass, template_string) == ""
     assert (
-        "Template variable warning: 'no_such_variable' is undefined when rendering "
-        f"'{template_string}'" in caplog.text
+        f"Template variable warning: 'no_such_variable' is undefined when rendering '{template_string}'"
+        in caplog.text
     )
 
 

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -1090,9 +1090,7 @@ def test_render_with_possible_json_value_undefined_json_error_value(
 def test_render_with_possible_json_value_non_string_value(hass: HomeAssistant) -> None:
     """Render with possible JSON value with non-string value."""
     tpl = template.Template(
-        """
-{{ strptime(value~'+0000', '%Y-%m-%d %H:%M:%S%z') }}
-        """,
+        """{{ strptime(value~'+0000', '%Y-%m-%d %H:%M:%S%z') }}""",
         hass,
     )
     value = datetime(2019, 1, 18, 12, 13, 14)
@@ -1152,41 +1150,31 @@ def test_is_state(hass: HomeAssistant) -> None:
     """Test is_state method."""
     hass.states.async_set("test.object", "available")
     tpl = template.Template(
-        """
-{% if is_state("test.object", "available") %}yes{% else %}no{% endif %}
-        """,
+        """{% if is_state("test.object", "available") %}yes{% else %}no{% endif %}""",
         hass,
     )
     assert tpl.async_render() == "yes"
 
     tpl = template.Template(
-        """
-{{ is_state("test.noobject", "available") }}
-        """,
+        """{{ is_state("test.noobject", "available") }}""",
         hass,
     )
     assert tpl.async_render() is False
 
     tpl = template.Template(
-        """
-{% if "test.object" is is_state("available") %}yes{% else %}no{% endif %}
-        """,
+        """{% if "test.object" is is_state("available") %}yes{% else %}no{% endif %}""",
         hass,
     )
     assert tpl.async_render() == "yes"
 
     tpl = template.Template(
-        """
-{{ ['test.object'] | select("is_state", "available") | first | default }}
-        """,
+        """{{ ['test.object'] | select("is_state", "available") | first | default }}""",
         hass,
     )
     assert tpl.async_render() == "test.object"
 
     tpl = template.Template(
-        """
-{{ is_state("test.object", ["on", "off", "available"]) }}
-        """,
+        """{{ is_state("test.object", ["on", "off", "available"]) }}""",
         hass,
     )
     assert tpl.async_render() is True
@@ -1196,49 +1184,37 @@ def test_is_state_attr(hass: HomeAssistant) -> None:
     """Test is_state_attr method."""
     hass.states.async_set("test.object", "available", {"mode": "on", "exists": None})
     tpl = template.Template(
-        """
-{% if is_state_attr("test.object", "mode", "on") %}yes{% else %}no{% endif %}
-            """,
+        """{% if is_state_attr("test.object", "mode", "on") %}yes{% else %}no{% endif %}""",
         hass,
     )
     assert tpl.async_render() == "yes"
 
     tpl = template.Template(
-        """
-{{ is_state_attr("test.noobject", "mode", "on") }}
-            """,
+        """{{ is_state_attr("test.noobject", "mode", "on") }}""",
         hass,
     )
     assert tpl.async_render() is False
 
     tpl = template.Template(
-        """
-{% if "test.object" is is_state_attr("mode", "on") %}yes{% else %}no{% endif %}
-        """,
+        """{% if "test.object" is is_state_attr("mode", "on") %}yes{% else %}no{% endif %}""",
         hass,
     )
     assert tpl.async_render() == "yes"
 
     tpl = template.Template(
-        """
-{{ ['test.object'] | select("is_state_attr", "mode", "on") | first | default }}
-        """,
+        """{{ ['test.object'] | select("is_state_attr", "mode", "on") | first | default }}""",
         hass,
     )
     assert tpl.async_render() == "test.object"
 
     tpl = template.Template(
-        """
-{% if is_state_attr("test.object", "exists", None) %}yes{% else %}no{% endif %}
-            """,
+        """{% if is_state_attr("test.object", "exists", None) %}yes{% else %}no{% endif %}""",
         hass,
     )
     assert tpl.async_render() == "yes"
 
     tpl = template.Template(
-        """
-{% if is_state_attr("test.object", "noexist", None) %}yes{% else %}no{% endif %}
-            """,
+        """{% if is_state_attr("test.object", "noexist", None) %}yes{% else %}no{% endif %}""",
         hass,
     )
     assert tpl.async_render() == "no"
@@ -1250,33 +1226,25 @@ def test_state_attr(hass: HomeAssistant) -> None:
         "test.object", "available", {"effect": "action", "mode": "on"}
     )
     tpl = template.Template(
-        """
-{% if state_attr("test.object", "mode") == "on" %}yes{% else %}no{% endif %}
-            """,
+        """{% if state_attr("test.object", "mode") == "on" %}yes{% else %}no{% endif %}""",
         hass,
     )
     assert tpl.async_render() == "yes"
 
     tpl = template.Template(
-        """
-{{ state_attr("test.noobject", "mode") == None }}
-            """,
+        """{{ state_attr("test.noobject", "mode") == None }}""",
         hass,
     )
     assert tpl.async_render() is True
 
     tpl = template.Template(
-        """
-{% if "test.object" | state_attr("mode") == "on" %}yes{% else %}no{% endif %}
-        """,
+        """{% if "test.object" | state_attr("mode") == "on" %}yes{% else %}no{% endif %}""",
         hass,
     )
     assert tpl.async_render() == "yes"
 
     tpl = template.Template(
-        """
-{{ ['test.object'] | map("state_attr", "effect") | first | default }}
-        """,
+        """{{ ['test.object'] | map("state_attr", "effect") | first | default }}""",
         hass,
     )
     assert tpl.async_render() == "action"
@@ -1292,17 +1260,13 @@ def test_states_function(hass: HomeAssistant) -> None:
     assert tpl2.async_render() == "unknown"
 
     tpl = template.Template(
-        """
-{% if "test.object" | states == "available" %}yes{% else %}no{% endif %}
-        """,
+        """{% if "test.object" | states == "available" %}yes{% else %}no{% endif %}""",
         hass,
     )
     assert tpl.async_render() == "yes"
 
     tpl = template.Template(
-        """
-{{ ['test.object'] | map("states") | first | default }}
-        """,
+        """{{ ['test.object'] | map("states") | first | default }}""",
         hass,
     )
     assert tpl.async_render() == "available"
@@ -1421,33 +1385,25 @@ def test_has_value(hass: HomeAssistant) -> None:
     hass.states.async_set("test.unavailable", STATE_UNAVAILABLE)
 
     tpl = template.Template(
-        """
-{{ has_value("test.value1") }}
-        """,
+        """{{ has_value("test.value1") }}""",
         hass,
     )
     assert tpl.async_render() is True
 
     tpl = template.Template(
-        """
-{{ has_value("test.unavailable") }}
-        """,
+        """{{ has_value("test.unavailable") }}""",
         hass,
     )
     assert tpl.async_render() is False
 
     tpl = template.Template(
-        """
-{{ has_value("test.unknown") }}
-        """,
+        """{{ has_value("test.unknown") }}""",
         hass,
     )
     assert tpl.async_render() is False
 
     tpl = template.Template(
-        """
-{% if "test.value1" is has_value %}yes{% else %}no{% endif %}
-        """,
+        """{% if "test.value1" is has_value %}yes{% else %}no{% endif %}""",
         hass,
     )
     assert tpl.async_render() == "yes"
@@ -2007,9 +1963,7 @@ def test_pack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
 
     # render as filter
     tpl = template.Template(
-        """
-{{ value | pack('>I') }}
-            """,
+        """{{ value | pack('>I') }}""",
         hass,
     )
     variables = {
@@ -2019,9 +1973,7 @@ def test_pack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
 
     # render as function
     tpl = template.Template(
-        """
-{{ pack(value, '>I') }}
-            """,
+        """{{ pack(value, '>I') }}""",
         hass,
     )
     variables = {
@@ -2031,9 +1983,7 @@ def test_pack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
 
     # test with None value
     tpl = template.Template(
-        """
-{{ pack(value, '>I') }}
-            """,
+        """{{ pack(value, '>I') }}""",
         hass,
     )
     variables = {
@@ -2049,9 +1999,7 @@ def test_pack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
 
     # test with invalid filter
     tpl = template.Template(
-        """
-{{ pack(value, 'invalid filter') }}
-            """,
+        """{{ pack(value, 'invalid filter') }}""",
         hass,
     )
     variables = {
@@ -2072,9 +2020,7 @@ def test_unpack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
 
     # render as filter
     tpl = template.Template(
-        """
-{{ value | unpack('>I') }}
-            """,
+        """{{ value | unpack('>I') }}""",
         hass,
     )
     variables = {
@@ -2084,9 +2030,7 @@ def test_unpack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
 
     # render as function
     tpl = template.Template(
-        """
-{{ unpack(value, '>I') }}
-            """,
+        """{{ unpack(value, '>I') }}""",
         hass,
     )
     variables = {
@@ -2096,9 +2040,7 @@ def test_unpack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
 
     # unpack with offset
     tpl = template.Template(
-        """
-{{ unpack(value, '>H', offset=2) }}
-            """,
+        """{{ unpack(value, '>H', offset=2) }}""",
         hass,
     )
     variables = {
@@ -2108,9 +2050,7 @@ def test_unpack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
 
     # test with an empty bytes object
     tpl = template.Template(
-        """
-{{ unpack(value, '>I') }}
-            """,
+        """{{ unpack(value, '>I') }}""",
         hass,
     )
     variables = {
@@ -2125,9 +2065,7 @@ def test_unpack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
 
     # test with invalid filter
     tpl = template.Template(
-        """
-{{ unpack(value, 'invalid filter') }}
-            """,
+        """{{ unpack(value, 'invalid filter') }}""",
         hass,
     )
     variables = {

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -1121,10 +1121,11 @@ def test_render_with_possible_json_value_and_dont_parse_result(
 def test_if_state_exists(hass: HomeAssistant) -> None:
     """Test if state exists works."""
     hass.states.async_set("test.object", "available")
-    tpl = template.Template(
-        "{% if states.test.object %}exists{% else %}not exists{% endif %}", hass
+
+    result = render(
+        hass, "{% if states.test.object %}exists{% else %}not exists{% endif %}"
     )
-    assert tpl.async_render() == "exists"
+    assert result == "exists"
 
 
 def test_is_hidden_entity(
@@ -1149,75 +1150,70 @@ def test_is_hidden_entity(
 def test_is_state(hass: HomeAssistant) -> None:
     """Test is_state method."""
     hass.states.async_set("test.object", "available")
-    tpl = template.Template(
+
+    result = render(
+        hass,
         """{% if is_state("test.object", "available") %}yes{% else %}no{% endif %}""",
-        hass,
     )
-    assert tpl.async_render() == "yes"
+    assert result == "yes"
 
-    tpl = template.Template(
-        """{{ is_state("test.noobject", "available") }}""",
+    result = render(hass, """{{ is_state("test.noobject", "available") }}""")
+    assert result is False
+
+    result = render(
         hass,
-    )
-    assert tpl.async_render() is False
-
-    tpl = template.Template(
         """{% if "test.object" is is_state("available") %}yes{% else %}no{% endif %}""",
-        hass,
     )
-    assert tpl.async_render() == "yes"
+    assert result == "yes"
 
-    tpl = template.Template(
+    result = render(
+        hass,
         """{{ ['test.object'] | select("is_state", "available") | first | default }}""",
-        hass,
     )
-    assert tpl.async_render() == "test.object"
+    assert result == "test.object"
 
-    tpl = template.Template(
-        """{{ is_state("test.object", ["on", "off", "available"]) }}""",
-        hass,
+    result = render(
+        hass, """{{ is_state("test.object", ["on", "off", "available"]) }}"""
     )
-    assert tpl.async_render() is True
+    assert result is True
 
 
 def test_is_state_attr(hass: HomeAssistant) -> None:
     """Test is_state_attr method."""
     hass.states.async_set("test.object", "available", {"mode": "on", "exists": None})
-    tpl = template.Template(
+
+    result = render(
+        hass,
         """{% if is_state_attr("test.object", "mode", "on") %}yes{% else %}no{% endif %}""",
-        hass,
     )
-    assert tpl.async_render() == "yes"
+    assert result == "yes"
 
-    tpl = template.Template(
-        """{{ is_state_attr("test.noobject", "mode", "on") }}""",
+    result = render(hass, """{{ is_state_attr("test.noobject", "mode", "on") }}""")
+    assert result is False
+
+    result = render(
         hass,
-    )
-    assert tpl.async_render() is False
-
-    tpl = template.Template(
         """{% if "test.object" is is_state_attr("mode", "on") %}yes{% else %}no{% endif %}""",
-        hass,
     )
-    assert tpl.async_render() == "yes"
+    assert result == "yes"
 
-    tpl = template.Template(
+    result = render(
+        hass,
         """{{ ['test.object'] | select("is_state_attr", "mode", "on") | first | default }}""",
-        hass,
     )
-    assert tpl.async_render() == "test.object"
+    assert result == "test.object"
 
-    tpl = template.Template(
+    result = render(
+        hass,
         """{% if is_state_attr("test.object", "exists", None) %}yes{% else %}no{% endif %}""",
-        hass,
     )
-    assert tpl.async_render() == "yes"
+    assert result == "yes"
 
-    tpl = template.Template(
-        """{% if is_state_attr("test.object", "noexist", None) %}yes{% else %}no{% endif %}""",
+    result = render(
         hass,
+        """{% if is_state_attr("test.object", "noexist", None) %}yes{% else %}no{% endif %}""",
     )
-    assert tpl.async_render() == "no"
+    assert result == "no"
 
 
 def test_state_attr(hass: HomeAssistant) -> None:
@@ -1225,51 +1221,47 @@ def test_state_attr(hass: HomeAssistant) -> None:
     hass.states.async_set(
         "test.object", "available", {"effect": "action", "mode": "on"}
     )
-    tpl = template.Template(
+
+    result = render(
+        hass,
         """{% if state_attr("test.object", "mode") == "on" %}yes{% else %}no{% endif %}""",
-        hass,
     )
-    assert tpl.async_render() == "yes"
+    assert result == "yes"
 
-    tpl = template.Template(
-        """{{ state_attr("test.noobject", "mode") == None }}""",
+    result = render(hass, """{{ state_attr("test.noobject", "mode") == None }}""")
+    assert result is True
+
+    result = render(
         hass,
-    )
-    assert tpl.async_render() is True
-
-    tpl = template.Template(
         """{% if "test.object" | state_attr("mode") == "on" %}yes{% else %}no{% endif %}""",
-        hass,
     )
-    assert tpl.async_render() == "yes"
+    assert result == "yes"
 
-    tpl = template.Template(
-        """{{ ['test.object'] | map("state_attr", "effect") | first | default }}""",
+    result = render(
         hass,
+        """{{ ['test.object'] | map("state_attr", "effect") | first | default }}""",
     )
-    assert tpl.async_render() == "action"
+    assert result == "action"
 
 
 def test_states_function(hass: HomeAssistant) -> None:
     """Test using states as a function."""
     hass.states.async_set("test.object", "available")
-    tpl = template.Template('{{ states("test.object") }}', hass)
-    assert tpl.async_render() == "available"
 
-    tpl2 = template.Template('{{ states("test.object2") }}', hass)
-    assert tpl2.async_render() == "unknown"
+    result = render(hass, '{{ states("test.object") }}')
+    assert result == "available"
 
-    tpl = template.Template(
+    result = render(hass, '{{ states("test.object2") }}')
+    assert result == "unknown"
+
+    result = render(
+        hass,
         """{% if "test.object" | states == "available" %}yes{% else %}no{% endif %}""",
-        hass,
     )
-    assert tpl.async_render() == "yes"
+    assert result == "yes"
 
-    tpl = template.Template(
-        """{{ ['test.object'] | map("states") | first | default }}""",
-        hass,
-    )
-    assert tpl.async_render() == "available"
+    result = render(hass, """{{ ['test.object'] | map("states") | first | default }}""")
+    assert result == "available"
 
 
 async def test_state_translated(
@@ -1324,31 +1316,27 @@ async def test_state_translated(
     )
     hass.states.async_set("light.hue_5678", "on", attributes={})
 
-    tpl = template.Template(
-        '{{ state_translated("switch.without_translations") }}', hass
-    )
-    assert tpl.async_render() == "on"
+    result = render(hass, '{{ state_translated("switch.without_translations") }}')
+    assert result == "on"
 
-    tp2 = template.Template(
-        '{{ state_translated("binary_sensor.without_device_class") }}', hass
+    result = render(
+        hass, '{{ state_translated("binary_sensor.without_device_class") }}'
     )
-    assert tp2.async_render() == "On"
+    assert result == "On"
 
-    tpl3 = template.Template(
-        '{{ state_translated("binary_sensor.with_device_class") }}', hass
-    )
-    assert tpl3.async_render() == "Detected"
+    result = render(hass, '{{ state_translated("binary_sensor.with_device_class") }}')
+    assert result == "Detected"
 
-    tpl4 = template.Template(
-        '{{ state_translated("binary_sensor.with_unknown_device_class") }}', hass
+    result = render(
+        hass, '{{ state_translated("binary_sensor.with_unknown_device_class") }}'
     )
-    assert tpl4.async_render() == "On"
+    assert result == "On"
 
     with pytest.raises(TemplateError):
         render(hass, '{{ state_translated("contextfunction") }}')
 
-    tpl6 = template.Template('{{ state_translated("switch.invalid") }}', hass)
-    assert tpl6.async_render() == "unknown"
+    result = render(hass, '{{ state_translated("switch.invalid") }}')
+    assert result == "unknown"
 
     with pytest.raises(TemplateError):
         render(hass, '{{ state_translated("-invalid") }}')
@@ -1369,14 +1357,14 @@ async def test_state_translated(
         "homeassistant.helpers.translation.async_get_cached_translations",
         side_effect=mock_get_cached_translations,
     ):
-        tpl8 = template.Template('{{ state_translated("light.hue_5678") }}', hass)
-        assert tpl8.async_render() == "state_is_on"
+        result = render(hass, '{{ state_translated("light.hue_5678") }}')
+        assert result == "state_is_on"
 
-    tpl11 = template.Template('{{ state_translated("domain.is_unavailable") }}', hass)
-    assert tpl11.async_render() == "unavailable"
+    result = render(hass, '{{ state_translated("domain.is_unavailable") }}')
+    assert result == "unavailable"
 
-    tpl12 = template.Template('{{ state_translated("domain.is_unknown") }}', hass)
-    assert tpl12.async_render() == "unknown"
+    result = render(hass, '{{ state_translated("domain.is_unknown") }}')
+    assert result == "unknown"
 
 
 def test_has_value(hass: HomeAssistant) -> None:
@@ -1384,29 +1372,19 @@ def test_has_value(hass: HomeAssistant) -> None:
     hass.states.async_set("test.value1", 1)
     hass.states.async_set("test.unavailable", STATE_UNAVAILABLE)
 
-    tpl = template.Template(
-        """{{ has_value("test.value1") }}""",
-        hass,
-    )
-    assert tpl.async_render() is True
+    result = render(hass, """{{ has_value("test.value1") }}""")
+    assert result is True
 
-    tpl = template.Template(
-        """{{ has_value("test.unavailable") }}""",
-        hass,
-    )
-    assert tpl.async_render() is False
+    result = render(hass, """{{ has_value("test.unavailable") }}""")
+    assert result is False
 
-    tpl = template.Template(
-        """{{ has_value("test.unknown") }}""",
-        hass,
-    )
-    assert tpl.async_render() is False
+    result = render(hass, """{{ has_value("test.unknown") }}""")
+    assert result is False
 
-    tpl = template.Template(
-        """{% if "test.value1" is has_value %}yes{% else %}no{% endif %}""",
-        hass,
+    result = render(
+        hass, """{% if "test.value1" is has_value %}yes{% else %}no{% endif %}"""
     )
-    assert tpl.async_render() == "yes"
+    assert result == "yes"
 
 
 @patch(
@@ -2086,8 +2064,9 @@ def test_distance_function_with_1_state(hass: HomeAssistant) -> None:
     hass.states.async_set(
         "test.object", "happy", {"latitude": 32.87336, "longitude": -117.22943}
     )
-    tpl = template.Template("{{ distance(states.test.object) | round }}", hass)
-    assert tpl.async_render() == 187
+
+    result = render(hass, "{{ distance(states.test.object) | round }}")
+    assert result == 187
 
 
 def test_distance_function_with_2_states(hass: HomeAssistant) -> None:
@@ -2101,17 +2080,19 @@ def test_distance_function_with_2_states(hass: HomeAssistant) -> None:
         "happy",
         {"latitude": hass.config.latitude, "longitude": hass.config.longitude},
     )
-    tpl = template.Template(
-        "{{ distance(states.test.object, states.test.object_2) | round }}", hass
+
+    result = render(
+        hass, "{{ distance(states.test.object, states.test.object_2) | round }}"
     )
-    assert tpl.async_render() == 187
+    assert result == 187
 
 
 def test_distance_function_with_1_coord(hass: HomeAssistant) -> None:
     """Test distance function with 1 coord."""
     _set_up_units(hass)
-    tpl = template.Template('{{ distance("32.87336", "-117.22943") | round }}', hass)
-    assert tpl.async_render() == 187
+
+    result = render(hass, '{{ distance("32.87336", "-117.22943") | round }}')
+    assert result == 187
 
 
 def test_distance_function_with_2_coords(hass: HomeAssistant) -> None:
@@ -2134,17 +2115,16 @@ def test_distance_function_with_1_state_1_coord(hass: HomeAssistant) -> None:
         "happy",
         {"latitude": hass.config.latitude, "longitude": hass.config.longitude},
     )
-    tpl = template.Template(
-        '{{ distance("32.87336", "-117.22943", states.test.object_2) | round }}',
-        hass,
-    )
-    assert tpl.async_render() == 187
 
-    tpl2 = template.Template(
-        '{{ distance(states.test.object_2, "32.87336", "-117.22943") | round }}',
-        hass,
+    result = render(
+        hass, '{{ distance("32.87336", "-117.22943", states.test.object_2) | round }}'
     )
-    assert tpl2.async_render() == 187
+    assert result == 187
+
+    result = render(
+        hass, '{{ distance(states.test.object_2, "32.87336", "-117.22943") | round }}'
+    )
+    assert result == 187
 
 
 def test_distance_function_return_none_if_invalid_state(hass: HomeAssistant) -> None:
@@ -2166,8 +2146,9 @@ def test_distance_function_return_none_if_invalid_coord(hass: HomeAssistant) -> 
         "happy",
         {"latitude": hass.config.latitude, "longitude": hass.config.longitude},
     )
-    tpl = template.Template('{{ distance("123", states.test_object_2) }}', hass)
-    assert tpl.async_render() is None
+
+    result = render(hass, '{{ distance("123", states.test_object_2) }}')
+    assert result is None
 
 
 def test_distance_function_with_2_entity_ids(hass: HomeAssistant) -> None:
@@ -2181,10 +2162,9 @@ def test_distance_function_with_2_entity_ids(hass: HomeAssistant) -> None:
         "happy",
         {"latitude": hass.config.latitude, "longitude": hass.config.longitude},
     )
-    tpl = template.Template(
-        '{{ distance("test.object", "test.object_2") | round }}', hass
-    )
-    assert tpl.async_render() == 187
+
+    result = render(hass, '{{ distance("test.object", "test.object_2") | round }}')
+    assert result == 187
 
 
 def test_distance_function_with_1_entity_1_coord(hass: HomeAssistant) -> None:
@@ -2195,10 +2175,11 @@ def test_distance_function_with_1_entity_1_coord(hass: HomeAssistant) -> None:
         "happy",
         {"latitude": hass.config.latitude, "longitude": hass.config.longitude},
     )
-    tpl = template.Template(
-        '{{ distance("test.object", "32.87336", "-117.22943") | round }}', hass
+
+    result = render(
+        hass, '{{ distance("test.object", "32.87336", "-117.22943") | round }}'
     )
-    assert tpl.async_render() == 187
+    assert result == 187
 
 
 def test_closest_function_home_vs_domain(hass: HomeAssistant) -> None:
@@ -3367,19 +3348,17 @@ def test_closest_function_to_coord(hass: HomeAssistant) -> None:
         },
     )
 
-    tpl = template.Template(
+    result = render(
+        hass,
         f'{{{{ closest("{hass.config.latitude + 0.3}", {hass.config.longitude + 0.3}, states.test_domain).entity_id }}}}',
-        hass,
     )
+    assert result == "test_domain.closest_zone"
 
-    assert tpl.async_render() == "test_domain.closest_zone"
-
-    tpl = template.Template(
+    result = render(
+        hass,
         f'{{{{ (states.test_domain | closest("{hass.config.latitude + 0.3}", {hass.config.longitude + 0.3})).entity_id }}}}',
-        hass,
     )
-
-    assert tpl.async_render() == "test_domain.closest_zone"
+    assert result == "test_domain.closest_zone"
 
 
 def test_async_render_to_info_with_branching(hass: HomeAssistant) -> None:
@@ -3856,23 +3835,19 @@ def test_state_with_unit(hass: HomeAssistant) -> None:
     hass.states.async_set("sensor.test", "23", {ATTR_UNIT_OF_MEASUREMENT: "beers"})
     hass.states.async_set("sensor.test2", "wow")
 
-    tpl = template.Template("{{ states.sensor.test.state_with_unit }}", hass)
+    result = render(hass, "{{ states.sensor.test.state_with_unit }}")
+    assert result == "23 beers"
 
-    assert tpl.async_render() == "23 beers"
+    result = render(hass, "{{ states.sensor.test2.state_with_unit }}")
+    assert result == "wow"
 
-    tpl = template.Template("{{ states.sensor.test2.state_with_unit }}", hass)
-
-    assert tpl.async_render() == "wow"
-
-    tpl = template.Template(
-        "{% for state in states %}{{ state.state_with_unit }} {% endfor %}", hass
+    result = render(
+        hass, "{% for state in states %}{{ state.state_with_unit }} {% endfor %}"
     )
+    assert result == "23 beers wow"
 
-    assert tpl.async_render() == "23 beers wow"
-
-    tpl = template.Template("{{ states.sensor.non_existing.state_with_unit }}", hass)
-
-    assert tpl.async_render() == ""
+    result = render(hass, "{{ states.sensor.non_existing.state_with_unit }}")
+    assert result == ""
 
 
 def test_state_with_unit_and_rounding(
@@ -3998,11 +3973,11 @@ def test_length_of_states(hass: HomeAssistant) -> None:
     hass.states.async_set("sensor.test2", "wow")
     hass.states.async_set("climate.test2", "cooling")
 
-    tpl = template.Template("{{ states | length }}", hass)
-    assert tpl.async_render() == 3
+    result = render(hass, "{{ states | length }}")
+    assert result == 3
 
-    tpl = template.Template("{{ states.sensor | length }}", hass)
-    assert tpl.async_render() == 2
+    result = render(hass, "{{ states.sensor | length }}")
+    assert result == 2
 
 
 def test_render_complex_handling_non_template_values(hass: HomeAssistant) -> None:
@@ -4014,46 +3989,48 @@ def test_render_complex_handling_non_template_values(hass: HomeAssistant) -> Non
 
 def test_as_timedelta(hass: HomeAssistant) -> None:
     """Test the as_timedelta function/filter."""
-    tpl = template.Template("{{ as_timedelta('PT10M') }}", hass)
-    assert tpl.async_render() == "0:10:00"
 
-    tpl = template.Template("{{ 'PT10M' | as_timedelta }}", hass)
-    assert tpl.async_render() == "0:10:00"
+    result = render(hass, "{{ as_timedelta('PT10M') }}")
+    assert result == "0:10:00"
 
-    tpl = template.Template("{{ 'T10M' | as_timedelta }}", hass)
-    assert tpl.async_render() is None
+    result = render(hass, "{{ 'PT10M' | as_timedelta }}")
+    assert result == "0:10:00"
+
+    result = render(hass, "{{ 'T10M' | as_timedelta }}")
+    assert result is None
 
 
 def test_iif(hass: HomeAssistant) -> None:
     """Test the immediate if function/filter."""
-    tpl = template.Template("{{ (1 == 1) | iif }}", hass)
-    assert tpl.async_render() is True
 
-    tpl = template.Template("{{ (1 == 2) | iif }}", hass)
-    assert tpl.async_render() is False
+    result = render(hass, "{{ (1 == 1) | iif }}")
+    assert result is True
 
-    tpl = template.Template("{{ (1 == 1) | iif('yes') }}", hass)
-    assert tpl.async_render() == "yes"
+    result = render(hass, "{{ (1 == 2) | iif }}")
+    assert result is False
 
-    tpl = template.Template("{{ (1 == 2) | iif('yes') }}", hass)
-    assert tpl.async_render() is False
+    result = render(hass, "{{ (1 == 1) | iif('yes') }}")
+    assert result == "yes"
 
-    tpl = template.Template("{{ (1 == 2) | iif('yes', 'no') }}", hass)
-    assert tpl.async_render() == "no"
+    result = render(hass, "{{ (1 == 2) | iif('yes') }}")
+    assert result is False
 
-    tpl = template.Template("{{ not_exists | default(None) | iif('yes', 'no') }}", hass)
-    assert tpl.async_render() == "no"
+    result = render(hass, "{{ (1 == 2) | iif('yes', 'no') }}")
+    assert result == "no"
 
-    tpl = template.Template(
-        "{{ not_exists | default(None) | iif('yes', 'no', 'unknown') }}", hass
+    result = render(hass, "{{ not_exists | default(None) | iif('yes', 'no') }}")
+    assert result == "no"
+
+    result = render(
+        hass, "{{ not_exists | default(None) | iif('yes', 'no', 'unknown') }}"
     )
-    assert tpl.async_render() == "unknown"
+    assert result == "unknown"
 
-    tpl = template.Template("{{ iif(1 == 1) }}", hass)
-    assert tpl.async_render() is True
+    result = render(hass, "{{ iif(1 == 1) }}")
+    assert result is True
 
-    tpl = template.Template("{{ iif(1 == 2, 'yes', 'no') }}", hass)
-    assert tpl.async_render() == "no"
+    result = render(hass, "{{ iif(1 == 2, 'yes', 'no') }}")
+    assert result == "no"
 
 
 @pytest.mark.usefixtures("hass")
@@ -4151,15 +4128,15 @@ async def test_slice_states(hass: HomeAssistant) -> None:
     """Test iterating states with a slice."""
     hass.states.async_set("sensor.test", "23")
 
-    tpl = template.Template(
+    result = render(
+        hass,
         (
             "{% for states in states | slice(1) -%}{% set state = states | first %}"
             "{{ state.entity_id }}"
             "{%- endfor %}"
         ),
-        hass,
     )
-    assert tpl.async_render() == "sensor.test"
+    assert result == "sensor.test"
 
 
 async def test_lifecycle(hass: HomeAssistant) -> None:
@@ -4280,41 +4257,23 @@ async def test_state_attributes(hass: HomeAssistant) -> None:
     """Test state attributes."""
     hass.states.async_set("sensor.test", "23")
 
-    tpl = template.Template(
-        "{{ states.sensor.test.last_changed }}",
-        hass,
-    )
-    assert tpl.async_render() == str(hass.states.get("sensor.test").last_changed)
+    result = render(hass, "{{ states.sensor.test.last_changed }}")
+    assert result == str(hass.states.get("sensor.test").last_changed)
 
-    tpl = template.Template(
-        "{{ states.sensor.test.object_id }}",
-        hass,
-    )
-    assert tpl.async_render() == hass.states.get("sensor.test").object_id
+    result = render(hass, "{{ states.sensor.test.object_id }}")
+    assert result == hass.states.get("sensor.test").object_id
 
-    tpl = template.Template(
-        "{{ states.sensor.test.domain }}",
-        hass,
-    )
-    assert tpl.async_render() == hass.states.get("sensor.test").domain
+    result = render(hass, "{{ states.sensor.test.domain }}")
+    assert result == hass.states.get("sensor.test").domain
 
-    tpl = template.Template(
-        "{{ states.sensor.test.context.id }}",
-        hass,
-    )
-    assert tpl.async_render() == hass.states.get("sensor.test").context.id
+    result = render(hass, "{{ states.sensor.test.context.id }}")
+    assert result == hass.states.get("sensor.test").context.id
 
-    tpl = template.Template(
-        "{{ states.sensor.test.state_with_unit }}",
-        hass,
-    )
-    assert tpl.async_render() == 23
+    result = render(hass, "{{ states.sensor.test.state_with_unit }}")
+    assert result == 23
 
-    tpl = template.Template(
-        "{{ states.sensor.test.invalid_prop }}",
-        hass,
-    )
-    assert tpl.async_render() == ""
+    result = render(hass, "{{ states.sensor.test.invalid_prop }}")
+    assert result == ""
 
     tpl = template.Template(
         "{{ states.sensor.test.invalid_prop.xx }}",
@@ -4334,25 +4293,25 @@ async def test_unavailable_states(hass: HomeAssistant) -> None:
     hass.states.async_set("light.unknown", "unknown")
     hass.states.async_set("light.none", "none")
 
-    tpl = template.Template(
+    result = render(
+        hass,
         (
             "{{ states | selectattr('state', 'in', ['unavailable','unknown','none']) "
             "| sort(attribute='entity_id') | map(attribute='entity_id') | list | join(', ') }}"
         ),
-        hass,
     )
-    assert tpl.async_render() == "light.none, light.unavailable, light.unknown"
+    assert result == "light.none, light.unavailable, light.unknown"
 
-    tpl = template.Template(
+    result = render(
+        hass,
         (
             "{{ states.light "
             "| selectattr('state', 'in', ['unavailable','unknown','none']) "
             "| sort(attribute='entity_id') | map(attribute='entity_id') | list "
             "| join(', ') }}"
         ),
-        hass,
     )
-    assert tpl.async_render() == "light.none, light.unavailable, light.unknown"
+    assert result == "light.none, light.unavailable, light.unknown"
 
 
 async def test_no_result_parsing(hass: HomeAssistant) -> None:
@@ -4440,8 +4399,9 @@ async def test_undefined_symbol_warnings(
     template_string: str,
 ) -> None:
     """Test a warning is logged on undefined variables."""
-    tpl = template.Template(template_string, hass)
-    assert tpl.async_render() == ""
+
+    result = render(hass, template_string)
+    assert result == ""
     assert (
         "Template variable warning: 'no_such_variable' is undefined when rendering "
         f"'{template_string}'" in caplog.text
@@ -5471,8 +5431,9 @@ async def test_response_empty_dict(
 
     service_response = {}
     _template = "{{ merge_response(" + str(service_response) + ") }}"
-    tpl = template.Template(_template, hass)
-    assert tpl.async_render() == []
+
+    result = render(hass, _template)
+    assert result == []
 
 
 async def test_response_incorrect_value(

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -1382,7 +1382,7 @@ def test_now(mock_is_safe, hass: HomeAssistant) -> None:
     """Test now method."""
     now = dt_util.now()
     with freeze_time(now):
-        info = template.Template("{{ now().isoformat() }}", hass).async_render_to_info()
+        info = render_to_info(hass, "{{ now().isoformat() }}")
         assert now.isoformat() == info.result()
 
     assert info.has_time is True
@@ -1396,9 +1396,7 @@ def test_utcnow(mock_is_safe, hass: HomeAssistant) -> None:
     """Test now method."""
     utcnow = dt_util.utcnow()
     with freeze_time(utcnow):
-        info = template.Template(
-            "{{ utcnow().isoformat() }}", hass
-        ).async_render_to_info()
+        info = render_to_info(hass, "{{ utcnow().isoformat() }}")
         assert utcnow.isoformat() == info.result()
 
     assert info.has_time is True
@@ -1451,9 +1449,7 @@ async def test_today_at(
     with pytest.raises(TemplateError):
         render(hass, "{{ today_at('bad') }}")
 
-    info = template.Template(
-        "{{ today_at('10:00').isoformat() }}", hass
-    ).async_render_to_info()
+    info = render_to_info(hass, "{{ today_at('10:00').isoformat() }}")
     assert info.has_time is True
 
     freezer.stop()
@@ -1556,7 +1552,7 @@ async def test_relative_time(mock_is_safe, hass: HomeAssistant) -> None:
         )
         assert result == "2000-01-01 11:00:00+00:00"
 
-        info = template.Template(relative_time_template, hass).async_render_to_info()
+        info = render_to_info(hass, relative_time_template)
         assert info.has_time is True
 
 
@@ -1713,7 +1709,7 @@ async def test_time_since(mock_is_safe, hass: HomeAssistant) -> None:
         result = render(hass, '{{time_since("string")}}')
         assert result == "string"
 
-        info = template.Template(time_since_template, hass).async_render_to_info()
+        info = render_to_info(hass, time_since_template)
         assert info.has_time is True
 
 
@@ -1871,7 +1867,7 @@ async def test_time_until(mock_is_safe, hass: HomeAssistant) -> None:
         result = render(hass, '{{time_until("string")}}')
         assert result == "string"
 
-        info = template.Template(time_until_template, hass).async_render_to_info()
+        info = render_to_info(hass, time_until_template)
         assert info.has_time is True
 
 
@@ -3685,15 +3681,14 @@ def test_generate_select(hass: HomeAssistant) -> None:
 |join(",", attribute="entity_id") }}
         """
 
-    tmp = template.Template(template_str, hass)
-    info = tmp.async_render_to_info()
+    info = render_to_info(hass, template_str)
     assert_result_info(info, "", [], [])
     assert info.domains_lifecycle == {"sensor"}
 
     hass.states.async_set("sensor.test_sensor", "off", {"attr": "value"})
     hass.states.async_set("sensor.test_sensor_on", "on")
 
-    info = tmp.async_render_to_info()
+    info = render_to_info(hass, template_str)
     assert_result_info(
         info,
         "sensor.test_sensor",
@@ -3705,12 +3700,7 @@ def test_generate_select(hass: HomeAssistant) -> None:
 
 async def test_async_render_to_info_in_conditional(hass: HomeAssistant) -> None:
     """Test extract entities function with none entities stuff."""
-    template_str = """
-{{ states("sensor.xyz") == "dog" }}
-        """
-
-    tmp = template.Template(template_str, hass)
-    info = tmp.async_render_to_info()
+    info = render_to_info(hass, '{{ states("sensor.xyz") == "dog" }}')
     assert_result_info(info, False, ["sensor.xyz"], [])
 
     hass.states.async_set("sensor.xyz", "dog")
@@ -3725,8 +3715,7 @@ async def test_async_render_to_info_in_conditional(hass: HomeAssistant) -> None:
 {% endif %}
         """
 
-    tmp = template.Template(template_str, hass)
-    info = tmp.async_render_to_info()
+    info = render_to_info(hass, template_str)
     assert_result_info(info, True, ["sensor.xyz", "sensor.cow"], [])
 
     hass.states.async_set("sensor.xyz", "sheep")
@@ -3734,8 +3723,7 @@ async def test_async_render_to_info_in_conditional(hass: HomeAssistant) -> None:
 
     await hass.async_block_till_done()
 
-    tmp = template.Template(template_str, hass)
-    info = tmp.async_render_to_info()
+    info = render_to_info(hass, template_str)
     assert_result_info(info, "oink", ["sensor.xyz", "sensor.pig"], [])
 
 
@@ -4079,9 +4067,7 @@ async def test_lifecycle(hass: HomeAssistant) -> None:
 
     await hass.async_block_till_done()
 
-    tmp = template.Template("{{ states | count }}", hass)
-
-    info = tmp.async_render_to_info()
+    info = render_to_info(hass, "{{ states | count }}")
     assert info.all_states is False
     assert info.all_states_lifecycle is True
     assert info.rate_limit is None
@@ -4149,8 +4135,7 @@ async def test_lights(hass: HomeAssistant) -> None:
         states.append(f"light.sensor{i}")
         hass.states.async_set(f"light.sensor{i}", "on")
 
-    tmp = template.Template(tmpl, hass)
-    info = tmp.async_render_to_info()
+    info = render_to_info(hass, tmpl)
     assert info.entities == set()
     assert info.domains == {"light"}
 

--- a/tests/helpers/template/test_render_info.py
+++ b/tests/helpers/template/test_render_info.py
@@ -17,9 +17,14 @@ from homeassistant.helpers.template.render_info import (
 )
 
 
-def test_render_info_initialization(hass: HomeAssistant) -> None:
+@pytest.fixture
+def template_obj(hass: HomeAssistant) -> template.Template:
+    """Template object for test_render_info."""
+    return template.Template("{{ 1 + 1 }}", hass)
+
+
+def test_render_info_initialization(template_obj: template.Template) -> None:
     """Test RenderInfo initialization."""
-    template_obj = template.Template("{{ 1 + 1 }}", hass)
     info = RenderInfo(template_obj)
 
     assert info.template is template_obj
@@ -37,9 +42,8 @@ def test_render_info_initialization(hass: HomeAssistant) -> None:
     assert info.filter is _true
 
 
-def test_render_info_repr(hass: HomeAssistant) -> None:
+def test_render_info_repr(template_obj: template.Template) -> None:
     """Test RenderInfo representation."""
-    template_obj = template.Template("{{ 1 + 1 }}", hass)
     info = RenderInfo(template_obj)
     info.domains.add("sensor")
     info.entities.add("sensor.test")
@@ -50,9 +54,8 @@ def test_render_info_repr(hass: HomeAssistant) -> None:
     assert "entities={'sensor.test'}" in repr_str
 
 
-def test_render_info_result(hass: HomeAssistant) -> None:
+def test_render_info_result(template_obj: template.Template) -> None:
     """Test RenderInfo result property."""
-    template_obj = template.Template("{{ 1 + 1 }}", hass)
     info = RenderInfo(template_obj)
 
     # Test with no result set - should return None cast as str
@@ -68,9 +71,10 @@ def test_render_info_result(hass: HomeAssistant) -> None:
         info.result()
 
 
-def test_render_info_filter_domains_and_entities(hass: HomeAssistant) -> None:
+def test_render_info_filter_domains_and_entities(
+    template_obj: template.Template,
+) -> None:
     """Test RenderInfo entity and domain filtering."""
-    template_obj = template.Template("{{ 1 + 1 }}", hass)
     info = RenderInfo(template_obj)
 
     # Add domain and entity
@@ -85,9 +89,8 @@ def test_render_info_filter_domains_and_entities(hass: HomeAssistant) -> None:
     assert info._filter_domains_and_entities("switch.kitchen") is False
 
 
-def test_render_info_filter_entities(hass: HomeAssistant) -> None:
+def test_render_info_filter_entities(template_obj: template.Template) -> None:
     """Test RenderInfo entity-only filtering."""
-    template_obj = template.Template("{{ 1 + 1 }}", hass)
     info = RenderInfo(template_obj)
 
     info.entities.add("sensor.test")
@@ -96,9 +99,8 @@ def test_render_info_filter_entities(hass: HomeAssistant) -> None:
     assert info._filter_entities("sensor.other") is False
 
 
-def test_render_info_filter_lifecycle_domains(hass: HomeAssistant) -> None:
+def test_render_info_filter_lifecycle_domains(template_obj: template.Template) -> None:
     """Test RenderInfo domain lifecycle filtering."""
-    template_obj = template.Template("{{ 1 + 1 }}", hass)
     info = RenderInfo(template_obj)
 
     info.domains_lifecycle.add("sensor")
@@ -107,9 +109,8 @@ def test_render_info_filter_lifecycle_domains(hass: HomeAssistant) -> None:
     assert info._filter_lifecycle_domains("light.test") is False
 
 
-def test_render_info_freeze_static(hass: HomeAssistant) -> None:
+def test_render_info_freeze_static(template_obj: template.Template) -> None:
     """Test RenderInfo static freezing."""
-    template_obj = template.Template("{{ 1 + 1 }}", hass)
     info = RenderInfo(template_obj)
 
     info.domains.add("sensor")
@@ -124,9 +125,8 @@ def test_render_info_freeze_static(hass: HomeAssistant) -> None:
     assert isinstance(info.entities, frozenset)
 
 
-def test_render_info_freeze(hass: HomeAssistant) -> None:
+def test_render_info_freeze(template_obj: template.Template) -> None:
     """Test RenderInfo freezing with rate limits."""
-    template_obj = template.Template("{{ 1 + 1 }}", hass)
     info = RenderInfo(template_obj)
 
     # Test all_states rate limit
@@ -147,9 +147,8 @@ def test_render_info_freeze(hass: HomeAssistant) -> None:
     assert info.rate_limit == ALL_STATES_RATE_LIMIT
 
 
-def test_render_info_freeze_filters(hass: HomeAssistant) -> None:
+def test_render_info_freeze_filters(template_obj: template.Template) -> None:
     """Test RenderInfo filter assignment during freeze."""
-    template_obj = template.Template("{{ 1 + 1 }}", hass)
 
     # Test lifecycle filter assignment
     info = RenderInfo(template_obj)
@@ -180,13 +179,12 @@ def test_render_info_freeze_filters(hass: HomeAssistant) -> None:
     assert info.filter is _false
 
 
-def test_render_info_context_var(hass: HomeAssistant) -> None:
+def test_render_info_context_var(template_obj: template.Template) -> None:
     """Test render_info_cv context variable."""
     # Should start as None
     assert render_info_cv.get() is None
 
     # Test setting and getting
-    template_obj = template.Template("{{ 1 + 1 }}", hass)
     info = RenderInfo(template_obj)
     render_info_cv.set(info)
     assert render_info_cv.get() is info


### PR DESCRIPTION
## Proposed change

This PR follows up on #154366 (which follows up on #152266, #152417, #152420, #152446, #152630, #152661) and is tangentially related to #154537 (which already uses these helpers in tests).

It refactors the test code for templates to broadly use the test helper functions that were refactored in #154366.

As mentioned in each commit, some of this was done mechanically with `ast-grep` and `ruff` fixes (see [this gist](https://gist.github.com/akx/64d8da89c361e793897314e504822fa3) for the mentioned ag-01-fix-simple-render-v2.yaml fix file if you're interested), and some of it was done by hand. No AI was tortured for these fixes.

Result: ~725 lines removed from the tests, coverage over `homeassistant/helpers/template` remains exactly the same as in current `dev` (f210bb35ed9a829d930b80ff2a821f872ffea3b4).


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #154366

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
  - It's all tests! 
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.
  - No generated code here! 

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
