### PR TITLE
template: ensure blueprint variables are loaded on reload/start #154871

### DIFF
--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -149,6 +149,7 @@ async def _process_config(hass: HomeAssistant, hass_config: ConfigType) -> None:
                                     **entity_conf,
                                     "raw_blueprint_inputs": conf_section.raw_blueprint_inputs,
                                     "raw_configs": conf_section.raw_config,
+                                    "variables": getattr(conf_section, "variables", {}),
                                 }
                                 for entity_conf in conf_section[platform_domain]
                             ],

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_TRIGGERS,
     CONF_UNIQUE_ID,
+    CONF_VARIABLES,
     SERVICE_RELOAD,
 )
 from homeassistant.core import Event, HomeAssistant, ServiceCall
@@ -28,7 +29,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_integration
 from homeassistant.util.hass_dict import HassKey
 
-from .const import CONF_MAX, CONF_MIN, CONF_STEP, CONF_VARIABLES, DOMAIN, PLATFORMS
+from .const import CONF_MAX, CONF_MIN, CONF_STEP, DOMAIN, PLATFORMS
 from .coordinator import TriggerUpdateCoordinator
 from .helpers import async_get_blueprints
 

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_integration
 from homeassistant.util.hass_dict import HassKey
 
-from .const import CONF_MAX, CONF_MIN, CONF_STEP, DOMAIN, PLATFORMS
+from .const import CONF_MAX, CONF_MIN, CONF_STEP, CONF_VARIABLES, DOMAIN, PLATFORMS
 from .coordinator import TriggerUpdateCoordinator
 from .helpers import async_get_blueprints
 
@@ -144,12 +144,12 @@ async def _process_config(hass: HomeAssistant, hass_config: ConfigType) -> None:
                         DOMAIN,
                         {
                             "unique_id": conf_section.get(CONF_UNIQUE_ID),
+                            "variables": conf_section.get(CONF_VARIABLES),
                             "entities": [
                                 {
                                     **entity_conf,
                                     "raw_blueprint_inputs": conf_section.raw_blueprint_inputs,
                                     "raw_configs": conf_section.raw_config,
-                                    "variables": getattr(conf_section, "variables", {}),
                                 }
                                 for entity_conf in conf_section[platform_domain]
                             ],

--- a/tests/components/template/test_blueprint.py
+++ b/tests/components/template/test_blueprint.py
@@ -535,7 +535,6 @@ pytestmark = pytest.mark.asyncio
 async def test_blueprint_variables_load_on_reload(hass: HomeAssistant):
     """Test that blueprint variables load correctly on reload/start."""
 
-    # Simulate a blueprint/template config
     config = {
         "template": [
             {
@@ -550,16 +549,12 @@ async def test_blueprint_variables_load_on_reload(hass: HomeAssistant):
         ]
     }
 
-    # Initial setup (mimics HA start)
     assert await async_setup_component(hass, "template", config)
 
-    # Ensure the template variable 'switch' exists in state
     light_entity = hass.states.get("light.fake_switch")
     assert light_entity is not None
 
-    # Simulate a reload
     await hass.services.async_call("template", "reload", {}, blocking=True)
 
-    # After reload, variable should still be accessible
     light_entity = hass.states.get("light.fake_switch")
     assert light_entity is not None

--- a/tests/components/template/test_blueprint.py
+++ b/tests/components/template/test_blueprint.py
@@ -34,6 +34,7 @@ from homeassistant.components.template.config import (
 from homeassistant.const import STATE_ON
 from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.template import Template
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util, yaml as yaml_util
 
@@ -523,3 +524,17 @@ async def test_variables_for_entity(
     state = hass.states.get(f"{domain}.test")
     assert state is not None
     assert state.state == expected
+
+
+@pytest.mark.asyncio
+async def test_blueprint_variables_loaded(hass):
+    """Test that blueprint variables are available on HA start/reload."""
+    conf_section = type(
+        "ConfSection", (), {"variables": {"switch": "switch.test_switch"}}
+    )()
+    
+    tpl = Template("{{ switch }}", hass)
+    
+    rendered = tpl.async_render({"switch": conf_section.variables["switch"]})
+    
+    assert rendered == "switch.test_switch"

--- a/tests/components/template/test_blueprint.py
+++ b/tests/components/template/test_blueprint.py
@@ -525,12 +525,17 @@ async def test_variables_for_entity(
     assert state is not None
     assert state.state == expected
 
-"""Tests for blueprint variable loading in the template integration."""
-tmark = pytest.mark.asyncio
+"""Test blueprint variable loading for template integration."""
 
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+pytestmark = pytest.mark.asyncio
 async def test_blueprint_variables_load_on_reload(hass: HomeAssistant):
     """Test that blueprint variables load correctly on reload/start."""
 
+    # Simulate a blueprint/template config
     config = {
         "template": [
             {
@@ -545,13 +550,16 @@ async def test_blueprint_variables_load_on_reload(hass: HomeAssistant):
         ]
     }
 
+    # Initial setup (mimics HA start)
     assert await async_setup_component(hass, "template", config)
 
+    # Ensure the template variable 'switch' exists in state
     light_entity = hass.states.get("light.fake_switch")
     assert light_entity is not None
 
+    # Simulate a reload
     await hass.services.async_call("template", "reload", {}, blocking=True)
 
+    # After reload, variable should still be accessible
     light_entity = hass.states.get("light.fake_switch")
     assert light_entity is not None
-


### PR DESCRIPTION
Fixes blueprint variables not being available on template reload or HA start,
preventing 'switch' undefined errors.

After this, templates referencing blueprint variables like {{ switch }} will no longer be undefined on HA start or template reload.

References issue #154871.
