### PR TITLE
Fix variables in icon, picture, and name for state based template entities

### DIFF
--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -200,7 +200,13 @@ class TemplateEntity(AbstractTemplateEntity):
                 """Name of this state."""
                 return "<None>"
 
-        variables = {"this": DummyState()}
+        # Render the current variables and add a dummy this variable to them.
+        variables = (
+            self._run_variables
+            if isinstance(self._run_variables, dict)
+            else self._run_variables.async_render(self.hass, {})
+        )
+        variables = {"this": DummyState(), **variables}
 
         # Try to render the name as it can influence the entity ID
         self._attr_name = None

--- a/tests/components/template/test_blueprint.py
+++ b/tests/components/template/test_blueprint.py
@@ -228,6 +228,90 @@ async def test_reload_template_when_blueprint_changes(hass: HomeAssistant) -> No
     assert not_inverted.state == "on"
 
 
+async def test_init_attribute_variables_from_blueprint(hass: HomeAssistant) -> None:
+    """Test a state based blueprint initializes icon, name, and picture with variables."""
+    blueprint = "test_init_attribute_variables.yaml"
+    source = "switch.foo"
+    entity_id = "sensor.foo"
+    hass.states.async_set(source, "on", {"friendly_name": "Foo"})
+    config = {
+        DOMAIN: [
+            {
+                "use_blueprint": {
+                    "path": blueprint,
+                    "input": {"switch": source},
+                },
+            }
+        ],
+    }
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        config,
+    )
+    await hass.async_block_till_done()
+
+    # Check initial state
+    sensor = hass.states.get(entity_id)
+    assert sensor
+    assert sensor.state == "True"
+    assert sensor.attributes["icon"] == "mdi:lightbulb"
+    assert sensor.attributes["entity_picture"] == "on.png"
+    assert sensor.attributes["friendly_name"] == "Foo"
+    assert sensor.attributes["extra"] == "ab"
+
+    hass.states.async_set(source, "off", {"friendly_name": "Foo"})
+    await hass.async_block_till_done()
+
+    # Check to see that the template light works
+    sensor = hass.states.get(entity_id)
+    assert sensor
+    assert sensor.state == "False"
+    assert sensor.attributes["icon"] == "mdi:lightbulb-off"
+    assert sensor.attributes["entity_picture"] == "off.png"
+    assert sensor.attributes["friendly_name"] == "Foo"
+    assert sensor.attributes["extra"] == "ab"
+
+    # Reload the templates without any change, but with updated blueprint
+    blueprint_config = yaml_util.load_yaml(
+        pathlib.Path("tests/testing_config/blueprints/template/") / blueprint
+    )
+    blueprint_config["variables"]["extraa"] = "c"
+    blueprint_config["sensor"]["variables"]["extrab"] = "d"
+    with (
+        patch(
+            "homeassistant.config.load_yaml_config_file",
+            autospec=True,
+            return_value=config,
+        ),
+        patch(
+            "homeassistant.components.blueprint.models.yaml_util.load_yaml_dict",
+            autospec=True,
+            return_value=blueprint_config,
+        ),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    sensor = hass.states.get(entity_id)
+    assert sensor
+    assert sensor.state == "False"
+    assert sensor.attributes["icon"] == "mdi:lightbulb-off"
+    assert sensor.attributes["entity_picture"] == "off.png"
+    assert sensor.attributes["friendly_name"] == "Foo"
+    assert sensor.attributes["extra"] == "cd"
+
+    hass.states.async_set(source, "on", {"friendly_name": "Foo"})
+    await hass.async_block_till_done()
+
+    sensor = hass.states.get(entity_id)
+    assert sensor
+    assert sensor.state == "True"
+    assert sensor.attributes["icon"] == "mdi:lightbulb"
+    assert sensor.attributes["entity_picture"] == "on.png"
+    assert sensor.attributes["friendly_name"] == "Foo"
+    assert sensor.attributes["extra"] == "cd"
+
+
 @pytest.mark.parametrize(
     ("blueprint"),
     ["test_event_sensor.yaml", "test_event_sensor_legacy_schema.yaml"],

--- a/tests/components/template/test_config.py
+++ b/tests/components/template/test_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 import voluptuous as vol
 
+from homeassistant.components.template import DOMAIN
 from homeassistant.components.template.config import (
     CONFIG_SECTION_SCHEMA,
     async_validate_config_section,
@@ -12,6 +13,7 @@ from homeassistant.components.template.config import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.script_variables import ScriptVariables
 from homeassistant.helpers.template import Template
+from homeassistant.setup import async_setup_component
 
 
 @pytest.mark.parametrize(
@@ -256,3 +258,59 @@ async def test_combined_trigger_variables(
     assert root_variables.as_dict() == expected_root
     variables: ScriptVariables = validated["binary_sensor"][0].get("variables", empty)
     assert variables.as_dict() == expected_entity
+
+
+async def test_state_init_attribute_variables(
+    hass: HomeAssistant,
+) -> None:
+    """Test a state based template entity initializes icon, name, and picture with variables."""
+    source = "switch.foo"
+    entity_id = "sensor.foo"
+
+    hass.states.async_set(source, "on", {"friendly_name": "Foo"})
+    config = {
+        "template": [
+            {
+                "variables": {
+                    "switch": "switch.foo",
+                    "on_icon": "mdi:lightbulb",
+                    "on_picture": "on.png",
+                },
+                "sensor": {
+                    "variables": {
+                        "off_icon": "mdi:lightbulb-off",
+                        "off_picture": "off.png",
+                    },
+                    "name": "{{ state_attr(switch, 'friendly_name') }}",
+                    "icon": "{{ on_icon if is_state(switch, 'on') else off_icon }}",
+                    "picture": "{{ on_picture if is_state(switch, 'on') else off_picture }}",
+                    "state": "{{ is_state(switch, 'on') }}",
+                },
+            }
+        ],
+    }
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        config,
+    )
+    await hass.async_block_till_done()
+
+    # Check initial state
+    sensor = hass.states.get(entity_id)
+    assert sensor
+    assert sensor.state == "True"
+    assert sensor.attributes["icon"] == "mdi:lightbulb"
+    assert sensor.attributes["entity_picture"] == "on.png"
+    assert sensor.attributes["friendly_name"] == "Foo"
+
+    hass.states.async_set(source, "off", {"friendly_name": "Foo"})
+    await hass.async_block_till_done()
+
+    # Check to see that the template light works
+    sensor = hass.states.get(entity_id)
+    assert sensor
+    assert sensor.state == "False"
+    assert sensor.attributes["icon"] == "mdi:lightbulb-off"
+    assert sensor.attributes["entity_picture"] == "off.png"
+    assert sensor.attributes["friendly_name"] == "Foo"

--- a/tests/testing_config/blueprints/template/test_init_attribute_variables.yaml
+++ b/tests/testing_config/blueprints/template/test_init_attribute_variables.yaml
@@ -1,0 +1,31 @@
+blueprint:
+  name: Switch to light
+  domain: template
+  input:
+    switch:
+      name: Switch
+      description: The switch which should be converted
+      selector:
+        entity:
+          multiple: false
+          filter:
+            - domain: switch
+      default: null
+
+variables:
+  switch: !input switch
+  on_icon: mdi:lightbulb
+  on_picture: "on.png"
+  extraa: "a"
+
+sensor:
+  variables:
+    off_icon: mdi:lightbulb-off
+    off_picture: "off.png"
+    extrab: "b"
+  name: "{{ state_attr(switch, 'friendly_name') }}"
+  icon: "{{ on_icon if is_state(switch, 'on') else off_icon }}"
+  picture: "{{ on_picture if is_state(switch, 'on') else off_picture }}"
+  state: "{{ is_state(switch, 'on') }}"
+  attributes:
+    extra: "{{ extraa ~ extrab }}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

State based template entities did not use variables for `icon`, `picture`, and `name` templates.  This PR resolves that issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/154871
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
