### PR TITLE
Use common variables in platform tests for UptimeRobot

### DIFF
--- a/tests/components/uptimerobot/common.py
+++ b/tests/components/uptimerobot/common.py
@@ -47,7 +47,13 @@ MOCK_UPTIMEROBOT_MONITOR_PAUSED = {
     "type": 1,
     "url": "http://example.com",
 }
-
+MOCK_UPTIMEROBOT_MONITOR_2 = {
+    "id": 5678,
+    "friendly_name": "Test monitor 2",
+    "status": 2,
+    "type": 1,
+    "url": "http://example2.com",
+}
 
 MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA = {
     "domain": DOMAIN,

--- a/tests/components/uptimerobot/test_binary_sensor.py
+++ b/tests/components/uptimerobot/test_binary_sensor.py
@@ -15,6 +15,7 @@ from homeassistant.util import dt as dt_util
 
 from .common import (
     MOCK_UPTIMEROBOT_MONITOR,
+    MOCK_UPTIMEROBOT_MONITOR_2,
     UPTIMEROBOT_BINARY_SENSOR_TEST_ENTITY,
     mock_uptimerobot_api_response,
     setup_uptimerobot_integration,
@@ -65,20 +66,8 @@ async def test_binary_sensor_dynamic(hass: HomeAssistant) -> None:
         "pyuptimerobot.UptimeRobot.async_get_monitors",
         return_value=mock_uptimerobot_api_response(
             data=[
-                {
-                    "id": 1234,
-                    "friendly_name": "Test monitor",
-                    "status": 2,
-                    "type": 1,
-                    "url": "http://example.com",
-                },
-                {
-                    "id": 5678,
-                    "friendly_name": "Test monitor 2",
-                    "status": 2,
-                    "type": 1,
-                    "url": "http://example2.com",
-                },
+                MOCK_UPTIMEROBOT_MONITOR,
+                MOCK_UPTIMEROBOT_MONITOR_2,
             ]
         ),
     ):

--- a/tests/components/uptimerobot/test_sensor.py
+++ b/tests/components/uptimerobot/test_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.util import dt as dt_util
 
 from .common import (
     MOCK_UPTIMEROBOT_MONITOR,
+    MOCK_UPTIMEROBOT_MONITOR_2,
     STATE_UP,
     UPTIMEROBOT_SENSOR_TEST_ENTITY,
     mock_uptimerobot_api_response,
@@ -69,20 +70,8 @@ async def test_sensor_dynamic(hass: HomeAssistant) -> None:
         "pyuptimerobot.UptimeRobot.async_get_monitors",
         return_value=mock_uptimerobot_api_response(
             data=[
-                {
-                    "id": 1234,
-                    "friendly_name": "Test monitor",
-                    "status": 2,
-                    "type": 1,
-                    "url": "http://example.com",
-                },
-                {
-                    "id": 5678,
-                    "friendly_name": "Test monitor 2",
-                    "status": 2,
-                    "type": 1,
-                    "url": "http://example2.com",
-                },
+                MOCK_UPTIMEROBOT_MONITOR,
+                MOCK_UPTIMEROBOT_MONITOR_2,
             ]
         ),
     ):

--- a/tests/components/uptimerobot/test_switch.py
+++ b/tests/components/uptimerobot/test_switch.py
@@ -21,6 +21,7 @@ from homeassistant.util import dt as dt_util
 from .common import (
     MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA,
     MOCK_UPTIMEROBOT_MONITOR,
+    MOCK_UPTIMEROBOT_MONITOR_2,
     MOCK_UPTIMEROBOT_MONITOR_PAUSED,
     UPTIMEROBOT_SWITCH_TEST_ENTITY,
     MockApiResponseKey,
@@ -197,20 +198,8 @@ async def test_switch_dynamic(hass: HomeAssistant) -> None:
         "pyuptimerobot.UptimeRobot.async_get_monitors",
         return_value=mock_uptimerobot_api_response(
             data=[
-                {
-                    "id": 1234,
-                    "friendly_name": "Test monitor",
-                    "status": 2,
-                    "type": 1,
-                    "url": "http://example.com",
-                },
-                {
-                    "id": 5678,
-                    "friendly_name": "Test monitor 2",
-                    "status": 2,
-                    "type": 1,
-                    "url": "http://example2.com",
-                },
+                MOCK_UPTIMEROBOT_MONITOR,
+                MOCK_UPTIMEROBOT_MONITOR_2,
             ]
         ),
     ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use common variables in platform tests.
This will limit changes to #153508 and simplify maintenance.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
