### PR TITLE
Add exception handling for library calls in Squeezebox

### DIFF
--- a/homeassistant/components/squeezebox/button.py
+++ b/homeassistant/components/squeezebox/button.py
@@ -162,6 +162,6 @@ class SqueezeboxButtonEntity(SqueezeboxEntity, ButtonEntity):
             self._player.async_query,
             "button",
             self.entity_description.press_action,
-            translation_key="exceptions.press_failed",
+            translation_key="press_failed",
             translation_placeholders={"action": self.entity_description.press_action},
         )

--- a/homeassistant/components/squeezebox/button.py
+++ b/homeassistant/components/squeezebox/button.py
@@ -15,7 +15,7 @@ from . import SqueezeboxConfigEntry
 from .const import SIGNAL_PLAYER_DISCOVERED
 from .coordinator import SqueezeBoxPlayerUpdateCoordinator
 from .entity import SqueezeboxEntity
-from .util import safe_call
+from .util import safe_library_call
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -158,7 +158,7 @@ class SqueezeboxButtonEntity(SqueezeboxEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Execute the button action."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_query,
             "button",
             self.entity_description.press_action,

--- a/homeassistant/components/squeezebox/button.py
+++ b/homeassistant/components/squeezebox/button.py
@@ -15,6 +15,7 @@ from . import SqueezeboxConfigEntry
 from .const import SIGNAL_PLAYER_DISCOVERED
 from .coordinator import SqueezeBoxPlayerUpdateCoordinator
 from .entity import SqueezeboxEntity
+from .util import safe_call
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -157,4 +158,10 @@ class SqueezeboxButtonEntity(SqueezeboxEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Execute the button action."""
-        await self._player.async_query("button", self.entity_description.press_action)
+        await safe_call(
+            self._player.async_query,
+            "button",
+            self.entity_description.press_action,
+            translation_key="exceptions.press_failed",
+            translation_placeholders={"action": self.entity_description.press_action},
+        )

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -435,10 +435,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
     async def async_turn_off(self) -> None:
         """Turn off media player."""
         await safe_library_call(
-            self._player.async_set_power,
-            False,
-            translation_key="turn_off_failed",
-            translation_placeholders={"error": "command rejected"},
+            self._player.async_set_power, False, translation_key="turn_off_failed"
         )
         await self.coordinator.async_refresh()
 
@@ -459,7 +456,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
             self._player.async_set_muting,
             mute,
             translation_key="set_mute_failed",
-            translation_placeholders={"state": "mute" if mute else "unmute"},
         )
         await self.coordinator.async_refresh()
 
@@ -468,7 +464,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_stop,
             translation_key="stop_failed",
-            translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
 
@@ -477,7 +472,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_toggle_pause,
             translation_key="play_pause_failed",
-            translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
 
@@ -486,7 +480,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_play,
             translation_key="play_failed",
-            translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
 
@@ -495,7 +488,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_pause,
             translation_key="pause_failed",
-            translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
 
@@ -505,7 +497,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
             self._player.async_index,
             "+1",
             translation_key="next_track_failed",
-            translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
 
@@ -515,7 +506,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
             self._player.async_index,
             "-1",
             translation_key="previous_track_failed",
-            translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
 
@@ -535,7 +525,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
             self._player.async_set_power,
             True,
             translation_key="turn_on_failed",
-            translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
 
@@ -734,7 +723,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
             self._player.async_set_repeat,
             repeat_mode,
             translation_key="set_repeat_failed",
-            translation_placeholders={"mode": repeat_mode},
         )
         await self.coordinator.async_refresh()
 
@@ -745,7 +733,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
             self._player.async_set_shuffle,
             shuffle_mode,
             translation_key="set_shuffle_failed",
-            translation_placeholders={"error": f"shuffle={shuffle_mode}"},
         )
         await self.coordinator.async_refresh()
 
@@ -754,7 +741,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_clear_playlist,
             translation_key="clear_playlist_failed",
-            translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
 
@@ -831,7 +817,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_unsync,
             translation_key="unjoin_failed",
-            translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from datetime import datetime
 import json
 import logging
@@ -31,7 +31,7 @@ from homeassistant.components.media_player import (
 from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY
 from homeassistant.const import ATTR_COMMAND, CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -70,6 +70,7 @@ from .const import (
 )
 from .coordinator import SqueezeBoxPlayerUpdateCoordinator
 from .entity import SqueezeboxEntity
+from .util import safe_call
 
 if TYPE_CHECKING:
     from . import SqueezeboxConfigEntry
@@ -433,7 +434,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_turn_off(self) -> None:
         """Turn off media player."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_set_power,
             False,
             translation_key="exceptions.turn_off_failed",
@@ -444,7 +445,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         volume_percent = str(round(volume * 100))
-        await self._safe_call(
+        await safe_call(
             self._player.async_set_volume,
             volume_percent,
             translation_key="exceptions.set_volume_failed",
@@ -454,7 +455,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute (true) or unmute (false) media player."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_set_muting,
             mute,
             translation_key="exceptions.set_mute_failed",
@@ -464,7 +465,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_stop(self) -> None:
         """Send stop command to media player."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_stop,
             translation_key="exceptions.stop_failed",
             translation_placeholders={"error": "command rejected"},
@@ -473,7 +474,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_play_pause(self) -> None:
         """Send pause/play toggle command to media player."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_toggle_pause,
             translation_key="exceptions.play_pause_failed",
             translation_placeholders={"error": "command rejected"},
@@ -482,7 +483,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_play(self) -> None:
         """Send play command to media player."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_play,
             translation_key="exceptions.play_failed",
             translation_placeholders={"error": "command rejected"},
@@ -491,7 +492,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_pause(self) -> None:
         """Send pause command to media player."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_pause,
             translation_key="exceptions.pause_failed",
             translation_placeholders={"error": "command rejected"},
@@ -500,7 +501,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_next_track(self) -> None:
         """Send next track command."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_index,
             "+1",
             translation_key="exceptions.next_track_failed",
@@ -510,7 +511,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_index,
             "-1",
             translation_key="exceptions.previous_track_failed",
@@ -520,7 +521,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_seek(self, position: float) -> None:
         """Send seek command."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_time,
             position,
             translation_key="exceptions.seek_failed",
@@ -530,7 +531,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_turn_on(self) -> None:
         """Turn the media player on."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_set_power,
             True,
             translation_key="exceptions.turn_on_failed",
@@ -723,7 +724,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         else:
             repeat_mode = "none"
 
-        await self._safe_call(
+        await safe_call(
             self._player.async_set_repeat,
             repeat_mode,
             translation_key="exceptions.set_repeat_failed",
@@ -734,7 +735,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
     async def async_set_shuffle(self, shuffle: bool) -> None:
         """Enable or disable shuffle mode."""
         shuffle_mode = "song" if shuffle else "none"
-        await self._safe_call(
+        await safe_call(
             self._player.async_set_shuffle,
             shuffle_mode,
             translation_key="exceptions.set_shuffle_failed",
@@ -744,7 +745,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_clear_playlist(self) -> None:
         """Send the media player the command to clear the playlist."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_clear_playlist,
             translation_key="exceptions.clear_playlist_failed",
             translation_placeholders={"error": "command rejected"},
@@ -763,7 +764,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         if parameters:
             all_params.extend(parameters)
 
-        await self._safe_call(
+        await safe_call(
             self._player.async_query,
             *all_params,
             translation_key="exceptions.call_method_failed",
@@ -782,7 +783,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         if parameters:
             all_params.extend(parameters)
 
-        self._query_result = await self._safe_call(
+        self._query_result = await safe_call(
             self._player.async_query,
             *all_params,
             translation_key="exceptions.call_query_failed",
@@ -821,7 +822,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_unjoin_player(self) -> None:
         """Unsync this Squeezebox player."""
-        await self._safe_call(
+        await safe_call(
             self._player.async_unsync,
             translation_key="exceptions.unjoin_failed",
             translation_placeholders={"error": "command rejected"},
@@ -899,37 +900,4 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         result = await self._async_fetch_image(image_url)
         if result == (None, None):
             _LOGGER.debug("Error retrieving proxied album art from %s", image_url)
-        return result
-
-    async def _safe_call(
-        self,
-        method: Callable[..., Awaitable[Any]],
-        *args: Any,
-        translation_key: str,
-        translation_placeholders: dict[str, Any] | None = None,
-        **kwargs: Any,
-    ) -> Any:
-        """Call a player method safely and raise HomeAssistantError on failure with translated message."""
-        try:
-            result = await method(*args, **kwargs)
-        except ValueError as err:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key=translation_key,
-                translation_placeholders={
-                    **(translation_placeholders or {}),
-                    "error": str(err),
-                },
-            ) from err
-
-        if result is False or result is None:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key=translation_key,
-                translation_placeholders={
-                    **(translation_placeholders or {}),
-                    "error": "unknown failure",
-                },
-            )
-
         return result

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -437,7 +437,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_set_power,
             False,
-            translation_key="exceptions.turn_off_failed",
+            translation_key="turn_off_failed",
             translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
@@ -448,7 +448,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_set_volume,
             volume_percent,
-            translation_key="exceptions.set_volume_failed",
+            translation_key="set_volume_failed",
             translation_placeholders={"volume": volume_percent},
         )
         await self.coordinator.async_refresh()
@@ -458,7 +458,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_set_muting,
             mute,
-            translation_key="exceptions.set_mute_failed",
+            translation_key="set_mute_failed",
             translation_placeholders={"state": "mute" if mute else "unmute"},
         )
         await self.coordinator.async_refresh()
@@ -467,7 +467,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         """Send stop command to media player."""
         await safe_library_call(
             self._player.async_stop,
-            translation_key="exceptions.stop_failed",
+            translation_key="stop_failed",
             translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
@@ -476,7 +476,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         """Send pause/play toggle command to media player."""
         await safe_library_call(
             self._player.async_toggle_pause,
-            translation_key="exceptions.play_pause_failed",
+            translation_key="play_pause_failed",
             translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
@@ -485,7 +485,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         """Send play command to media player."""
         await safe_library_call(
             self._player.async_play,
-            translation_key="exceptions.play_failed",
+            translation_key="play_failed",
             translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
@@ -494,7 +494,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         """Send pause command to media player."""
         await safe_library_call(
             self._player.async_pause,
-            translation_key="exceptions.pause_failed",
+            translation_key="pause_failed",
             translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
@@ -504,7 +504,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_index,
             "+1",
-            translation_key="exceptions.next_track_failed",
+            translation_key="next_track_failed",
             translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
@@ -514,7 +514,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_index,
             "-1",
-            translation_key="exceptions.previous_track_failed",
+            translation_key="previous_track_failed",
             translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
@@ -524,7 +524,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_time,
             position,
-            translation_key="exceptions.seek_failed",
+            translation_key="seek_failed",
             translation_placeholders={"position": position},
         )
         await self.coordinator.async_refresh()
@@ -534,7 +534,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_set_power,
             True,
-            translation_key="exceptions.turn_on_failed",
+            translation_key="turn_on_failed",
             translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
@@ -574,7 +574,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
             if media_type not in MediaType.MUSIC:
                 raise ServiceValidationError(
                     translation_domain=DOMAIN,
-                    translation_key="exceptions.invalid_announce_media_type",
+                    translation_key="invalid_announce_media_type",
                     translation_placeholders={"media_type": str(media_type)},
                 )
 
@@ -612,7 +612,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
                 self._player.async_load_url,
                 media_id,
                 cmd,
-                translation_key="exceptions.load_url_failed",
+                translation_key="load_url_failed",
                 translation_placeholders={"media_id": media_id, "cmd": cmd},
             )
             return
@@ -644,7 +644,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
             self._player.async_load_playlist,
             playlist,
             cmd,
-            translation_key="exceptions.load_playlist_failed",
+            translation_key="load_playlist_failed",
             translation_placeholders={"cmd": cmd},
         )
 
@@ -733,7 +733,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_set_repeat,
             repeat_mode,
-            translation_key="exceptions.set_repeat_failed",
+            translation_key="set_repeat_failed",
             translation_placeholders={"mode": repeat_mode},
         )
         await self.coordinator.async_refresh()
@@ -744,7 +744,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_set_shuffle,
             shuffle_mode,
-            translation_key="exceptions.set_shuffle_failed",
+            translation_key="set_shuffle_failed",
             translation_placeholders={"error": f"shuffle={shuffle_mode}"},
         )
         await self.coordinator.async_refresh()
@@ -753,7 +753,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         """Send the media player the command to clear the playlist."""
         await safe_library_call(
             self._player.async_clear_playlist,
-            translation_key="exceptions.clear_playlist_failed",
+            translation_key="clear_playlist_failed",
             translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
@@ -773,7 +773,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         await safe_library_call(
             self._player.async_query,
             *all_params,
-            translation_key="exceptions.call_method_failed",
+            translation_key="call_method_failed",
             translation_placeholders={"command": command},
         )
 
@@ -792,7 +792,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         self._query_result = await safe_library_call(
             self._player.async_query,
             *all_params,
-            translation_key="exceptions.call_query_failed",
+            translation_key="call_query_failed",
             translation_placeholders={"command": command},
         )
         _LOGGER.debug("call_query got result %s", self._query_result)
@@ -830,7 +830,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         """Unsync this Squeezebox player."""
         await safe_library_call(
             self._player.async_unsync,
-            translation_key="exceptions.unjoin_failed",
+            translation_key="unjoin_failed",
             translation_placeholders={"error": "command rejected"},
         )
         await self.coordinator.async_refresh()
@@ -903,7 +903,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
             image_url = await safe_library_call(
                 self._player.generate_image_url_from_track_id,
                 media_image_id,
-                translation_key="exceptions.generate_image_url_failed",
+                translation_key="generate_image_url_failed",
                 translation_placeholders={"track_id": media_image_id},
             )
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -70,7 +70,7 @@ from .const import (
 )
 from .coordinator import SqueezeBoxPlayerUpdateCoordinator
 from .entity import SqueezeboxEntity
-from .util import safe_call
+from .util import safe_library_call
 
 if TYPE_CHECKING:
     from . import SqueezeboxConfigEntry
@@ -434,7 +434,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_turn_off(self) -> None:
         """Turn off media player."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_set_power,
             False,
             translation_key="exceptions.turn_off_failed",
@@ -445,7 +445,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         volume_percent = str(round(volume * 100))
-        await safe_call(
+        await safe_library_call(
             self._player.async_set_volume,
             volume_percent,
             translation_key="exceptions.set_volume_failed",
@@ -455,7 +455,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute (true) or unmute (false) media player."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_set_muting,
             mute,
             translation_key="exceptions.set_mute_failed",
@@ -465,7 +465,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_stop(self) -> None:
         """Send stop command to media player."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_stop,
             translation_key="exceptions.stop_failed",
             translation_placeholders={"error": "command rejected"},
@@ -474,7 +474,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_play_pause(self) -> None:
         """Send pause/play toggle command to media player."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_toggle_pause,
             translation_key="exceptions.play_pause_failed",
             translation_placeholders={"error": "command rejected"},
@@ -483,7 +483,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_play(self) -> None:
         """Send play command to media player."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_play,
             translation_key="exceptions.play_failed",
             translation_placeholders={"error": "command rejected"},
@@ -492,7 +492,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_pause(self) -> None:
         """Send pause command to media player."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_pause,
             translation_key="exceptions.pause_failed",
             translation_placeholders={"error": "command rejected"},
@@ -501,7 +501,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_next_track(self) -> None:
         """Send next track command."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_index,
             "+1",
             translation_key="exceptions.next_track_failed",
@@ -511,7 +511,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_index,
             "-1",
             translation_key="exceptions.previous_track_failed",
@@ -521,7 +521,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_media_seek(self, position: float) -> None:
         """Send seek command."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_time,
             position,
             translation_key="exceptions.seek_failed",
@@ -531,7 +531,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_turn_on(self) -> None:
         """Turn the media player on."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_set_power,
             True,
             translation_key="exceptions.turn_on_failed",
@@ -724,7 +724,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         else:
             repeat_mode = "none"
 
-        await safe_call(
+        await safe_library_call(
             self._player.async_set_repeat,
             repeat_mode,
             translation_key="exceptions.set_repeat_failed",
@@ -735,7 +735,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
     async def async_set_shuffle(self, shuffle: bool) -> None:
         """Enable or disable shuffle mode."""
         shuffle_mode = "song" if shuffle else "none"
-        await safe_call(
+        await safe_library_call(
             self._player.async_set_shuffle,
             shuffle_mode,
             translation_key="exceptions.set_shuffle_failed",
@@ -745,7 +745,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_clear_playlist(self) -> None:
         """Send the media player the command to clear the playlist."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_clear_playlist,
             translation_key="exceptions.clear_playlist_failed",
             translation_placeholders={"error": "command rejected"},
@@ -764,7 +764,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         if parameters:
             all_params.extend(parameters)
 
-        await safe_call(
+        await safe_library_call(
             self._player.async_query,
             *all_params,
             translation_key="exceptions.call_method_failed",
@@ -783,7 +783,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         if parameters:
             all_params.extend(parameters)
 
-        self._query_result = await safe_call(
+        self._query_result = await safe_library_call(
             self._player.async_query,
             *all_params,
             translation_key="exceptions.call_query_failed",
@@ -822,7 +822,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_unjoin_player(self) -> None:
         """Unsync this Squeezebox player."""
-        await safe_call(
+        await safe_library_call(
             self._player.async_unsync,
             translation_key="exceptions.unjoin_failed",
             translation_placeholders={"error": "command rejected"},

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -209,67 +209,67 @@
       "message": "If specified, Media content type must be one of {media_content_type}"
     },
     "turn_on_failed": {
-      "message": "Failed to turn on the player: {error}"
+      "message": "Failed to turn on the player."
     },
     "turn_off_failed": {
-      "message": "Failed to turn off the player: {error}"
+      "message": "Failed to turn off the player."
     },
     "set_shuffle_failed": {
-      "message": "Failed to set shuffle mode: {error}"
+      "message": "Failed to set shuffle mode."
     },
     "set_volume_failed": {
-      "message": "Failed to set volume to {volume}%: {error}"
+      "message": "Failed to set volume to {volume}%."
     },
     "set_mute_failed": {
-      "message": "Failed to mute/unmute the player: {error}"
+      "message": "Failed to mute/unmute the player."
     },
     "stop_failed": {
-      "message": "Failed to stop playback: {error}"
+      "message": "Failed to stop playback."
     },
     "play_pause_failed": {
-      "message": "Failed to toggle play/pause: {error}"
+      "message": "Failed to toggle play/pause."
     },
     "play_failed": {
-      "message": "Failed to start playback: {error}"
+      "message": "Failed to start playback."
     },
     "pause_failed": {
-      "message": "Failed to pause playback: {error}"
+      "message": "Failed to pause playback."
     },
     "next_track_failed": {
-      "message": "Failed to skip to the next track: {error}"
+      "message": "Failed to skip to the next track."
     },
     "previous_track_failed": {
-      "message": "Failed to return to the previous track: {error}"
+      "message": "Failed to return to the previous track."
     },
     "seek_failed": {
-      "message": "Failed to seek to position {position} seconds: {error}"
+      "message": "Failed to seek to position {position} seconds."
     },
     "set_repeat_failed": {
-      "message": "Failed to set repeat mode: {error}"
+      "message": "Failed to set repeat mode."
     },
     "clear_playlist_failed": {
-      "message": "Failed to clear the playlist: {error}"
+      "message": "Failed to clear the playlist."
     },
     "call_method_failed": {
-      "message": "Failed to call method {command}: {error}"
+      "message": "Failed to call method {command}."
     },
     "call_query_failed": {
-      "message": "Failed to query method {command}: {error}"
+      "message": "Failed to query method {command}."
     },
     "unjoin_failed": {
-      "message": "Failed to unsync the player: {error}"
+      "message": "Failed to unsync the player."
     },
     "press_failed": {
-      "message": "Failed to execute button action {action}: {error}"
+      "message": "Failed to execute button action {action}."
     },
     "load_url_failed": {
-      "message": "Failed to load media URL {media_id} with command {cmd}: {error}"
+      "message": "Failed to load media URL {media_id} with command {cmd}."
     },
     "load_playlist_failed": {
-      "message": "Failed to load playlist with command {cmd}: {error}"
+      "message": "Failed to load playlist with command {cmd}."
     },
     "generate_image_url_failed": {
-      "message": "Failed to generate image URL for track ID {track_id}: {error}"
+      "message": "Failed to generate image URL for track ID {track_id}."
     }
   }
 }

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -258,6 +258,9 @@
     },
     "unjoin_failed": {
       "message": "Failed to unsync the player: {error}"
+    },
+    "press_failed": {
+      "message": "Failed to execute button action {action}."
     }
   }
 }

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -261,6 +261,15 @@
     },
     "press_failed": {
       "message": "Failed to execute button action {action}."
+    },
+    "load_url_failed": {
+      "message": "Failed to load media URL {media_id} with command {cmd}."
+    },
+    "load_playlist_failed": {
+      "message": "Failed to load playlist with command {cmd}."
+    },
+    "generate_image_url_failed": {
+      "message": "Failed to generate image URL for track ID {track_id}."
     }
   }
 }

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -215,13 +215,13 @@
       "message": "Failed to turn off the player: {error}"
     },
     "set_shuffle_failed": {
-      "message": "Failed to set shuffle mode to {mode}."
+      "message": "Failed to set shuffle mode: {error}"
     },
     "set_volume_failed": {
-      "message": "Failed to set volume to {volume}%."
+      "message": "Failed to set volume to {volume}%: {error}"
     },
     "set_mute_failed": {
-      "message": "Failed to {state} the player."
+      "message": "Failed to mute/unmute the player: {error}"
     },
     "stop_failed": {
       "message": "Failed to stop playback: {error}"
@@ -242,34 +242,34 @@
       "message": "Failed to return to the previous track: {error}"
     },
     "seek_failed": {
-      "message": "Failed to seek to position {position} seconds."
+      "message": "Failed to seek to position {position} seconds: {error}"
     },
     "set_repeat_failed": {
-      "message": "Failed to set repeat mode to {mode}."
+      "message": "Failed to set repeat mode: {error}"
     },
     "clear_playlist_failed": {
       "message": "Failed to clear the playlist: {error}"
     },
     "call_method_failed": {
-      "message": "Failed to call method {command}."
+      "message": "Failed to call method {command}: {error}"
     },
     "call_query_failed": {
-      "message": "Failed to query method {command}."
+      "message": "Failed to query method {command}: {error}"
     },
     "unjoin_failed": {
       "message": "Failed to unsync the player: {error}"
     },
     "press_failed": {
-      "message": "Failed to execute button action {action}."
+      "message": "Failed to execute button action {action}: {error}"
     },
     "load_url_failed": {
-      "message": "Failed to load media URL {media_id} with command {cmd}."
+      "message": "Failed to load media URL {media_id} with command {cmd}: {error}"
     },
     "load_playlist_failed": {
-      "message": "Failed to load playlist with command {cmd}."
+      "message": "Failed to load playlist with command {cmd}: {error}"
     },
     "generate_image_url_failed": {
-      "message": "Failed to generate image URL for track ID {track_id}."
+      "message": "Failed to generate image URL for track ID {track_id}: {error}"
     }
   }
 }

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -207,6 +207,57 @@
     },
     "invalid_search_media_content_type": {
       "message": "If specified, Media content type must be one of {media_content_type}"
+    },
+    "turn_on_failed": {
+      "message": "Failed to turn on the player: {error}"
+    },
+    "turn_off_failed": {
+      "message": "Failed to turn off the player: {error}"
+    },
+    "set_shuffle_failed": {
+      "message": "Failed to set shuffle mode to {mode}."
+    },
+    "set_volume_failed": {
+      "message": "Failed to set volume to {volume}%."
+    },
+    "set_mute_failed": {
+      "message": "Failed to {state} the player."
+    },
+    "stop_failed": {
+      "message": "Failed to stop playback: {error}"
+    },
+    "play_pause_failed": {
+      "message": "Failed to toggle play/pause: {error}"
+    },
+    "play_failed": {
+      "message": "Failed to start playback: {error}"
+    },
+    "pause_failed": {
+      "message": "Failed to pause playback: {error}"
+    },
+    "next_track_failed": {
+      "message": "Failed to skip to the next track: {error}"
+    },
+    "previous_track_failed": {
+      "message": "Failed to return to the previous track: {error}"
+    },
+    "seek_failed": {
+      "message": "Failed to seek to position {position} seconds."
+    },
+    "set_repeat_failed": {
+      "message": "Failed to set repeat mode to {mode}."
+    },
+    "clear_playlist_failed": {
+      "message": "Failed to clear the playlist: {error}"
+    },
+    "call_method_failed": {
+      "message": "Failed to call method {command}."
+    },
+    "call_query_failed": {
+      "message": "Failed to query method {command}."
+    },
+    "unjoin_failed": {
+      "message": "Failed to unsync the player: {error}"
     }
   }
 }

--- a/homeassistant/components/squeezebox/util.py
+++ b/homeassistant/components/squeezebox/util.py
@@ -1,0 +1,43 @@
+"""Utility functions for Squeezebox integration."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN
+
+
+async def safe_call(
+    method: Callable[..., Awaitable[Any]],
+    *args: Any,
+    translation_key: str,
+    translation_placeholders: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Call a player method safely and raise HomeAssistantError on failure with translated message."""
+    try:
+        result = await method(*args, **kwargs)
+    except ValueError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key=translation_key,
+            translation_placeholders={
+                **(translation_placeholders or {}),
+                "error": str(err),
+            },
+        ) from err
+
+    if result is False or result is None:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key=translation_key,
+            translation_placeholders={
+                **(translation_placeholders or {}),
+                "error": "unknown failure",
+            },
+        )
+
+    return result

--- a/homeassistant/components/squeezebox/util.py
+++ b/homeassistant/components/squeezebox/util.py
@@ -27,7 +27,6 @@ async def safe_library_call(
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key=translation_key,
-            # translation_placeholders={**(translation_placeholders or {})},
             translation_placeholders=translation_placeholders,
         )
 

--- a/homeassistant/components/squeezebox/util.py
+++ b/homeassistant/components/squeezebox/util.py
@@ -20,24 +20,15 @@ async def safe_library_call(
     """Call a player method safely and raise HomeAssistantError on failure."""
     try:
         result = await method(*args, **kwargs)
-    except ValueError as err:
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key=translation_key,
-            translation_placeholders={
-                **(translation_placeholders or {}),
-                "error": str(err),
-            },
-        ) from err
+    except ValueError:
+        result = None
 
     if result is False or result is None:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key=translation_key,
-            translation_placeholders={
-                **(translation_placeholders or {}),
-                "error": "",
-            },
+            # translation_placeholders={**(translation_placeholders or {})},
+            translation_placeholders=translation_placeholders,
         )
 
     return result

--- a/homeassistant/components/squeezebox/util.py
+++ b/homeassistant/components/squeezebox/util.py
@@ -36,7 +36,7 @@ async def safe_library_call(
             translation_key=translation_key,
             translation_placeholders={
                 **(translation_placeholders or {}),
-                "error": "unknown failure",
+                "error": "",
             },
         )
 

--- a/homeassistant/components/squeezebox/util.py
+++ b/homeassistant/components/squeezebox/util.py
@@ -10,14 +10,14 @@ from homeassistant.exceptions import HomeAssistantError
 from .const import DOMAIN
 
 
-async def safe_call(
+async def safe_library_call(
     method: Callable[..., Awaitable[Any]],
     *args: Any,
     translation_key: str,
     translation_placeholders: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> Any:
-    """Call a player method safely and raise HomeAssistantError on failure with translated message."""
+    """Call a player method safely and raise HomeAssistantError on failure."""
     try:
         result = await method(*args, **kwargs)
     except ValueError as err:


### PR DESCRIPTION

## Proposed change
The quality scale requires exception handling when, for example, making calls to the underlying libraries.  Currently, the squeezebox integration doesn't do this consistently.  This PR adds a new function in utils.py which is used to wrap all the required library calls so that HomeAssistantError is called if an error occurs.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
