### PR TITLE
vesync show fan speed for smart tower fans

### DIFF
--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -40,14 +40,13 @@ VS_FAN_MODE_PET = "pet"
 VS_FAN_MODE_MANUAL = "manual"
 VS_FAN_MODE_NORMAL = "normal"
 
-# not a full list as manual is used as speed not present
+# not a full list as manual and normal is used as speed not present
 VS_FAN_MODE_PRESET_LIST_HA = [
     VS_FAN_MODE_AUTO,
     VS_FAN_MODE_SLEEP,
     VS_FAN_MODE_ADVANCED_SLEEP,
     VS_FAN_MODE_TURBO,
     VS_FAN_MODE_PET,
-    VS_FAN_MODE_NORMAL,
 ]
 NIGHT_LIGHT_LEVEL_BRIGHT = "bright"
 NIGHT_LIGHT_LEVEL_DIM = "dim"

--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -40,13 +40,14 @@ VS_FAN_MODE_PET = "pet"
 VS_FAN_MODE_MANUAL = "manual"
 VS_FAN_MODE_NORMAL = "normal"
 
-# not a full list as manual and normal is used as speed not present
+# not a full list as manual is used as speed not present
 VS_FAN_MODE_PRESET_LIST_HA = [
     VS_FAN_MODE_AUTO,
     VS_FAN_MODE_SLEEP,
     VS_FAN_MODE_ADVANCED_SLEEP,
     VS_FAN_MODE_TURBO,
     VS_FAN_MODE_PET,
+    VS_FAN_MODE_NORMAL,
 ]
 NIGHT_LIGHT_LEVEL_BRIGHT = "bright"
 NIGHT_LIGHT_LEVEL_DIM = "dim"

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -115,7 +115,10 @@ class VeSyncFanHA(VeSyncBaseEntity, FanEntity):
         """Return the currently set speed."""
 
         current_level = self.device.state.fan_level
-        if self.device.state.mode == VS_FAN_MODE_MANUAL and current_level is not None:
+        if (
+            self.device.state.mode in (VS_FAN_MODE_MANUAL, VS_FAN_MODE_NORMAL)
+            and current_level is not None
+        ):
             if current_level == 0:
                 return 0
             return ordered_list_item_to_percentage(
@@ -207,7 +210,7 @@ class VeSyncFanHA(VeSyncBaseEntity, FanEntity):
                 )
 
         # Switch to manual mode if not already set
-        if self.device.state.mode != VS_FAN_MODE_MANUAL:
+        if self.device.state.mode not in (VS_FAN_MODE_MANUAL, VS_FAN_MODE_NORMAL):
             if not await self.device.set_manual_mode():
                 raise HomeAssistantError(
                     "An error occurred while setting manual mode."

--- a/tests/components/vesync/snapshots/test_fan.ambr
+++ b/tests/components/vesync/snapshots/test_fan.ambr
@@ -670,7 +670,7 @@
       'friendly_name': 'SmartTowerFan',
       'mode': 'normal',
       'oscillating': True,
-      'percentage': None,
+      'percentage': 0,
       'percentage_step': 8.333333333333334,
       'preset_mode': 'normal',
       'preset_modes': list([


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This integration supports purifiers and a "smart tower fan" as fan platform.   They however are different devices with different modes. Both "manual"(purifiers) and "normal"(fans) are manually set speeds.   As such this change shows fan speeds when in either mode.  Tested on my purifier and see no impact as expected.   Snapshots show it solves the issue. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/154325
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
