### PR TITLE
Translate Z-Wave "Socket device path" in config flow

### DIFF
--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -40,6 +40,7 @@
     "step": {
       "configure_addon_user": {
         "data": {
+          "socket_path": "Socket device path",
           "usb_path": "[%key:common::config_flow::data::usb_path%]"
         },
         "description": "Select your Z-Wave adapter",
@@ -71,6 +72,7 @@
           "s2_access_control_key": "[%key:component::zwave_js::config::step::configure_security_keys::data::s2_access_control_key%]",
           "s2_authenticated_key": "[%key:component::zwave_js::config::step::configure_security_keys::data::s2_authenticated_key%]",
           "s2_unauthenticated_key": "[%key:component::zwave_js::config::step::configure_security_keys::data::s2_unauthenticated_key%]",
+          "socket_path": "[%key:component::zwave_js::config::step::configure_addon_user::data::socket_path%]",
           "usb_path": "[%key:common::config_flow::data::usb_path%]"
         },
         "description": "[%key:component::zwave_js::config::step::configure_addon_user::description%]",
@@ -158,6 +160,7 @@
       },
       "choose_serial_port": {
         "data": {
+          "socket_path": "[%key:component::zwave_js::config::step::configure_addon_user::data::socket_path%]",
           "usb_path": "[%key:common::config_flow::data::usb_path%]"
         },
         "title": "Select your Z-Wave device"


### PR DESCRIPTION
## Proposed change

This allows for translation of the `socket_path` text field in three steps of Z-Wave's config flow.
For English, "Socket device path" is used.

<details><summary>Old and new screenshots (click to open)</summary>
<p>

### Before

<img width="501" height="442" alt="Bildschirmfoto 2025-10-21 um 12 50 21" src="https://github.com/user-attachments/assets/8fa3a981-399b-4ef8-957d-a12deeed88a6" />

### After

Choose serial port step | Configure addon reconfigure step | Configure addon user step 
---- | ---- | ----
<img width="445" height="447" alt="Bildschirmfoto 2025-10-21 um 13 27 50" src="https://github.com/user-attachments/assets/78b6c8f1-598c-4dd8-8ac2-e9f8daa25746" /> | <img width="508" height="969" alt="Bildschirmfoto 2025-10-21 um 13 29 11" src="https://github.com/user-attachments/assets/7bdd06ba-4d45-4e57-8624-107c6a97351b" /> | <img width="499" height="457" alt="Bildschirmfoto 2025-10-21 um 13 29 43" src="https://github.com/user-attachments/assets/269e72c2-266e-4079-b631-e47ff374344e" />

</p>
</details> 

### Notes

We should also look at streamlining some of these config flow options in the future, e.g. "Z-Wave adapter" vs "Z-Wave device" and check if the (untranslated) "Use Socket" option in two of the three steps can be avoided.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Original PR adding the `socket_path` field: https://github.com/home-assistant/core/pull/152590
 
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
