### PR TITLE
Add stop_record service to Camera

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -70,6 +70,7 @@ from .const import (
     PREF_ORIENTATION,
     PREF_PRELOAD_STREAM,
     SERVICE_RECORD,
+    SERVICE_STOP_RECORD,
     CameraState,
     StreamType,
 )
@@ -143,6 +144,8 @@ CAMERA_SERVICE_RECORD: VolDictType = {
     vol.Optional(CONF_DURATION, default=30): vol.Coerce(int),
     vol.Optional(CONF_LOOKBACK, default=0): vol.Coerce(int),
 }
+
+CAMERA_SERVICE_STOP_RECORD: VolDictType = {}
 
 
 class CameraEntityDescription(EntityDescription, frozen_or_thawed=True):
@@ -398,6 +401,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
     component.async_register_entity_service(
         SERVICE_RECORD, CAMERA_SERVICE_RECORD, async_handle_record_service
+    )
+
+    component.async_register_entity_service(
+        SERVICE_STOP_RECORD,
+        CAMERA_SERVICE_STOP_RECORD,
+        async_handle_stop_record_service,
     )
 
     @callback
@@ -1108,3 +1117,11 @@ async def async_handle_record_service(
         duration=service_call.data[CONF_DURATION],
         lookback=service_call.data[CONF_LOOKBACK],
     )
+
+
+async def async_handle_stop_record_service(
+    camera: Camera, service_call: ServiceCall
+) -> None:
+    """Handle stop stream recording service calls: stops recording if any is on going else does nothing."""
+    if camera.stream is not None and camera.stream.is_recording():
+        await camera.stream.async_stop_record()

--- a/homeassistant/components/camera/const.py
+++ b/homeassistant/components/camera/const.py
@@ -22,6 +22,7 @@ PREF_PRELOAD_STREAM: Final = "preload_stream"
 PREF_ORIENTATION: Final = "orientation"
 
 SERVICE_RECORD: Final = "record"
+SERVICE_STOP_RECORD: Final = "stop_record"
 
 CONF_LOOKBACK: Final = "lookback"
 CONF_DURATION: Final = "duration"

--- a/homeassistant/components/camera/icons.json
+++ b/homeassistant/components/camera/icons.json
@@ -23,6 +23,9 @@
     "snapshot": {
       "service": "mdi:camera"
     },
+    "stop_record": {
+      "service": "mdi:stop"
+    },
     "turn_off": {
       "service": "mdi:video-off"
     },

--- a/homeassistant/components/camera/services.yaml
+++ b/homeassistant/components/camera/services.yaml
@@ -72,3 +72,8 @@ record:
           min: 0
           max: 300
           unit_of_measurement: seconds
+
+stop_record:
+  target:
+    entity:
+      domain: camera

--- a/homeassistant/components/camera/strings.json
+++ b/homeassistant/components/camera/strings.json
@@ -106,6 +106,10 @@
           "description": "Planned lookback period to include in the recording (in addition to the duration). Only available if there is currently an active HLS stream. The actual length of the lookback period may vary."
         }
       }
+    },
+    "stop_record": {
+      "name": "Stop Recording",
+      "description": "Stops an on-going Recording."
     }
   },
   "selector": {}

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -589,6 +589,18 @@ class Stream:
 
         await recorder.async_record()
 
+    def is_recording(self) -> bool:
+        """Return True if the stream is currently recording."""
+        return RECORDER_PROVIDER in self._outputs
+
+    async def async_stop_record(self) -> None:
+        """Stop stream recording."""
+        # Remove recorder
+        if (recorder := self._outputs.get(RECORDER_PROVIDER)) is None:
+            raise HomeAssistantError("Stream not recording!")
+
+        await self.remove_provider(recorder)
+
     async def async_get_image(
         self,
         width: int | None = None,

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -80,6 +80,27 @@ async def test_record_stream(hass: HomeAssistant, filename, h264_video) -> None:
     assert os.path.exists(filename)
 
 
+async def test_stop_record(hass: HomeAssistant, filename, h264_video) -> None:
+    """Test stop_record stream."""
+
+    stream = create_stream(hass, h264_video, {}, dynamic_stream_settings())
+    stream.add_provider(RECORDER_PROVIDER)
+    assert stream.is_recording()
+    await stream.async_stop_record()
+    assert not stream.is_recording()
+
+
+async def test_stop_record_not_recording(
+    hass: HomeAssistant, filename, h264_video
+) -> None:
+    """Test stop_record not recording stream."""
+
+    stream = create_stream(hass, h264_video, {}, dynamic_stream_settings())
+    assert not stream.is_recording()
+    with pytest.raises(HomeAssistantError):
+        await stream.async_stop_record()
+
+
 async def test_record_lookback(hass: HomeAssistant, filename, h264_video) -> None:
     """Exercise record with lookback."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add `stop_record` service to Camera integration. The goal is to be able to stop an on-going recording before its initially setup `duration` when it was started using the`record` service.

The added service/action is internally calling the internal `stream` of the Camera to proceed with the stop of the on-going recording if any. If no recording is on-going, nothing is done and no Error is raised so that this action could also be called if the user wants to force stop any on-going recording before starting a new one.

The `Stream` integration has also been updated to add a function to stop the recording: it does the same than what the `record` action does when it reaches its `duration`: it removes the "recorder" from the `stream` providers.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://community.home-assistant.io/t/camera-service-to-stop-recording/132556
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41372
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
