### PR TITLE
Add logbook support for args same as params for zha

### DIFF
--- a/homeassistant/components/zha/logbook.py
+++ b/homeassistant/components/zha/logbook.py
@@ -79,6 +79,9 @@ def async_describe_events(
         if params := event_data.get("params"):
             message = f"{message} with parameters: {params}"
 
+        if args := event_data.get("args"):
+            message = f"{message} with arguments: {args}"
+
         return {
             LOGBOOK_ENTRY_NAME: device_name,
             LOGBOOK_ENTRY_MESSAGE: message,

--- a/tests/components/zha/test_logbook.py
+++ b/tests/components/zha/test_logbook.py
@@ -32,6 +32,7 @@ COMMAND_SHAKE = "shake"
 COMMAND_HOLD = "hold"
 COMMAND_SINGLE = "single"
 COMMAND_DOUBLE = "double"
+COMMAND_ATTRIBUTE_UPDATED = "attribute_updated"
 DOUBLE_PRESS = "remote_button_double_press"
 SHORT_PRESS = "remote_button_short_press"
 LONG_PRESS = "remote_button_long_press"
@@ -230,6 +231,22 @@ async def test_zha_logbook_event_device_no_triggers(
                     "cluster_id": 6,
                 },
             ),
+            MockRow(
+                ZHA_EVENT,
+                {
+                    CONF_DEVICE_ID: reg_device.id,
+                    COMMAND: COMMAND_ATTRIBUTE_UPDATED,
+                    "device_ieee": str(ieee_address),
+                    CONF_UNIQUE_ID: f"{ieee_address!s}:1:0x0006",
+                    "endpoint_id": 1,
+                    "cluster_id": 6,
+                    "args": {
+                        "attribute_id": 1234,
+                        "attribute_name": "name",
+                        "attribute_value": "value",
+                    },
+                },
+            ),
         ],
     )
 
@@ -253,6 +270,13 @@ async def test_zha_logbook_event_device_no_triggers(
     assert events[3]["name"] == "FakeManufacturer FakeModel"
     assert events[3]["domain"] == "zha"
     assert events[3]["message"] == "Zha Event was fired"
+
+    assert events[4]["name"] == "FakeManufacturer FakeModel"
+    assert events[4]["domain"] == "zha"
+    assert (
+        events[4]["message"]
+        == "Attribute Updated event was fired with arguments: {'attribute_id': 1234, 'attribute_name': 'name', 'attribute_value': 'value'}"
+    )
 
 
 async def test_zha_logbook_event_device_no_device(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make sure logbook logs args same as params which is used for attribute updated events.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
