### PR TITLE
Revert "Adding __all__ export to device_tracker"

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from homeassistant.const import STATE_HOME
+from homeassistant.const import ATTR_GPS_ACCURACY, STATE_HOME  # noqa: F401
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
-from .config_entry import (
+from .config_entry import (  # noqa: F401
     ScannerEntity,
     ScannerEntityDescription,
     TrackerEntity,
@@ -15,7 +15,7 @@ from .config_entry import (
     async_setup_entry,
     async_unload_entry,
 )
-from .const import (
+from .const import (  # noqa: F401
     ATTR_ATTRIBUTES,
     ATTR_BATTERY,
     ATTR_DEV_ID,
@@ -37,7 +37,7 @@ from .const import (
     SCAN_INTERVAL,
     SourceType,
 )
-from .legacy import (
+from .legacy import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
     SERVICE_SEE,
@@ -61,44 +61,3 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the device tracker."""
     async_setup_legacy_integration(hass, config)
     return True
-
-
-__all__ = (
-    "ATTR_ATTRIBUTES",
-    "ATTR_BATTERY",
-    "ATTR_DEV_ID",
-    "ATTR_GPS",
-    "ATTR_HOST_NAME",
-    "ATTR_IP",
-    "ATTR_LOCATION_NAME",
-    "ATTR_MAC",
-    "ATTR_SOURCE_TYPE",
-    "CONF_CONSIDER_HOME",
-    "CONF_NEW_DEVICE_DEFAULTS",
-    "CONF_SCAN_INTERVAL",
-    "CONF_TRACK_NEW",
-    "CONNECTED_DEVICE_REGISTERED",
-    "DEFAULT_CONSIDER_HOME",
-    "DEFAULT_TRACK_NEW",
-    "DOMAIN",
-    "ENTITY_ID_FORMAT",
-    "PLATFORM_SCHEMA",
-    "PLATFORM_SCHEMA_BASE",
-    "SCAN_INTERVAL",
-    "SERVICE_SEE",
-    "SERVICE_SEE_PAYLOAD_SCHEMA",
-    "SOURCE_TYPES",
-    "AsyncSeeCallback",
-    "DeviceScanner",
-    "ScannerEntity",
-    "ScannerEntityDescription",
-    "SeeCallback",
-    "SourceType",
-    "TrackerEntity",
-    "TrackerEntityDescription",
-    "async_setup",
-    "async_setup_entry",
-    "async_unload_entry",
-    "is_on",
-    "see",
-)


### PR DESCRIPTION
Reverts home-assistant/core#154525

It should not have been merged "as-is" (see #154597), and I think it best to revert this one and implement it correctly