### PR TITLE
Check translation placeholders in CI

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -75,6 +75,9 @@ jobs:
         env:
           LOKALISE_TOKEN: ${{ secrets.LOKALISE_TOKEN }}
 
+      - name: Validate Translations
+        run: python3 -m script.translations validate
+
       - name: Archive translations
         shell: bash
         run: find ./homeassistant/components/*/translations -name "*.json" | tar zcvf translations.tar.gz -T -

--- a/script/translations/develop.py
+++ b/script/translations/develop.py
@@ -10,6 +10,10 @@ from .const import INTEGRATIONS_DIR
 from .util import flatten_translations, get_base_arg_parser, substitute_references
 
 
+class InvalidSubstitutionKey(Exception):
+    """Exception for invalid substitution keys."""
+
+
 def valid_integration(integration):
     """Test if it's a valid integration."""
     if not (INTEGRATIONS_DIR / integration).is_dir():
@@ -28,6 +32,47 @@ def get_arguments() -> argparse.Namespace:
     )
     parser.add_argument("--all", action="store_true", help="Process all integrations.")
     return parser.parse_args()
+
+
+def substitute_translation_references(integration_strings, flattened_translations):
+    """Recursively processes all translation strings for the integration."""
+    result = {}
+    for key, value in integration_strings.items():
+        if isinstance(value, dict):
+            sub_dict = substitute_translation_references(value, flattened_translations)
+            result[key] = sub_dict
+        elif isinstance(value, str):
+            try:
+                result[key] = substitute_reference(value, flattened_translations)
+            except InvalidSubstitutionKey as err:
+                print(f"Error: {err}")
+                sys.exit(1)
+
+    return result
+
+
+def substitute_reference(value, flattened_translations):
+    """Substitute localization key references in a translation string."""
+    matches = re.findall(r"\[\%key:([a-z0-9_]+(?:::(?:[a-z0-9-_])+)+)\%\]", value)
+    if not matches:
+        return value
+
+    new = value
+    for key in matches:
+        if key in flattened_translations:
+            new = new.replace(
+                f"[%key:{key}%]",
+                # New value can also be a substitution reference
+                substitute_reference(
+                    flattened_translations[key], flattened_translations
+                ),
+            )
+        else:
+            raise InvalidSubstitutionKey(
+                f"Invalid substitution key '{key}' found in string '{value}'"
+            )
+
+    return new
 
 
 def run_single(translations, flattened_translations, integration):

--- a/script/translations/develop.py
+++ b/script/translations/develop.py
@@ -34,47 +34,6 @@ def get_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def substitute_translation_references(integration_strings, flattened_translations):
-    """Recursively processes all translation strings for the integration."""
-    result = {}
-    for key, value in integration_strings.items():
-        if isinstance(value, dict):
-            sub_dict = substitute_translation_references(value, flattened_translations)
-            result[key] = sub_dict
-        elif isinstance(value, str):
-            try:
-                result[key] = substitute_reference(value, flattened_translations)
-            except InvalidSubstitutionKey as err:
-                print(f"Error: {err}")
-                sys.exit(1)
-
-    return result
-
-
-def substitute_reference(value, flattened_translations):
-    """Substitute localization key references in a translation string."""
-    matches = re.findall(r"\[\%key:([a-z0-9_]+(?:::(?:[a-z0-9-_])+)+)\%\]", value)
-    if not matches:
-        return value
-
-    new = value
-    for key in matches:
-        if key in flattened_translations:
-            new = new.replace(
-                f"[%key:{key}%]",
-                # New value can also be a substitution reference
-                substitute_reference(
-                    flattened_translations[key], flattened_translations
-                ),
-            )
-        else:
-            raise InvalidSubstitutionKey(
-                f"Invalid substitution key '{key}' found in string '{value}'"
-            )
-
-    return new
-
-
 def run_single(translations, flattened_translations, integration):
     """Run the script for a single integration."""
     print(f"Generating translations for {integration}")

--- a/script/translations/util.py
+++ b/script/translations/util.py
@@ -5,6 +5,7 @@ import json
 import os
 import pathlib
 import re
+import string
 import subprocess
 from typing import Any
 
@@ -25,6 +26,7 @@ def get_base_arg_parser() -> argparse.ArgumentParser:
             "frontend",
             "migrate",
             "upload",
+            "validate",
         ],
     )
     parser.add_argument("--debug", action="store_true", help="Enable log output")
@@ -139,3 +141,9 @@ def substitute_references(
             result[key] = substituted
 
     return result
+
+
+def extract_placeholders(value: str) -> set[str]:
+    """Extract placeholders from a format string."""
+    tuples = list(string.Formatter().parse(value))
+    return {tup[1] for tup in tuples if tup[1] is not None}

--- a/script/translations/validate.py
+++ b/script/translations/validate.py
@@ -46,7 +46,7 @@ def validate_integration_placeholders(
                 )
                 localized_value = substitute_reference(localized_value, localized_flat)
             except InvalidSubstitutionKey as err:
-                errors.append(f"  [{locale}] {key}: {err}")
+                errors.append(f"  [{locale}] {full_key} - {err}")
                 continue
 
             # Extract placeholders from both versions
@@ -54,26 +54,27 @@ def validate_integration_placeholders(
                 english_placeholders = extract_placeholders(english_value)
             except ValueError as err:
                 errors.append(
-                    f"  [{locale}] Invalid format string in strings.json at {key}: {err}"
+                    f"  [{locale}] {full_key} - Invalid format string in strings.json:"
+                    f" {err}"
                 )
                 continue
 
             try:
                 localized_placeholders = extract_placeholders(localized_value)
             except ValueError as err:
-                errors.append(f"  [{locale}] Invalid format string at {key}: {err}")
+                errors.append(f"  [{locale}] {full_key} Invalid format string: {err}")
                 continue
 
             # Compare placeholders
             if english_placeholders != localized_placeholders:
                 if english_placeholders < localized_placeholders:
                     errors.append(
-                        f"  [{locale}] {key}: placeholders were added "
+                        f"  [{locale}] {full_key} - new placeholders were added "
                         f"({localized_placeholders} > {english_placeholders})"
                     )
                 else:
                     errors.append(
-                        f"  [{locale}] {key}: placeholder mismatch "
+                        f"  [{locale}] {full_key} - placeholder mismatch "
                         f"({localized_placeholders} != {english_placeholders})"
                     )
 

--- a/script/translations/validate.py
+++ b/script/translations/validate.py
@@ -1,0 +1,140 @@
+"""Validate translation placeholder consistency."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .const import INTEGRATIONS_DIR
+from .develop import InvalidSubstitutionKey, substitute_reference
+from .upload import generate_upload_data
+from .util import extract_placeholders, flatten_translations, get_base_arg_parser
+
+
+def valid_integration(integration):
+    """Test if it's a valid integration."""
+    if not (INTEGRATIONS_DIR / integration).is_dir():
+        raise argparse.ArgumentTypeError(
+            f"The integration {integration} does not exist."
+        )
+    return integration
+
+
+def get_arguments() -> argparse.Namespace:
+    """Get parsed passed in arguments."""
+    parser = get_base_arg_parser()
+    parser.add_argument(
+        "--integration", type=valid_integration, help="Integration to validate."
+    )
+    return parser.parse_args()
+
+
+def validate_integration_placeholders(
+    integration_name: str,
+    integration_path: Path,
+    flattened_english: dict[str, str],
+) -> list[str]:
+    """Validate placeholder consistency for an integration.
+
+    Returns list of error messages.
+    """
+    errors = []
+
+    for translation_file in (integration_path / "translations").glob("*.json"):
+        locale = translation_file.stem
+
+        # Skip platform-specific files (e.g., sensor.nl.json) and backup files
+        if "." in locale:
+            continue
+
+        localized_data = json.loads(translation_file.read_text())
+        localized_flat = flatten_translations(localized_data)
+
+        for key, localized_value in localized_flat.items():
+            full_key = f"component::{integration_name}::{key}"
+
+            # Skip if key doesn't exist in English
+            if full_key not in flattened_english:
+                continue
+
+            # Resolve references
+            try:
+                english_value = substitute_reference(
+                    flattened_english[full_key], flattened_english
+                )
+                localized_value = substitute_reference(
+                    localized_value, flattened_english
+                )
+            except InvalidSubstitutionKey as err:
+                errors.append(f"  [{locale}] {key}: {err}")
+                continue
+
+            # Extract placeholders from both versions
+            try:
+                english_placeholders = extract_placeholders(english_value)
+            except ValueError as err:
+                errors.append(
+                    f"  [{locale}] Invalid format string in strings.json at {key}: {err}"
+                )
+                continue
+
+            try:
+                localized_placeholders = extract_placeholders(localized_value)
+            except ValueError as err:
+                errors.append(f"  [{locale}] Invalid format string at {key}: {err}")
+                continue
+
+            # Compare placeholders
+            if english_placeholders != localized_placeholders:
+                if english_placeholders < localized_placeholders:
+                    errors.append(
+                        f"  [{locale}] {key}: placeholders were added "
+                        f"({localized_placeholders} > {english_placeholders})"
+                    )
+                else:
+                    errors.append(
+                        f"  [{locale}] {key}: placeholder mismatch "
+                        f"({localized_placeholders} != {english_placeholders})"
+                    )
+
+    return errors
+
+
+def run():
+    """Run the validation."""
+    args = get_arguments()
+
+    # Load all English translations once
+    print("Loading English translations...")
+    translations = generate_upload_data()
+    flattened_english = flatten_translations(translations)
+
+    if args.integration:
+        integrations = [args.integration]
+    else:
+        # Validate all integrations
+        integrations = sorted(
+            [
+                d.name
+                for d in INTEGRATIONS_DIR.iterdir()
+                if d.is_dir() and (d / "strings.json").is_file()
+            ]
+        )
+
+    return_code = 0
+
+    for integration in integrations:
+        integration_path = INTEGRATIONS_DIR / integration
+        errors = validate_integration_placeholders(
+            integration, integration_path, flattened_english
+        )
+
+        if errors:
+            return_code = 1
+            print(f"\n{integration}:")
+
+            for error in errors:
+                print(error)
+
+    return return_code

--- a/script/translations/validate.py
+++ b/script/translations/validate.py
@@ -6,9 +6,9 @@ import json
 from pathlib import Path
 
 from .const import INTEGRATIONS_DIR
-from .develop import InvalidSubstitutionKey, substitute_reference
+from .error import MissingReference
 from .upload import generate_upload_data
-from .util import extract_placeholders, flatten_translations
+from .util import extract_placeholders, flatten_translations, substitute_reference
 
 
 def validate_integration_placeholders(
@@ -45,7 +45,7 @@ def validate_integration_placeholders(
                     flattened_english[full_key], flattened_english
                 )
                 localized_value = substitute_reference(localized_value, localized_flat)
-            except InvalidSubstitutionKey as err:
+            except MissingReference as err:
                 errors.append(f"  [{locale}] {full_key} - {err}")
                 continue
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Recent hardware integration changes have exposed a bug in translations: out-of-date translations can cause config flows to fail to translate. This PR adds some checks to validate translations.

This PR adds a new translations script as part of CI:
```console
$ python3 -m script.translations validate

tesla_wall_connector:
  [nb] config::flow_title: placeholder mismatch (set() != {'host', 'serial_number'})

blink:
  [zh-Hans] services::save_recent_clips::description: placeholders were added ({'camera name'} > set())

deconz:
  [et] device_automation::trigger_type::remote_button_rotated_fast: placeholder mismatch ({' subtype'} != {'subtype'})

honeywell:
  [ko] config::step::reauth_confirm::title: placeholder mismatch (set() != {'name'})

...
```

Attached is the full output on translations pulled from 2025.10.3: [validate.txt](https://github.com/user-attachments/files/23004190/validate.txt).

There are a few classes of error:
1. Core `strings.json` looks like `"flow_title": "{serial_number} ({host})",` but the translation provides `"flow_title": "",`:
   ```
   tesla_wall_connector:
     [nb] config::flow_title: placeholder mismatch (set() != {'host', 'serial_number'})
   ```
2. New placeholders were added to Core. This technically isn't a failure condition because we can still use the old translation:
   ```
    blink:
      [zh-Hans] services::save_recent_clips::description: placeholders were added ({'camera name'} > set())
    ```
3. Invalid substitution referenced in a translation:
   ```
   fyta:
     [et] entity::sensor::light_status::state::perfect: Invalid substitution key 'component::fyta::entity::sensor::plant_status::state::perfect' found in string '[%key:component::fyta::entity::sensor::plant_status::state::perfect%]'
   ```
4. Translation string contains an invalid placeholder, usually a stray bracket (`"message": "Viga {key} {option} } valimisel"`):
   ```
   lamarzocco:
     [et] Invalid format string at exceptions::select_option_error::message: Single '}' encountered in format string
   ```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
