### PR TITLE
Improve KNX config-UI group address labels and descriptions

### DIFF
--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -13,7 +13,7 @@
   "requirements": [
     "xknx==3.10.0",
     "xknxproject==3.8.2",
-    "knx-frontend==2025.10.9.185845"
+    "knx-frontend==2025.10.17.202411"
   ],
   "single_config_entry": true
 }

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -93,7 +93,6 @@ BASE_ENTITY_SCHEMA = vol.All(
 
 BINARY_SENSOR_KNX_SCHEMA = vol.Schema(
     {
-        "section_binary_sensor": KNXSectionFlat(),
         vol.Required(CONF_GA_SENSOR): GASelector(
             write=False, state_required=True, valid_dpt="1"
         ),
@@ -117,10 +116,8 @@ BINARY_SENSOR_KNX_SCHEMA = vol.Schema(
 COVER_KNX_SCHEMA = AllSerializeFirst(
     vol.Schema(
         {
-            "section_binary_control": KNXSectionFlat(),
             vol.Optional(CONF_GA_UP_DOWN): GASelector(state=False, valid_dpt="1"),
             vol.Optional(CoverConf.INVERT_UPDOWN): selector.BooleanSelector(),
-            "section_stop_control": KNXSectionFlat(),
             vol.Optional(CONF_GA_STOP): GASelector(state=False, valid_dpt="1"),
             vol.Optional(CONF_GA_STEP): GASelector(state=False, valid_dpt="1"),
             "section_position_control": KNXSectionFlat(collapsible=True),
@@ -195,11 +192,9 @@ _hs_color_inclusion_msg = (
 LIGHT_KNX_SCHEMA = AllSerializeFirst(
     vol.Schema(
         {
-            "section_switch": KNXSectionFlat(),
             vol.Optional(CONF_GA_SWITCH): GASelector(
                 write_required=True, valid_dpt="1"
             ),
-            "section_brightness": KNXSectionFlat(),
             vol.Optional(CONF_GA_BRIGHTNESS): GASelector(
                 write_required=True, valid_dpt="5.001"
             ),
@@ -229,28 +224,24 @@ LIGHT_KNX_SCHEMA = AllSerializeFirst(
                 GroupSelectOption(
                     translation_key="individual_addresses",
                     schema={
-                        "section_red": KNXSectionFlat(),
                         vol.Optional(CONF_GA_RED_SWITCH): GASelector(
                             write_required=False, valid_dpt="1"
                         ),
                         vol.Required(CONF_GA_RED_BRIGHTNESS): GASelector(
                             write_required=True, valid_dpt="5.001"
                         ),
-                        "section_green": KNXSectionFlat(),
                         vol.Optional(CONF_GA_GREEN_SWITCH): GASelector(
                             write_required=False, valid_dpt="1"
                         ),
                         vol.Required(CONF_GA_GREEN_BRIGHTNESS): GASelector(
                             write_required=True, valid_dpt="5.001"
                         ),
-                        "section_blue": KNXSectionFlat(),
                         vol.Optional(CONF_GA_BLUE_SWITCH): GASelector(
                             write_required=False, valid_dpt="1"
                         ),
                         vol.Required(CONF_GA_BLUE_BRIGHTNESS): GASelector(
                             write_required=True, valid_dpt="5.001"
                         ),
-                        "section_white": KNXSectionFlat(),
                         vol.Optional(CONF_GA_WHITE_SWITCH): GASelector(
                             write_required=False, valid_dpt="1"
                         ),
@@ -313,7 +304,6 @@ LIGHT_KNX_SCHEMA = AllSerializeFirst(
 
 SWITCH_KNX_SCHEMA = vol.Schema(
     {
-        "section_switch": KNXSectionFlat(),
         vol.Required(CONF_GA_SWITCH): GASelector(write_required=True, valid_dpt="1"),
         vol.Optional(CONF_INVERT, default=False): selector.BooleanSelector(),
         vol.Optional(CONF_RESPOND_TO_READ, default=False): selector.BooleanSelector(),

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -386,9 +386,9 @@
         "binary_sensor": {
           "description": "Read-only entity for binary datapoints. Window or door states etc.",
           "knx": {
-            "section_binary_sensor": {
-              "title": "Binary sensor",
-              "description": "DPT 1 group addresses representing binary states."
+            "ga_sensor": {
+              "label": "State",
+              "description": "Group address representing a binary state."
             },
             "invert": {
               "label": "Invert",
@@ -415,50 +415,47 @@
         "cover": {
           "description": "The KNX cover platform is used as an interface to shutter actuators.",
           "knx": {
-            "section_binary_control": {
-              "title": "Open/Close control",
-              "description": "DPT 1 group addresses triggering full movement."
-            },
             "ga_up_down": {
-              "label": "Open/Close"
+              "label": "Open/Close control",
+              "description": "Group addresses triggering a full movement."
             },
             "invert_updown": {
-              "label": "Invert",
+              "label": "Invert open/close",
               "description": "Default is UP (0) to open a cover and DOWN (1) to close a cover. Enable this to invert the open/close commands from/to your KNX actuator."
             },
-            "section_stop_control": {
-              "title": "Stop",
-              "description": "DPT 1 group addresses for stopping movement."
-            },
             "ga_stop": {
-              "label": "Stop"
+              "label": "Stop",
+              "description": "Group addresses for stopping movement."
             },
             "ga_step": {
-              "label": "Stepwise move"
+              "label": "Stepwise move",
+              "description": "Group addresses for stepwise movement. Used to stop the cover when no dedicated stop address is available."
             },
             "section_position_control": {
               "title": "Position",
-              "description": "DPT 5 group addresses for cover position."
+              "description": "Control cover position."
             },
             "ga_position_set": {
-              "label": "Set position"
+              "label": "Set position",
+              "description": "Group addresses for setting a new absolute position."
             },
             "ga_position_state": {
-              "label": "Current position"
+              "label": "Current position",
+              "description": "Group addresses reporting the current position."
             },
             "invert_position": {
-              "label": "Invert",
-              "description": "Invert payload before processing. Enable if KNX reports 0% as fully closed."
+              "label": "Invert position",
+              "description": "Invert telegram payload before processing. Enable if KNX reports 0% as fully closed."
             },
             "section_tilt_control": {
               "title": "Tilt",
-              "description": "DPT 5 group addresses for slat tilt angle."
+              "description": "Control slat tilt angle."
             },
             "ga_angle": {
               "label": "Tilt angle"
             },
             "invert_angle": {
-              "label": "[%key:component::knx::config_panel::entities::create::cover::knx::invert_position::label%]",
+              "label": "Invert angle",
               "description": "[%key:component::knx::config_panel::entities::create::cover::knx::invert_position::description%]"
             },
             "section_travel_time": {
@@ -466,38 +463,32 @@
               "description": "Used to calculate intermediate positions of the cover while traveling."
             },
             "travelling_time_up": {
-              "label": "Travel time for opening",
-              "description": "Time the cover needs to fully open in seconds."
+              "label": "Time for opening",
+              "description": "Time in seconds the cover needs to fully open."
             },
             "travelling_time_down": {
-              "label": "Travel time for closing",
-              "description": "Time the cover needs to fully close in seconds."
+              "label": "Time for closing",
+              "description": "Time in seconds the cover needs to fully close."
             }
           }
         },
         "light": {
           "description": "The KNX light platform is used as an interface to dimming actuators, LED controllers, DALI gateways and similar.",
           "knx": {
-            "section_switch": {
-              "title": "Switch",
+            "ga_switch": {
+              "label": "Switch",
               "description": "Turn the light on/off."
             },
-            "ga_switch": {
-              "label": "Switch"
-            },
-            "section_brightness": {
-              "title": "Brightness",
-              "description": "Control the brightness of the light."
-            },
             "ga_brightness": {
-              "label": "Brightness"
+              "label": "Brightness",
+              "description": "Control the absolute brightness of the light."
             },
             "section_color_temp": {
               "title": "Color temperature",
               "description": "Control the color temperature of the light."
             },
             "ga_color_temp": {
-              "label": "Color temperature",
+              "label": "Color temperature addresses",
               "options": {
                 "5_001": "Percent",
                 "7_600": "Kelvin",
@@ -520,60 +511,52 @@
                 },
                 "individual_addresses": {
                   "label": "Individual addresses",
-                  "description": "RGB(W) using individual state and brightness group addresses."
+                  "description": "RGB(W) using individual group addresses for each color channel's state and brightness."
                 },
                 "hsv_addresses": {
                   "label": "HSV",
-                  "description": "Hue, saturation and brightness using individual group addresses."
+                  "description": "Hue, saturation and brightness controlled by individual group addresses."
                 }
               },
               "ga_color": {
-                "label": "Color",
+                "label": "Color addresses",
                 "options": {
                   "232_600": "RGB",
                   "242_600": "XYY",
                   "251_600": "RGBW"
                 }
               },
-              "section_red": {
-                "title": "Red",
-                "description": "Controls the light's red color component. Brightness group address is required."
-              },
               "ga_red_switch": {
-                "label": "Red switch"
+                "label": "Red switch",
+                "description": "Group address to switch the color channel on/off."
               },
               "ga_red_brightness": {
-                "label": "Red brightness"
-              },
-              "section_green": {
-                "title": "Green",
-                "description": "Controls the light's green color component. Brightness group address is required."
+                "label": "Red brightness",
+                "description": "Group address to control the brightness of the color channel. Required."
               },
               "ga_green_switch": {
-                "label": "Green switch"
+                "label": "Green switch",
+                "description": "[%key:component::knx::config_panel::entities::create::light::knx::color::ga_red_switch::description%]"
               },
               "ga_green_brightness": {
-                "label": "Green brightness"
-              },
-              "section_blue": {
-                "title": "Blue",
-                "description": "Controls the light's blue color component. Brightness group address is required."
+                "label": "Green brightness",
+                "description": "[%key:component::knx::config_panel::entities::create::light::knx::color::ga_red_brightness::description%]"
               },
               "ga_blue_switch": {
-                "label": "Blue switch"
+                "label": "Blue switch",
+                "description": "[%key:component::knx::config_panel::entities::create::light::knx::color::ga_red_switch::description%]"
               },
               "ga_blue_brightness": {
-                "label": "Blue brightness"
-              },
-              "section_white": {
-                "title": "White",
-                "description": "Controls the light's white color component. Brightness group address is required."
+                "label": "Blue brightness",
+                "description": "[%key:component::knx::config_panel::entities::create::light::knx::color::ga_red_brightness::description%]"
               },
               "ga_white_switch": {
-                "label": "White switch"
+                "label": "White switch",
+                "description": "[%key:component::knx::config_panel::entities::create::light::knx::color::ga_red_switch::description%]"
               },
               "ga_white_brightness": {
-                "label": "White brightness"
+                "label": "White brightness",
+                "description": "Group address to control the brightness of the color channel."
               },
               "ga_hue": {
                 "label": "Hue",
@@ -589,10 +572,6 @@
         "switch": {
           "description": "The KNX switch platform is used as an interface to switching actuators.",
           "knx": {
-            "section_switch": {
-              "title": "Switching",
-              "description": "DPT 1 group addresses controlling the switch function."
-            },
             "ga_switch": {
               "label": "Switch",
               "description": "Group address to switch the device on/off."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1328,7 +1328,7 @@ kiwiki-client==0.1.1
 knocki==0.4.2
 
 # homeassistant.components.knx
-knx-frontend==2025.10.9.185845
+knx-frontend==2025.10.17.202411
 
 # homeassistant.components.konnected
 konnected==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1153,7 +1153,7 @@ kegtron-ble==1.0.2
 knocki==0.4.2
 
 # homeassistant.components.knx
-knx-frontend==2025.10.9.185845
+knx-frontend==2025.10.17.202411
 
 # homeassistant.components.konnected
 konnected==1.2.0

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -4,12 +4,6 @@
     'id': 1,
     'result': list([
       dict({
-        'collapsible': False,
-        'name': 'section_binary_sensor',
-        'required': False,
-        'type': 'knx_section_flat',
-      }),
-      dict({
         'name': 'ga_sensor',
         'options': dict({
           'passive': True,
@@ -100,12 +94,6 @@
     'id': 1,
     'result': list([
       dict({
-        'collapsible': False,
-        'name': 'section_binary_control',
-        'required': False,
-        'type': 'knx_section_flat',
-      }),
-      dict({
         'name': 'ga_up_down',
         'optional': True,
         'options': dict({
@@ -133,12 +121,6 @@
           }),
         }),
         'type': 'ha_selector',
-      }),
-      dict({
-        'collapsible': False,
-        'name': 'section_stop_control',
-        'required': False,
-        'type': 'knx_section_flat',
       }),
       dict({
         'name': 'ga_stop',
@@ -323,12 +305,6 @@
     'id': 1,
     'result': list([
       dict({
-        'collapsible': False,
-        'name': 'section_switch',
-        'required': False,
-        'type': 'knx_section_flat',
-      }),
-      dict({
         'name': 'ga_switch',
         'optional': True,
         'options': dict({
@@ -348,12 +324,6 @@
         }),
         'required': False,
         'type': 'knx_group_address',
-      }),
-      dict({
-        'collapsible': False,
-        'name': 'section_brightness',
-        'required': False,
-        'type': 'knx_section_flat',
       }),
       dict({
         'name': 'ga_brightness',
@@ -509,12 +479,6 @@
           dict({
             'schema': list([
               dict({
-                'collapsible': False,
-                'name': 'section_red',
-                'required': False,
-                'type': 'knx_section_flat',
-              }),
-              dict({
                 'name': 'ga_red_switch',
                 'optional': True,
                 'options': dict({
@@ -554,12 +518,6 @@
                 }),
                 'required': True,
                 'type': 'knx_group_address',
-              }),
-              dict({
-                'collapsible': False,
-                'name': 'section_green',
-                'required': False,
-                'type': 'knx_section_flat',
               }),
               dict({
                 'name': 'ga_green_switch',
@@ -603,12 +561,6 @@
                 'type': 'knx_group_address',
               }),
               dict({
-                'collapsible': False,
-                'name': 'section_blue',
-                'required': False,
-                'type': 'knx_section_flat',
-              }),
-              dict({
                 'name': 'ga_blue_switch',
                 'optional': True,
                 'options': dict({
@@ -648,12 +600,6 @@
                 }),
                 'required': True,
                 'type': 'knx_group_address',
-              }),
-              dict({
-                'collapsible': False,
-                'name': 'section_white',
-                'required': False,
-                'type': 'knx_section_flat',
               }),
               dict({
                 'name': 'ga_white_switch',
@@ -767,12 +713,6 @@
   dict({
     'id': 1,
     'result': list([
-      dict({
-        'collapsible': False,
-        'name': 'section_switch',
-        'required': False,
-        'type': 'knx_section_flat',
-      }),
       dict({
         'name': 'ga_switch',
         'options': dict({


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/XKNX/knx-frontend/releases/tag/2025.10.17.202411

This makes `knx-group-address-selector`s look more like standard HA selectors with their title and description above the input box.
Previously `KNXSectionFlat ` was used to accomplish a similar look.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
