### PR TITLE
Correctly calculate average color for light groups in HS Color Mode

### DIFF
--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -55,7 +55,7 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .entity import GroupEntity
-from .util import find_state_attributes, mean_tuple, reduce_attribute
+from .util import find_state_attributes, mean_circle, mean_tuple, reduce_attribute
 
 DEFAULT_NAME = "Light Group"
 CONF_ALL = "all"
@@ -229,7 +229,7 @@ class LightGroup(GroupEntity, LightEntity):
         self._attr_brightness = reduce_attribute(on_states, ATTR_BRIGHTNESS)
 
         self._attr_hs_color = reduce_attribute(
-            on_states, ATTR_HS_COLOR, reduce=mean_tuple
+            on_states, ATTR_HS_COLOR, reduce=mean_circle
         )
         self._attr_rgb_color = reduce_attribute(
             on_states, ATTR_RGB_COLOR, reduce=mean_tuple

--- a/homeassistant/components/group/util.py
+++ b/homeassistant/components/group/util.py
@@ -35,6 +35,9 @@ def mean_tuple(*args: Any) -> tuple[float | Any, ...]:
 
 def mean_circle(*args: Any) -> tuple[float | Any, ...]:
     """Return the circular mean of hue values and arithmetic mean of saturation values from HS color tuples."""
+    if not args:
+        return ()
+
     hues, saturations = zip(*args, strict=False)
 
     sum_x = sum(cos(radians(h)) for h in hues)

--- a/homeassistant/components/group/util.py
+++ b/homeassistant/components/group/util.py
@@ -34,7 +34,7 @@ def mean_tuple(*args: Any) -> tuple[float | Any, ...]:
 
 
 def mean_circle(*args: Any) -> tuple[float | Any, ...]:
-    """Return the mean position of supplied values on a circle."""
+    """Return the circular mean of hue values and arithmetic mean of saturation values from HS color tuples."""
     hues, saturations = zip(*args, strict=False)
 
     sum_x = sum(cos(radians(h)) for h in hues)

--- a/homeassistant/components/group/util.py
+++ b/homeassistant/components/group/util.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from itertools import groupby
+from math import atan2, cos, degrees, radians, sin
 from typing import Any
 
 from homeassistant.core import State
@@ -30,6 +31,20 @@ def mean_int(*args: Any) -> int:
 def mean_tuple(*args: Any) -> tuple[float | Any, ...]:
     """Return the mean values along the columns of the supplied values."""
     return tuple(sum(x) / len(x) for x in zip(*args, strict=False))
+
+
+def mean_circle(*args: Any) -> tuple[float | Any, ...]:
+    """Return the mean position of supplied values on a circle."""
+    hues, saturations = zip(*args, strict=False)
+
+    sum_x = sum(cos(radians(h)) for h in hues)
+    sum_y = sum(sin(radians(h)) for h in hues)
+
+    mean_angle = degrees(atan2(sum_y, sum_x)) % 360
+
+    saturation = sum(saturations) / len(saturations)
+
+    return (mean_angle, saturation)
 
 
 def attribute_equal(states: list[State], key: str) -> bool:

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -404,6 +404,33 @@ async def test_color_hs(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": [entity0.entity_id], ATTR_HS_COLOR: (355, 100)},
+        blocking=True,
+    )
+
+    await hass.async_block_till_done()
+    state = hass.states.get("light.light_group")
+    assert state.attributes[ATTR_COLOR_MODE] == "hs"
+    assert state.attributes[ATTR_HS_COLOR] == (357.5, 75)
+    assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": [entity1.entity_id], ATTR_HS_COLOR: (5, 90)},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("light.light_group")
+    assert state.attributes[ATTR_COLOR_MODE] == "hs"
+    assert state.attributes[ATTR_HS_COLOR] == (360, 95)
+    assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
+
 
 async def test_color_rgb(hass: HomeAssistant) -> None:
     """Test rgbw color reporting."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change implements the `mean_circle()` function that takes in an arbitrary number of Tuples with HS values and returns one single Tuple with the average hue and saturation value for all of the given values.

While this fixes the issue with hue sums above `360°` returning an average color on the opposite side of the color wheel, it introduces a new 'quirk':
When one color moves from `180°` to `-180°` from another color, the resulting average jumps from `90°` between these colors to `-90°` between those colors. This is the correct behavior, but might look weird to a user.
I'm not sure if there should be a documentation update somewhere, however since I could not find any existing documentation about the current behavior of averaging a light group's color, I'd first like to discuss this with maintainers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #154578
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
