### PR TITLE
Fix empty via_device in ViCare integration

### DIFF
--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -52,10 +52,11 @@ class ViCareEntity(Entity):
             configuration_url=VIESSMANN_DEVELOPER_PORTAL,
         )
 
-        if device_serial is not None and device_serial.startswith("zigbee-"):
-            parts = device_serial.split("-")
-            if len(parts) == 3:  # expect format zigbee-<zigbee-ieee>-<channel-id>
+        if device_serial and device_serial.startswith("zigbee-"):
+            parts = device_serial.split("-", 2)
+            if len(parts) == 3:
+                _, zigbee_ieee, _ = parts
                 self._attr_device_info["via_device"] = (
                     DOMAIN,
-                    f"{gateway_serial}_zigbee_{parts[1]}",
+                    f"{gateway_serial}_zigbee_{zigbee_ieee}",
                 )

--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -29,18 +29,12 @@ class ViCareEntity(Entity):
         gateway_serial = device_config.getConfig().serial
         device_id = device_config.getId()
         model = device_config.getModel().replace("_", " ")
-        via_device_identifier: tuple[str, str] | None = None
 
         identifier = (
             f"{gateway_serial}_{device_serial.replace('-', '_')}"
             if device_serial is not None
             else f"{gateway_serial}_{device_id}"
         )
-
-        if device_serial is not None and device_serial.startswith("zigbee-"):
-            parts = device_serial.split("-")
-            if len(parts) == 3:  # expect format zigbee-<zigbee-ieee>-<channel-id>
-                via_device_identifier = (DOMAIN, f"{gateway_serial}_zigbee_{parts[1]}")
 
         self._api: PyViCareDevice | PyViCareHeatingDeviceComponent = (
             component if component else device
@@ -56,5 +50,12 @@ class ViCareEntity(Entity):
             manufacturer="Viessmann",
             model=model,
             configuration_url=VIESSMANN_DEVELOPER_PORTAL,
-            via_device=via_device_identifier,
         )
+
+        if device_serial is not None and device_serial.startswith("zigbee-"):
+            parts = device_serial.split("-")
+            if len(parts) == 3:  # expect format zigbee-<zigbee-ieee>-<channel-id>
+                self._attr_device_info["via_device"] = (
+                    DOMAIN,
+                    f"{gateway_serial}_zigbee_{parts[1]}",
+                )

--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -29,7 +29,7 @@ class ViCareEntity(Entity):
         gateway_serial = device_config.getConfig().serial
         device_id = device_config.getId()
         model = device_config.getModel().replace("_", " ")
-        via_device_identifier: tuple[str, str] = ("", "")
+        via_device_identifier: tuple[str, str] | None = None
 
         identifier = (
             f"{gateway_serial}_{device_serial.replace('-', '_')}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes the empty `via_device` introduced in https://github.com/home-assistant/core/pull/154541
```
Detected that custom integration 'vicare' calls `device_registry.async_get_or_create` referencing a non existing `via_device` ('', ''), with device info: {'configuration_url': 'https://app.developer.viessmann-climatesolutions.com', 'identifiers': {('vicare', 'xxx_xxx')}, 'manufacturer': 'Viessmann', 'model': 'E3 Vitocal', 'name': 'E3 Vitocal', 'serial_number': '7994218410668126', 'via_device': ('', '')} at custom_components/vicare/climate.py, line 132: async_add_entities(. This will stop working in Home Assistant 2025.12.0, please report it to the author of the 'vicare' custom integration
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/154541
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
