### PR TITLE
Add missing tests for Nintendo Parental controls integration

### DIFF
--- a/homeassistant/components/nintendo_parental_controls/quality_scale.yaml
+++ b/homeassistant/components/nintendo_parental_controls/quality_scale.yaml
@@ -36,9 +36,9 @@ rules:
   entity-unavailable: todo
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: todo
-  reauthentication-flow: todo
-  test-coverage: todo
+  parallel-updates: done
+  reauthentication-flow: done
+  test-coverage: done
 
   # Gold
   devices: done

--- a/tests/components/nintendo_parental_controls/conftest.py
+++ b/tests/components/nintendo_parental_controls/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from pynintendoparental import NintendoParental
 from pynintendoparental.device import Device
+from pynintendoparental.exceptions import InvalidOAuthConfigurationException
 import pytest
 
 from homeassistant.components.nintendo_parental_controls.const import DOMAIN
@@ -69,6 +70,34 @@ def mock_nintendo_authenticator() -> Generator[MagicMock]:
         mock_auth.complete_login = AsyncMock()
         type(mock_auth).complete_login = mock_auth.complete_login
         mock_auth_class.generate_login.return_value = mock_auth
+        yield mock_auth
+
+
+@pytest.fixture
+def mock_failed_nintendo_authenticator() -> Generator[MagicMock]:
+    """Mock a failed Nintendo Authenticator."""
+    with (
+        patch(
+            "homeassistant.components.nintendo_parental_controls.Authenticator",
+            autospec=True,
+        ) as mock_auth_class,
+        patch(
+            "homeassistant.components.nintendo_parental_controls.config_flow.Authenticator",
+            new=mock_auth_class,
+        ),
+        patch(
+            "homeassistant.components.nintendo_parental_controls.coordinator.NintendoParental.update",
+            return_value=None,
+        ),
+    ):
+        mock_auth = MagicMock()
+        mock_auth.complete_login = AsyncMock(
+            side_effect=InvalidOAuthConfigurationException(
+                status_code=401,
+                message="Authentication failed",
+            )
+        )
+        mock_auth_class.complete_login = mock_auth.complete_login
         yield mock_auth
 
 

--- a/tests/components/nintendo_parental_controls/conftest.py
+++ b/tests/components/nintendo_parental_controls/conftest.py
@@ -34,6 +34,7 @@ def mock_nintendo_device() -> Device:
     mock.extra = {"firmwareVersion": {"displayedVersion": "99.99.99"}}
     mock.limit_time = 120
     mock.today_playing_time = 110
+    mock.today_time_remaining = 10
     mock.bedtime_alarm = time(hour=19)
     mock.set_bedtime_alarm.return_value = None
     mock.update_max_daily_playtime.return_value = None

--- a/tests/components/nintendo_parental_controls/snapshots/test_sensor.ambr
+++ b/tests/components/nintendo_parental_controls/snapshots/test_sensor.ambr
@@ -1,0 +1,113 @@
+# serializer version: 1
+# name: test_number[sensor.home_assistant_test_screen_time_remaining-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.home_assistant_test_screen_time_remaining',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Screen time remaining',
+    'platform': 'nintendo_parental_controls',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <NintendoParentalControlsSensor.TIME_REMAINING: 'time_remaining'>,
+    'unique_id': 'testdevid_time_remaining',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_number[sensor.home_assistant_test_screen_time_remaining-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Home Assistant Test Screen time remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.home_assistant_test_screen_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---
+# name: test_number[sensor.home_assistant_test_used_screen_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.home_assistant_test_used_screen_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Used screen time',
+    'platform': 'nintendo_parental_controls',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <NintendoParentalControlsSensor.PLAYING_TIME: 'playing_time'>,
+    'unique_id': 'testdevid_playing_time',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_number[sensor.home_assistant_test_used_screen_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Home Assistant Test Used screen time',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.home_assistant_test_used_screen_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '110',
+  })
+# ---

--- a/tests/components/nintendo_parental_controls/test_coordinator.py
+++ b/tests/components/nintendo_parental_controls/test_coordinator.py
@@ -1,0 +1,35 @@
+"""Test coordinator error handling."""
+
+from unittest.mock import AsyncMock
+
+from pynintendoparental.exceptions import InvalidOAuthConfigurationException
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_invalid_authentication(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nintendo_client: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test handling of invalid authentication."""
+    mock_nintendo_client.update.side_effect = InvalidOAuthConfigurationException(
+        status_code=401, message="Authentication failed"
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    # Ensure no entities are created
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    assert len(entries) == 0
+    # Ensure the config entry is marked as error
+    assert mock_config_entry.state == ConfigEntryState.SETUP_ERROR

--- a/tests/components/nintendo_parental_controls/test_init.py
+++ b/tests/components/nintendo_parental_controls/test_init.py
@@ -1,0 +1,29 @@
+"""Test __init__ error handling."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_invalid_authentication(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_failed_nintendo_authenticator: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test handling of invalid authentication."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Ensure no entities are created
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    assert len(entries) == 0
+    # Ensure the config entry is marked as error
+    assert mock_config_entry.state == ConfigEntryState.SETUP_ERROR

--- a/tests/components/nintendo_parental_controls/test_sensor.py
+++ b/tests/components/nintendo_parental_controls/test_sensor.py
@@ -1,4 +1,4 @@
-"""Test sensir platform."""
+"""Test sensor platform."""
 
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/nintendo_parental_controls/test_sensor.py
+++ b/tests/components/nintendo_parental_controls/test_sensor.py
@@ -1,0 +1,30 @@
+"""Test sensir platform."""
+
+from unittest.mock import AsyncMock, patch
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_number(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nintendo_client: AsyncMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test number platform."""
+    with patch(
+        "homeassistant.components.nintendo_parental_controls._PLATFORMS",
+        [Platform.SENSOR],
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds missing tests for the Nintendo Parental Controls integration:

- coordinator auth exception
- `async_setup_entry` auth exception
- sensor platform

Updated the quality scale:

test-coverage: 100%
reauth: added in https://github.com/home-assistant/core/pull/154077
parallel updates: already set but refined in https://github.com/home-assistant/core/pull/154866

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
