### PR TITLE
Hide HA Connect Zigbee adapters in Z-Wave serial port selector

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -124,6 +124,14 @@ RF_REGIONS = [
     "USA",
 ]
 
+# USB devices to ignore in serial port selection (non-Z-Wave devices)
+# Format: (manufacturer, description)
+IGNORED_USB_DEVICES = [
+    ("Nabu Casa", "SkyConnect v1.0"),
+    ("Nabu Casa", "Home Assistant Connect ZBT-1"),
+    ("Nabu Casa", "ZBT-2"),
+]
+
 
 def get_manual_schema(user_input: dict[str, Any]) -> vol.Schema:
     """Return a schema for the manual step."""
@@ -155,6 +163,9 @@ def get_usb_ports() -> dict[str, str]:
     ports = list_ports.comports()
     port_descriptions = {}
     for port in ports:
+        if (port.manufacturer, port.description) in IGNORED_USB_DEVICES:
+            continue
+
         vid: str | None = None
         pid: str | None = None
         if port.vid is not None and port.pid is not None:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -126,11 +126,11 @@ RF_REGIONS = [
 
 # USB devices to ignore in serial port selection (non-Z-Wave devices)
 # Format: (manufacturer, description)
-IGNORED_USB_DEVICES = [
+IGNORED_USB_DEVICES = {
     ("Nabu Casa", "SkyConnect v1.0"),
     ("Nabu Casa", "Home Assistant Connect ZBT-1"),
     ("Nabu Casa", "ZBT-2"),
-]
+}
 
 
 def get_manual_schema(user_input: dict[str, Any]) -> vol.Schema:


### PR DESCRIPTION
## Proposed change

Change Z-Wave's config flow to ignore Home Assistant Connect ZBT-1/ZBT-2 Zigbee adapters in the serial port selector.
This is done by implementing a new `IGNORED_USB_DEVICES` list with `(manufacturer, usb_description)` tuples and known Nabu Casa Zigbee adapter names.

Note: We cannot use VID/PID for this, as ZWA-2 and early ZBT-2 units share the same VID/PID.


### Additional notes

This addresses https://github.com/zwave-js/backlog/issues/137.

I've also looked at fetching this info from USB discovery for Home Assistant hardware and Zigbee integrations, but that adds a lot of complexity and weird dependencies. This simple solution seems better and avoids any false-positives (e.g. ignoring a Zigbee + Z-Wave adapter with the same USB info).

We'll also look at doing something similar for the Zigbee integration (ZHA).

In the future, we wanna look at implementing a (custom) serial port selector in the frontend, also used by integrations for other Open Home Protocols. This/similar logic might be moved to that serial port selector then.
For now, this PR implements a simple way of hiding known non Z-Wave devices. Other manufacturers can also be added.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/137
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
