### PR TITLE
Add Demo valves with position support

### DIFF
--- a/homeassistant/components/demo/valve.py
+++ b/homeassistant/components/demo/valve.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.valve import ValveEntity, ValveEntityFeature, ValveState
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_track_utc_time_change
 
 OPEN_CLOSE_DELAY = 2  # Used to give a realistic open/close experience in frontend
 
@@ -23,6 +25,8 @@ async def async_setup_entry(
         [
             DemoValve("Front Garden", ValveState.OPEN),
             DemoValve("Orchard", ValveState.CLOSED),
+            DemoValve("Back Garden", ValveState.CLOSED, position=70),
+            DemoValve("Trees", ValveState.CLOSED, position=30),
         ]
     )
 
@@ -37,6 +41,7 @@ class DemoValve(ValveEntity):
         name: str,
         state: str,
         moveable: bool = True,
+        position: int | None = None,
     ) -> None:
         """Initialize the valve."""
         self._attr_name = name
@@ -46,11 +51,23 @@ class DemoValve(ValveEntity):
             )
         self._state = state
         self._moveable = moveable
+        self._attr_reports_position = False
+        self._unsub_listener_valve: CALLBACK_TYPE | None = None
+        self._set_position: int = 0
+        self._position: int = 0
+        if position is None:
+            return
+
+        self._position = self._set_position = position
+        self._attr_reports_position = True
+        self._attr_supported_features |= (
+            ValveEntityFeature.SET_POSITION | ValveEntityFeature.STOP
+        )
 
     @property
-    def is_open(self) -> bool:
-        """Return true if valve is open."""
-        return self._state == ValveState.OPEN
+    def current_valve_position(self) -> int:
+        """Return current position of valve."""
+        return self._position
 
     @property
     def is_opening(self) -> bool:
@@ -67,11 +84,6 @@ class DemoValve(ValveEntity):
         """Return true if valve is closed."""
         return self._state == ValveState.CLOSED
 
-    @property
-    def reports_position(self) -> bool:
-        """Return True if entity reports position, False otherwise."""
-        return False
-
     async def async_open_valve(self, **kwargs: Any) -> None:
         """Open the valve."""
         self._state = ValveState.OPENING
@@ -86,4 +98,46 @@ class DemoValve(ValveEntity):
         self.async_write_ha_state()
         await asyncio.sleep(OPEN_CLOSE_DELAY)
         self._state = ValveState.CLOSED
+        self.async_write_ha_state()
+
+    async def async_stop_valve(self) -> None:
+        """Stop the valve."""
+        self._state = ValveState.OPEN if self._position > 0 else ValveState.CLOSED
+        if self._unsub_listener_valve is not None:
+            self._unsub_listener_valve()
+            self._unsub_listener_valve = None
+        self.async_write_ha_state()
+
+    async def async_set_valve_position(self, position: int) -> None:
+        """Move the valve to a specific position."""
+        if position == self._position:
+            return
+        if position > self._position:
+            self._state = ValveState.OPENING
+        else:
+            self._state = ValveState.CLOSING
+
+        self._set_position = round(position, -1)
+        self._listen_valve()
+        self.async_write_ha_state()
+
+    @callback
+    def _listen_valve(self) -> None:
+        """Listen for changes in valve."""
+        if self._unsub_listener_valve is None:
+            self._unsub_listener_valve = async_track_utc_time_change(
+                self.hass, self._time_changed_valve
+            )
+
+    async def _time_changed_valve(self, now: datetime) -> None:
+        """Track time changes."""
+        if self._state == ValveState.OPENING:
+            self._position += 10
+        elif self._state == ValveState.CLOSING:
+            self._position -= 10
+
+        if self._position in (100, 0, self._set_position):
+            await self.async_stop_valve()
+            return
+
         self.async_write_ha_state()

--- a/tests/components/demo/test_valve.py
+++ b/tests/components/demo/test_valve.py
@@ -1,24 +1,30 @@
 """The tests for the Demo valve platform."""
 
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components.demo import DOMAIN, valve as demo_valve
 from homeassistant.components.valve import (
+    ATTR_CURRENT_POSITION,
+    ATTR_POSITION,
     DOMAIN as VALVE_DOMAIN,
     SERVICE_CLOSE_VALVE,
     SERVICE_OPEN_VALVE,
+    SERVICE_SET_VALVE_POSITION,
     ValveState,
 )
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_STATE_CHANGED, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
-from tests.common import async_capture_events
+from tests.common import async_capture_events, async_fire_time_changed
 
 FRONT_GARDEN = "valve.front_garden"
 ORCHARD = "valve.orchard"
+BACK_GARDEN = "valve.back_garden"
 
 
 @pytest.fixture
@@ -81,3 +87,59 @@ async def test_opening(hass: HomeAssistant) -> None:
 
     assert state_changes[1].data["entity_id"] == ORCHARD
     assert state_changes[1].data["new_state"].state == ValveState.OPEN
+
+
+async def test_set_valve_position(hass: HomeAssistant) -> None:
+    """Test moving the valve to a specific position."""
+    state = hass.states.get(BACK_GARDEN)
+    assert state.attributes[ATTR_CURRENT_POSITION] == 70
+
+    # close to 10%
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_SET_VALVE_POSITION,
+        {ATTR_ENTITY_ID: BACK_GARDEN, ATTR_POSITION: 10},
+        blocking=True,
+    )
+    state = hass.states.get(BACK_GARDEN)
+    assert state.state == ValveState.CLOSING
+
+    for _ in range(6):
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(BACK_GARDEN)
+    assert state.attributes[ATTR_CURRENT_POSITION] == 10
+    assert state.state == ValveState.OPEN
+
+    # open to 80%
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_SET_VALVE_POSITION,
+        {ATTR_ENTITY_ID: BACK_GARDEN, ATTR_POSITION: 80},
+        blocking=True,
+    )
+    state = hass.states.get(BACK_GARDEN)
+    assert state.state == ValveState.OPENING
+
+    for _ in range(7):
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(BACK_GARDEN)
+    assert state.attributes[ATTR_CURRENT_POSITION] == 80
+    assert state.state == ValveState.OPEN
+
+    # test cover is at requested position
+    state_changes = async_capture_events(hass, EVENT_STATE_CHANGED)
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        SERVICE_SET_VALVE_POSITION,
+        {ATTR_ENTITY_ID: BACK_GARDEN, ATTR_POSITION: 80},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert len(state_changes) == 0

--- a/tests/components/demo/test_valve.py
+++ b/tests/components/demo/test_valve.py
@@ -132,7 +132,7 @@ async def test_set_valve_position(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_CURRENT_POSITION] == 80
     assert state.state == ValveState.OPEN
 
-    # test cover is at requested position
+    # test valve is at requested position
     state_changes = async_capture_events(hass, EVENT_STATE_CHANGED)
     await hass.services.async_call(
         VALVE_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I notice the Demo valve is very basic and does not simulate valves that support position, this PR adds 2 demo valves that supports position and simulation of movement when changing the valve position.

Note: I did not change the `async_open_valve` and `async_close_valve` (they currently simulate a valve that takes 2 seconds to change state) since if a valve supports position set the only service that is used to move the valve is `async_set_valve_position` (this defined by the base valve entity).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
