### PR TITLE
Add engine start/stop buttons to Volvo integration

### DIFF
--- a/homeassistant/components/volvo/button.py
+++ b/homeassistant/components/volvo/button.py
@@ -24,6 +24,7 @@ class VolvoButtonDescription(VolvoEntityDescription, ButtonEntityDescription):
 
     api_command: str
     required_command_key: str
+    data: dict[str, int] | None = None
 
 
 _DESCRIPTIONS: tuple[VolvoButtonDescription, ...] = (
@@ -36,6 +37,17 @@ _DESCRIPTIONS: tuple[VolvoButtonDescription, ...] = (
         key="climatization_stop",
         api_command="climatization-stop",
         required_command_key="CLIMATIZATION_STOP",
+    ),
+    VolvoButtonDescription(
+        key="engine_start",
+        api_command="engine-start",
+        required_command_key="ENGINE_START",
+        data={"runtimeMinutes": 15},
+    ),
+    VolvoButtonDescription(
+        key="engine_stop",
+        api_command="engine-stop",
+        required_command_key="ENGINE_STOP",
     ),
     VolvoButtonDescription(
         key="flash",
@@ -84,7 +96,7 @@ class VolvoButton(VolvoBaseEntity, ButtonEntity):
 
         try:
             result = await self.entry.runtime_data.context.api.async_execute_command(
-                self.entity_description.api_command
+                self.entity_description.api_command, self.entity_description.data
             )
         except VolvoApiException as ex:
             _LOGGER.debug("Command '%s' error", command)

--- a/homeassistant/components/volvo/icons.json
+++ b/homeassistant/components/volvo/icons.json
@@ -267,6 +267,12 @@
       "climatization_stop": {
         "default": "mdi:air-conditioner"
       },
+      "engine_start": {
+        "default": "mdi:engine"
+      },
+      "engine_stop": {
+        "default": "mdi:engine-off"
+      },
       "flash": {
         "default": "mdi:alarm-light-outline"
       },

--- a/homeassistant/components/volvo/strings.json
+++ b/homeassistant/components/volvo/strings.json
@@ -194,6 +194,12 @@
       "climatization_stop": {
         "name": "Stop climatization"
       },
+      "engine_start": {
+        "name": "Start engine"
+      },
+      "engine_stop": {
+        "name": "Stop engine"
+      },
       "flash": {
         "name": "Flash"
       },

--- a/tests/components/volvo/snapshots/test_button.ambr
+++ b/tests/components/volvo/snapshots/test_button.ambr
@@ -911,6 +911,54 @@
     'state': 'unknown',
   })
 # ---
+# name: test_button[xc90_petrol_2019][button.volvo_xc90_start_engine-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.volvo_xc90_start_engine',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Start engine',
+    'platform': 'volvo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'engine_start',
+    'unique_id': 'yv1abcdefg1234567_engine_start',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[xc90_petrol_2019][button.volvo_xc90_start_engine-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Volvo XC90 Start engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.volvo_xc90_start_engine',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_button[xc90_petrol_2019][button.volvo_xc90_stop_climatization-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -953,6 +1001,54 @@
     }),
     'context': <ANY>,
     'entity_id': 'button.volvo_xc90_stop_climatization',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[xc90_petrol_2019][button.volvo_xc90_stop_engine-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.volvo_xc90_stop_engine',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Stop engine',
+    'platform': 'volvo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'engine_stop',
+    'unique_id': 'yv1abcdefg1234567_engine_stop',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[xc90_petrol_2019][button.volvo_xc90_stop_engine-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Volvo XC90 Stop engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.volvo_xc90_stop_engine',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds back the buttons to start and stop the engine. They were [pulled from the original PR](https://github.com/home-assistant/core/pull/153272#discussion_r2394161292) to add the button platform.

I've asked the community to check if the `engine_status` changes to running if they start the engine remotely via the official app.  Of the x vehicles that were tested, only one claims that the sensor changes based on the start/stop engine action.

- https://github.com/orgs/home-assistant/discussions/1253#discussioncomment-14653606
- https://community.home-assistant.io/t/volvo-cars-integration/796417/413?u=thomas_be
- private chat with @lagge78

| Model | Sensor updates |
|--------|--------|
| XC90 Diesel MY19 | No |
| XC90 Diesel MY24 | No |
| XC90 PHEV MY25 | No |
| XC60 PHEV MY24 | No | 
| V90 PHEV MY25 | No | 
| V90CC D4 MY19 | No |
| Some PHEV | Yes | 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/orgs/home-assistant/discussions/1253
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41393
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
