### PR TITLE
Log script condition warnings with the instance logger

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -761,13 +761,10 @@ class _ScriptRun:
         if_data = await self._script._async_get_if_data(self._step)  # noqa: SLF001
 
         test_conditions: bool | None = False
-        try:
-            with trace_path("if"):
-                test_conditions = self._test_conditions(
-                    if_data["if_conditions"], "if", "condition"
-                )
-        except exceptions.ConditionError as ex:
-            self._log("Error in 'if' evaluation:\n%s", ex, level=logging.WARNING)
+        with trace_path("if"):
+            test_conditions = self._test_conditions(
+                if_data["if_conditions"], "if", "condition"
+            )
 
         if test_conditions:
             trace_set_result(choice="then")
@@ -858,15 +855,9 @@ class _ScriptRun:
             ]
             for iteration in itertools.count(1):
                 set_repeat_var(iteration)
-                try:
-                    if self._stop.done():
-                        break
-                    if not self._test_conditions(conditions, "while"):
-                        break
-                except exceptions.ConditionError as ex:
-                    self._log(
-                        "Error in 'while' evaluation:\n%s", ex, level=logging.WARNING
-                    )
+                if self._stop.done():
+                    break
+                if not self._test_conditions(conditions, "while"):
                     break
 
                 if iteration > 1:
@@ -908,15 +899,9 @@ class _ScriptRun:
             for iteration in itertools.count(1):
                 set_repeat_var(iteration)
                 await async_run_sequence(iteration)
-                try:
-                    if self._stop.done():
-                        break
-                    if self._test_conditions(conditions, "until") in [True, None]:
-                        break
-                except exceptions.ConditionError as ex:
-                    self._log(
-                        "Error in 'until' evaluation:\n%s", ex, level=logging.WARNING
-                    )
+                if self._stop.done():
+                    break
+                if self._test_conditions(conditions, "until") in [True, None]:
                     break
 
                 if iteration >= REPEAT_WARN_ITERATIONS:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -698,7 +698,13 @@ class _ScriptRun:
                             if cond(hass, variables) is False:
                                 return False
             except exceptions.ConditionError as ex:
-                _LOGGER.warning("Error in '%s[%s]' evaluation: %s", name, idx, ex)
+                self._log(
+                    "Error in '%s[%s]' evaluation: %s",
+                    name,
+                    idx,
+                    ex,
+                    level=logging.WARNING,
+                )
                 return None
 
             return True
@@ -719,7 +725,11 @@ class _ScriptRun:
                                 await self._async_run_script(script)
                                 return
                     except exceptions.ConditionError as ex:
-                        _LOGGER.warning("Error in 'choose' evaluation:\n%s", ex)
+                        self._log(
+                            "Error in 'choose' evaluation:\n%s",
+                            ex,
+                            level=logging.WARNING,
+                        )
 
         if choose_data["default"] is not None:
             trace_set_result(choice="default")
@@ -738,7 +748,7 @@ class _ScriptRun:
                 trace_element.reuse_by_child = True
             check = cond(self._hass, self._variables)
         except exceptions.ConditionError as ex:
-            _LOGGER.warning("Error in 'condition' evaluation:\n%s", ex)
+            self._log("Error in 'condition' evaluation:\n%s", ex, level=logging.WARNING)
             check = False
 
         self._log("Test condition %s: %s", self._script.last_action, check)
@@ -757,7 +767,7 @@ class _ScriptRun:
                     if_data["if_conditions"], "if", "condition"
                 )
         except exceptions.ConditionError as ex:
-            _LOGGER.warning("Error in 'if' evaluation:\n%s", ex)
+            self._log("Error in 'if' evaluation:\n%s", ex, level=logging.WARNING)
 
         if test_conditions:
             trace_set_result(choice="then")
@@ -854,7 +864,9 @@ class _ScriptRun:
                     if not self._test_conditions(conditions, "while"):
                         break
                 except exceptions.ConditionError as ex:
-                    _LOGGER.warning("Error in 'while' evaluation:\n%s", ex)
+                    self._log(
+                        "Error in 'while' evaluation:\n%s", ex, level=logging.WARNING
+                    )
                     break
 
                 if iteration > 1:
@@ -902,7 +914,9 @@ class _ScriptRun:
                     if self._test_conditions(conditions, "until") in [True, None]:
                         break
                 except exceptions.ConditionError as ex:
-                    _LOGGER.warning("Error in 'until' evaluation:\n%s", ex)
+                    self._log(
+                        "Error in 'until' evaluation:\n%s", ex, level=logging.WARNING
+                    )
                     break
 
                 if iteration >= REPEAT_WARN_ITERATIONS:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -864,20 +864,19 @@ class _ScriptRun:
                     if iteration > REPEAT_WARN_ITERATIONS:
                         if not warned_too_many_loops:
                             warned_too_many_loops = True
-                            _LOGGER.warning(
-                                "While condition %s in script `%s` looped %s times",
+                            self._log(
+                                "While condition %s looped %s times",
                                 repeat[CONF_WHILE],
-                                self._script.name,
                                 REPEAT_WARN_ITERATIONS,
+                                level=logging.WARNING,
                             )
 
                         if iteration > REPEAT_TERMINATE_ITERATIONS:
-                            _LOGGER.critical(
-                                "While condition %s in script `%s` "
-                                "terminated because it looped %s times",
+                            self._log(
+                                "While condition %s terminated because it looped %s times",
                                 repeat[CONF_WHILE],
-                                self._script.name,
                                 REPEAT_TERMINATE_ITERATIONS,
+                                level=logging.CRITICAL,
                             )
                             raise _AbortScript(
                                 f"While condition {repeat[CONF_WHILE]} "
@@ -907,20 +906,19 @@ class _ScriptRun:
                 if iteration >= REPEAT_WARN_ITERATIONS:
                     if not warned_too_many_loops:
                         warned_too_many_loops = True
-                        _LOGGER.warning(
-                            "Until condition %s in script `%s` looped %s times",
+                        self._log(
+                            "Until condition %s looped %s times",
                             repeat[CONF_UNTIL],
-                            self._script.name,
                             REPEAT_WARN_ITERATIONS,
+                            level=logging.WARNING,
                         )
 
                     if iteration >= REPEAT_TERMINATE_ITERATIONS:
-                        _LOGGER.critical(
-                            "Until condition %s in script `%s` "
-                            "terminated because it looped %s times",
+                        self._log(
+                            "Until condition %s terminated because it looped %s times",
                             repeat[CONF_UNTIL],
-                            self._script.name,
                             REPEAT_TERMINATE_ITERATIONS,
+                            level=logging.CRITICAL,
                         )
                         raise _AbortScript(
                             f"Until condition {repeat[CONF_UNTIL]} "

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -3181,12 +3181,9 @@ async def test_repeat_limits(
 
     title_condition = condition.title()
 
-    assert f"{title_condition} condition" in caplog.text
-    assert f"in script `Test {condition}` looped 5 times" in caplog.text
-    assert (
-        f"script `Test {condition}` terminated because it looped 10 times"
-        in caplog.text
-    )
+    assert f"Test {condition}: {title_condition} condition" in caplog.text
+    assert "looped 5 times" in caplog.text
+    assert "terminated because it looped 10 times" in caplog.text
 
     assert len(events) == 10
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
I will sometimes find warnings in my logs:

`2025-10-22 00:10:40.992 WARNING (MainThread) [homeassistant.helpers.script] Error in 'while[0]' evaluation: In 'template' condition: UndefinedError: 'event' is undefined`

What script is it from? I have no idea. Can we change it to use the script's logging instance instead?

`2025-10-21 23:55:42.173 WARNING (MainThread) [homeassistant.components.script.script_with_an_error] Script with an Error: Error in 'while[0]' evaluation: In 'template' condition: UndefinedError: 'event' is undefined`


This module seems to use a mix of:
 - Logging w/ instance of the script (includes domain, script/automation id, and prepends name to the message)
 - Module-level logger, but with the script's name just manually included the string.
 - Module-level logger, but with no indication of what script it comes from.
 
 I'm not really sure if there is any reason why it is this way, but using the first one seems right to me?


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
