### PR TITLE
Add config flow exceptions to IOMeter

### DIFF
--- a/homeassistant/components/iometer/strings.json
+++ b/homeassistant/components/iometer/strings.json
@@ -20,6 +20,8 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]"
     },
     "error": {
+      "no_status": "No status received from the IOmeter. Check your device status in the IOmeter App",
+      "no_readings": "No readings received from the IOmeter. Please attach the Core to the electricity meter and wait for the first reading.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }

--- a/homeassistant/components/iometer/strings.json
+++ b/homeassistant/components/iometer/strings.json
@@ -20,7 +20,7 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]"
     },
     "error": {
-      "no_status": "No status received from the IOmeter. Check your device status in the IOmeter App",
+      "no_status": "No status received from the IOmeter. Check your device status in the IOmeter app",
       "no_readings": "No readings received from the IOmeter. Please attach the Core to the electricity meter and wait for the first reading.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/homeassistant/components/iometer/strings.json
+++ b/homeassistant/components/iometer/strings.json
@@ -21,7 +21,7 @@
     },
     "error": {
       "no_status": "No status received from the IOmeter. Check your device status in the IOmeter app",
-      "no_readings": "No readings received from the IOmeter. Please attach the Core to the electricity meter and wait for the first reading.",
+      "no_readings": "No readings received from the IOmeter. Please attach the IOmeter Core to the electricity meter and wait for the first reading.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }

--- a/tests/components/iometer/test_config_flow.py
+++ b/tests/components/iometer/test_config_flow.py
@@ -217,7 +217,7 @@ async def test_user_flow_no_readings(
     mock_setup_entry: AsyncMock,
 ) -> None:
     """Test flow error due to no readings received."""
-    mock_iometer_client.get_current_status.side_effect = IOmeterNoReadingsError()
+    mock_iometer_client.get_current_reading.side_effect = IOmeterNoReadingsError()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -236,7 +236,7 @@ async def test_user_flow_no_readings(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "no_readings"}
 
-    mock_iometer_client.get_current_status.side_effect = None
+    mock_iometer_client.get_current_reading.side_effect = None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/iometer/test_config_flow.py
+++ b/tests/components/iometer/test_config_flow.py
@@ -4,7 +4,6 @@ from ipaddress import ip_address
 from unittest.mock import AsyncMock
 
 from iometer import IOmeterConnectionError, IOmeterNoReadingsError, IOmeterNoStatusError
-import pytest
 
 from homeassistant.components import zeroconf
 from homeassistant.components.iometer.const import DOMAIN
@@ -94,28 +93,12 @@ async def test_zeroconf_flow_abort_duplicate(
     assert result["reason"] == "already_configured"
 
 
-@pytest.mark.parametrize(
-    ("exception", "reason"),
-    [
-        (IOmeterNoStatusError(), "no_status"),
-        (IOmeterNoReadingsError(), "no_readings"),
-        (IOmeterConnectionError(), "cannot_connect"),
-    ],
-)
-async def test_zeroconf_flow_abort_errors(
+async def test_zeroconf_flow_abort_no_status(
     hass: HomeAssistant,
-    mock_iometer_client: AsyncMock,
-    exception: Exception,
-    reason: str,
+    mock_iometer_client: MockConfigEntry,
 ) -> None:
-    """Test zeroconf flow aborts with various errors."""
-    if isinstance(exception, IOmeterNoStatusError):
-        mock_iometer_client.get_current_status.side_effect = exception
-    elif isinstance(exception, IOmeterNoReadingsError):
-        mock_iometer_client.get_current_reading.side_effect = exception
-    else:
-        mock_iometer_client.get_current_status.side_effect = exception
-
+    """Test zeroconf flow aborts because no status exception was raised."""
+    mock_iometer_client.get_current_status.side_effect = IOmeterNoStatusError()
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
@@ -123,7 +106,39 @@ async def test_zeroconf_flow_abort_errors(
     )
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == reason
+    assert result["reason"] == "no_status"
+
+
+async def test_zeroconf_flow_abort_no_readings(
+    hass: HomeAssistant,
+    mock_iometer_client: MockConfigEntry,
+) -> None:
+    """Test zeroconf flow aborts because no readings exception was raised."""
+    mock_iometer_client.get_current_reading.side_effect = IOmeterNoReadingsError()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_readings"
+
+
+async def test_zeroconf_flow_connection_error(
+    hass: HomeAssistant,
+    mock_iometer_client: AsyncMock,
+) -> None:
+    """Test zeroconf flow aborts with connection error."""
+    mock_iometer_client.get_current_status.side_effect = IOmeterConnectionError()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_user_flow_connection_error(
@@ -161,25 +176,13 @@ async def test_user_flow_connection_error(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.parametrize(
-    ("exception", "error_key"),
-    [
-        (IOmeterNoStatusError(), "no_status"),
-        (IOmeterNoReadingsError(), "no_readings"),
-    ],
-)
-async def test_user_flow_errors(
+async def test_user_flow_no_status(
     hass: HomeAssistant,
     mock_iometer_client: AsyncMock,
     mock_setup_entry: AsyncMock,
-    exception: Exception,
-    error_key: str,
 ) -> None:
-    """Test flow errors during user configuration."""
-    if isinstance(exception, IOmeterNoStatusError):
-        mock_iometer_client.get_current_status.side_effect = exception
-    else:
-        mock_iometer_client.get_current_reading.side_effect = exception
+    """Test flow error due to no status received."""
+    mock_iometer_client.get_current_status.side_effect = IOmeterNoStatusError()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -196,12 +199,44 @@ async def test_user_flow_errors(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": error_key}
+    assert result["errors"] == {"base": "no_status"}
 
-    if isinstance(exception, IOmeterNoStatusError):
-        mock_iometer_client.get_current_status.side_effect = None
-    else:
-        mock_iometer_client.get_current_reading.side_effect = None
+    mock_iometer_client.get_current_status.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: IP_ADDRESS},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_no_readings(
+    hass: HomeAssistant,
+    mock_iometer_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test flow error due to no readings received."""
+    mock_iometer_client.get_current_reading.side_effect = IOmeterNoReadingsError()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: IP_ADDRESS},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "no_readings"}
+
+    mock_iometer_client.get_current_reading.side_effect = None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR uses two new exceptions from the recently bumped iometer.py version (v0.2.0). Previously when HA tried to connect to a IOmeter device with no readings a `IOmeterConnectionError` was thrown. Most users didn't know the source of this issue. Therefore the exceptions with error messages are added.

When the IOmeter device has never been attached to a electricity meter, it subsequently has no readings of said meter. Therefore no meter number is known to the device. Previously an error was caused by this.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ x Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
