### PR TITLE
Bump pysma to 1.0.2 and enable type checking

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -477,6 +477,7 @@ homeassistant.components.skybell.*
 homeassistant.components.slack.*
 homeassistant.components.sleep_as_android.*
 homeassistant.components.sleepiq.*
+homeassistant.components.sma.*
 homeassistant.components.smhi.*
 homeassistant.components.smlight.*
 homeassistant.components.smtp.*

--- a/homeassistant/components/sma/__init__.py
+++ b/homeassistant/components/sma/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from pysma import SMA
+from pysma import SMAWebConnect
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -35,7 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SMAConfigEntry) -> bool:
     protocol = "https" if entry.data[CONF_SSL] else "http"
     url = f"{protocol}://{entry.data[CONF_HOST]}"
 
-    sma = SMA(
+    sma = SMAWebConnect(
         session=async_get_clientsession(
             hass=hass, verify_ssl=entry.data[CONF_VERIFY_SSL]
         ),

--- a/homeassistant/components/sma/config_flow.py
+++ b/homeassistant/components/sma/config_flow.py
@@ -6,7 +6,12 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
-import pysma
+from pysma import (
+    SmaAuthenticationException,
+    SmaConnectionException,
+    SmaReadException,
+    SMAWebConnect,
+)
 import voluptuous as vol
 from yarl import URL
 
@@ -42,7 +47,7 @@ async def validate_input(
     host = data[CONF_HOST] if data is not None else user_input[CONF_HOST]
     url = URL.build(scheme=protocol, host=host)
 
-    sma = pysma.SMA(
+    sma = SMAWebConnect(
         session, str(url), user_input[CONF_PASSWORD], group=user_input[CONF_GROUP]
     )
 
@@ -90,11 +95,11 @@ class SmaConfigFlow(ConfigFlow, domain=DOMAIN):
             device_info = await validate_input(
                 self.hass, user_input=user_input, data=self._data
             )
-        except pysma.exceptions.SmaConnectionException:
+        except SmaConnectionException:
             errors["base"] = "cannot_connect"
-        except pysma.exceptions.SmaAuthenticationException:
+        except SmaAuthenticationException:
             errors["base"] = "invalid_auth"
-        except pysma.exceptions.SmaReadException:
+        except SmaReadException:
             errors["base"] = "cannot_retrieve_device_info"
         except Exception:
             _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/sma/config_flow.py
+++ b/homeassistant/components/sma/config_flow.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
+import attrs
 from pysma import (
     SmaAuthenticationException,
     SmaConnectionException,
@@ -56,7 +57,7 @@ async def validate_input(
     device_info = await sma.device_info()
     await sma.close_session()
 
-    return device_info
+    return attrs.asdict(device_info)
 
 
 class SmaConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/sma/coordinator.py
+++ b/homeassistant/components/sma/coordinator.py
@@ -6,13 +6,13 @@ from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
-from pysma import SMA
-from pysma.exceptions import (
+from pysma import (
     SmaAuthenticationException,
     SmaConnectionException,
     SmaReadException,
+    SMAWebConnect,
 )
-from pysma.sensor import Sensor
+from pysma.sensor import Sensors
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL
@@ -30,7 +30,7 @@ class SMACoordinatorData:
     """Data class for SMA sensors."""
 
     sma_device_info: dict[str, str]
-    sensors: list[Sensor]
+    sensors: Sensors
 
 
 class SMADataUpdateCoordinator(DataUpdateCoordinator[SMACoordinatorData]):
@@ -42,7 +42,7 @@ class SMADataUpdateCoordinator(DataUpdateCoordinator[SMACoordinatorData]):
         self,
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        sma: SMA,
+        sma: SMAWebConnect,
     ) -> None:
         """Initialize the SMA Data Update Coordinator."""
         super().__init__(
@@ -58,7 +58,7 @@ class SMADataUpdateCoordinator(DataUpdateCoordinator[SMACoordinatorData]):
         )
         self.sma = sma
         self._sma_device_info: dict[str, str] = {}
-        self._sensors: list[Sensor] = []
+        self._sensors = Sensors()
 
     async def _async_setup(self) -> None:
         """Setup the SMA Data Update Coordinator."""

--- a/homeassistant/components/sma/coordinator.py
+++ b/homeassistant/components/sma/coordinator.py
@@ -12,6 +12,7 @@ from pysma import (
     SmaReadException,
     SMAWebConnect,
 )
+from pysma.helpers import DeviceInfo
 from pysma.sensor import Sensors
 
 from homeassistant.config_entries import ConfigEntry
@@ -29,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 class SMACoordinatorData:
     """Data class for SMA sensors."""
 
-    sma_device_info: dict[str, str]
+    sma_device_info: DeviceInfo
     sensors: Sensors
 
 
@@ -57,7 +58,7 @@ class SMADataUpdateCoordinator(DataUpdateCoordinator[SMACoordinatorData]):
             ),
         )
         self.sma = sma
-        self._sma_device_info: dict[str, str] = {}
+        self._sma_device_info = DeviceInfo()
         self._sensors = Sensors()
 
     async def _async_setup(self) -> None:

--- a/homeassistant/components/sma/manifest.json
+++ b/homeassistant/components/sma/manifest.json
@@ -13,5 +13,5 @@
   "documentation": "https://www.home-assistant.io/integrations/sma",
   "iot_class": "local_polling",
   "loggers": ["pysma"],
-  "requirements": ["pysma==1.0.1"]
+  "requirements": ["pysma==1.0.2"]
 }

--- a/homeassistant/components/sma/manifest.json
+++ b/homeassistant/components/sma/manifest.json
@@ -13,5 +13,5 @@
   "documentation": "https://www.home-assistant.io/integrations/sma",
   "iot_class": "local_polling",
   "loggers": ["pysma"],
-  "requirements": ["pysma==0.7.5"]
+  "requirements": ["pysma==1.0.1"]
 }

--- a/homeassistant/components/sma/sensor.py
+++ b/homeassistant/components/sma/sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import pysma
+from pysma.sensor import Sensor
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -859,7 +859,7 @@ class SMAsensor(CoordinatorEntity[SMADataUpdateCoordinator], SensorEntity):
         self,
         coordinator: SMADataUpdateCoordinator,
         description: SensorEntityDescription | None,
-        pysma_sensor: pysma.sensor.Sensor,
+        pysma_sensor: Sensor,
         entry: SMAConfigEntry,
     ) -> None:
         """Initialize the sensor."""
@@ -873,17 +873,17 @@ class SMAsensor(CoordinatorEntity[SMADataUpdateCoordinator], SensorEntity):
         url = f"{protocol}://{entry.data[CONF_HOST]}"
 
         self._sensor = pysma_sensor
-        self._serial = coordinator.data.sma_device_info["serial"]
+        self._serial = coordinator.data.sma_device_info.serial
         assert entry.unique_id
 
         self._attr_device_info = DeviceInfo(
             configuration_url=url,
             identifiers={(DOMAIN, entry.unique_id)},
-            manufacturer=coordinator.data.sma_device_info["manufacturer"],
-            model=coordinator.data.sma_device_info["type"],
-            name=coordinator.data.sma_device_info["name"],
-            sw_version=coordinator.data.sma_device_info["sw_version"],
-            serial_number=coordinator.data.sma_device_info["serial"],
+            manufacturer=coordinator.data.sma_device_info.manufacturer,
+            model=coordinator.data.sma_device_info.type,
+            name=coordinator.data.sma_device_info.name,
+            sw_version=coordinator.data.sma_device_info.sw_version,
+            serial_number=coordinator.data.sma_device_info.serial,
         )
         self._attr_unique_id = (
             f"{entry.unique_id}-{pysma_sensor.key}_{pysma_sensor.key_idx}"
@@ -908,7 +908,7 @@ class SMAsensor(CoordinatorEntity[SMADataUpdateCoordinator], SensorEntity):
         """Return if the device is available."""
         return (
             super().available
-            and self._serial == self.coordinator.data.sma_device_info["serial"]
+            and self._serial == self.coordinator.data.sma_device_info.serial
         )
 
     @property

--- a/mypy.ini
+++ b/mypy.ini
@@ -4526,6 +4526,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.sma.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.smhi.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2387,7 +2387,7 @@ pysignalclirestapi==0.3.24
 pyskyqhub==0.1.4
 
 # homeassistant.components.sma
-pysma==1.0.1
+pysma==1.0.2
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2387,7 +2387,7 @@ pysignalclirestapi==0.3.24
 pyskyqhub==0.1.4
 
 # homeassistant.components.sma
-pysma==0.7.5
+pysma==1.0.1
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1993,7 +1993,7 @@ pysiaalarm==3.1.1
 pysignalclirestapi==0.3.24
 
 # homeassistant.components.sma
-pysma==0.7.5
+pysma==1.0.1
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1993,7 +1993,7 @@ pysiaalarm==3.1.1
 pysignalclirestapi==0.3.24
 
 # homeassistant.components.sma
-pysma==1.0.1
+pysma==1.0.2
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/tests/components/sma/__init__.py
+++ b/tests/components/sma/__init__.py
@@ -1,5 +1,7 @@
 """Tests for the sma integration."""
 
+from pysma.helpers import DeviceInfo
+
 from homeassistant.components.sma.const import CONF_GROUP
 from homeassistant.const import (
     CONF_HOST,
@@ -12,13 +14,14 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
-MOCK_DEVICE = {
-    "manufacturer": "SMA",
-    "name": "SMA Device Name",
-    "type": "Sunny Boy 3.6",
-    "serial": 123456789,
-    "sw_version": "1.0.0",
-}
+MOCK_DEVICE = DeviceInfo(
+    manufacturer="SMA",
+    name="SMA Device Name",
+    type="Sunny Boy 3.6",
+    serial=123456789,
+    sw_version="1.0.0",
+)
+
 
 MOCK_USER_INPUT = {
     CONF_HOST: "1.1.1.1",

--- a/tests/components/sma/conftest.py
+++ b/tests/components/sma/conftest.py
@@ -8,7 +8,7 @@ from pysma.const import (
     GENERIC_SENSORS,
     OPTIMIZERS_VIA_INVERTER,
 )
-from pysma.definitions import sensor_map
+from pysma.definitions.webconnect import sensor_map
 from pysma.sensor import Sensors
 import pytest
 

--- a/tests/components/sma/conftest.py
+++ b/tests/components/sma/conftest.py
@@ -26,8 +26,8 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
 
     return MockConfigEntry(
         domain=DOMAIN,
-        title=MOCK_DEVICE["name"],
-        unique_id=str(MOCK_DEVICE["serial"]),
+        title=MOCK_DEVICE.name,
+        unique_id=str(MOCK_DEVICE.serial),
         data=MOCK_USER_INPUT,
         minor_version=2,
         entry_id="sma_entry_123",
@@ -47,7 +47,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 def mock_sma_client() -> Generator[MagicMock]:
     """Mock the SMA client."""
     with patch(
-        "homeassistant.components.sma.coordinator.SMA", autospec=True
+        "homeassistant.components.sma.coordinator.SMAWebConnect", autospec=True
     ) as sma_cls:
         sma_instance: MagicMock = sma_cls.return_value
         sma_instance.device_info = AsyncMock(return_value=MOCK_DEVICE)
@@ -80,8 +80,11 @@ def mock_sma_client() -> Generator[MagicMock]:
         sma_instance.read = AsyncMock(side_effect=_async_mock_read)
 
         with (
-            patch("homeassistant.components.sma.config_flow.pysma.SMA", new=sma_cls),
-            patch("homeassistant.components.sma.SMA", new=sma_cls),
-            patch("pysma.SMA", new=sma_cls),
+            patch(
+                "homeassistant.components.sma.config_flow.SMAWebConnect",
+                new=sma_cls,
+            ),
+            patch("homeassistant.components.sma.SMAWebConnect", new=sma_cls),
+            patch("pysma.SMAWebConnect", new=sma_cls),
         ):
             yield sma_instance

--- a/tests/components/sma/test_config_flow.py
+++ b/tests/components/sma/test_config_flow.py
@@ -87,7 +87,7 @@ async def test_form_exceptions(
     )
 
     with patch(
-        "homeassistant.components.sma.config_flow.pysma.SMA.new_session",
+        "homeassistant.components.sma.config_flow.SMAWebConnect.new_session",
         side_effect=exception,
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -207,7 +207,7 @@ async def test_dhcp_exceptions(
         data=DHCP_DISCOVERY,
     )
 
-    with patch("homeassistant.components.sma.config_flow.pysma.SMA") as mock_sma:
+    with patch("homeassistant.components.sma.config_flow.SMAWebConnect") as mock_sma:
         mock_sma_instance = mock_sma.return_value
         mock_sma_instance.new_session = AsyncMock(side_effect=exception)
 
@@ -219,7 +219,7 @@ async def test_dhcp_exceptions(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": error}
 
-    with patch("homeassistant.components.sma.config_flow.pysma.SMA") as mock_sma:
+    with patch("homeassistant.components.sma.config_flow.SMAWebConnect") as mock_sma:
         mock_sma_instance = mock_sma.return_value
         mock_sma_instance.new_session = AsyncMock(return_value=True)
         mock_sma_instance.device_info = AsyncMock(return_value=MOCK_DEVICE)
@@ -287,7 +287,7 @@ async def test_reauth_flow_exceptions(
 
     result = await entry.start_reauth_flow(hass)
 
-    with patch("homeassistant.components.sma.config_flow.pysma.SMA") as mock_sma:
+    with patch("homeassistant.components.sma.config_flow.SMAWebConnect") as mock_sma:
         mock_sma_instance = mock_sma.return_value
         mock_sma_instance.new_session = AsyncMock(side_effect=exception)
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/sma/test_config_flow.py
+++ b/tests/components/sma/test_config_flow.py
@@ -2,11 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from pysma.exceptions import (
-    SmaAuthenticationException,
-    SmaConnectionException,
-    SmaReadException,
-)
+from pysma import SmaAuthenticationException, SmaConnectionException, SmaReadException
 import pytest
 
 from homeassistant.components.sma.const import DOMAIN

--- a/tests/components/sma/test_init.py
+++ b/tests/components/sma/test_init.py
@@ -2,11 +2,7 @@
 
 from collections.abc import AsyncGenerator, Generator
 
-from pysma.exceptions import (
-    SmaAuthenticationException,
-    SmaConnectionException,
-    SmaReadException,
-)
+from pysma import SmaAuthenticationException, SmaConnectionException, SmaReadException
 import pytest
 
 from homeassistant.components.sma.const import DOMAIN

--- a/tests/components/sma/test_init.py
+++ b/tests/components/sma/test_init.py
@@ -1,6 +1,7 @@
 """Test the sma init file."""
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock
 
 from pysma import SmaAuthenticationException, SmaConnectionException, SmaReadException
 import pytest
@@ -22,8 +23,8 @@ async def test_migrate_entry_minor_version_1_2(
     """Test migrating a 1.1 config entry to 1.2."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        title=MOCK_DEVICE["name"],
-        unique_id=MOCK_DEVICE["serial"],  # Not converted to str
+        title=MOCK_DEVICE.name,
+        unique_id=MOCK_DEVICE.serial,
         data=MOCK_USER_INPUT,
         source=SOURCE_IMPORT,
         minor_version=1,
@@ -32,7 +33,8 @@ async def test_migrate_entry_minor_version_1_2(
     assert await hass.config_entries.async_setup(entry.entry_id)
     assert entry.version == 1
     assert entry.minor_version == 2
-    assert entry.unique_id == str(MOCK_DEVICE["serial"])
+    assert isinstance(MOCK_DEVICE.serial, str)
+    assert entry.unique_id == MOCK_DEVICE.serial
 
 
 @pytest.mark.parametrize(
@@ -45,7 +47,7 @@ async def test_migrate_entry_minor_version_1_2(
 )
 async def test_setup_exceptions(
     hass: HomeAssistant,
-    mock_sma_client: Generator,
+    mock_sma_client: MagicMock,
     mock_config_entry: MockConfigEntry,
     exception: Exception,
     expected_state: ConfigEntryState,

--- a/tests/components/sma/test_sensor.py
+++ b/tests/components/sma/test_sensor.py
@@ -1,7 +1,7 @@
 """Test the SMA sensor platform."""
 
 from collections.abc import Generator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from pysma import SmaAuthenticationException, SmaConnectionException, SmaReadException
@@ -52,7 +52,7 @@ async def test_all_entities(
 async def test_refresh_exceptions(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_sma_client: Generator,
+    mock_sma_client: MagicMock,
     freezer: FrozenDateTimeFactory,
     exception: Exception,
 ) -> None:
@@ -67,4 +67,5 @@ async def test_refresh_exceptions(
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.sma_device_name_battery_capacity_a")
+    assert state
     assert state.state == STATE_UNAVAILABLE

--- a/tests/components/sma/test_sensor.py
+++ b/tests/components/sma/test_sensor.py
@@ -4,11 +4,7 @@ from collections.abc import Generator
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
-from pysma.exceptions import (
-    SmaAuthenticationException,
-    SmaConnectionException,
-    SmaReadException,
-)
+from pysma import SmaAuthenticationException, SmaConnectionException, SmaReadException
 import pytest
 from syrupy.assertion import SnapshotAssertion
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request updates the SMA integration in Home Assistant to support the new `pysma` 1.0.1 release, migrating from the legacy `SMA` class to the new `SMAWebConnect` API and updating exception handling and sensor definitions accordingly. It also improves type checking for the integration and updates requirements files.

* pysma updates
  * https://github.com/kellerza/pysma/releases/tag/v1.0.0 - Update to uv, ruff, add typing. Include 2 new temperature sensors.
  * https://github.com/kellerza/pysma/releases/tag/v1.0.1 - Update typing and exports
  * Full Changes - https://github.com/kellerza/pysma/compare/0.7.5...v1.0.1
* Changed the sensors data structure from a list of `Sensor` objects to the `Sensors` class in the coordinator

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
