### PR TITLE
Allow to remove OpenRGB devices that are disconnected

### DIFF
--- a/homeassistant/components/openrgb/__init__.py
+++ b/homeassistant/components/openrgb/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN
 from .coordinator import OpenRGBConfigEntry, OpenRGBCoordinator
@@ -48,3 +49,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> b
 async def async_unload_entry(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: OpenRGBConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Remove the config entry if the device is no longer connected."""
+    coordinator = entry.runtime_data
+
+    for domain, identifier in device_entry.identifiers:
+        if domain != DOMAIN:
+            continue
+
+        # Block removal of the OpenRGB SDK Server device
+        if identifier == entry.entry_id:
+            return False
+
+        # Block removal of the OpenRGB device if it is still connected
+        if identifier in coordinator.data:
+            return False
+
+        return True
+
+    # Not our device
+    return True

--- a/homeassistant/components/openrgb/__init__.py
+++ b/homeassistant/components/openrgb/__init__.py
@@ -54,7 +54,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> 
 async def async_remove_config_entry_device(
     hass: HomeAssistant, entry: OpenRGBConfigEntry, device_entry: DeviceEntry
 ) -> bool:
-    """Remove the config entry if the device is no longer connected."""
+    """Allows removal of device if it is no longer connected."""
     coordinator = entry.runtime_data
 
     for domain, identifier in device_entry.identifiers:
@@ -69,7 +69,5 @@ async def async_remove_config_entry_device(
         if identifier in coordinator.data:
             return False
 
-        return True
-
-    # Not our device
+    # Device is not connected or is not an OpenRGB device, allow removal
     return True

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -8,6 +8,7 @@ from openrgb.utils import ControllerParsingError, OpenRGBDisconnected, SDKVersio
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.openrgb import async_remove_config_entry_device
 from homeassistant.components.openrgb.const import DOMAIN, SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
@@ -57,6 +58,96 @@ async def test_server_device_registry(
     )
 
     assert server_device == snapshot
+
+
+async def test_remove_config_entry_device_server(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+) -> None:
+    """Test that server device cannot be removed."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    server_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    )
+
+    assert server_device is not None
+
+    # Try to remove server device - should be blocked
+    result = await async_remove_config_entry_device(
+        hass, mock_config_entry, server_device
+    )
+
+    assert result is False
+
+
+async def test_remove_config_entry_device_still_connected(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+) -> None:
+    """Test that connected devices cannot be removed."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+
+    # Get a device that's in coordinator.data (still connected)
+    devices = dr.async_entries_for_config_entry(
+        device_registry, mock_config_entry.entry_id
+    )
+    rgb_device = next(
+        (d for d in devices if d.identifiers != {(DOMAIN, mock_config_entry.entry_id)}),
+        None,
+    )
+
+    if rgb_device:
+        # Try to remove device that's still connected - should be blocked
+        result = await async_remove_config_entry_device(
+            hass, mock_config_entry, rgb_device
+        )
+        assert result is False
+
+
+async def test_remove_config_entry_device_disconnected(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that disconnected devices can be removed."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Create a device that's not in coordinator.data (disconnected)
+    entry_id = mock_config_entry.entry_id
+    disconnected_device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={
+            (
+                DOMAIN,
+                f"{entry_id}||KEYBOARD||Old Vendor||Old Device||OLD123||Old Location",
+            )
+        },
+        name="Old Disconnected Device",
+        via_device=(DOMAIN, entry_id),
+    )
+
+    # Try to remove disconnected device - should succeed
+    result = await async_remove_config_entry_device(
+        hass, mock_config_entry, disconnected_device
+    )
+
+    assert result is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR changes the OpenRGB integration so that users can delete the devices. However, only deletion of disconnected devices will be permitted.

This is useful in case the user has changed some RGB peripheral and it's not coming back. The alternative would be to _Reconfigure_ the integration entry, but this provides a nicer user experience.

However, two things could be done in Home Assistant to improve this user experience:

1. Would be nice if integrations could mark individual devices can be deleted, so that the Delete button only appear where applicable. If this existed, number 2 below wouldn't be applicable.
2. Would be nice if Home Assistant allowed integrations to return a reason why a a device deletion was rejected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
