### PR TITLE
Add async_on_create_entry method to create config entries

### DIFF
--- a/homeassistant/components/bayesian/config_flow.py
+++ b/homeassistant/components/bayesian/config_flow.py
@@ -38,6 +38,7 @@ from homeassistant.config_entries import (
     ConfigSubentry,
     ConfigSubentryData,
     ConfigSubentryFlow,
+    FlowType,
     SubentryFlowResult,
 )
 from homeassistant.const import (
@@ -517,7 +518,12 @@ class BayesianConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
         ]
 
         self.async_config_flow_finished(data)
-        return super().async_create_entry(data=data, subentries=subentries, **kwargs)
+        return super().async_create_entry(
+            data=data,
+            subentries=subentries,
+            next_flow=(FlowType.CONFIG_SUBENTRIES_FLOW, None, "observation"),
+            **kwargs,
+        )
 
 
 class ObservationSubentryFlowHandler(ConfigSubentryFlow):

--- a/homeassistant/components/bayesian/config_flow.py
+++ b/homeassistant/components/bayesian/config_flow.py
@@ -33,14 +33,11 @@ from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
 from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN
 from homeassistant.config_entries import (
-    SOURCE_USER,
     ConfigEntry,
     ConfigFlowResult,
     ConfigSubentry,
     ConfigSubentryData,
     ConfigSubentryFlow,
-    FlowType,
-    SubentryFlowContext,
     SubentryFlowResult,
 )
 from homeassistant.const import (
@@ -521,18 +518,6 @@ class BayesianConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
 
         self.async_config_flow_finished(data)
         return super().async_create_entry(data=data, subentries=subentries, **kwargs)
-
-    async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
-        """Create subentry flow after creating the main entry."""
-        subentry_result = await self.hass.config_entries.subentries.async_init(
-            (result["result"].entry_id, "observation"),
-            context=SubentryFlowContext(source=SOURCE_USER),
-        )
-        result["next_flow"] = (
-            FlowType.CONFIG_SUBENTRIES_FLOW,
-            subentry_result["flow_id"],
-        )
-        return result
 
 
 class ObservationSubentryFlowHandler(ConfigSubentryFlow):

--- a/homeassistant/components/bayesian/config_flow.py
+++ b/homeassistant/components/bayesian/config_flow.py
@@ -520,11 +520,7 @@ class BayesianConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
         ]
 
         self.async_config_flow_finished(data)
-        return super().async_create_entry(
-            data=data,
-            subentries=subentries,
-            **kwargs,
-        )
+        return super().async_create_entry(data=data, subentries=subentries, **kwargs)
 
     async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
         """Create subentry flow after creating the main entry."""

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3313,10 +3313,11 @@ class ConfigFlow(ConfigEntryBaseFlow):
         return result
 
     async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
-        """Run when config flow creates a config entry.
+        """Runs after a config flow has created a config entry.
 
-        Should be overwritten by integrations to add additional data to the result.
-        Example: creating next flow entries to the result.
+        Can be overwritten by integrations to add additional data to the result.
+        Example: creating next flow entries to the result which needs a
+        config entry created before it can start.
         """
         return result
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -319,8 +319,7 @@ class FlowType(StrEnum):
     """Flow type."""
 
     CONFIG_FLOW = "config_flow"
-    # Add other flow types here as needed in the future,
-    # if we want to support them in the `next_flow` parameter.
+    OPTIONS_FLOW = "options_flow"
     CONFIG_SUBENTRIES_FLOW = "config_subentries_flow"
 
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -307,7 +307,7 @@ class ConfigFlowResult(FlowResult[ConfigFlowContext, str], total=False):
     """Typed result dict for config flow."""
 
     # Extra keys, only present if type is CREATE_ENTRY
-    next_flow: tuple[FlowType, str, str]  # (flow type, flow id, subentry_type)
+    next_flow: tuple[FlowType, str]  # (flow type, flow id)
     minor_version: int
     options: Mapping[str, Any]
     result: ConfigEntry
@@ -1599,6 +1599,23 @@ class ConfigEntriesFlowManager(
                 issue_id = f"config_entry_reauth_{flow.handler}_{entry_id}"
                 ir.async_delete_issue(self.hass, HOMEASSISTANT_DOMAIN, issue_id)
 
+    def _async_validate_next_flow(
+        self,
+        result: ConfigFlowResult,
+    ) -> None:
+        """Validate and set next_flow in result if provided."""
+        if (next_flow := result.get("next_flow")) is None:
+            return
+        flow_type, flow_id = next_flow
+        if flow_type not in {FlowType.CONFIG_FLOW, FlowType.CONFIG_SUBENTRIES_FLOW}:
+            raise HomeAssistantError("Invalid next_flow type")
+        if flow_type == FlowType.CONFIG_FLOW:
+            # Raises UnknownFlow if the flow does not exist.
+            self.hass.config_entries.flow.async_get(flow_id)
+        if flow_type == FlowType.CONFIG_SUBENTRIES_FLOW:
+            # Raises UnknownFlow if the flow does not exist.
+            self.hass.config_entries.subentries.async_get(flow_id)
+
     async def async_finish_flow(
         self,
         flow: data_entry_flow.FlowHandler[ConfigFlowContext, ConfigFlowResult],
@@ -1749,6 +1766,10 @@ class ConfigEntriesFlowManager(
             version=result["version"],
         )
 
+        if not existing_entry:
+            result = await flow.async_on_create_entry(result)
+            self._async_validate_next_flow(result)
+
         if existing_entry is not None:
             # Unload and remove the existing entry, but don't clean up devices and
             # entities until the new entry is added
@@ -1761,20 +1782,6 @@ class ConfigEntriesFlowManager(
             self.config_entries._async_clean_up(existing_entry)  # noqa: SLF001
 
         result["result"] = entry
-
-        if (
-            result.get("next_flow")
-            and result["next_flow"][0] == FlowType.CONFIG_SUBENTRIES_FLOW
-        ):
-            subentry_result = await self.hass.config_entries.subentries.async_init(
-                (entry.entry_id, result["next_flow"][2]),
-                context=SubentryFlowContext(source=SOURCE_USER),
-            )
-            result["next_flow"] = (
-                result["next_flow"][0],
-                subentry_result["flow_id"],
-                result["next_flow"][2],
-            )
 
         return result
 
@@ -3287,41 +3294,27 @@ class ConfigFlow(ConfigEntryBaseFlow):
         """Handle a flow initialized by Zeroconf discovery."""
         return await self._async_step_discovery_without_unique_id()
 
-    def _async_set_next_flow_if_valid(
-        self,
-        result: ConfigFlowResult,
-        next_flow: tuple[FlowType, str, str] | None,
-    ) -> None:
-        """Validate and set next_flow in result if provided."""
-        if next_flow is None:
-            return
-        flow_type, flow_id, subentry_type = next_flow
-        if flow_type not in {FlowType.CONFIG_FLOW, FlowType.CONFIG_SUBENTRIES_FLOW}:
-            raise HomeAssistantError("Invalid next_flow type")
-        if flow_type == FlowType.CONFIG_FLOW:
-            # Raises UnknownFlow if the flow does not exist.
-            self.hass.config_entries.flow.async_get(flow_id)
-        if flow_type == FlowType.CONFIG_SUBENTRIES_FLOW and not subentry_type:
-            raise HomeAssistantError(
-                "subentry_type must be provided for subentry flows"
-            )
-
-        result["next_flow"] = next_flow
-
     @callback
     def async_abort(
         self,
         *,
         reason: str,
         description_placeholders: Mapping[str, str] | None = None,
-        next_flow: tuple[FlowType, str, str] | None = None,
+        next_flow: tuple[FlowType, str] | None = None,
     ) -> ConfigFlowResult:
         """Abort the config flow."""
         result = super().async_abort(
             reason=reason,
             description_placeholders=description_placeholders,
         )
-        self._async_set_next_flow_if_valid(result, next_flow)
+        return result  # noqa: RET504
+
+    async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
+        """Run when config flow creates a config entry.
+
+        Should be overwritten by integrations to add additional data to the result.
+        Example: creating next flow entries to the result.
+        """
         return result
 
     @callback
@@ -3332,7 +3325,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         data: Mapping[str, Any],
         description: str | None = None,
         description_placeholders: Mapping[str, str] | None = None,
-        next_flow: tuple[FlowType, str, str] | None = None,
+        next_flow: tuple[FlowType, str] | None = None,
         options: Mapping[str, Any] | None = None,
         subentries: Iterable[ConfigSubentryData] | None = None,
     ) -> ConfigFlowResult:
@@ -3351,7 +3344,6 @@ class ConfigFlow(ConfigEntryBaseFlow):
         )
 
         result["minor_version"] = self.MINOR_VERSION
-        self._async_set_next_flow_if_valid(result, next_flow)
         result["options"] = options or {}
         result["subentries"] = subentries or ()
         result["version"] = self.VERSION

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1606,11 +1606,14 @@ class ConfigEntriesFlowManager(
         if (next_flow := result.get("next_flow")) is None:
             return
         flow_type, flow_id = next_flow
-        if flow_type not in {FlowType.CONFIG_FLOW, FlowType.CONFIG_SUBENTRIES_FLOW}:
+        if flow_type not in FlowType:
             raise HomeAssistantError("Invalid next_flow type")
         if flow_type == FlowType.CONFIG_FLOW:
             # Raises UnknownFlow if the flow does not exist.
             self.hass.config_entries.flow.async_get(flow_id)
+        if flow_type == FlowType.OPTIONS_FLOW:
+            # Raises UnknownFlow if the flow does not exist.
+            self.hass.config_entries.options.async_get(flow_id)
         if flow_type == FlowType.CONFIG_SUBENTRIES_FLOW:
             # Raises UnknownFlow if the flow does not exist.
             self.hass.config_entries.subentries.async_get(flow_id)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1767,10 +1767,6 @@ class ConfigEntriesFlowManager(
             version=result["version"],
         )
 
-        if not existing_entry:
-            result = await flow.async_on_create_entry(result)
-            self._async_validate_next_flow(result)
-
         if existing_entry is not None:
             # Unload and remove the existing entry, but don't clean up devices and
             # entities until the new entry is added
@@ -1783,6 +1779,10 @@ class ConfigEntriesFlowManager(
             self.config_entries._async_clean_up(existing_entry)  # noqa: SLF001
 
         result["result"] = entry
+        if not existing_entry:
+            result = await flow.async_on_create_entry(result)
+            self._async_validate_next_flow(result)
+
         return result
 
     async def async_create_flow(

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1784,7 +1784,6 @@ class ConfigEntriesFlowManager(
             self.config_entries._async_clean_up(existing_entry)  # noqa: SLF001
 
         result["result"] = entry
-
         return result
 
     async def async_create_flow(

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1664,6 +1664,8 @@ class ConfigEntriesFlowManager(
                 self.config_entries.async_update_entry(
                     entry, discovery_keys=new_discovery_keys
                 )
+
+            self._async_validate_next_flow(result)
             return result
 
         # Mark the step as done.

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -307,7 +307,7 @@ class ConfigFlowResult(FlowResult[ConfigFlowContext, str], total=False):
     """Typed result dict for config flow."""
 
     # Extra keys, only present if type is CREATE_ENTRY
-    next_flow: tuple[FlowType, str]  # (flow type, flow id)
+    next_flow: tuple[FlowType, str, str]  # (flow type, flow id, subentry_type)
     minor_version: int
     options: Mapping[str, Any]
     result: ConfigEntry
@@ -321,6 +321,7 @@ class FlowType(StrEnum):
     CONFIG_FLOW = "config_flow"
     # Add other flow types here as needed in the future,
     # if we want to support them in the `next_flow` parameter.
+    CONFIG_SUBENTRIES_FLOW = "config_subentries_flow"
 
 
 def _validate_item(*, disabled_by: ConfigEntryDisabler | Any | None = None) -> None:
@@ -1760,6 +1761,21 @@ class ConfigEntriesFlowManager(
             self.config_entries._async_clean_up(existing_entry)  # noqa: SLF001
 
         result["result"] = entry
+
+        if (
+            result.get("next_flow")
+            and result["next_flow"][0] == FlowType.CONFIG_SUBENTRIES_FLOW
+        ):
+            subentry_result = await self.hass.config_entries.subentries.async_init(
+                (entry.entry_id, result["next_flow"][2]),
+                context=SubentryFlowContext(source=SOURCE_USER),
+            )
+            result["next_flow"] = (
+                result["next_flow"][0],
+                subentry_result["flow_id"],
+                result["next_flow"][2],
+            )
+
         return result
 
     async def async_create_flow(
@@ -3274,16 +3290,22 @@ class ConfigFlow(ConfigEntryBaseFlow):
     def _async_set_next_flow_if_valid(
         self,
         result: ConfigFlowResult,
-        next_flow: tuple[FlowType, str] | None,
+        next_flow: tuple[FlowType, str, str] | None,
     ) -> None:
         """Validate and set next_flow in result if provided."""
         if next_flow is None:
             return
-        flow_type, flow_id = next_flow
-        if flow_type != FlowType.CONFIG_FLOW:
+        flow_type, flow_id, subentry_type = next_flow
+        if flow_type not in {FlowType.CONFIG_FLOW, FlowType.CONFIG_SUBENTRIES_FLOW}:
             raise HomeAssistantError("Invalid next_flow type")
-        # Raises UnknownFlow if the flow does not exist.
-        self.hass.config_entries.flow.async_get(flow_id)
+        if flow_type == FlowType.CONFIG_FLOW:
+            # Raises UnknownFlow if the flow does not exist.
+            self.hass.config_entries.flow.async_get(flow_id)
+        if flow_type == FlowType.CONFIG_SUBENTRIES_FLOW and not subentry_type:
+            raise HomeAssistantError(
+                "subentry_type must be provided for subentry flows"
+            )
+
         result["next_flow"] = next_flow
 
     @callback
@@ -3292,7 +3314,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         *,
         reason: str,
         description_placeholders: Mapping[str, str] | None = None,
-        next_flow: tuple[FlowType, str] | None = None,
+        next_flow: tuple[FlowType, str, str] | None = None,
     ) -> ConfigFlowResult:
         """Abort the config flow."""
         result = super().async_abort(
@@ -3310,7 +3332,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         data: Mapping[str, Any],
         description: str | None = None,
         description_placeholders: Mapping[str, str] | None = None,
-        next_flow: tuple[FlowType, str] | None = None,
+        next_flow: tuple[FlowType, str, str] | None = None,
         options: Mapping[str, Any] | None = None,
         subentries: Iterable[ConfigSubentryData] | None = None,
     ) -> ConfigFlowResult:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3307,7 +3307,9 @@ class ConfigFlow(ConfigEntryBaseFlow):
             reason=reason,
             description_placeholders=description_placeholders,
         )
-        return result  # noqa: RET504
+        if next_flow:
+            result["next_flow"] = next_flow
+        return result
 
     async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
         """Run when config flow creates a config entry.
@@ -3344,6 +3346,8 @@ class ConfigFlow(ConfigEntryBaseFlow):
         )
 
         result["minor_version"] = self.MINOR_VERSION
+        if next_flow:
+            result["next_flow"] = next_flow
         result["options"] = options or {}
         result["subentries"] = subentries or ()
         result["version"] = self.VERSION

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3297,6 +3297,23 @@ class ConfigFlow(ConfigEntryBaseFlow):
         """Handle a flow initialized by Zeroconf discovery."""
         return await self._async_step_discovery_without_unique_id()
 
+    def _async_set_next_flow_if_valid(
+        self,
+        result: ConfigFlowResult,
+        next_flow: tuple[FlowType, str] | None,
+    ) -> None:
+        """Validate and set next_flow in result if provided."""
+        if next_flow is None:
+            return
+        flow_type, flow_id = next_flow
+        if flow_type not in FlowType:
+            raise HomeAssistantError(f"Invalid flow type: {flow_type}")
+        if flow_type != FlowType.CONFIG_FLOW:
+            return
+        # Raises UnknownFlow if the flow does not exist.
+        self.hass.config_entries.flow.async_get(flow_id)
+        result["next_flow"] = next_flow
+
     @callback
     def async_abort(
         self,
@@ -3311,7 +3328,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
             description_placeholders=description_placeholders,
         )
         if next_flow:
-            result["next_flow"] = next_flow
+            self._async_set_next_flow_if_valid(result, next_flow)
         return result
 
     async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
@@ -3351,7 +3368,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
 
         result["minor_version"] = self.MINOR_VERSION
         if next_flow:
-            result["next_flow"] = next_flow
+            self._async_set_next_flow_if_valid(result, next_flow)
         result["options"] = options or {}
         result["subentries"] = subentries or ()
         result["version"] = self.VERSION

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3309,6 +3309,8 @@ class ConfigFlow(ConfigEntryBaseFlow):
         if flow_type not in FlowType:
             raise HomeAssistantError(f"Invalid flow type: {flow_type}")
         if flow_type != FlowType.CONFIG_FLOW:
+            # This early validation only supports config flows as all other
+            # types require a config entry to exist before they can start
             return
         # Raises UnknownFlow if the flow does not exist.
         self.hass.config_entries.flow.async_get(flow_id)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -316,7 +316,7 @@ class ConfigFlowResult(FlowResult[ConfigFlowContext, str], total=False):
 
 
 class FlowType(StrEnum):
-    """Flow type."""
+    """Flow type supported in `next_flow` of ConfigFlowResult."""
 
     CONFIG_FLOW = "config_flow"
     OPTIONS_FLOW = "options_flow"

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3306,8 +3306,6 @@ class ConfigFlow(ConfigEntryBaseFlow):
         if next_flow is None:
             return
         flow_type, flow_id = next_flow
-        if flow_type not in FlowType:
-            raise HomeAssistantError(f"Invalid flow type: {flow_type}")
         if flow_type != FlowType.CONFIG_FLOW:
             raise HomeAssistantError(
                 "next_flow only supports FlowType.CONFIG_FLOW; "

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3309,9 +3309,10 @@ class ConfigFlow(ConfigEntryBaseFlow):
         if flow_type not in FlowType:
             raise HomeAssistantError(f"Invalid flow type: {flow_type}")
         if flow_type != FlowType.CONFIG_FLOW:
-            # This early validation only supports config flows as all other
-            # types require a config entry to exist before they can start
-            return
+            raise HomeAssistantError(
+                "next_flow only supports FlowType.CONFIG_FLOW; "
+                "use async_on_create_entry for options or subentry flows"
+            )
         # Raises UnknownFlow if the flow does not exist.
         self.hass.config_entries.flow.async_get(flow_id)
         result["next_flow"] = next_flow

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1602,7 +1602,7 @@ class ConfigEntriesFlowManager(
         self,
         result: ConfigFlowResult,
     ) -> None:
-        """Validate and set next_flow in result if provided."""
+        """Validate `next_flow` in result if provided."""
         if (next_flow := result.get("next_flow")) is None:
             return
         flow_type, flow_id = next_flow

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3336,7 +3336,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
     async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
         """Runs after a config flow has created a config entry.
 
-        Can be overwritten by integrations to add additional data to the result.
+        Can be overridden by integrations to add additional data to the result.
         Example: creating next flow entries to the result which needs a
         config entry created before it can start.
         """

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1607,7 +1607,7 @@ class ConfigEntriesFlowManager(
             return
         flow_type, flow_id = next_flow
         if flow_type not in FlowType:
-            raise HomeAssistantError("Invalid next_flow type")
+            raise HomeAssistantError(f"Invalid flow type: {flow_type}")
         if flow_type == FlowType.CONFIG_FLOW:
             # Raises UnknownFlow if the flow does not exist.
             self.hass.config_entries.flow.async_get(flow_id)
@@ -3327,8 +3327,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
             reason=reason,
             description_placeholders=description_placeholders,
         )
-        if next_flow:
-            self._async_set_next_flow_if_valid(result, next_flow)
+        self._async_set_next_flow_if_valid(result, next_flow)
         return result
 
     async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
@@ -3367,8 +3366,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         )
 
         result["minor_version"] = self.MINOR_VERSION
-        if next_flow:
-            self._async_set_next_flow_if_valid(result, next_flow)
+        self._async_set_next_flow_if_valid(result, next_flow)
         result["options"] = options or {}
         result["subentries"] = subentries or ()
         result["version"] = self.VERSION

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1878,28 +1878,18 @@ async def test_create_entry_next_flow(
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
 
-        async def async_on_create_entry(
-            self, result: config_entries.ConfigFlowResult
-        ) -> config_entries.ConfigFlowResult:
-            """Create a next flow."""
-            new_flow = await hass.config_entries.flow.async_init(
-                "comp",
-                context={"source": config_entries.SOURCE_USER},
-            )
-            result["next_flow"] = (
-                config_entries.FlowType.CONFIG_FLOW,
-                new_flow["flow_id"],
-            )
-            return await super().async_on_create_entry(result)
-
         async def async_step_import(
             self, user_input: dict[str, Any] | None = None
         ) -> config_entries.ConfigFlowResult:
             """Test create entry with next_flow parameter."""
-
+            result = await hass.config_entries.flow.async_init(
+                "comp",
+                context={"source": config_entries.SOURCE_USER},
+            )
             return self.async_create_entry(
                 title="import",
                 data={"flow": "import"},
+                next_flow=(config_entries.FlowType.CONFIG_FLOW, result["flow_id"]),
             )
 
         async def async_step_user(
@@ -1952,8 +1942,6 @@ async def test_create_entry_next_flow(
         assert async_setup_entry.call_count == 2
         entries = hass.config_entries.async_entries("comp")
         entry = next(entry for entry in entries if entry.data.get("flow") == "user")
-        flows = hass.config_entries.flow.async_progress()
-        new_flow = flows[0]
         assert result == {
             "context": {"source": "user"},
             "data": {"flow": "user"},
@@ -1962,7 +1950,6 @@ async def test_create_entry_next_flow(
             "flow_id": user_flow["flow_id"],
             "handler": "comp",
             "minor_version": 1,
-            "next_flow": (config_entries.FlowType.CONFIG_FLOW, new_flow["flow_id"]),
             "options": {},
             "result": entry,
             "subentries": (),
@@ -2005,13 +1992,6 @@ async def test_create_entry_next_flow_invalid(
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
 
-        async def async_on_create_entry(
-            self, result: config_entries.ConfigFlowResult
-        ) -> config_entries.ConfigFlowResult:
-            """Create a next flow."""
-            result["next_flow"] = invalid_next_flow
-            return await super().async_on_create_entry(result)
-
         async def async_step_import(
             self, user_input: dict[str, Any] | None = None
         ) -> config_entries.ConfigFlowResult:
@@ -2023,6 +2003,7 @@ async def test_create_entry_next_flow_invalid(
             return self.async_create_entry(
                 title="import",
                 data={"flow": "import"},
+                next_flow=invalid_next_flow,  # type: ignore[arg-type]
             )
 
         async def async_step_user(
@@ -9643,7 +9624,7 @@ async def test_async_update_title_placeholders(hass: HomeAssistant) -> None:
         assert len(events) == 2
 
 
-async def test_config_flow_abort_with_next_flow2(hass: HomeAssistant) -> None:
+async def test_config_flow_abort_with_next_flow(hass: HomeAssistant) -> None:
     """Test that ConfigFlow.async_abort() can include next_flow parameter."""
 
     class TargetFlow(config_entries.ConfigFlow):
@@ -9657,25 +9638,20 @@ async def test_config_flow_abort_with_next_flow2(hass: HomeAssistant) -> None:
     class TestFlow(config_entries.ConfigFlow):
         VERSION = 1
 
-        async def async_on_create_entry(
-            self, result: config_entries.ConfigFlowResult
-        ) -> config_entries.ConfigFlowResult:
-            """Create next flow."""
-            target_result = await hass.config_entries.flow.async_init(
-                "test2", context={"source": config_entries.SOURCE_USER}
-            )
-            result["next_flow"] = (
-                config_entries.FlowType.CONFIG_FLOW,
-                target_result["flow_id"],
-            )
-            return result
-
         async def async_step_user(
             self, user_input: dict[str, Any] | None = None
         ) -> config_entries.ConfigFlowResult:
             # Create target flow first
+            target_result = await hass.config_entries.flow.async_init(
+                "test2", context={"source": config_entries.SOURCE_USER}
+            )
+            # Abort with next_flow
             return self.async_abort(
                 reason="provision_successful",
+                next_flow=(
+                    config_entries.FlowType.CONFIG_FLOW,
+                    target_result["flow_id"],
+                ),
             )
 
     mock_integration(hass, MockModule("test"))

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2023,7 +2023,7 @@ async def test_create_entry_next_flow_invalid(
                 context={"source": config_entries.SOURCE_IMPORT},
             )
 
-        assert async_setup_entry.call_count == 1
+        assert async_setup_entry.call_count == 0
 
 
 async def test_create_entry_options(
@@ -2384,11 +2384,10 @@ async def test_invalid_on_create_entry(
             return self.async_create_entry(
                 title="user_flow",
                 data={"flow": "user"},
-                next_flow=(config_entries.FlowType.CONFIG_FLOW, result["flow_id"]),
             )
 
     class TestOptionsFlowHandler(config_entries.OptionsFlow):
-        """Handle Yale options."""
+        """Handle options."""
 
         async def async_step_init(
             self, user_input: dict[str, Any] | None = None
@@ -10029,7 +10028,7 @@ async def test_config_flow_abort_with_invalid_next_flow_type(
 
     with (
         mock_config_flow("test", TestFlow),
-        pytest.raises(HomeAssistantError, match="Invalid next_flow type"),
+        pytest.raises(HomeAssistantError, match="Invalid flow type: invalid_type"),
     ):
         await hass.config_entries.flow.async_init(
             "test", context={"source": config_entries.SOURCE_USER}

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2023,7 +2023,7 @@ async def test_create_entry_next_flow_invalid(
                 context={"source": config_entries.SOURCE_IMPORT},
             )
 
-        assert async_setup_entry.call_count == 0
+        assert async_setup_entry.call_count == 1
 
 
 async def test_create_entry_options(
@@ -2081,7 +2081,7 @@ async def test_create_entry_options(
 async def test_on_create_entry_with_subentry_flow(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test next_flow parameter for create entry."""
+    """Test use async_on_create_entry with creating a subentry flow."""
 
     async def mock_async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Mock setup."""
@@ -2201,6 +2201,213 @@ async def test_on_create_entry_with_subentry_flow(
             "type": FlowResultType.CREATE_ENTRY,
             "unique_id": None,
         }
+
+
+async def test_on_create_entry_with_options_flow(
+    hass: HomeAssistant, manager: config_entries.ConfigEntries
+) -> None:
+    """Test use async_on_create_entry with creating an options flow."""
+
+    async def mock_async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+        """Mock setup."""
+        return True
+
+    async_setup_entry = AsyncMock(return_value=True)
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup=mock_async_setup,
+            async_setup_entry=async_setup_entry,
+        ),
+    )
+    mock_platform(hass, "comp.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        @staticmethod
+        @callback
+        def async_get_options_flow(config_entry: ConfigEntry) -> TestOptionsFlowHandler:
+            """Get the options flow for this handler."""
+            return TestOptionsFlowHandler()
+
+        async def async_on_create_entry(
+            self, result: config_entries.ConfigFlowResult
+        ) -> config_entries.ConfigFlowResult:
+            config_entry_id = result["result"].entry_id
+            new_flow = await hass.config_entries.options.async_init(
+                config_entry_id, context={"source": config_entries.SOURCE_USER}
+            )
+            result["next_flow"] = (
+                config_entries.FlowType.OPTIONS_FLOW,
+                new_flow["flow_id"],
+            )
+            return result
+
+        async def async_step_user(
+            self, user_input: dict[str, Any] | None = None
+        ) -> config_entries.ConfigFlowResult:
+            """Test next step."""
+            if user_input is None:
+                return self.async_show_form(step_id="user")
+            return self.async_create_entry(
+                title="user_flow",
+                data={"flow": "user"},
+                next_flow=(config_entries.FlowType.CONFIG_FLOW, result["flow_id"]),
+            )
+
+    class TestOptionsFlowHandler(config_entries.OptionsFlow):
+        """Handle Yale options."""
+
+        async def async_step_init(
+            self, user_input: dict[str, Any] | None = None
+        ) -> config_entries.ConfigFlowResult:
+            """Manage options."""
+
+            if user_input is None:
+                return self.async_show_form(step_id="init")
+            return self.async_create_entry(title="options", data={"flow": "options"})
+
+    with mock_config_flow("comp", TestFlow):
+        assert await async_setup_component(hass, "comp", {})
+
+        result = await hass.config_entries.flow.async_init(
+            "comp", context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+        flows = hass.config_entries.flow.async_progress()
+        assert len(flows) == 0
+        option_flows = hass.config_entries.options.async_progress()
+        assert len(option_flows) == 1
+        option_flow = option_flows[0]
+
+        entries = hass.config_entries.async_entries("comp")
+        assert len(entries) == 1
+        entry = entries[0]
+        assert result == {
+            "context": {"source": "user"},
+            "data": {"flow": "user"},
+            "description_placeholders": None,
+            "description": None,
+            "flow_id": ANY,
+            "handler": "comp",
+            "minor_version": 1,
+            "next_flow": (
+                config_entries.FlowType.OPTIONS_FLOW,
+                option_flow["flow_id"],
+            ),
+            "options": {},
+            "result": entry,
+            "subentries": (),
+            "title": "user_flow",
+            "type": FlowResultType.CREATE_ENTRY,
+            "version": 1,
+        }
+
+        result = await hass.config_entries.options.async_configure(
+            option_flow["flow_id"], {}
+        )
+        option_flows = hass.config_entries.options.async_progress()
+        assert len(option_flows) == 0
+
+        assert result == {
+            "context": {"source": "user"},
+            "data": {"flow": "options"},
+            "description_placeholders": None,
+            "description": None,
+            "flow_id": ANY,
+            "handler": entry.entry_id,
+            "title": "options",
+            "type": FlowResultType.CREATE_ENTRY,
+        }
+
+
+@pytest.mark.parametrize(
+    ("invalid_next_flow", "error"),
+    [
+        (("invalid_flow_type", "invalid_flow_id"), HomeAssistantError),
+        ((config_entries.FlowType.CONFIG_FLOW, "invalid_flow_id"), UnknownFlow),
+        ((config_entries.FlowType.OPTIONS_FLOW, "invalid_flow_id"), UnknownFlow),
+        (
+            (config_entries.FlowType.CONFIG_SUBENTRIES_FLOW, "invalid_flow_id"),
+            UnknownFlow,
+        ),
+    ],
+)
+async def test_invalid_on_create_entry(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    invalid_next_flow: tuple[str, str],
+    error: type[Exception],
+) -> None:
+    """Test use invalid flows in async_on_create_entry."""
+
+    async def mock_async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+        """Mock setup."""
+        return True
+
+    async_setup_entry = AsyncMock(return_value=True)
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup=mock_async_setup,
+            async_setup_entry=async_setup_entry,
+        ),
+    )
+    mock_platform(hass, "comp.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        @staticmethod
+        @callback
+        def async_get_options_flow(config_entry: ConfigEntry) -> TestOptionsFlowHandler:
+            """Get the options flow for this handler."""
+            return TestOptionsFlowHandler()
+
+        async def async_on_create_entry(
+            self, result: config_entries.ConfigFlowResult
+        ) -> config_entries.ConfigFlowResult:
+            result["next_flow"] = invalid_next_flow  # type: ignore[arg-type]
+            return result
+
+        async def async_step_user(
+            self, user_input: dict[str, Any] | None = None
+        ) -> config_entries.ConfigFlowResult:
+            """Test next step."""
+            if user_input is None:
+                return self.async_show_form(step_id="user")
+            return self.async_create_entry(
+                title="user_flow",
+                data={"flow": "user"},
+                next_flow=(config_entries.FlowType.CONFIG_FLOW, result["flow_id"]),
+            )
+
+    class TestOptionsFlowHandler(config_entries.OptionsFlow):
+        """Handle Yale options."""
+
+        async def async_step_init(
+            self, user_input: dict[str, Any] | None = None
+        ) -> config_entries.ConfigFlowResult:
+            """Manage options."""
+
+            if user_input is None:
+                return self.async_show_form(step_id="init")
+            return self.async_create_entry(title="options", data={"flow": "options"})
+
+    with mock_config_flow("comp", TestFlow):
+        assert await async_setup_component(hass, "comp", {})
+
+        result = await hass.config_entries.flow.async_init(
+            "comp", context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+        with pytest.raises(error):
+            await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
 
 async def test_entry_options(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1878,18 +1878,28 @@ async def test_create_entry_next_flow(
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
 
+        async def async_on_create_entry(
+            self, result: config_entries.ConfigFlowResult
+        ) -> config_entries.ConfigFlowResult:
+            """Create a next flow."""
+            new_flow = await hass.config_entries.flow.async_init(
+                "comp",
+                context={"source": config_entries.SOURCE_USER},
+            )
+            result["next_flow"] = (
+                config_entries.FlowType.CONFIG_FLOW,
+                new_flow["flow_id"],
+            )
+            return await super().async_on_create_entry(result)
+
         async def async_step_import(
             self, user_input: dict[str, Any] | None = None
         ) -> config_entries.ConfigFlowResult:
             """Test create entry with next_flow parameter."""
-            result = await hass.config_entries.flow.async_init(
-                "comp",
-                context={"source": config_entries.SOURCE_USER},
-            )
+
             return self.async_create_entry(
                 title="import",
                 data={"flow": "import"},
-                next_flow=(config_entries.FlowType.CONFIG_FLOW, result["flow_id"]),
             )
 
         async def async_step_user(
@@ -1942,6 +1952,8 @@ async def test_create_entry_next_flow(
         assert async_setup_entry.call_count == 2
         entries = hass.config_entries.async_entries("comp")
         entry = next(entry for entry in entries if entry.data.get("flow") == "user")
+        flows = hass.config_entries.flow.async_progress()
+        new_flow = flows[0]
         assert result == {
             "context": {"source": "user"},
             "data": {"flow": "user"},
@@ -1950,6 +1962,7 @@ async def test_create_entry_next_flow(
             "flow_id": user_flow["flow_id"],
             "handler": "comp",
             "minor_version": 1,
+            "next_flow": (config_entries.FlowType.CONFIG_FLOW, new_flow["flow_id"]),
             "options": {},
             "result": entry,
             "subentries": (),
@@ -1992,6 +2005,13 @@ async def test_create_entry_next_flow_invalid(
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
 
+        async def async_on_create_entry(
+            self, result: config_entries.ConfigFlowResult
+        ) -> config_entries.ConfigFlowResult:
+            """Create a next flow."""
+            result["next_flow"] = invalid_next_flow
+            return await super().async_on_create_entry(result)
+
         async def async_step_import(
             self, user_input: dict[str, Any] | None = None
         ) -> config_entries.ConfigFlowResult:
@@ -2003,7 +2023,6 @@ async def test_create_entry_next_flow_invalid(
             return self.async_create_entry(
                 title="import",
                 data={"flow": "import"},
-                next_flow=invalid_next_flow,  # type: ignore[arg-type]
             )
 
         async def async_step_user(
@@ -9624,7 +9643,7 @@ async def test_async_update_title_placeholders(hass: HomeAssistant) -> None:
         assert len(events) == 2
 
 
-async def test_config_flow_abort_with_next_flow(hass: HomeAssistant) -> None:
+async def test_config_flow_abort_with_next_flow2(hass: HomeAssistant) -> None:
     """Test that ConfigFlow.async_abort() can include next_flow parameter."""
 
     class TargetFlow(config_entries.ConfigFlow):
@@ -9638,20 +9657,25 @@ async def test_config_flow_abort_with_next_flow(hass: HomeAssistant) -> None:
     class TestFlow(config_entries.ConfigFlow):
         VERSION = 1
 
+        async def async_on_create_entry(
+            self, result: config_entries.ConfigFlowResult
+        ) -> config_entries.ConfigFlowResult:
+            """Create next flow."""
+            target_result = await hass.config_entries.flow.async_init(
+                "test2", context={"source": config_entries.SOURCE_USER}
+            )
+            result["next_flow"] = (
+                config_entries.FlowType.CONFIG_FLOW,
+                target_result["flow_id"],
+            )
+            return result
+
         async def async_step_user(
             self, user_input: dict[str, Any] | None = None
         ) -> config_entries.ConfigFlowResult:
             # Create target flow first
-            target_result = await hass.config_entries.flow.async_init(
-                "test2", context={"source": config_entries.SOURCE_USER}
-            )
-            # Abort with next_flow
             return self.async_abort(
                 reason="provision_successful",
-                next_flow=(
-                    config_entries.FlowType.CONFIG_FLOW,
-                    target_result["flow_id"],
-                ),
             )
 
     mock_integration(hass, MockModule("test"))

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2078,6 +2078,131 @@ async def test_create_entry_options(
         assert entries[0].options == {"example": "option"}
 
 
+async def test_on_create_entry_with_subentry_flow(
+    hass: HomeAssistant, manager: config_entries.ConfigEntries
+) -> None:
+    """Test next_flow parameter for create entry."""
+
+    async def mock_async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+        """Mock setup."""
+        return True
+
+    async_setup_entry = AsyncMock(return_value=True)
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup=mock_async_setup,
+            async_setup_entry=async_setup_entry,
+        ),
+    )
+    mock_platform(hass, "comp.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        @classmethod
+        @callback
+        def async_get_supported_subentry_types(
+            cls, config_entry: ConfigEntry
+        ) -> dict[str, type[config_entries.ConfigSubentryFlow]]:
+            """Return subentries supported by this integration."""
+            return {"sub_flow": TestSubentryFlowHandler}
+
+        async def async_on_create_entry(
+            self, result: config_entries.ConfigFlowResult
+        ) -> config_entries.ConfigFlowResult:
+            config_entry_id = result["result"].entry_id
+            new_flow = await hass.config_entries.subentries.async_init(
+                handler=(config_entry_id, "sub_flow"),
+                context={"source": config_entries.SOURCE_USER},
+            )
+            result["next_flow"] = (
+                config_entries.FlowType.CONFIG_SUBENTRIES_FLOW,
+                new_flow["flow_id"],
+            )
+            return result
+
+        async def async_step_user(
+            self, user_input: dict[str, Any] | None = None
+        ) -> config_entries.ConfigFlowResult:
+            """Test next step."""
+            if user_input is None:
+                return self.async_show_form(step_id="user")
+            return self.async_create_entry(
+                title="user_flow",
+                data={"flow": "user"},
+                next_flow=(config_entries.FlowType.CONFIG_FLOW, result["flow_id"]),
+            )
+
+    class TestSubentryFlowHandler(config_entries.ConfigSubentryFlow):
+        """Test subentry flow."""
+
+        async def async_step_user(
+            self, user_input: dict[str, Any] | None = None
+        ) -> config_entries.SubentryFlowResult:
+            """User flow."""
+            if user_input is None:
+                return self.async_show_form(step_id="user")
+            return self.async_create_entry(title="subentry", data={"flow": "subentry"})
+
+    with mock_config_flow("comp", TestFlow):
+        assert await async_setup_component(hass, "comp", {})
+
+        result = await hass.config_entries.flow.async_init(
+            "comp", context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+        flows = hass.config_entries.flow.async_progress()
+        assert len(flows) == 0
+        sub_flows = hass.config_entries.subentries.async_progress()
+        assert len(sub_flows) == 1
+        subentry_flow = sub_flows[0]
+
+        entries = hass.config_entries.async_entries("comp")
+        assert len(entries) == 1
+        entry = entries[0]
+        assert result == {
+            "context": {"source": "user"},
+            "data": {"flow": "user"},
+            "description_placeholders": None,
+            "description": None,
+            "flow_id": ANY,
+            "handler": "comp",
+            "minor_version": 1,
+            "next_flow": (
+                config_entries.FlowType.CONFIG_SUBENTRIES_FLOW,
+                subentry_flow["flow_id"],
+            ),
+            "options": {},
+            "result": entry,
+            "subentries": (),
+            "title": "user_flow",
+            "type": FlowResultType.CREATE_ENTRY,
+            "version": 1,
+        }
+
+        result = await hass.config_entries.subentries.async_configure(
+            subentry_flow["flow_id"], {}
+        )
+        sub_flows = hass.config_entries.subentries.async_progress()
+        assert len(sub_flows) == 0
+
+        assert result == {
+            "context": {"source": "user"},
+            "data": {"flow": "subentry"},
+            "description_placeholders": None,
+            "description": None,
+            "flow_id": ANY,
+            "handler": (entry.entry_id, "sub_flow"),
+            "title": "subentry",
+            "type": FlowResultType.CREATE_ENTRY,
+            "unique_id": None,
+        }
+
+
 async def test_entry_options(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2326,6 +2326,66 @@ async def test_on_create_entry_with_options_flow(
 @pytest.mark.parametrize(
     ("invalid_next_flow", "error"),
     [
+        ((config_entries.FlowType.OPTIONS_FLOW, "invalid_flow_id"), HomeAssistantError),
+        (
+            (config_entries.FlowType.CONFIG_SUBENTRIES_FLOW, "invalid_flow_id"),
+            HomeAssistantError,
+        ),
+    ],
+)
+async def test_next_flow_with_unsupported_flow_type(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    invalid_next_flow: tuple[str, str],
+    error: type[Exception],
+) -> None:
+    """Test use async_on_create_entry with creating an options flow."""
+
+    async def mock_async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+        """Mock setup."""
+        return True
+
+    async_setup_entry = AsyncMock(return_value=True)
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup=mock_async_setup,
+            async_setup_entry=async_setup_entry,
+        ),
+    )
+    mock_platform(hass, "comp.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        async def async_step_user(
+            self, user_input: dict[str, Any] | None = None
+        ) -> config_entries.ConfigFlowResult:
+            """Test next step."""
+            if user_input is None:
+                return self.async_show_form(step_id="user")
+            return self.async_create_entry(
+                title="user_flow", data={"flow": "user"}, next_flow=invalid_next_flow
+            )
+
+    with mock_config_flow("comp", TestFlow):
+        assert await async_setup_component(hass, "comp", {})
+
+        result = await hass.config_entries.flow.async_init(
+            "comp", context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+        with pytest.raises(
+            error,
+            match="next_flow only supports FlowType.CONFIG_FLOW; use async_on_create_entry for options or subentry flows",
+        ):
+            await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+
+@pytest.mark.parametrize(
+    ("invalid_next_flow", "error"),
+    [
         (("invalid_flow_type", "invalid_flow_id"), HomeAssistantError),
         ((config_entries.FlowType.CONFIG_FLOW, "invalid_flow_id"), UnknownFlow),
         ((config_entries.FlowType.OPTIONS_FLOW, "invalid_flow_id"), UnknownFlow),

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2132,7 +2132,6 @@ async def test_on_create_entry_with_subentry_flow(
             return self.async_create_entry(
                 title="user_flow",
                 data={"flow": "user"},
-                next_flow=(config_entries.FlowType.CONFIG_FLOW, result["flow_id"]),
             )
 
     class TestSubentryFlowHandler(config_entries.ConfigSubentryFlow):
@@ -2254,7 +2253,6 @@ async def test_on_create_entry_with_options_flow(
             return self.async_create_entry(
                 title="user_flow",
                 data={"flow": "user"},
-                next_flow=(config_entries.FlowType.CONFIG_FLOW, result["flow_id"]),
             )
 
     class TestOptionsFlowHandler(config_entries.OptionsFlow):

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2339,7 +2339,7 @@ async def test_next_flow_with_unsupported_flow_type(
     invalid_next_flow: tuple[str, str],
     error: type[Exception],
 ) -> None:
-    """Test use async_on_create_entry with creating an options flow."""
+    """Test use next_flow parameter with unsupported flow types."""
 
     async def mock_async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Mock setup."""
@@ -2378,7 +2378,10 @@ async def test_next_flow_with_unsupported_flow_type(
         await hass.async_block_till_done()
         with pytest.raises(
             error,
-            match="next_flow only supports FlowType.CONFIG_FLOW; use async_on_create_entry for options or subentry flows",
+            match=(
+                "next_flow only supports FlowType.CONFIG_FLOW;"
+                " use async_on_create_entry for options or subentry flows"
+            ),
         ):
             await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
@@ -10086,7 +10089,13 @@ async def test_config_flow_abort_with_invalid_next_flow_type(
 
     with (
         mock_config_flow("test", TestFlow),
-        pytest.raises(HomeAssistantError, match="Invalid flow type: invalid_type"),
+        pytest.raises(
+            HomeAssistantError,
+            match=(
+                "next_flow only supports FlowType.CONFIG_FLOW;"
+                " use async_on_create_entry for options or subentry flows"
+            ),
+        ),
     ):
         await hass.config_entries.flow.async_init(
             "test", context={"source": config_entries.SOURCE_USER}

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2256,7 +2256,7 @@ async def test_on_create_entry_with_options_flow(
             )
 
     class TestOptionsFlowHandler(config_entries.OptionsFlow):
-        """Handle Yale options."""
+        """Handle options."""
 
         async def async_step_init(
             self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
## Breaking change


## Proposed change
Adds `async_on_create_entry` method to config entries to be able to modify the `ConfigFlowResult` after the main config entry has been created.
This enables the possibility to start subconfig flows and options flows and attach them as `next_flow` to the creation of the main config entry.

Frontend: https://github.com/home-assistant/frontend/pull/27597
Dev docs: https://github.com/home-assistant/developers.home-assistant/pull/2849

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 