### PR TITLE
Add support for tuya scene switches

### DIFF
--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -97,16 +97,6 @@ SWITCHES: dict[DeviceCategory, tuple[SwitchEntityDescription, ...]] = {
             translation_key="indexed_switch",
             translation_placeholders={"index": "4"},
         ),
-        SwitchEntityDescription(
-            key=DPCode.SWITCH_5,
-            translation_key="indexed_switch",
-            translation_placeholders={"index": "5"},
-        ),
-        SwitchEntityDescription(
-            key=DPCode.SWITCH_6,
-            translation_key="indexed_switch",
-            translation_placeholders={"index": "6"},
-        ),
     ),
     DeviceCategory.CL: (
         SwitchEntityDescription(

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -76,6 +76,38 @@ SWITCHES: dict[DeviceCategory, tuple[SwitchEntityDescription, ...]] = {
             entity_category=EntityCategory.CONFIG,
         ),
     ),
+    DeviceCategory.CJKG: (
+        SwitchEntityDescription(
+            key=DPCode.SWITCH_1,
+            translation_key="indexed_switch",
+            translation_placeholders={"index": "1"},
+        ),
+        SwitchEntityDescription(
+            key=DPCode.SWITCH_2,
+            translation_key="indexed_switch",
+            translation_placeholders={"index": "2"},
+        ),
+        SwitchEntityDescription(
+            key=DPCode.SWITCH_3,
+            translation_key="indexed_switch",
+            translation_placeholders={"index": "3"},
+        ),
+        SwitchEntityDescription(
+            key=DPCode.SWITCH_4,
+            translation_key="indexed_switch",
+            translation_placeholders={"index": "4"},
+        ),
+        SwitchEntityDescription(
+            key=DPCode.SWITCH_5,
+            translation_key="indexed_switch",
+            translation_placeholders={"index": "5"},
+        ),
+        SwitchEntityDescription(
+            key=DPCode.SWITCH_6,
+            translation_key="indexed_switch",
+            translation_placeholders={"index": "6"},
+        ),
+    ),
     DeviceCategory.CL: (
         SwitchEntityDescription(
             key=DPCode.CONTROL_BACK,

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -15,6 +15,7 @@ from tests.common import MockConfigEntry
 DEVICE_MOCKS = [
     "bzyd_45idzfufidgee7ir",  # https://github.com/orgs/home-assistant/discussions/717
     "bzyd_ssimhf6r8kgwepfb",  # https://github.com/orgs/home-assistant/discussions/718
+    "cjkg_hmabvy81",  # https://github.com/orgs/home-assistant/discussions/1297
     "cjkg_uenof8jd",  # https://github.com/home-assistant/core/issues/151825
     "ckmkzq_1yyqfw4djv9eii3q",  # https://github.com/home-assistant/core/issues/150856
     "cl_3r8gc33pnqsxfe1g",  # https://github.com/tuya/tuya-home-assistant/issues/754

--- a/tests/components/tuya/fixtures/cjkg_hmabvy81.json
+++ b/tests/components/tuya/fixtures/cjkg_hmabvy81.json
@@ -1,0 +1,283 @@
+{
+  "endpoint": "https://apigw.tuyaus.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Interruptor",
+  "category": "cjkg",
+  "product_id": "hmabvy81",
+  "product_name": "Interruptor Zigbee",
+  "online": true,
+  "sub": true,
+  "time_zone": "-03:00",
+  "active_time": "2025-10-07T09:56:22+00:00",
+  "create_time": "2025-10-07T09:56:22+00:00",
+  "update_time": "2025-10-07T09:56:22+00:00",
+  "function": {
+    "scene_1": {
+      "type": "Enum",
+      "value": {
+        "range": ["scene"]
+      }
+    },
+    "scene_2": {
+      "type": "Enum",
+      "value": {
+        "range": ["scene"]
+      }
+    },
+    "scene_3": {
+      "type": "Enum",
+      "value": {
+        "range": ["scene"]
+      }
+    },
+    "scene_4": {
+      "type": "Enum",
+      "value": {
+        "range": ["scene"]
+      }
+    },
+    "mode_1": {
+      "type": "Enum",
+      "value": {
+        "range": ["switch_1", "scene_1"]
+      }
+    },
+    "mode_2": {
+      "type": "Enum",
+      "value": {
+        "range": ["switch_2", "scene_2"]
+      }
+    },
+    "mode_3": {
+      "type": "Enum",
+      "value": {
+        "range": ["switch_3", "scene_3"]
+      }
+    },
+    "mode_4": {
+      "type": "Enum",
+      "value": {
+        "range": ["switch_4", "scene_4"]
+      }
+    },
+    "switch_1": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "switch_2": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "switch_3": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "switch_4": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "countdown_1": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 43200,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "countdown_2": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 43200,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "countdown_3": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 43200,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "countdown_4": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 43200,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "switch_backlight": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "light_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["none", "relay", "pos"]
+      }
+    },
+    "relay_status": {
+      "type": "Enum",
+      "value": {
+        "range": ["power_off", "power_on", "last"]
+      }
+    }
+  },
+  "status_range": {
+    "scene_1": {
+      "type": "Enum",
+      "value": {
+        "range": ["scene"]
+      }
+    },
+    "scene_2": {
+      "type": "Enum",
+      "value": {
+        "range": ["scene"]
+      }
+    },
+    "scene_3": {
+      "type": "Enum",
+      "value": {
+        "range": ["scene"]
+      }
+    },
+    "scene_4": {
+      "type": "Enum",
+      "value": {
+        "range": ["scene"]
+      }
+    },
+    "mode_1": {
+      "type": "Enum",
+      "value": {
+        "range": ["switch_1", "scene_1"]
+      }
+    },
+    "mode_2": {
+      "type": "Enum",
+      "value": {
+        "range": ["switch_2", "scene_2"]
+      }
+    },
+    "mode_3": {
+      "type": "Enum",
+      "value": {
+        "range": ["switch_3", "scene_3"]
+      }
+    },
+    "mode_4": {
+      "type": "Enum",
+      "value": {
+        "range": ["switch_4", "scene_4"]
+      }
+    },
+    "switch_1": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "switch_2": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "switch_3": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "switch_4": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "countdown_1": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 43200,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "countdown_2": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 43200,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "countdown_3": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 43200,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "countdown_4": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 43200,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "switch_backlight": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "light_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["none", "relay", "pos"]
+      }
+    },
+    "relay_status": {
+      "type": "Enum",
+      "value": {
+        "range": ["power_off", "power_on", "last"]
+      }
+    }
+  },
+  "status": {
+    "scene_1": "scene",
+    "scene_2": "scene",
+    "scene_3": "scene",
+    "scene_4": "scene",
+    "mode_1": "switch_1",
+    "mode_2": "switch_2",
+    "mode_3": "switch_3",
+    "mode_4": "switch_4",
+    "switch_1": true,
+    "switch_2": true,
+    "switch_3": true,
+    "switch_4": true,
+    "countdown_1": 0,
+    "countdown_2": 0,
+    "countdown_3": 0,
+    "countdown_4": 0,
+    "switch_backlight": true,
+    "light_mode": "relay",
+    "relay_status": "power_off"
+  },
+  "set_up": false,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -1,4 +1,35 @@
 # serializer version: 1
+# name: test_device_registry[18yvbamhgkjc]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tuya',
+        '18yvbamhgkjc',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Tuya',
+    'model': 'Interruptor Zigbee',
+    'model_id': 'hmabvy81',
+    'name': 'Interruptor',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_device_registry[1nw1rysgyj8th1l5qbnxw]
   DeviceRegistryEntrySnapshot({
     'area_id': None,
@@ -2748,7 +2779,7 @@
     'labels': set({
     }),
     'manufacturer': 'Tuya',
-    'model': 'Smart Switch (unsupported)',
+    'model': 'Smart Switch',
     'model_id': 'uenof8jd',
     'name': 'Smart Switch',
     'name_by_user': None,

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -4644,6 +4644,198 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[switch.interruptor_switch_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.interruptor_switch_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Switch 1',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indexed_switch',
+    'unique_id': 'tuya.18yvbamhgkjcswitch_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.interruptor_switch_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Interruptor Switch 1',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.interruptor_switch_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.interruptor_switch_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.interruptor_switch_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Switch 2',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indexed_switch',
+    'unique_id': 'tuya.18yvbamhgkjcswitch_2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.interruptor_switch_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Interruptor Switch 2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.interruptor_switch_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.interruptor_switch_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.interruptor_switch_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Switch 3',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indexed_switch',
+    'unique_id': 'tuya.18yvbamhgkjcswitch_3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.interruptor_switch_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Interruptor Switch 3',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.interruptor_switch_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.interruptor_switch_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.interruptor_switch_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Switch 4',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indexed_switch',
+    'unique_id': 'tuya.18yvbamhgkjcswitch_4',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.interruptor_switch_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Interruptor Switch 4',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.interruptor_switch_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_platform_setup_and_discovery[switch.ion1000pro_child_lock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -7692,6 +7884,102 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.smart_odor_eliminator_pro_switch',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.smart_switch_switch_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.smart_switch_switch_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Switch 1',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indexed_switch',
+    'unique_id': 'tuya.dj8foneugkjcswitch_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.smart_switch_switch_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smart Switch Switch 1',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.smart_switch_switch_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.smart_switch_switch_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.smart_switch_switch_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Switch 2',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indexed_switch',
+    'unique_id': 'tuya.dj8foneugkjcswitch_2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.smart_switch_switch_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smart Switch Switch 2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.smart_switch_switch_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
## Proposed change

This change adds support to Tuya Scene Switch device category (`cjkg`).

Reference documentation:
* https://developer.tuya.com/en/docs/iot/f?id=K9gf7nx6jelo8
* https://developer.tuya.com/en/docs/iot/s?id=K9gf7o5o3iuww

Tested using Home Assistant OS and a real Tuya scene switch (previously unsupported).
_Product page:_ https://www.novadigitalsmart.com.br/produtos/interruptor-inteligente-zigbee-linha-topazio-full-switch

It works! 😁 
<img width="1097" height="842" alt="image" src="https://github.com/user-attachments/assets/5c41717c-a1ca-4b8e-b57f-8fdd6a6b9f87" />

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

This is related to this discussion: https://github.com/orgs/home-assistant/discussions/1297

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] ~Tests have been added to verify that the new code works.~
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] ~Documentation added/updated for [www.home-assistant.io][docs-repository]~

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] ~New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.~
- [ ] ~For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.~

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
