### PR TITLE
2025.10.3

### DIFF
--- a/homeassistant/components/airq/manifest.json
+++ b/homeassistant/components/airq/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["aioairq"],
-  "requirements": ["aioairq==0.4.6"]
+  "requirements": ["aioairq==0.4.7"]
 }

--- a/homeassistant/components/alexa_devices/manifest.json
+++ b/homeassistant/components/alexa_devices/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["aioamazondevices"],
   "quality_scale": "platinum",
-  "requirements": ["aioamazondevices==6.4.0"]
+  "requirements": ["aioamazondevices==6.4.1"]
 }

--- a/homeassistant/components/alexa_devices/manifest.json
+++ b/homeassistant/components/alexa_devices/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["aioamazondevices"],
   "quality_scale": "platinum",
-  "requirements": ["aioamazondevices==6.4.3"]
+  "requirements": ["aioamazondevices==6.4.4"]
 }

--- a/homeassistant/components/alexa_devices/manifest.json
+++ b/homeassistant/components/alexa_devices/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["aioamazondevices"],
   "quality_scale": "platinum",
-  "requirements": ["aioamazondevices==6.4.1"]
+  "requirements": ["aioamazondevices==6.4.3"]
 }

--- a/homeassistant/components/asuswrt/bridge.py
+++ b/homeassistant/components/asuswrt/bridge.py
@@ -13,7 +13,7 @@ from aioasuswrt.asuswrt import AsusWrt as AsusWrtLegacy
 from aiohttp import ClientSession
 from asusrouter import AsusRouter, AsusRouterError
 from asusrouter.config import ARConfigKey
-from asusrouter.modules.client import AsusClient
+from asusrouter.modules.client import AsusClient, ConnectionState
 from asusrouter.modules.data import AsusData
 from asusrouter.modules.homeassistant import convert_to_ha_data, convert_to_ha_sensors
 from asusrouter.tools.connection import get_cookie_jar
@@ -436,6 +436,7 @@ class AsusWrtHttpBridge(AsusWrtBridge):
             if dev.connection is not None
             and dev.description is not None
             and dev.connection.ip_address is not None
+            and dev.state is ConnectionState.CONNECTED
         }
 
     async def async_get_available_sensors(self) -> dict[str, dict[str, Any]]:

--- a/homeassistant/components/asuswrt/bridge.py
+++ b/homeassistant/components/asuswrt/bridge.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 from collections.abc import Awaitable, Callable, Coroutine
 import functools
 import logging
-from typing import Any, cast
+from typing import Any
 
 from aioasuswrt.asuswrt import AsusWrt as AsusWrtLegacy
 from aiohttp import ClientSession
@@ -219,7 +219,7 @@ class AsusWrtLegacyBridge(AsusWrtBridge):
     @property
     def is_connected(self) -> bool:
         """Get connected status."""
-        return cast(bool, self._api.is_connected)
+        return self._api.is_connected
 
     async def async_connect(self) -> None:
         """Connect to the device."""
@@ -235,8 +235,7 @@ class AsusWrtLegacyBridge(AsusWrtBridge):
 
     async def async_disconnect(self) -> None:
         """Disconnect to the device."""
-        if self._api is not None and self._protocol == PROTOCOL_TELNET:
-            self._api.connection.disconnect()
+        await self._api.async_disconnect()
 
     async def async_get_connected_devices(self) -> dict[str, WrtDevice]:
         """Get list of connected devices."""

--- a/homeassistant/components/asuswrt/manifest.json
+++ b/homeassistant/components/asuswrt/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["aioasuswrt", "asusrouter", "asyncssh"],
-  "requirements": ["aioasuswrt==1.4.0", "asusrouter==1.21.0"]
+  "requirements": ["aioasuswrt==1.5.1", "asusrouter==1.21.0"]
 }

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -36,11 +36,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: AugustConfigEntry) -> bo
         raise ConfigEntryAuthFailed("Migration to OAuth required")
 
     session = async_create_august_clientsession(hass)
-    implementation = (
-        await config_entry_oauth2_flow.async_get_config_entry_implementation(
-            hass, entry
+    try:
+        implementation = (
+            await config_entry_oauth2_flow.async_get_config_entry_implementation(
+                hass, entry
+            )
         )
-    )
+    except ValueError as err:
+        raise ConfigEntryNotReady("OAuth implementation not available") from err
     oauth_session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
     august_gateway = AugustGateway(Path(hass.config.config_dir), session, oauth_session)
     try:

--- a/homeassistant/components/bluetooth/match.py
+++ b/homeassistant/components/bluetooth/match.py
@@ -68,12 +68,17 @@ class IntegrationMatchHistory:
     manufacturer_data: bool
     service_data: set[str]
     service_uuids: set[str]
+    name: str
 
 
 def seen_all_fields(
-    previous_match: IntegrationMatchHistory, advertisement_data: AdvertisementData
+    previous_match: IntegrationMatchHistory,
+    advertisement_data: AdvertisementData,
+    name: str,
 ) -> bool:
     """Return if we have seen all fields."""
+    if previous_match.name != name:
+        return False
     if not previous_match.manufacturer_data and advertisement_data.manufacturer_data:
         return False
     if advertisement_data.service_data and (
@@ -122,10 +127,11 @@ class IntegrationMatcher:
         device = service_info.device
         advertisement_data = service_info.advertisement
         connectable = service_info.connectable
+        name = service_info.name
         matched = self._matched_connectable if connectable else self._matched
         matched_domains: set[str] = set()
         if (previous_match := matched.get(device.address)) and seen_all_fields(
-            previous_match, advertisement_data
+            previous_match, advertisement_data, name
         ):
             # We have seen all fields so we can skip the rest of the matchers
             return matched_domains
@@ -140,11 +146,13 @@ class IntegrationMatcher:
             )
             previous_match.service_data |= set(advertisement_data.service_data)
             previous_match.service_uuids |= set(advertisement_data.service_uuids)
+            previous_match.name = name
         else:
             matched[device.address] = IntegrationMatchHistory(
                 manufacturer_data=bool(advertisement_data.manufacturer_data),
                 service_data=set(advertisement_data.service_data),
                 service_uuids=set(advertisement_data.service_uuids),
+                name=name,
             )
         return matched_domains
 

--- a/homeassistant/components/co2signal/config_flow.py
+++ b/homeassistant/components/co2signal/config_flow.py
@@ -38,6 +38,10 @@ TYPE_SPECIFY_COUNTRY = "specify_country_code"
 
 _LOGGER = logging.getLogger(__name__)
 
+DESCRIPTION_PLACEHOLDER = {
+    "register_link": "https://electricitymaps.com/free-tier",
+}
+
 
 class ElectricityMapsConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Co2signal."""
@@ -70,6 +74,7 @@ class ElectricityMapsConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="user",
                 data_schema=data_schema,
+                description_placeholders=DESCRIPTION_PLACEHOLDER,
             )
 
         data = {CONF_API_KEY: user_input[CONF_API_KEY]}
@@ -179,4 +184,5 @@ class ElectricityMapsConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id=step_id,
             data_schema=data_schema,
             errors=errors,
+            description_placeholders=DESCRIPTION_PLACEHOLDER,
         )

--- a/homeassistant/components/co2signal/strings.json
+++ b/homeassistant/components/co2signal/strings.json
@@ -6,7 +6,7 @@
           "location": "[%key:common::config_flow::data::location%]",
           "api_key": "[%key:common::config_flow::data::access_token%]"
         },
-        "description": "Visit https://electricitymaps.com/free-tier to request a token."
+        "description": "Visit the [Electricity Maps page]({register_link}) to request a token."
       },
       "coordinates": {
         "data": {

--- a/homeassistant/components/coinbase/config_flow.py
+++ b/homeassistant/components/coinbase/config_flow.py
@@ -166,6 +166,7 @@ class CoinbaseConfigFlow(ConfigFlow, domain=DOMAIN):
                 data_schema=STEP_USER_DATA_SCHEMA,
                 description_placeholders={
                     "account_name": self.reauth_entry.title,
+                    "developer_url": "https://www.coinbase.com/developer-platform",
                 },
                 errors=errors,
             )
@@ -195,6 +196,7 @@ class CoinbaseConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=STEP_USER_DATA_SCHEMA,
             description_placeholders={
                 "account_name": self.reauth_entry.title,
+                "developer_url": "https://www.coinbase.com/developer-platform",
             },
             errors=errors,
         )

--- a/homeassistant/components/coinbase/strings.json
+++ b/homeassistant/components/coinbase/strings.json
@@ -11,7 +11,7 @@
       },
       "reauth_confirm": {
         "title": "Update Coinbase API credentials",
-        "description": "Your current Coinbase API key appears to be for the deprecated v2 API. Please reconfigure with a new API key created for the v3 API. Visit https://www.coinbase.com/developer-platform  to create new credentials for {account_name}.",
+        "description": "Your current Coinbase API key appears to be for the deprecated v2 API. Please reconfigure with a new API key created for the v3 API. Visit the [Developer Platform]({developer_url}) to create new credentials for {account_name}.",
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "api_token": "API secret"

--- a/homeassistant/components/comelit/manifest.json
+++ b/homeassistant/components/comelit/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["aiocomelit"],
   "quality_scale": "platinum",
-  "requirements": ["aiocomelit==1.1.1"]
+  "requirements": ["aiocomelit==1.1.2"]
 }

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -61,5 +61,8 @@ class EcobeeFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="authorize",
             errors=errors,
-            description_placeholders={"pin": self._ecobee.pin},
+            description_placeholders={
+                "pin": self._ecobee.pin,
+                "auth_url": "https://www.ecobee.com/consumerportal/index.html",
+            },
         )

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -8,7 +8,7 @@
         }
       },
       "authorize": {
-        "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with PIN code:\n\n{pin}\n\nThen, select **Submit**."
+        "description": "Please authorize this app at {auth_url} with PIN code:\n\n{pin}\n\nThen, select **Submit**."
       }
     },
     "error": {

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["home-assistant-frontend==20251001.2"]
+  "requirements": ["home-assistant-frontend==20251001.4"]
 }

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -158,7 +158,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         has_fn=lambda data: data.measurement.energy_import_kwh is not None,
-        value_fn=lambda data: data.measurement.energy_import_kwh,
+        value_fn=lambda data: data.measurement.energy_import_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t1_kwh",
@@ -172,7 +172,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
             data.measurement.energy_import_t1_kwh is not None
             and data.measurement.energy_export_t2_kwh is not None
         ),
-        value_fn=lambda data: data.measurement.energy_import_t1_kwh,
+        value_fn=lambda data: data.measurement.energy_import_t1_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t2_kwh",
@@ -182,7 +182,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         has_fn=lambda data: data.measurement.energy_import_t2_kwh is not None,
-        value_fn=lambda data: data.measurement.energy_import_t2_kwh,
+        value_fn=lambda data: data.measurement.energy_import_t2_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t3_kwh",
@@ -192,7 +192,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         has_fn=lambda data: data.measurement.energy_import_t3_kwh is not None,
-        value_fn=lambda data: data.measurement.energy_import_t3_kwh,
+        value_fn=lambda data: data.measurement.energy_import_t3_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t4_kwh",
@@ -202,7 +202,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         has_fn=lambda data: data.measurement.energy_import_t4_kwh is not None,
-        value_fn=lambda data: data.measurement.energy_import_t4_kwh,
+        value_fn=lambda data: data.measurement.energy_import_t4_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_kwh",
@@ -212,7 +212,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         has_fn=lambda data: data.measurement.energy_export_kwh is not None,
         enabled_fn=lambda data: data.measurement.energy_export_kwh != 0,
-        value_fn=lambda data: data.measurement.energy_export_kwh,
+        value_fn=lambda data: data.measurement.energy_export_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t1_kwh",
@@ -227,7 +227,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
             and data.measurement.energy_export_t2_kwh is not None
         ),
         enabled_fn=lambda data: data.measurement.energy_export_t1_kwh != 0,
-        value_fn=lambda data: data.measurement.energy_export_t1_kwh,
+        value_fn=lambda data: data.measurement.energy_export_t1_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t2_kwh",
@@ -238,7 +238,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         has_fn=lambda data: data.measurement.energy_export_t2_kwh is not None,
         enabled_fn=lambda data: data.measurement.energy_export_t2_kwh != 0,
-        value_fn=lambda data: data.measurement.energy_export_t2_kwh,
+        value_fn=lambda data: data.measurement.energy_export_t2_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t3_kwh",
@@ -249,7 +249,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         has_fn=lambda data: data.measurement.energy_export_t3_kwh is not None,
         enabled_fn=lambda data: data.measurement.energy_export_t3_kwh != 0,
-        value_fn=lambda data: data.measurement.energy_export_t3_kwh,
+        value_fn=lambda data: data.measurement.energy_export_t3_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t4_kwh",
@@ -260,7 +260,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         has_fn=lambda data: data.measurement.energy_export_t4_kwh is not None,
         enabled_fn=lambda data: data.measurement.energy_export_t4_kwh != 0,
-        value_fn=lambda data: data.measurement.energy_export_t4_kwh,
+        value_fn=lambda data: data.measurement.energy_export_t4_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="active_power_w",

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -112,6 +112,9 @@ class HuaweiLteConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors or {},
+            description_placeholders={
+                "sample_ip": "http://192.168.X.1",
+            },
         )
 
     async def _async_show_reauth_form(
@@ -132,6 +135,9 @@ class HuaweiLteConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors or {},
+            description_placeholders={
+                "sample_ip": "http://192.168.X.1",
+            },
         )
 
     async def _connect(
@@ -406,4 +412,10 @@ class HuaweiLteOptionsFlow(OptionsFlow):
                 ): bool,
             }
         )
-        return self.async_show_form(step_id="init", data_schema=data_schema)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=data_schema,
+            description_placeholders={
+                "sample_ip": "http://192.168.X.1",
+            },
+        )

--- a/homeassistant/components/huawei_lte/strings.json
+++ b/homeassistant/components/huawei_lte/strings.json
@@ -41,7 +41,7 @@
         },
         "data_description": {
           "password": "Password for accessing the router's API. Typically, the same as the one used for the router's web interface.",
-          "url": "Base URL to the API of the router. Typically, something like `http://192.168.X.1`. This is the beginning of the location shown in a browser when accessing the router's web interface.",
+          "url": "Base URL to the API of the router. Typically, something like `{sample_ip}`. This is the beginning of the location shown in a browser when accessing the router's web interface.",
           "username": "Username for accessing the router's API. Typically, the same as the one used for the router's web interface. Usually, either `admin`, or left empty (recommended if that works).",
           "verify_ssl": "Whether to verify the SSL certificate of the router when accessing it. Applicable only if the router is accessed via HTTPS."
         },

--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -68,6 +68,7 @@
       "initial_press": "\"{subtype}\" pressed initially",
       "repeat": "\"{subtype}\" held down",
       "short_release": "\"{subtype}\" released after short press",
+      "long_press": "\"{subtype}\" long pressed",
       "long_release": "[%key:component::hue::device_automation::trigger_type::remote_button_long_release%]",
       "double_short_release": "[%key:component::hue::device_automation::trigger_type::remote_double_button_short_press%]",
       "start": "[%key:component::hue::device_automation::trigger_type::initial_press%]"

--- a/homeassistant/components/igloohome/config_flow.py
+++ b/homeassistant/components/igloohome/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
+from .const import API_ACCESS_URL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,5 +57,8 @@ class IgloohomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={"api_access_url": API_ACCESS_URL},
         )

--- a/homeassistant/components/igloohome/const.py
+++ b/homeassistant/components/igloohome/const.py
@@ -1,3 +1,4 @@
 """Constants for the igloohome integration."""
 
 DOMAIN = "igloohome"
+API_ACCESS_URL = "https://access.igloocompany.co/api-access"

--- a/homeassistant/components/igloohome/strings.json
+++ b/homeassistant/components/igloohome/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Copy & paste your [API access credentials](https://access.igloocompany.co/api-access) to give Home Assistant access to your account.",
+        "description": "Copy & paste your [API access credentials]({api_access_url}) to give Home Assistant access to your account.",
         "data": {
           "client_id": "Client ID",
           "client_secret": "Client secret"

--- a/homeassistant/components/isy994/config_flow.py
+++ b/homeassistant/components/isy994/config_flow.py
@@ -177,6 +177,9 @@ class Isy994ConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=_data_schema(self.discovered_conf),
             errors=errors,
+            description_placeholders={
+                "sample_ip": "http://192.168.10.100:80",
+            },
         )
 
     async def _async_set_unique_id_or_update(
@@ -302,7 +305,10 @@ class Isy994ConfigFlow(ConfigFlow, domain=DOMAIN):
             CONF_HOST: existing_data[CONF_HOST],
         }
         return self.async_show_form(
-            description_placeholders={CONF_HOST: existing_data[CONF_HOST]},
+            description_placeholders={
+                CONF_HOST: existing_data[CONF_HOST],
+                "sample_ip": "http://192.168.10.100:80",
+            },
             step_id="reauth_confirm",
             data_schema=vol.Schema(
                 {
@@ -347,7 +353,13 @@ class OptionsFlowHandler(OptionsFlowWithReload):
             }
         )
 
-        return self.async_show_form(step_id="init", data_schema=options_schema)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=options_schema,
+            description_placeholders={
+                "sample_ip": "http://192.168.10.100:80",
+            },
+        )
 
 
 class InvalidHost(HomeAssistantError):

--- a/homeassistant/components/isy994/strings.json
+++ b/homeassistant/components/isy994/strings.json
@@ -9,7 +9,7 @@
           "password": "[%key:common::config_flow::data::password%]",
           "tls": "The TLS version of the ISY controller."
         },
-        "description": "The host entry must be in full URL format, e.g., http://192.168.10.100:80",
+        "description": "The host entry must be in full URL format, e.g., {sample_ip}",
         "title": "Connect to your ISY"
       },
       "reauth_confirm": {
@@ -26,7 +26,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_host": "The host entry was not in full URL format, e.g., http://192.168.10.100:80"
+      "invalid_host": "The host entry was not in full URL format, e.g., {sample_ip}"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -134,4 +134,8 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
                     data=user_input,
                 )
 
-        return self.show_user_form(user_input, errors)
+        return self.show_user_form(
+            user_input,
+            errors,
+            description_placeholders={"example_url": "https://mastodon.social"},
+        )

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -9,7 +9,7 @@
           "access_token": "[%key:common::config_flow::data::access_token%]"
         },
         "data_description": {
-          "base_url": "The URL of your Mastodon instance e.g. https://mastodon.social.",
+          "base_url": "The URL of your Mastodon instance e.g. {example_url}.",
           "client_id": "The client key for the application created within your Mastodon account.",
           "client_secret": "The client secret for the application created within your Mastodon account.",
           "access_token": "The access token for the application created within your Mastodon account."

--- a/homeassistant/components/mealie/config_flow.py
+++ b/homeassistant/components/mealie/config_flow.py
@@ -26,6 +26,8 @@ REAUTH_SCHEMA = vol.Schema(
     }
 )
 
+EXAMPLE_URL = "http://192.168.1.123:1234"
+
 
 class MealieConfigFlow(ConfigFlow, domain=DOMAIN):
     """Mealie config flow."""
@@ -84,6 +86,7 @@ class MealieConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=USER_SCHEMA,
             errors=errors,
+            description_placeholders={"example_url": EXAMPLE_URL},
         )
 
     async def async_step_reauth(
@@ -114,6 +117,7 @@ class MealieConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=REAUTH_SCHEMA,
             errors=errors,
+            description_placeholders={"example_url": EXAMPLE_URL},
         )
 
     async def async_step_reconfigure(
@@ -142,4 +146,5 @@ class MealieConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reconfigure",
             data_schema=USER_SCHEMA,
             errors=errors,
+            description_placeholders={"example_url": EXAMPLE_URL},
         )

--- a/homeassistant/components/mealie/strings.json
+++ b/homeassistant/components/mealie/strings.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "data_description_host": "The URL of your Mealie instance, for example, http://192.168.1.123:1234",
+    "data_description_host": "The URL of your Mealie instance, for example, {example_url}.",
     "data_description_api_token": "The API token of your Mealie instance from your user profile within Mealie.",
     "data_description_verify_ssl": "Should SSL certificates be verified? This should be off for self-signed certificates."
   },

--- a/homeassistant/components/nibe_heatpump/config_flow.py
+++ b/homeassistant/components/nibe_heatpump/config_flow.py
@@ -73,6 +73,13 @@ STEP_MODBUS_DATA_SCHEMA = vol.Schema(
 )
 
 
+STEP_MODBUS_PLACEHOLDERS = {
+    "tcp": "tcp://[HOST]:[PORT]",
+    "serial": "serial://[LOCAL DEVICE]",
+    "rfc2217": "rfc2217://[HOST]:[PORT]",
+}
+
+
 class FieldError(Exception):
     """Field with invalid data."""
 
@@ -183,7 +190,9 @@ class NibeHeatPumpConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the modbus step."""
         if user_input is None:
             return self.async_show_form(
-                step_id="modbus", data_schema=STEP_MODBUS_DATA_SCHEMA
+                step_id="modbus",
+                data_schema=STEP_MODBUS_DATA_SCHEMA,
+                description_placeholders=STEP_MODBUS_PLACEHOLDERS,
             )
 
         errors = {}
@@ -200,7 +209,10 @@ class NibeHeatPumpConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(title=title, data=data)
 
         return self.async_show_form(
-            step_id="modbus", data_schema=STEP_MODBUS_DATA_SCHEMA, errors=errors
+            step_id="modbus",
+            data_schema=STEP_MODBUS_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders=STEP_MODBUS_PLACEHOLDERS,
         )
 
     async def async_step_nibegw(

--- a/homeassistant/components/nibe_heatpump/strings.json
+++ b/homeassistant/components/nibe_heatpump/strings.json
@@ -15,7 +15,7 @@
           "modbus_unit": "Modbus unit identifier"
         },
         "data_description": {
-          "modbus_url": "Modbus URL that describes the connection to your heat pump or MODBUS40 unit. It should be in the form:\n - `tcp://[HOST]:[PORT]` for Modbus TCP connection\n - `serial://[LOCAL DEVICE]` for a local Modbus RTU connection\n - `rfc2217://[HOST]:[PORT]` for a remote Telnet-based Modbus RTU connection.",
+          "modbus_url": "Modbus URL that describes the connection to your heat pump or MODBUS40 unit. It should be in the form:\n - `{tcp}` for Modbus TCP connection\n - `{serial}` for a local Modbus RTU connection\n - `{rfc2217}` for a remote Telnet-based Modbus RTU connection.",
           "modbus_unit": "Unit identification for your heat pump. Can usually be left at 0."
         }
       },

--- a/homeassistant/components/nuheat/config_flow.py
+++ b/homeassistant/components/nuheat/config_flow.py
@@ -89,7 +89,10 @@ class NuHeatConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(
-            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+            step_id="user",
+            data_schema=DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={"nuheat_url": "https://MyNuHeat.com"},
         )
 
 

--- a/homeassistant/components/nuheat/strings.json
+++ b/homeassistant/components/nuheat/strings.json
@@ -12,7 +12,7 @@
     "step": {
       "user": {
         "title": "Connect to the NuHeat",
-        "description": "You will need to obtain your thermostat\u2019s numeric serial number or ID by logging into https://MyNuHeat.com and selecting your thermostat(s).",
+        "description": "You will need to obtain your thermostat\u2019s numeric serial number or ID by logging into {nuheat_url} and selecting your thermostat(s).",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
   "quality_scale": "bronze",
-  "requirements": ["opower==0.15.6"]
+  "requirements": ["opower==0.15.7"]
 }

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -210,7 +210,9 @@ class OverkizConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the local authentication step via config flow."""
         errors = {}
-        description_placeholders = {}
+        description_placeholders = {
+            "somfy-developer-mode-docs": "https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode#getting-started"
+        }
 
         if user_input:
             self._host = user_input[CONF_HOST]

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -120,7 +120,7 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         icon="mdi:water",
         native_unit_of_measurement=UnitOfVolume.LITERS,
         device_class=SensorDeviceClass.WATER,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL,
     ),
     OverkizSensorDescription(
         key=OverkizState.IO_OUTLET_ENGINE,

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -32,7 +32,7 @@
         }
       },
       "local": {
-        "description": "By activating the [Developer Mode of your TaHoma box](https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode#getting-started), you can authorize third-party software (like Home Assistant) to connect to it via your local network.\n\n1. Open the TaHoma By Somfy application on your device.\n2. Navigate to the Help & advanced features -> Advanced features menu in the application.\n3. Activate Developer Mode by tapping 7 times on the version number of your gateway (like 2025.1.4-11).\n4. Generate a token from the Developer Mode menu to authenticate your API calls.\n\n5. Enter the generated token below and update the host to include your Gateway PIN or the IP address of your gateway.",
+        "description": "By activating the [Developer Mode of your TaHoma box]({somfy-developer-mode-docs}), you can authorize third-party software (like Home Assistant) to connect to it via your local network.\n\n1. Open the TaHoma By Somfy application on your device.\n2. Navigate to the Help & advanced features -> Advanced features menu in the application.\n3. Activate Developer Mode by tapping 7 times on the version number of your gateway (like 2025.1.4-11).\n4. Generate a token from the Developer Mode menu to authenticate your API calls.\n\n5. Enter the generated token below and update the host to include your Gateway PIN or the IP address of your gateway.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "token": "[%key:common::config_flow::data::api_token%]",

--- a/homeassistant/components/probe_plus/manifest.json
+++ b/homeassistant/components/probe_plus/manifest.json
@@ -15,5 +15,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "quality_scale": "bronze",
-  "requirements": ["pyprobeplus==1.0.1"]
+  "requirements": ["pyprobeplus==1.1.0"]
 }

--- a/homeassistant/components/pushsafer/notify.py
+++ b/homeassistant/components/pushsafer/notify.py
@@ -88,7 +88,7 @@ class PushsaferNotificationService(BaseNotificationService):
             _LOGGER.debug("%s target(s) specified", len(targets))
 
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
-        data = kwargs.get(ATTR_DATA, {})
+        data = kwargs.get(ATTR_DATA) or {}
 
         # Converting the specified image to base64
         picture1 = data.get(ATTR_PICTURE1)

--- a/homeassistant/components/pyload/config_flow.py
+++ b/homeassistant/components/pyload/config_flow.py
@@ -72,6 +72,7 @@ REAUTH_SCHEMA = vol.Schema(
         ),
     }
 )
+PLACEHOLDER = {"example_url": "https://example.com:8000/path"}
 
 
 async def validate_input(hass: HomeAssistant, user_input: dict[str, Any]) -> None:
@@ -134,6 +135,7 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
                 STEP_USER_DATA_SCHEMA, user_input
             ),
             errors=errors,
+            description_placeholders=PLACEHOLDER,
         )
 
     async def async_step_reauth(
@@ -211,7 +213,10 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
                 STEP_USER_DATA_SCHEMA,
                 suggested_values,
             ),
-            description_placeholders={CONF_NAME: reconfig_entry.data[CONF_USERNAME]},
+            description_placeholders={
+                CONF_NAME: reconfig_entry.data[CONF_USERNAME],
+                **PLACEHOLDER,
+            },
             errors=errors,
         )
 

--- a/homeassistant/components/pyload/strings.json
+++ b/homeassistant/components/pyload/strings.json
@@ -9,7 +9,7 @@
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
-          "url": "Specify the full URL of your pyLoad web interface, including the protocol (HTTP or HTTPS), hostname or IP address, port (pyLoad uses 8000 by default), and any path prefix if applicable.\nExample: `https://example.com:8000/path`",
+          "url": "Specify the full URL of your pyLoad web interface, including the protocol (HTTP or HTTPS), hostname or IP address, port (pyLoad uses 8000 by default), and any path prefix if applicable.\nExample: `{example_url}`",
           "username": "The username used to access the pyLoad instance.",
           "password": "The password associated with the pyLoad account.",
           "verify_ssl": "If checked, the SSL certificate will be validated to ensure a secure connection."

--- a/homeassistant/components/sabnzbd/config_flow.py
+++ b/homeassistant/components/sabnzbd/config_flow.py
@@ -90,4 +90,8 @@ class SABnzbdConfigFlow(ConfigFlow, domain=DOMAIN):
                 else user_input,
             ),
             errors=errors,
+            description_placeholders={
+                "sabnzbd_full_url_local": "http://localhost:8080",
+                "sabnzbd_full_url_addon": "http://a02368d7-sabnzbd:8080",
+            },
         )

--- a/homeassistant/components/sabnzbd/strings.json
+++ b/homeassistant/components/sabnzbd/strings.json
@@ -7,7 +7,7 @@
           "url": "[%key:common::config_flow::data::url%]"
         },
         "data_description": {
-          "url": "The full URL, including port, of the SABnzbd server. Example: `http://localhost:8080` or `http://a02368d7-sabnzbd:8080`, if you are using the add-on.",
+          "url": "The full URL, including port, of the SABnzbd server. Example: `{sabnzbd_full_url_local}` or `{sabnzbd_full_url_addon}`, if you are using the add-on.",
           "api_key": "The API key of the SABnzbd server. This can be found in the SABnzbd web interface under Config cog (top right) > General > Security."
         }
       }

--- a/homeassistant/components/sfr_box/config_flow.py
+++ b/homeassistant/components/sfr_box/config_flow.py
@@ -61,7 +61,13 @@ class SFRBoxFlowHandler(ConfigFlow, domain=DOMAIN):
 
         data_schema = self.add_suggested_values_to_schema(DATA_SCHEMA, user_input)
         return self.async_show_form(
-            step_id="user", data_schema=data_schema, errors=errors
+            step_id="user",
+            data_schema=data_schema,
+            errors=errors,
+            description_placeholders={
+                "sample_ip": "192.168.1.1",
+                "sample_url": "https://sfrbox.example.com",
+            },
         )
 
     async def async_step_choose_auth(

--- a/homeassistant/components/sfr_box/strings.json
+++ b/homeassistant/components/sfr_box/strings.json
@@ -27,7 +27,7 @@
           "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "host": "The hostname, IP address, or full URL of your SFR device. e.g.: '192.168.1.1' or 'https://sfrbox.example.com'"
+          "host": "The hostname, IP address, or full URL of your SFR device. e.g.: `{sample_ip}` or `{sample_url}`"
         },
         "description": "Setting the credentials is optional, but enables additional functionality."
       }

--- a/homeassistant/components/smart_meter_texas/sensor.py
+++ b/homeassistant/components/smart_meter_texas/sensor.py
@@ -67,7 +67,7 @@ class SmartMeterTexasSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         }
 
     @callback
-    def _state_update(self):
+    def _handle_coordinator_update(self) -> None:
         """Call when the coordinator has an update."""
         self._attr_available = self.coordinator.last_update_success
         if self._attr_available:
@@ -77,7 +77,6 @@ class SmartMeterTexasSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         await super().async_added_to_hass()
-        self.async_on_remove(self.coordinator.async_add_listener(self._state_update))
 
         # If the background update finished before
         # we added the entity, there is no need to restore

--- a/homeassistant/components/snoo/strings.json
+++ b/homeassistant/components/snoo/strings.json
@@ -68,6 +68,7 @@
         "name": "State",
         "state": {
           "baseline": "Baseline",
+          "weaning_baseline": "Baseline (Weaning)",
           "level1": "Level 1",
           "level2": "Level 2",
           "level3": "Level 3",

--- a/homeassistant/components/squeezebox/manifest.json
+++ b/homeassistant/components/squeezebox/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://www.home-assistant.io/integrations/squeezebox",
   "iot_class": "local_polling",
   "loggers": ["pysqueezebox"],
-  "requirements": ["pysqueezebox==0.12.1"]
+  "requirements": ["pysqueezebox==0.13.0"]
 }

--- a/homeassistant/components/switcher_kis/config_flow.py
+++ b/homeassistant/components/switcher_kis/config_flow.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_TOKEN, CONF_USERNAME
 
-from .const import DOMAIN
+from .const import DOMAIN, PREREQUISITES_URL
 from .utils import async_discover_devices
 
 _LOGGER = logging.getLogger(__name__)
@@ -77,7 +77,10 @@ class SwitcherFlowHandler(ConfigFlow, domain=DOMAIN):
             errors["base"] = "invalid_auth"
 
         return self.async_show_form(
-            step_id="credentials", data_schema=CONFIG_SCHEMA, errors=errors
+            step_id="credentials",
+            data_schema=CONFIG_SCHEMA,
+            errors=errors,
+            description_placeholders={"prerequisites_url": PREREQUISITES_URL},
         )
 
     async def async_step_reauth(
@@ -106,6 +109,7 @@ class SwitcherFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=CONFIG_SCHEMA,
             errors=errors,
+            description_placeholders={"prerequisites_url": PREREQUISITES_URL},
         )
 
     async def _create_entry(self) -> ConfigFlowResult:

--- a/homeassistant/components/switcher_kis/const.py
+++ b/homeassistant/components/switcher_kis/const.py
@@ -14,3 +14,7 @@ SERVICE_TURN_ON_WITH_TIMER_NAME = "turn_on_with_timer"
 
 # Defines the maximum interval device must send an update before it marked unavailable
 MAX_UPDATE_INTERVAL_SEC = 30
+
+PREREQUISITES_URL = (
+    "https://www.home-assistant.io/integrations/switcher_kis/#prerequisites"
+)

--- a/homeassistant/components/switcher_kis/strings.json
+++ b/homeassistant/components/switcher_kis/strings.json
@@ -5,7 +5,7 @@
         "description": "[%key:common::config_flow::description::confirm_setup%]"
       },
       "credentials": {
-        "description": "Found a Switcher device that requires a token\nEnter your username and token\nFor more information see https://www.home-assistant.io/integrations/switcher_kis/#prerequisites",
+        "description": "Found a Switcher device that requires a token\nEnter your username and token\nFor more information see {prerequisites_url}",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "token": "[%key:common::config_flow::data::access_token%]"

--- a/homeassistant/components/uptime_kuma/config_flow.py
+++ b/homeassistant/components/uptime_kuma/config_flow.py
@@ -42,6 +42,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Optional(CONF_API_KEY, default=""): str})
+PLACEHOLDER = {"example_url": "https://uptime.example.com:3001"}
 
 
 async def validate_connection(
@@ -100,6 +101,7 @@ class UptimeKumaConfigFlow(ConfigFlow, domain=DOMAIN):
                 data_schema=STEP_USER_DATA_SCHEMA, suggested_values=user_input
             ),
             errors=errors,
+            description_placeholders=PLACEHOLDER,
         )
 
     async def async_step_reauth(
@@ -170,6 +172,7 @@ class UptimeKumaConfigFlow(ConfigFlow, domain=DOMAIN):
                 suggested_values=user_input or entry.data,
             ),
             errors=errors,
+            description_placeholders=PLACEHOLDER,
         )
 
     async def async_step_hassio(

--- a/homeassistant/components/uptime_kuma/strings.json
+++ b/homeassistant/components/uptime_kuma/strings.json
@@ -9,7 +9,7 @@
           "api_key": "[%key:common::config_flow::data::api_key%]"
         },
         "data_description": {
-          "url": "Enter the full URL of your Uptime Kuma instance. Be sure to include the protocol (`http` or `https`), the hostname or IP address, the port number (if it is a non-default port), and any path prefix if applicable. Example: `https://uptime.example.com`",
+          "url": "Enter the full URL of your Uptime Kuma instance. Be sure to include the protocol (`http` or `https`), the hostname or IP address, the port number (if it is a non-default port), and any path prefix if applicable. Example: `{example_url}`",
           "verify_ssl": "Enable SSL certificate verification for secure connections. Disable only if connecting to an Uptime Kuma instance using a self-signed certificate or via IP address",
           "api_key": "Enter an API key. To create a new API key navigate to **Settings → API Keys** and select **Add API Key**"
         }

--- a/homeassistant/components/vesync/manifest.json
+++ b/homeassistant/components/vesync/manifest.json
@@ -13,5 +13,5 @@
   "documentation": "https://www.home-assistant.io/integrations/vesync",
   "iot_class": "cloud_polling",
   "loggers": ["pyvesync"],
-  "requirements": ["pyvesync==3.1.0"]
+  "requirements": ["pyvesync==3.1.2"]
 }

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -23,6 +23,7 @@ from .const import (
     DEFAULT_HEATING_TYPE,
     DOMAIN,
     VICARE_NAME,
+    VIESSMANN_DEVELOPER_PORTAL,
     HeatingType,
 )
 from .utils import login
@@ -70,6 +71,9 @@ class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
+            description_placeholders={
+                "viessmann_developer_portal": VIESSMANN_DEVELOPER_PORTAL
+            },
             data_schema=USER_SCHEMA,
             errors=errors,
         )
@@ -102,6 +106,9 @@ class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reauth_confirm",
+            description_placeholders={
+                "viessmann_developer_portal": VIESSMANN_DEVELOPER_PORTAL
+            },
             data_schema=self.add_suggested_values_to_schema(
                 REAUTH_SCHEMA, reauth_entry.data
             ),

--- a/homeassistant/components/vicare/const.py
+++ b/homeassistant/components/vicare/const.py
@@ -29,6 +29,8 @@ UNSUPPORTED_DEVICES = [
 VICARE_NAME = "ViCare"
 VICARE_TOKEN_FILENAME = "vicare_token.save"
 
+VIESSMANN_DEVELOPER_PORTAL = "https://app.developer.viessmann-climatesolutions.com"
+
 CONF_CIRCUIT = "circuit"
 CONF_HEATING_TYPE = "heating_type"
 

--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -9,7 +9,7 @@ from PyViCare.PyViCareHeatingDevice import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
-from .const import DOMAIN
+from .const import DOMAIN, VIESSMANN_DEVELOPER_PORTAL
 
 
 class ViCareEntity(Entity):
@@ -49,5 +49,5 @@ class ViCareEntity(Entity):
             name=model,
             manufacturer="Viessmann",
             model=model,
-            configuration_url="https://developer.viessmann.com/",
+            configuration_url=VIESSMANN_DEVELOPER_PORTAL,
         )

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "description": "Set up ViCare integration. To generate client ID go to https://app.developer.viessmann.com",
+        "description": "Set up ViCare integration.",
         "data": {
           "username": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]",
@@ -13,7 +13,7 @@
         "data_description": {
           "username": "The email address to log in to your ViCare account.",
           "password": "The password to log in to your ViCare account.",
-          "client_id": "The ID of the API client created in the Viessmann developer portal.",
+          "client_id": "The ID of the API client created in the [Viessmann developer portal]({viessmann_developer_portal}).",
           "heating_type": "Allows to overrule the device auto detection."
         }
       },

--- a/homeassistant/components/yale/__init__.py
+++ b/homeassistant/components/yale/__init__.py
@@ -27,13 +27,16 @@ type YaleConfigEntry = ConfigEntry[YaleData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: YaleConfigEntry) -> bool:
-    """Set up yale from a config entry."""
+    """Set up Yale from a config entry."""
     session = async_create_yale_clientsession(hass)
-    implementation = (
-        await config_entry_oauth2_flow.async_get_config_entry_implementation(
-            hass, entry
+    try:
+        implementation = (
+            await config_entry_oauth2_flow.async_get_config_entry_implementation(
+                hass, entry
+            )
         )
-    )
+    except ValueError as err:
+        raise ConfigEntryNotReady("OAuth implementation not available") from err
     oauth_session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
     yale_gateway = YaleGateway(Path(hass.config.config_dir), session, oauth_session)
     try:

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2025
 MINOR_VERSION: Final = 10
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 2)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -39,7 +39,7 @@ habluetooth==5.6.4
 hass-nabucasa==1.1.1
 hassil==3.2.0
 home-assistant-bluetooth==1.13.1
-home-assistant-frontend==20251001.2
+home-assistant-frontend==20251001.4
 home-assistant-intents==2025.10.1
 httpx==0.28.1
 ifaddr==0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant"
-version = "2025.10.2"
+version = "2025.10.3"
 license = "Apache-2.0"
 license-files = ["LICENSE*", "homeassistant/backports/LICENSE*"]
 description = "Open-source home automation platform running on Python 3."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -176,7 +176,7 @@ aio-georss-gdacs==0.10
 aioacaia==0.1.17
 
 # homeassistant.components.airq
-aioairq==0.4.6
+aioairq==0.4.7
 
 # homeassistant.components.airzone_cloud
 aioairzone-cloud==0.7.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1649,7 +1649,7 @@ openwrt-luci-rpc==1.1.17
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.opower
-opower==0.15.6
+opower==0.15.7
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1186,7 +1186,7 @@ hole==0.9.0
 holidays==0.82
 
 # homeassistant.components.frontend
-home-assistant-frontend==20251001.2
+home-assistant-frontend==20251001.4
 
 # homeassistant.components.conversation
 home-assistant-intents==2025.10.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -217,7 +217,7 @@ aiobafi6==0.9.0
 aiobotocore==2.21.1
 
 # homeassistant.components.comelit
-aiocomelit==1.1.1
+aiocomelit==1.1.2
 
 # homeassistant.components.dhcp
 aiodhcpwatcher==1.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aioairzone-cloud==0.7.2
 aioairzone==1.0.1
 
 # homeassistant.components.alexa_devices
-aioamazondevices==6.4.1
+aioamazondevices==6.4.3
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2290,7 +2290,7 @@ pypoint==3.0.0
 pyportainer==1.0.3
 
 # homeassistant.components.probe_plus
-pyprobeplus==1.0.1
+pyprobeplus==1.1.0
 
 # homeassistant.components.profiler
 pyprof2calltree==1.4.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aioairzone-cloud==0.7.2
 aioairzone==1.0.1
 
 # homeassistant.components.alexa_devices
-aioamazondevices==6.4.3
+aioamazondevices==6.4.4
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aioairzone-cloud==0.7.2
 aioairzone==1.0.1
 
 # homeassistant.components.alexa_devices
-aioamazondevices==6.4.0
+aioamazondevices==6.4.1
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -201,7 +201,7 @@ aioaquacell==0.2.0
 aioaseko==1.0.0
 
 # homeassistant.components.asuswrt
-aioasuswrt==1.4.0
+aioasuswrt==1.5.1
 
 # homeassistant.components.husqvarna_automower
 aioautomower==2.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2414,7 +2414,7 @@ pyspcwebgw==0.7.0
 pyspeex-noise==1.0.2
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.12.1
+pysqueezebox==0.13.0
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2611,7 +2611,7 @@ pyvera==0.3.16
 pyversasense==0.0.6
 
 # homeassistant.components.vesync
-pyvesync==3.1.0
+pyvesync==3.1.2
 
 # homeassistant.components.vizio
 pyvizio==0.1.61

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1035,7 +1035,7 @@ hole==0.9.0
 holidays==0.82
 
 # homeassistant.components.frontend
-home-assistant-frontend==20251001.2
+home-assistant-frontend==20251001.4
 
 # homeassistant.components.conversation
 home-assistant-intents==2025.10.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1405,7 +1405,7 @@ openhomedevice==2.2.0
 openwebifpy==4.3.1
 
 # homeassistant.components.opower
-opower==0.15.6
+opower==0.15.7
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -164,7 +164,7 @@ aio-georss-gdacs==0.10
 aioacaia==0.1.17
 
 # homeassistant.components.airq
-aioairq==0.4.6
+aioairq==0.4.7
 
 # homeassistant.components.airzone_cloud
 aioairzone-cloud==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2169,7 +2169,7 @@ pyuptimerobot==22.2.0
 pyvera==0.3.16
 
 # homeassistant.components.vesync
-pyvesync==3.1.0
+pyvesync==3.1.2
 
 # homeassistant.components.vizio
 pyvizio==0.1.61

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -173,7 +173,7 @@ aioairzone-cloud==0.7.2
 aioairzone==1.0.1
 
 # homeassistant.components.alexa_devices
-aioamazondevices==6.4.0
+aioamazondevices==6.4.1
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -205,7 +205,7 @@ aiobafi6==0.9.0
 aiobotocore==2.21.1
 
 # homeassistant.components.comelit
-aiocomelit==1.1.1
+aiocomelit==1.1.2
 
 # homeassistant.components.dhcp
 aiodhcpwatcher==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -189,7 +189,7 @@ aioaquacell==0.2.0
 aioaseko==1.0.0
 
 # homeassistant.components.asuswrt
-aioasuswrt==1.4.0
+aioasuswrt==1.5.1
 
 # homeassistant.components.husqvarna_automower
 aioautomower==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2017,7 +2017,7 @@ pyspcwebgw==0.7.0
 pyspeex-noise==1.0.2
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.12.1
+pysqueezebox==0.13.0
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -173,7 +173,7 @@ aioairzone-cloud==0.7.2
 aioairzone==1.0.1
 
 # homeassistant.components.alexa_devices
-aioamazondevices==6.4.1
+aioamazondevices==6.4.3
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -173,7 +173,7 @@ aioairzone-cloud==0.7.2
 aioairzone==1.0.1
 
 # homeassistant.components.alexa_devices
-aioamazondevices==6.4.3
+aioamazondevices==6.4.4
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1914,7 +1914,7 @@ pypoint==3.0.0
 pyportainer==1.0.3
 
 # homeassistant.components.probe_plus
-pyprobeplus==1.0.1
+pyprobeplus==1.1.0
 
 # homeassistant.components.profiler
 pyprof2calltree==1.4.5

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -256,7 +256,6 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
     "sense": {"sense-energy": {"async-timeout"}},
     "slimproto": {"aioslimproto": {"async-timeout"}},
     "songpal": {"async-upnp-client": {"async-timeout"}},
-    "squeezebox": {"pysqueezebox": {"async-timeout"}},
     "ssdp": {"async-upnp-client": {"async-timeout"}},
     "surepetcare": {"surepy": {"async-timeout"}},
     "travisci": {

--- a/tests/components/asuswrt/common.py
+++ b/tests/components/asuswrt/common.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 from aioasuswrt.asuswrt import Device as LegacyDevice
+from asusrouter.modules.client import ConnectionState
 
 from homeassistant.components.asuswrt.const import (
     CONF_SSH_KEY,
@@ -71,6 +72,7 @@ def make_client(mac, ip, name, node):
     client = MagicMock()
     client.connection = connection
     client.description = description
+    client.state = ConnectionState.CONNECTED
     return client
 
 

--- a/tests/components/asuswrt/test_init.py
+++ b/tests/components/asuswrt/test_init.py
@@ -26,5 +26,5 @@ async def test_disconnect_on_stop(hass: HomeAssistant, connect_legacy) -> None:
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
 
-    assert connect_legacy.return_value.connection.disconnect.call_count == 1
+    assert connect_legacy.return_value.async_disconnect.await_count == 1
     assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -1,6 +1,6 @@
 """The tests for the august platform."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from aiohttp import ClientResponseError
 import pytest
@@ -33,6 +33,8 @@ from .mocks import (
     _mock_inoperative_august_lock_detail,
     _mock_lock_with_offline_key,
     _mock_operative_august_lock_detail,
+    mock_august_config_entry,
+    mock_client_credentials,
 )
 
 from tests.common import MockConfigEntry
@@ -284,3 +286,18 @@ async def test_oauth_migration_on_legacy_entry(hass: HomeAssistant) -> None:
     assert len(flows) == 1
     assert flows[0]["step_id"] == "pick_implementation"
     assert flows[0]["context"]["source"] == "reauth"
+
+
+async def test_oauth_implementation_not_available(hass: HomeAssistant) -> None:
+    """Test that unavailable OAuth implementation raises ConfigEntryNotReady."""
+    await mock_client_credentials(hass)
+    entry = await mock_august_config_entry(hass)
+
+    with patch(
+        "homeassistant.components.august.config_entry_oauth2_flow.async_get_config_entry_implementation",
+        side_effect=ValueError("Implementation not available"),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -703,6 +703,67 @@ async def test_discovery_match_by_local_name(
         assert mock_config_flow.mock_calls[0][1][0] == "switchbot"
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_discovery_match_by_service_uuid_when_name_changes_from_mac(
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
+) -> None:
+    """Test bluetooth discovery still matches when name changes from MAC address to real name."""
+    mock_bt = [
+        {
+            "domain": "improv_ble",
+            "service_uuid": "00467768-6228-2272-4663-277478268000",
+        }
+    ]
+    with (
+        patch(
+            "homeassistant.components.bluetooth.async_get_bluetooth",
+            return_value=mock_bt,
+        ),
+        patch.object(hass.config_entries.flow, "async_init") as mock_config_flow,
+    ):
+        await async_setup_with_default_adapter(hass)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        assert len(mock_bleak_scanner_start.mock_calls) == 1
+
+        # First advertisement: name is MAC address, with service UUID
+        # This should trigger discovery
+        device_mac_name = generate_ble_device("64:E8:33:7E:0D:9E", "64:E8:33:7E:0D:9E")
+        adv_mac_name = generate_advertisement_data(
+            local_name="64:E8:33:7E:0D:9E",
+            service_uuids=["00467768-6228-2272-4663-277478268000"],
+            service_data={
+                "00004677-0000-1000-8000-00805f9b34fb": b"\x02\x00\x00\x00\x00\x00"
+            },
+        )
+
+        inject_advertisement(hass, device_mac_name, adv_mac_name)
+        await hass.async_block_till_done()
+
+        assert len(mock_config_flow.mock_calls) == 1
+        assert mock_config_flow.mock_calls[0][1][0] == "improv_ble"
+        mock_config_flow.reset_mock()
+
+        # Second advertisement: name changes to real name, same service UUID
+        # This should trigger discovery again because the name changed
+        device_real_name = generate_ble_device("64:E8:33:7E:0D:9E", "improvtest")
+        adv_real_name = generate_advertisement_data(
+            local_name="improvtest",
+            service_uuids=["00467768-6228-2272-4663-277478268000"],
+            service_data={
+                "00004677-0000-1000-8000-00805f9b34fb": b"\x02\x00\x00\x00\x00\x00"
+            },
+        )
+
+        inject_advertisement(hass, device_real_name, adv_real_name)
+        await hass.async_block_till_done()
+
+        # Should still match improv_ble even though name changed
+        assert len(mock_config_flow.mock_calls) == 1
+        assert mock_config_flow.mock_calls[0][1][0] == "improv_ble"
+
+
 @pytest.mark.usefixtures("macos_adapter")
 async def test_discovery_match_by_manufacturer_id_and_manufacturer_data_start(
     hass: HomeAssistant, mock_bleak_scanner_start: MagicMock

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -48,7 +48,10 @@ async def test_pin_request_succeeds(hass: HomeAssistant) -> None:
 
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "authorize"
-        assert result["description_placeholders"] == {"pin": "test-pin"}
+        assert result["description_placeholders"] == {
+            "pin": "test-pin",
+            "auth_url": "https://www.ecobee.com/consumerportal/index.html",
+        }
 
 
 async def test_pin_request_fails(hass: HomeAssistant) -> None:
@@ -107,4 +110,7 @@ async def test_token_request_fails(hass: HomeAssistant) -> None:
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "authorize"
         assert result["errors"]["base"] == "token_request_failed"
-        assert result["description_placeholders"] == {"pin": "test-pin"}
+        assert result["description_placeholders"] == {
+            "pin": "test-pin",
+            "auth_url": "https://www.ecobee.com/consumerportal/index.html",
+        }

--- a/tests/components/homewizard/snapshots/test_sensor.ambr
+++ b/tests/components/homewizard/snapshots/test_sensor.ambr
@@ -12599,7 +12599,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': 'unavailable',
   })
 # ---
 # name: test_sensors[HWE-P1-zero-values-entity_ids1][sensor.device_energy_export_tariff_1:device-registry]
@@ -12690,7 +12690,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': 'unavailable',
   })
 # ---
 # name: test_sensors[HWE-P1-zero-values-entity_ids1][sensor.device_energy_export_tariff_2:device-registry]
@@ -12781,7 +12781,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': 'unavailable',
   })
 # ---
 # name: test_sensors[HWE-P1-zero-values-entity_ids1][sensor.device_energy_export_tariff_3:device-registry]
@@ -12872,7 +12872,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': 'unavailable',
   })
 # ---
 # name: test_sensors[HWE-P1-zero-values-entity_ids1][sensor.device_energy_export_tariff_4:device-registry]
@@ -12963,7 +12963,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': 'unavailable',
   })
 # ---
 # name: test_sensors[HWE-P1-zero-values-entity_ids1][sensor.device_energy_import:device-registry]
@@ -13054,7 +13054,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': 'unavailable',
   })
 # ---
 # name: test_sensors[HWE-P1-zero-values-entity_ids1][sensor.device_energy_import_tariff_1:device-registry]
@@ -13145,7 +13145,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': 'unavailable',
   })
 # ---
 # name: test_sensors[HWE-P1-zero-values-entity_ids1][sensor.device_energy_import_tariff_2:device-registry]
@@ -13236,7 +13236,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': 'unavailable',
   })
 # ---
 # name: test_sensors[HWE-P1-zero-values-entity_ids1][sensor.device_energy_import_tariff_3:device-registry]
@@ -13327,7 +13327,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': 'unavailable',
   })
 # ---
 # name: test_sensors[HWE-P1-zero-values-entity_ids1][sensor.device_energy_import_tariff_4:device-registry]
@@ -13418,7 +13418,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': 'unavailable',
   })
 # ---
 # name: test_sensors[HWE-P1-zero-values-entity_ids1][sensor.device_frequency:device-registry]
@@ -15249,7 +15249,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': 'unavailable',
   })
 # ---
 # name: test_sensors[HWE-SKT-11-entity_ids2][sensor.device_energy_import:device-registry]

--- a/tests/components/yale/test_init.py
+++ b/tests/components/yale/test_init.py
@@ -1,6 +1,6 @@
 """The tests for the yale platform."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from aiohttp import ClientResponseError
 import pytest
@@ -28,6 +28,8 @@ from .mocks import (
     _mock_inoperative_yale_lock_detail,
     _mock_lock_with_offline_key,
     _mock_operative_yale_lock_detail,
+    mock_client_credentials,
+    mock_yale_config_entry,
 )
 
 from tests.typing import WebSocketGenerator
@@ -234,3 +236,18 @@ async def test_device_remove_devices(
     )
     response = await client.remove_device(dead_device_entry.id, config_entry.entry_id)
     assert response["success"]
+
+
+async def test_oauth_implementation_not_available(hass: HomeAssistant) -> None:
+    """Test that unavailable OAuth implementation raises ConfigEntryNotReady."""
+    await mock_client_credentials(hass)
+    entry = await mock_yale_config_entry(hass)
+
+    with patch(
+        "homeassistant.components.yale.config_entry_oauth2_flow.async_get_config_entry_implementation",
+        side_effect=ValueError("Implementation not available"),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
- Bump aioasuswrt to 1.5.1 ([@kennedyshead] - [#153209]) ([asuswrt docs]) (dependency)
- PushSafer: Handle empty data section properly ([@LennartC] - [#154109]) ([pushsafer docs])
- Remove redudant state write in Smart Meter Texas ([@srirams] - [#154126]) ([smart_meter_texas docs])
- Fix state class for Overkiz water consumption ([@Yvan13120] - [#154164]) ([overkiz docs])
- Bump frontend 20251001.4 ([@piitaya] - [#154218]) ([frontend docs])
- Bump aioamazondevices to 6.4.1 ([@chemelli74] - [#154228]) ([alexa_devices docs]) (dependency)
- Move URL out of Mealie strings.json ([@andrew-codechimp] - [#154230]) ([mealie docs])
- Move URL out of Mastodon strings.json ([@andrew-codechimp] - [#154231]) ([mastodon docs])
- Move URL out of Switcher strings.json ([@thecode] - [#154240]) ([switcher_kis docs])
- Remove URL from ViCare strings.json ([@CFenner] - [#154243]) ([vicare docs])
- Fix August integration to handle unavailable OAuth implementation at startup ([@bdraco] - [#154244]) ([august docs])
- Fix Yale integration to handle unavailable OAuth implementation at startup ([@bdraco] - [#154245]) ([yale docs])
- Move url like strings to placeholders for nibe ([@elupus] - [#154249]) ([nibe_heatpump docs])
- Add description placeholders in Uptime Kuma config flow ([@tr4nt0r] - [#154252]) ([uptime_kuma docs])
- Add description placeholders to pyLoad config flow ([@tr4nt0r] - [#154254]) ([pyload docs])
- Fix home wiziard total increasing sensors returning 0 ([@jbouwh] - [#154264]) ([homewizard docs])
- Bump pyprobeplus to 1.1.0 ([@pantherale0] - [#154265]) ([probe_plus docs]) (dependency)
- Update Snoo strings.json to include weaning_baseline ([@dschafer] - [#154268]) ([snoo docs])
- Move Electricity Maps url out of strings.json ([@jpbede] - [#154284]) ([co2signal docs])
- Bump aioamazondevices to 6.4.3 ([@chemelli74] - [#154293]) ([alexa_devices docs]) (dependency)
- Move URL out of Overkiz Config Flow descriptions ([@iMicknl] - [#154315]) ([overkiz docs])
- AsusWRT: Pass only online clients to the device list from the API ([@Vaskivskyi] - [#154322]) ([asuswrt docs])
- Move Ecobee authorization URL out of strings.json ([@ogruendel] - [#154332]) ([ecobee docs])
- Move URLs out of SABnzbd strings.json ([@shaiu] - [#154333]) ([sabnzbd docs])
- Move developer url out of strings.json for coinbase setup flow ([@ogruendel] - [#154339]) ([coinbase docs])
- Fix Bluetooth discovery for devices with alternating advertisement names ([@bdraco] - [#154347]) ([bluetooth docs])
- Bump opower to 0.15.7 ([@tronikos] - [#154351]) ([opower docs]) (dependency)
- update pysqueezebox lib to 0.13.0 ([@wollew] - [#154358]) ([squeezebox docs]) (dependency)
- Move URL out of sfr_box strings.json ([@epenet] - [#154364]) ([sfr_box docs])
- Move translatable URLs out of strings.json for huawei lte ([@sonianuj287] - [#154368]) ([huawei_lte docs])
- Bump aioairq to 0.4.7 ([@Sibgatulin] - [#154386]) ([airq docs]) (dependency)
- Bump aiocomelit to 1.1.2 ([@chemelli74] - [#154393]) ([comelit docs]) (dependency)
- Use `async_schedule_reload` instead of `async_reload` for ZHA ([@puddly] - [#154397]) ([zha docs])
- Move igloohome API access URL into constant placeholders ([@DannyS95] - [#154430]) ([igloohome docs])
- Add missing`long_press` entry for trigger_type in strings.json for Hue ([@mvdwetering] - [#154437]) ([hue docs])
- Move translatable URLs out of strings.json for isy994 ([@sonianuj287] - [#154464]) ([isy994 docs])
- OpenUV: Fix update by skipping when protection window is null ([@wbyoung] - [#154487]) ([openuv docs])
- Bump aioamazondevices to 6.4.4 ([@chemelli74] - [#154538]) ([alexa_devices docs]) (dependency)
- Move URL out of Nuheat strings.json ([@tstabrawa] - [#154580]) ([nuheat docs])
- Bump pyvesync version to 3.1.2 ([@cdnninja] - [#154650]) ([vesync docs]) (dependency)

[#152881]: https://github.com/home-assistant/core/pull/152881
[#153209]: https://github.com/home-assistant/core/pull/153209
[#153582]: https://github.com/home-assistant/core/pull/153582
[#154109]: https://github.com/home-assistant/core/pull/154109
[#154126]: https://github.com/home-assistant/core/pull/154126
[#154164]: https://github.com/home-assistant/core/pull/154164
[#154181]: https://github.com/home-assistant/core/pull/154181
[#154218]: https://github.com/home-assistant/core/pull/154218
[#154228]: https://github.com/home-assistant/core/pull/154228
[#154230]: https://github.com/home-assistant/core/pull/154230
[#154231]: https://github.com/home-assistant/core/pull/154231
[#154240]: https://github.com/home-assistant/core/pull/154240
[#154243]: https://github.com/home-assistant/core/pull/154243
[#154244]: https://github.com/home-assistant/core/pull/154244
[#154245]: https://github.com/home-assistant/core/pull/154245
[#154249]: https://github.com/home-assistant/core/pull/154249
[#154252]: https://github.com/home-assistant/core/pull/154252
[#154254]: https://github.com/home-assistant/core/pull/154254
[#154264]: https://github.com/home-assistant/core/pull/154264
[#154265]: https://github.com/home-assistant/core/pull/154265
[#154268]: https://github.com/home-assistant/core/pull/154268
[#154284]: https://github.com/home-assistant/core/pull/154284
[#154293]: https://github.com/home-assistant/core/pull/154293
[#154315]: https://github.com/home-assistant/core/pull/154315
[#154322]: https://github.com/home-assistant/core/pull/154322
[#154332]: https://github.com/home-assistant/core/pull/154332
[#154333]: https://github.com/home-assistant/core/pull/154333
[#154339]: https://github.com/home-assistant/core/pull/154339
[#154347]: https://github.com/home-assistant/core/pull/154347
[#154351]: https://github.com/home-assistant/core/pull/154351
[#154358]: https://github.com/home-assistant/core/pull/154358
[#154364]: https://github.com/home-assistant/core/pull/154364
[#154368]: https://github.com/home-assistant/core/pull/154368
[#154386]: https://github.com/home-assistant/core/pull/154386
[#154393]: https://github.com/home-assistant/core/pull/154393
[#154397]: https://github.com/home-assistant/core/pull/154397
[#154430]: https://github.com/home-assistant/core/pull/154430
[#154437]: https://github.com/home-assistant/core/pull/154437
[#154464]: https://github.com/home-assistant/core/pull/154464
[#154487]: https://github.com/home-assistant/core/pull/154487
[#154538]: https://github.com/home-assistant/core/pull/154538
[#154580]: https://github.com/home-assistant/core/pull/154580
[#154650]: https://github.com/home-assistant/core/pull/154650
[@CFenner]: https://github.com/CFenner
[@DannyS95]: https://github.com/DannyS95
[@LennartC]: https://github.com/LennartC
[@Sibgatulin]: https://github.com/Sibgatulin
[@Vaskivskyi]: https://github.com/Vaskivskyi
[@Yvan13120]: https://github.com/Yvan13120
[@andrew-codechimp]: https://github.com/andrew-codechimp
[@bdraco]: https://github.com/bdraco
[@cdnninja]: https://github.com/cdnninja
[@chemelli74]: https://github.com/chemelli74
[@dschafer]: https://github.com/dschafer
[@elupus]: https://github.com/elupus
[@epenet]: https://github.com/epenet
[@frenck]: https://github.com/frenck
[@iMicknl]: https://github.com/iMicknl
[@jbouwh]: https://github.com/jbouwh
[@jpbede]: https://github.com/jpbede
[@kennedyshead]: https://github.com/kennedyshead
[@mvdwetering]: https://github.com/mvdwetering
[@ogruendel]: https://github.com/ogruendel
[@pantherale0]: https://github.com/pantherale0
[@piitaya]: https://github.com/piitaya
[@puddly]: https://github.com/puddly
[@shaiu]: https://github.com/shaiu
[@sonianuj287]: https://github.com/sonianuj287
[@srirams]: https://github.com/srirams
[@thecode]: https://github.com/thecode
[@tr4nt0r]: https://github.com/tr4nt0r
[@tronikos]: https://github.com/tronikos
[@tstabrawa]: https://github.com/tstabrawa
[@wbyoung]: https://github.com/wbyoung
[@wollew]: https://github.com/wollew
[airq docs]: https://www.home-assistant.io/integrations/airq/
[alexa_devices docs]: https://www.home-assistant.io/integrations/alexa_devices/
[asuswrt docs]: https://www.home-assistant.io/integrations/asuswrt/
[august docs]: https://www.home-assistant.io/integrations/august/
[bluetooth docs]: https://www.home-assistant.io/integrations/bluetooth/
[co2signal docs]: https://www.home-assistant.io/integrations/co2signal/
[coinbase docs]: https://www.home-assistant.io/integrations/coinbase/
[comelit docs]: https://www.home-assistant.io/integrations/comelit/
[ecobee docs]: https://www.home-assistant.io/integrations/ecobee/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[homewizard docs]: https://www.home-assistant.io/integrations/homewizard/
[huawei_lte docs]: https://www.home-assistant.io/integrations/huawei_lte/
[hue docs]: https://www.home-assistant.io/integrations/hue/
[igloohome docs]: https://www.home-assistant.io/integrations/igloohome/
[isy994 docs]: https://www.home-assistant.io/integrations/isy994/
[mastodon docs]: https://www.home-assistant.io/integrations/mastodon/
[mealie docs]: https://www.home-assistant.io/integrations/mealie/
[nibe_heatpump docs]: https://www.home-assistant.io/integrations/nibe_heatpump/
[nuheat docs]: https://www.home-assistant.io/integrations/nuheat/
[openuv docs]: https://www.home-assistant.io/integrations/openuv/
[opower docs]: https://www.home-assistant.io/integrations/opower/
[overkiz docs]: https://www.home-assistant.io/integrations/overkiz/
[probe_plus docs]: https://www.home-assistant.io/integrations/probe_plus/
[pushsafer docs]: https://www.home-assistant.io/integrations/pushsafer/
[pyload docs]: https://www.home-assistant.io/integrations/pyload/
[sabnzbd docs]: https://www.home-assistant.io/integrations/sabnzbd/
[sfr_box docs]: https://www.home-assistant.io/integrations/sfr_box/
[smart_meter_texas docs]: https://www.home-assistant.io/integrations/smart_meter_texas/
[snoo docs]: https://www.home-assistant.io/integrations/snoo/
[squeezebox docs]: https://www.home-assistant.io/integrations/squeezebox/
[switcher_kis docs]: https://www.home-assistant.io/integrations/switcher_kis/
[uptime_kuma docs]: https://www.home-assistant.io/integrations/uptime_kuma/
[vesync docs]: https://www.home-assistant.io/integrations/vesync/
[vicare docs]: https://www.home-assistant.io/integrations/vicare/
[yale docs]: https://www.home-assistant.io/integrations/yale/
[zha docs]: https://www.home-assistant.io/integrations/zha/