### PR TITLE
Move Yeelight URLs out of translatable strings

### DIFF
--- a/homeassistant/components/yeelight/config_flow.py
+++ b/homeassistant/components/yeelight/config_flow.py
@@ -36,6 +36,8 @@ from .const import (
     CONF_SAVE_ON_CHANGE,
     CONF_TRANSITION,
     DOMAIN,
+    FLOW_OBJECTS_URL,
+    FLOW_TRANSITIONS_URL,
     NIGHTLIGHT_SWITCH_TYPE_LIGHT,
 )
 from .device import (
@@ -344,6 +346,10 @@ class OptionsFlowHandler(OptionsFlowWithReload):
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(schema_dict),
+            description_placeholders={
+                "flow_transitions_url": FLOW_TRANSITIONS_URL,
+                "flow_objects_url": FLOW_OBJECTS_URL,
+            },
         )
 
 

--- a/homeassistant/components/yeelight/const.py
+++ b/homeassistant/components/yeelight/const.py
@@ -4,6 +4,11 @@ from datetime import timedelta
 
 from homeassistant.const import Platform
 
+FLOW_TRANSITIONS_URL = "https://yeelight.readthedocs.io/en/stable/flow.html"
+FLOW_OBJECTS_URL = (
+    "https://yeelight.readthedocs.io/en/stable/yeelight.html#flow-objects"
+)
+
 DOMAIN = "yeelight"
 
 

--- a/homeassistant/components/yeelight/strings.json
+++ b/homeassistant/components/yeelight/strings.json
@@ -123,7 +123,7 @@
         },
         "transitions": {
           "name": "Transitions",
-          "description": "Array of transitions, for desired effect. See the Yeelight flow transitions documentation for examples."
+          "description": "Array of transitions, for desired effect. [Examples]({flow_transitions_url})."
         }
       }
     },
@@ -143,7 +143,7 @@
     },
     "start_flow": {
       "name": "Start flow",
-      "description": "Starts a custom flow, using transitions from the Yeelight flow objects documentation.",
+      "description": "Starts a custom flow, using transitions from [{flow_objects_url}]({flow_objects_url}).",
       "fields": {
         "count": {
           "name": "Count",

--- a/homeassistant/components/yeelight/strings.json
+++ b/homeassistant/components/yeelight/strings.json
@@ -123,7 +123,7 @@
         },
         "transitions": {
           "name": "Transitions",
-          "description": "Array of transitions, for desired effect. Examples https://yeelight.readthedocs.io/en/stable/flow.html."
+          "description": "Array of transitions, for desired effect. See the Yeelight flow transitions documentation for examples."
         }
       }
     },
@@ -143,7 +143,7 @@
     },
     "start_flow": {
       "name": "Start flow",
-      "description": "Starts a custom flow, using transitions from https://yeelight.readthedocs.io/en/stable/yeelight.html#flow-objects.",
+      "description": "Starts a custom flow, using transitions from the Yeelight flow objects documentation.",
       "fields": {
         "count": {
           "name": "Count",


### PR DESCRIPTION
## Proposed change
This PR moves two hardcoded URLs for the `yeelight` integration out of the `strings.json` translation file and into `const.py`.

This resolves the `yeelight` portion of the larger task outlined in #154226, ensuring that these URLs are no longer included in translation files where they could be accidentally modified or broken during localization.

**Note on Tests:**  
All local `pytest` suites pass for the changes introduced in this PR.  
There is a known, unrelated failure in `test_init.py::test_connection_dropped_resyncs_properties` on the current `dev` branch that is not caused by this PR.

---

## Type of change
- [x] Code quality improvements to existing code or addition of tests

---

## Additional information
- This PR fixes or closes issue: fixes #154226 (for the `yeelight` integration)
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

---

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist].
- [x] I have followed the [perfect PR recommendations][perfect-pr].
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`).
- [x] Tests have been added to verify that the new code works.

