### PR TITLE
Improve client mock for Brother tests

### DIFF
--- a/tests/components/brother/conftest.py
+++ b/tests/components/brother/conftest.py
@@ -116,6 +116,9 @@ def mock_brother_client() -> Generator[MagicMock]:
         client.model = "HL-L2340DW"
         client.firmware = "1.2.3"
 
+        # Add the create method to the client so tests can set side_effect
+        client.create = mock_client.create
+
         yield client
 
 

--- a/tests/components/brother/conftest.py
+++ b/tests/components/brother/conftest.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from brother import BrotherSensors
 import pytest
@@ -100,26 +100,26 @@ def mock_unload_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_brother_client() -> Generator[MagicMock]:
-    """Mock Brother client."""
+def mock_brother() -> Generator[AsyncMock]:
+    """Mock the Brother class."""
     with (
-        patch("homeassistant.components.brother.Brother", autospec=True) as mock_client,
-        patch(
-            "homeassistant.components.brother.config_flow.Brother",
-            new=mock_client,
-        ),
+        patch("homeassistant.components.brother.Brother", autospec=True) as mock_class,
+        patch("homeassistant.components.brother.config_flow.Brother", new=mock_class),
     ):
-        client = mock_client.create.return_value
-        client.async_update.return_value = BROTHER_DATA
-        client.serial = "0123456789"
-        client.mac = "AA:BB:CC:DD:EE:FF"
-        client.model = "HL-L2340DW"
-        client.firmware = "1.2.3"
+        yield mock_class
 
-        # Add the create method to the client so tests can set side_effect
-        client.create = mock_client.create
 
-        yield client
+@pytest.fixture
+def mock_brother_client(mock_brother: AsyncMock) -> AsyncMock:
+    """Mock Brother client."""
+    client = mock_brother.create.return_value
+    client.async_update.return_value = BROTHER_DATA
+    client.serial = "0123456789"
+    client.mac = "AA:BB:CC:DD:EE:FF"
+    client.model = "HL-L2340DW"
+    client.firmware = "1.2.3"
+
+    return client
 
 
 @pytest.fixture

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -98,15 +98,14 @@ async def test_errors(
     assert result["errors"] == {"base": base_error}
 
 
-async def test_unsupported_model_error(hass: HomeAssistant) -> None:
+async def test_unsupported_model_error(
+    hass: HomeAssistant, mock_brother_client: AsyncMock
+) -> None:
     """Test unsupported printer model error."""
-    with patch(
-        "homeassistant.components.brother.Brother.create",
-        new=AsyncMock(side_effect=UnsupportedModelError("error")),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
-        )
+    mock_brother_client.create.side_effect = UnsupportedModelError("error")
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unsupported_model"
@@ -153,25 +152,24 @@ async def test_zeroconf_exception(
     assert result["reason"] == "cannot_connect"
 
 
-async def test_zeroconf_unsupported_model(hass: HomeAssistant) -> None:
+async def test_zeroconf_unsupported_model(
+    hass: HomeAssistant, mock_brother_client: AsyncMock
+) -> None:
     """Test unsupported printer model error."""
-    with patch(
-        "homeassistant.components.brother.Brother.create",
-        new=AsyncMock(side_effect=UnsupportedModelError("error")),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_ZEROCONF},
-            data=ZeroconfServiceInfo(
-                ip_address=ip_address("127.0.0.1"),
-                ip_addresses=[ip_address("127.0.0.1")],
-                hostname="example.local.",
-                name="Brother Printer",
-                port=None,
-                properties={"product": "MFC-8660DN"},
-                type="mock_type",
-            ),
-        )
+    mock_brother_client.create.side_effect = UnsupportedModelError("error")
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZeroconfServiceInfo(
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
+            hostname="example.local.",
+            name="Brother Printer",
+            port=None,
+            properties={"product": "MFC-8660DN"},
+            type="mock_type",
+        ),
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unsupported_model"

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -99,10 +99,10 @@ async def test_errors(
 
 
 async def test_unsupported_model_error(
-    hass: HomeAssistant, mock_brother_client: AsyncMock
+    hass: HomeAssistant, mock_brother: AsyncMock, mock_brother_client: AsyncMock
 ) -> None:
     """Test unsupported printer model error."""
-    mock_brother_client.create.side_effect = UnsupportedModelError("error")
+    mock_brother.create.side_effect = UnsupportedModelError("error")
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
     )
@@ -153,10 +153,10 @@ async def test_zeroconf_exception(
 
 
 async def test_zeroconf_unsupported_model(
-    hass: HomeAssistant, mock_brother_client: AsyncMock
+    hass: HomeAssistant, mock_brother: AsyncMock, mock_brother_client: AsyncMock
 ) -> None:
     """Test unsupported printer model error."""
-    mock_brother_client.create.side_effect = UnsupportedModelError("error")
+    mock_brother.create.side_effect = UnsupportedModelError("error")
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},

--- a/tests/components/brother/test_init.py
+++ b/tests/components/brother/test_init.py
@@ -48,10 +48,11 @@ async def test_error_on_init(
     hass: HomeAssistant,
     exc: Exception,
     mock_config_entry: MockConfigEntry,
+    mock_brother: AsyncMock,
     mock_brother_client: AsyncMock,
 ) -> None:
     """Test for error on init."""
-    mock_brother_client.create.side_effect = exc
+    mock_brother.create.side_effect = exc
 
     await init_integration(hass, mock_config_entry)
 

--- a/tests/components/brother/test_init.py
+++ b/tests/components/brother/test_init.py
@@ -1,6 +1,6 @@
 """Test init of Brother integration."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from brother import SnmpError
 import pytest
@@ -45,14 +45,15 @@ async def test_config_not_ready(
 
 @pytest.mark.parametrize("exc", [(SnmpError("SNMP Error")), (ConnectionError)])
 async def test_error_on_init(
-    hass: HomeAssistant, exc: Exception, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    exc: Exception,
+    mock_config_entry: MockConfigEntry,
+    mock_brother_client: AsyncMock,
 ) -> None:
     """Test for error on init."""
-    with patch(
-        "homeassistant.components.brother.Brother.create",
-        new=AsyncMock(side_effect=exc),
-    ):
-        await init_integration(hass, mock_config_entry)
+    mock_brother_client.create.side_effect = exc
+
+    await init_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improvement for the `mock_brother_client` to not use `patch()`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
