### PR TITLE
Refresh Zeroconf broadcast when cloud or core external URL changes

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -31,7 +31,6 @@ from homeassistant.helpers.deprecation import (
     check_if_deprecated_constant,
     dir_with_deprecated_constants,
 )
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.service_info.zeroconf import (
     ATTR_PROPERTIES_ID as _ATTR_PROPERTIES_ID,
@@ -359,9 +358,9 @@ def _async_setup_homeassistant_service_updaters(
         _hass: HomeAssistant, _component: str
     ) -> None:
         from homeassistant.components.cloud import (  # noqa: PLC0415
-            SIGNAL_CLOUD_CONNECTION_STATE,
             CloudConnectionState,
             async_is_connected,
+            async_listen_connection_change,
         )
 
         @callback
@@ -369,9 +368,7 @@ def _async_setup_homeassistant_service_updaters(
             hass.async_create_task(_async_refresh_homeassistant_service(hass, state))
 
         state.listeners.append(
-            async_dispatcher_connect(
-                hass, SIGNAL_CLOUD_CONNECTION_STATE, _handle_cloud_state
-            )
+            async_listen_connection_change(hass, _handle_cloud_state)
         )
 
         if async_is_connected(hass):

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable, Mapping
 from contextlib import suppress
+from dataclasses import dataclass, field
+from functools import partial
 from ipaddress import IPv4Address, IPv6Address
 import logging
 import sys
@@ -14,13 +18,25 @@ from zeroconf.asyncio import AsyncServiceInfo
 
 from homeassistant.components import network
 from homeassistant.const import (
+    EVENT_CORE_CONFIG_UPDATE,
     EVENT_HOMEASSISTANT_CLOSE,
     EVENT_HOMEASSISTANT_STOP,
     __version__,
 )
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, instance_id
+from homeassistant.helpers.deprecation import (
+    DeprecatedConstant,
+    all_with_deprecated_constants,
+    check_if_deprecated_constant,
+    dir_with_deprecated_constants,
+)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.network import NoURLAvailableError, get_url
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID as _ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo as _ZeroconfServiceInfo,
+)
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_homekit, async_get_zeroconf, bind_hass
 from homeassistant.setup import async_when_setup_or_start
@@ -38,7 +54,6 @@ from .usage import install_multiple_zeroconf_catcher
 
 _LOGGER = logging.getLogger(__name__)
 
-
 CONF_DEFAULT_INTERFACE = "default_interface"
 CONF_IPV6 = "ipv6"
 DEFAULT_DEFAULT_INTERFACE = True
@@ -50,6 +65,27 @@ MAX_PROPERTY_VALUE_LEN = 230
 
 # Dns label max length
 MAX_NAME_LEN = 63
+
+DATA_HOMEASSISTANT_SERVICE = "zeroconf_homeassistant_service"
+
+
+@dataclass(slots=True)
+class _HomeAssistantServiceState:
+    """Track the Home Assistant Zeroconf service."""
+
+    aio_zc: HaAsyncZeroconf
+    info: AsyncServiceInfo
+    uuid: str
+    listeners: list[Callable[[], None]] = field(default_factory=list)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+# Attributes for ZeroconfServiceInfo[ATTR_PROPERTIES]
+_DEPRECATED_ATTR_PROPERTIES_ID = DeprecatedConstant(
+    _ATTR_PROPERTIES_ID,
+    "homeassistant.helpers.service_info.zeroconf.ATTR_PROPERTIES_ID",
+    "2026.2",
+)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -65,6 +101,12 @@ CONFIG_SCHEMA = vol.Schema(
         )
     },
     extra=vol.ALLOW_EXTRA,
+)
+
+_DEPRECATED_ZeroconfServiceInfo = DeprecatedConstant(
+    _ZeroconfServiceInfo,
+    "homeassistant.helpers.service_info.zeroconf.ZeroconfServiceInfo",
+    "2026.2",
 )
 
 
@@ -184,10 +226,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         Wait till started or otherwise HTTP is not up and running.
         """
-        await _async_register_hass_zc_service(aio_zc, local_service_info)
+        await _async_register_hass_zc_service(hass, aio_zc, local_service_info)
 
     async def _async_zeroconf_hass_stop(_event: Event) -> None:
         await discovery.async_stop()
+        _async_cleanup_homeassistant_service_state(hass)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_zeroconf_hass_stop)
     async_when_setup_or_start(hass, "frontend", _async_zeroconf_hass_start)
@@ -203,13 +246,154 @@ def _filter_disallowed_characters(name: str) -> str:
     return name.replace(".", " ")
 
 
-async def _async_register_hass_zc_service(
-    aio_zc: HaAsyncZeroconf, local_service_info: AsyncServiceInfo
+def _get_property(properties: Mapping[Any, Any], key: str) -> Any:
+    """Return a property value allowing for str or bytes keys."""
+    str_mapping = cast(Mapping[str, Any], properties)
+    if key in str_mapping:
+        return str_mapping[key]
+
+    bytes_mapping = cast(Mapping[bytes, Any], properties)
+    return bytes_mapping.get(key.encode())
+
+
+def _get_location_name(properties: Mapping[Any, Any]) -> str | None:
+    """Return the `location_name` property as string when available."""
+    value = _get_property(properties, "location_name")
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        return value.decode()
+    return None
+
+
+@callback
+def _async_cleanup_homeassistant_service_state(hass: HomeAssistant) -> None:
+    """Remove listeners tracking the Home Assistant Zeroconf service."""
+    if (state := hass.data.pop(DATA_HOMEASSISTANT_SERVICE, None)) is None:
+        return
+
+    for unsub in state.listeners:
+        unsub()
+
+
+async def _async_build_service_info(hass: HomeAssistant, uuid: str) -> AsyncServiceInfo:
+    """Build AsyncServiceInfo for this Home Assistant instance."""
+    valid_location_name = _truncate_location_name_to_valid(
+        _filter_disallowed_characters(hass.config.location_name or "Home")
+    )
+
+    params = {
+        "location_name": valid_location_name,
+        "uuid": uuid,
+        "version": __version__,
+        "external_url": "",
+        "internal_url": "",
+        # Old base URL, for backward compatibility
+        "base_url": "",
+        # Always needs authentication
+        "requires_api_password": True,
+    }
+
+    with suppress(NoURLAvailableError):
+        params["external_url"] = get_url(hass, allow_internal=False)
+
+    with suppress(NoURLAvailableError):
+        params["internal_url"] = get_url(hass, allow_external=False)
+
+    params["base_url"] = params["external_url"] or params["internal_url"]
+
+    _suppress_invalid_properties(params)
+
+    return AsyncServiceInfo(
+        ZEROCONF_TYPE,
+        name=f"{valid_location_name}.{ZEROCONF_TYPE}",
+        server=f"{uuid}.local.",
+        parsed_addresses=await network.async_get_announce_addresses(hass),
+        port=hass.http.server_port,
+        properties=params,
+    )
+
+
+async def _async_refresh_homeassistant_service(
+    hass: HomeAssistant, state: _HomeAssistantServiceState
 ) -> None:
-    """Register the zeroconf service for the local Home Assistant instance."""
+    """Refresh the Zeroconf announcement for this Home Assistant instance."""
+    async with state.lock:
+        new_info = await _async_build_service_info(hass, state.uuid)
+
+        previous_location = _get_location_name(state.info.properties)
+        current_location = _get_location_name(new_info.properties)
+
+        if previous_location != current_location:
+            await state.aio_zc.async_unregister_service(state.info)
+            await state.aio_zc.async_register_service(new_info, allow_name_change=True)
+            state.info = new_info
+            return
+
+        if new_info.name != state.info.name:
+            new_info.name = state.info.name
+
+        await state.aio_zc.async_update_service(new_info)
+        state.info = new_info
+
+
+@callback
+def _async_setup_homeassistant_service_updaters(
+    hass: HomeAssistant, aio_zc: HaAsyncZeroconf, uuid: str, info: AsyncServiceInfo
+) -> None:
+    """Register listeners to keep Zeroconf properties up to date."""
+    _async_cleanup_homeassistant_service_state(hass)
+
+    state = _HomeAssistantServiceState(aio_zc=aio_zc, info=info, uuid=uuid)
+    hass.data[DATA_HOMEASSISTANT_SERVICE] = state
+
+    @callback
+    def _handle_core_config_update(_: Event) -> None:
+        hass.async_create_task(_async_refresh_homeassistant_service(hass, state))
+
+    state.listeners.append(
+        hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, _handle_core_config_update)
+    )
+
+    async def _async_setup_cloud_listener(
+        _hass: HomeAssistant, _component: str
+    ) -> None:
+        from homeassistant.components.cloud import (  # noqa: PLC0415
+            SIGNAL_CLOUD_CONNECTION_STATE,
+            CloudConnectionState,
+            async_is_connected,
+        )
+
+        @callback
+        def _handle_cloud_state(_: CloudConnectionState) -> None:
+            hass.async_create_task(_async_refresh_homeassistant_service(hass, state))
+
+        state.listeners.append(
+            async_dispatcher_connect(
+                hass, SIGNAL_CLOUD_CONNECTION_STATE, _handle_cloud_state
+            )
+        )
+
+        if async_is_connected(hass):
+            hass.async_create_task(_async_refresh_homeassistant_service(hass, state))
+
+    async_when_setup_or_start(hass, "cloud", _async_setup_cloud_listener)
+
+
+async def _async_register_hass_zc_service(
+    hass: HomeAssistant, aio_zc: HaAsyncZeroconf, local_service_info: AsyncServiceInfo
+) -> None:
+    uuid_value = _get_property(local_service_info.properties, "uuid")
+    if isinstance(uuid_value, bytes):
+        uuid_value = uuid_value.decode()
+    if not isinstance(uuid_value, str):
+        uuid_value = await instance_id.async_get(hass)
 
     _LOGGER.info("Starting Zeroconf broadcast")
     await aio_zc.async_register_service(local_service_info, allow_name_change=True)
+    _async_setup_homeassistant_service_updaters(
+        hass, aio_zc, uuid_value, local_service_info
+    )
 
 
 def _suppress_invalid_properties(properties: dict) -> None:
@@ -250,40 +434,13 @@ def _truncate_location_name_to_valid(location_name: str) -> str:
 
 async def _async_get_local_service_info(hass: HomeAssistant) -> AsyncServiceInfo:
     """Return the zeroconf service info for the local Home Assistant instance."""
-    valid_location_name = _truncate_location_name_to_valid(
-        _filter_disallowed_characters(hass.config.location_name or "Home")
-    )
     uuid = await instance_id.async_get(hass)
+    return await _async_build_service_info(hass, uuid)
 
-    params = {
-        "location_name": valid_location_name,
-        "uuid": uuid,
-        "version": __version__,
-        "external_url": "",
-        "internal_url": "",
-        # Old base URL, for backward compatibility
-        "base_url": "",
-        # Always needs authentication
-        "requires_api_password": True,
-    }
 
-    # Get instance URL's
-    with suppress(NoURLAvailableError):
-        params["external_url"] = get_url(hass, allow_internal=False)
-
-    with suppress(NoURLAvailableError):
-        params["internal_url"] = get_url(hass, allow_external=False)
-
-    # Set old base URL based on external or internal
-    params["base_url"] = params["external_url"] or params["internal_url"]
-
-    _suppress_invalid_properties(params)
-
-    return AsyncServiceInfo(
-        ZEROCONF_TYPE,
-        name=f"{valid_location_name}.{ZEROCONF_TYPE}",
-        server=f"{uuid}.local.",
-        parsed_addresses=await network.async_get_announce_addresses(hass),
-        port=hass.http.server_port,
-        properties=params,
-    )
+# These can be removed if no deprecated constant are in this module anymore
+__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
+__dir__ = partial(
+    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
+)
+__all__ = all_with_deprecated_constants(globals())

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -318,6 +318,26 @@ async def _async_refresh_homeassistant_service(
 
 
 @callback
+def _async_schedule_homeassistant_service_refresh(
+    hass: HomeAssistant, state: _HomeAssistantServiceState
+) -> None:
+    """Schedule service refresh and log unexpected failures."""
+    task = hass.async_create_task(_async_refresh_homeassistant_service(hass, state))
+
+    @callback
+    def _log_refresh_failure(done_task: asyncio.Task[None]) -> None:
+        if done_task.cancelled():
+            return
+        if exc := done_task.exception():
+            _LOGGER.exception(
+                "Unexpected error while refreshing Home Assistant service announcement",
+                exc_info=exc,
+            )
+
+    task.add_done_callback(_log_refresh_failure)
+
+
+@callback
 def _async_setup_homeassistant_service_updaters(
     hass: HomeAssistant, aio_zc: HaAsyncZeroconf, uuid: str, info: AsyncServiceInfo
 ) -> None:
@@ -329,7 +349,7 @@ def _async_setup_homeassistant_service_updaters(
 
     @callback
     def _handle_core_config_update(_: Event) -> None:
-        hass.async_create_task(_async_refresh_homeassistant_service(hass, state))
+        _async_schedule_homeassistant_service_refresh(hass, state)
 
     state.listeners.append(
         hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, _handle_core_config_update)
@@ -346,14 +366,14 @@ def _async_setup_homeassistant_service_updaters(
 
         @callback
         def _handle_cloud_state(_: CloudConnectionState) -> None:
-            hass.async_create_task(_async_refresh_homeassistant_service(hass, state))
+            _async_schedule_homeassistant_service_refresh(hass, state)
 
         state.listeners.append(
             async_listen_connection_change(hass, _handle_cloud_state)
         )
 
         if async_is_connected(hass):
-            hass.async_create_task(_async_refresh_homeassistant_service(hass, state))
+            _async_schedule_homeassistant_service_refresh(hass, state)
 
     async_when_setup_or_start(hass, "cloud", _async_setup_cloud_listener)
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -255,16 +255,6 @@ def _get_property(properties: Mapping[Any, Any], key: str) -> Any:
     return bytes_mapping.get(key.encode())
 
 
-def _get_location_name(properties: Mapping[Any, Any]) -> str | None:
-    """Return the `location_name` property as string when available."""
-    value = _get_property(properties, "location_name")
-    if isinstance(value, str):
-        return value
-    if isinstance(value, bytes):
-        return value.decode()
-    return None
-
-
 @callback
 def _async_cleanup_homeassistant_service_state(hass: HomeAssistant) -> None:
     """Remove listeners tracking the Home Assistant Zeroconf service."""
@@ -319,15 +309,6 @@ async def _async_refresh_homeassistant_service(
     """Refresh the Zeroconf announcement for this Home Assistant instance."""
     async with state.lock:
         new_info = await _async_build_service_info(hass, state.uuid)
-
-        previous_location = _get_location_name(state.info.properties)
-        current_location = _get_location_name(new_info.properties)
-
-        if previous_location != current_location:
-            await state.aio_zc.async_unregister_service(state.info)
-            await state.aio_zc.async_register_service(new_info, allow_name_change=True)
-            state.info = new_info
-            return
 
         if new_info.name != state.info.name:
             new_info.name = state.info.name

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "zeroconf",
   "name": "Zero-configuration networking (zeroconf)",
+  "after_dependencies": ["cloud"],
   "codeowners": ["@bdraco"],
   "dependencies": ["network", "api"],
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,7 +1,10 @@
 """Test Zeroconf component setup process."""
 
+from enum import Enum
+import sys
+from types import ModuleType
 from typing import Any
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from zeroconf import (
@@ -17,6 +20,7 @@ from homeassistant.components import zeroconf
 from homeassistant.components.zeroconf import discovery
 from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
+    EVENT_CORE_CONFIG_UPDATE,
     EVENT_HOMEASSISTANT_CLOSE,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STARTED,
@@ -25,9 +29,19 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.generated import zeroconf as zc_gen
 from homeassistant.helpers.discovery_flow import DiscoveryKey
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 from homeassistant.setup import ATTR_COMPONENT, async_setup_component
 
-from tests.common import MockConfigEntry, MockModule, mock_integration
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    import_and_test_deprecated_constant,
+    mock_integration,
+)
 
 NON_UTF8_VALUE = b"ABCDEF\x8a"
 NON_ASCII_KEY = b"non-ascii-key\x8a"
@@ -36,6 +50,23 @@ PROPERTIES = {
     b"non-utf8-value": NON_UTF8_VALUE,
     NON_ASCII_KEY: None,
 }
+
+
+def _get_property(info: AsyncServiceInfo, key: str) -> str:
+    """Helper to retrieve string properties regardless of key encoding."""
+    if key in info.properties:
+        value = info.properties[key]
+    elif (key_bytes := key.encode()) in info.properties:
+        value = info.properties[key_bytes]
+    else:
+        raise KeyError(key)  # pragma: no cover - mirrors original expectation
+
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode()
+    return value
+
 
 HOMEKIT_STATUS_UNPAIRED = b"1"
 HOMEKIT_STATUS_PAIRED = b"0"
@@ -1431,63 +1462,6 @@ async def test_zeroconf_removed(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("mock_async_zeroconf")
-async def test_zeroconf_removed_dismiss_protected(hass: HomeAssistant) -> None:
-    """Test dismiss-protected flows are not aborted when a PTR record is removed."""
-
-    def _device_removed_mock(zeroconf, services, handlers):
-        """Call service update handler."""
-        handlers[0](
-            zeroconf,
-            "_http._tcp.local.",
-            "Shelly108._http._tcp.local.",
-            ServiceStateChange.Removed,
-        )
-
-    with (
-        patch.dict(
-            zc_gen.ZEROCONF,
-            {
-                "_http._tcp.local.": [
-                    {
-                        "domain": "shelly",
-                        "name": "shelly*",
-                    }
-                ]
-            },
-            clear=True,
-        ),
-        patch.object(
-            hass.config_entries.flow,
-            "async_progress_by_init_data_type",
-            return_value=[
-                {
-                    "flow_id": "protected_flow_id",
-                    "context": {
-                        "dismiss_protected": True,
-                    },
-                },
-                {"flow_id": "unprotected_flow_id", "context": {}},
-            ],
-        ),
-        patch.object(hass.config_entries.flow, "async_abort") as mock_async_abort,
-        patch.object(
-            discovery, "AsyncServiceBrowser", side_effect=_device_removed_mock
-        ),
-        patch(
-            "homeassistant.components.zeroconf.discovery.AsyncServiceInfo",
-            side_effect=get_zeroconf_info_mock("FFAADDCC11DD"),
-        ),
-    ):
-        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-        await hass.async_block_till_done()
-
-    # Only the unprotected flow should be aborted
-    assert len(mock_async_abort.mock_calls) == 1
-    assert mock_async_abort.mock_calls[0][1][0] == "unprotected_flow_id"
-
-
-@pytest.mark.usefixtures("mock_async_zeroconf")
 @pytest.mark.parametrize(
     (
         "entry_domain",
@@ -1743,3 +1717,177 @@ async def test_zeroconf_rediscover_no_match(
 
         assert len(mock_service_browser.mock_calls) == 1
         assert len(mock_config_flow.mock_calls) == 1
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homeassistant_service_updates_on_cloud_signal(
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
+) -> None:
+    """Ensure cloud connection updates external_url in Zeroconf."""
+    hass.config.components.add("cloud")
+    hass.config.internal_url = "http://internal:8123"
+    external_url = "https://remote.example"
+
+    fake_cloud = ModuleType("homeassistant.components.cloud")
+    fake_signal = "cloud_signal"
+    connection = {"connected": False}
+
+    class FakeCloudState(Enum):
+        CLOUD_CONNECTED = "cloud_connected"
+        CLOUD_DISCONNECTED = "cloud_disconnected"
+
+    fake_cloud.CloudConnectionState = FakeCloudState
+    fake_cloud.SIGNAL_CLOUD_CONNECTION_STATE = fake_signal
+
+    class FakeCloudNotAvailable(Exception):
+        """Placeholder cloud error."""
+
+    def fake_async_remote_ui_url(_hass: HomeAssistant) -> str:
+        raise FakeCloudNotAvailable
+
+    fake_cloud.CloudNotAvailable = FakeCloudNotAvailable
+    fake_cloud.async_remote_ui_url = fake_async_remote_ui_url
+
+    def fake_async_is_connected(_hass: HomeAssistant) -> bool:
+        return connection["connected"]
+
+    fake_cloud.async_is_connected = fake_async_is_connected
+
+    with (
+        patch.dict(sys.modules, {"homeassistant.components.cloud": fake_cloud}),
+        patch(
+            "homeassistant.components.http.start_http_server_and_save_config",
+            AsyncMock(),
+        ),
+    ):
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        assert mock_async_zeroconf.async_register_service.await_count == 1
+        initial_info = mock_async_zeroconf.async_register_service.await_args_list[
+            0
+        ].args[0]
+        assert _get_property(initial_info, "external_url") == ""
+        assert _get_property(initial_info, "base_url") == hass.config.internal_url
+        assert mock_async_zeroconf.async_update_service.await_count == 0
+
+        connection["connected"] = True
+        hass.config.external_url = external_url
+        async_dispatcher_send(hass, fake_signal, FakeCloudState.CLOUD_CONNECTED)
+        await hass.async_block_till_done()
+
+        assert mock_async_zeroconf.async_update_service.await_count >= 1
+        update_info = mock_async_zeroconf.async_update_service.await_args_list[-1].args[
+            0
+        ]
+        assert _get_property(update_info, "external_url") == external_url
+        assert _get_property(update_info, "base_url") == external_url
+
+        connection["connected"] = False
+        hass.config.external_url = None
+        async_dispatcher_send(
+            hass,
+            fake_signal,
+            FakeCloudState.CLOUD_DISCONNECTED,
+        )
+        await hass.async_block_till_done()
+
+        assert mock_async_zeroconf.async_update_service.await_count >= 2
+        post_disconnect_info = mock_async_zeroconf.async_update_service.await_args_list[
+            -1
+        ].args[0]
+        assert _get_property(post_disconnect_info, "external_url") == ""
+        assert (
+            _get_property(post_disconnect_info, "base_url") == hass.config.internal_url
+        )
+
+    assert mock_async_zeroconf.async_unregister_service.await_count == 0
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homeassistant_service_updates_on_config_change(
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
+) -> None:
+    """Ensure core config updates external_url in Zeroconf."""
+    hass.config.internal_url = "http://internal:8123"
+    assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    assert mock_async_zeroconf.async_register_service.await_count == 1
+    initial_info = mock_async_zeroconf.async_register_service.await_args_list[0].args[0]
+    assert _get_property(initial_info, "external_url") == ""
+    assert _get_property(initial_info, "base_url") == hass.config.internal_url
+
+    hass.config.external_url = "https://example.com"
+    hass.bus.async_fire(EVENT_CORE_CONFIG_UPDATE, {})
+    await hass.async_block_till_done()
+
+    assert mock_async_zeroconf.async_update_service.await_count >= 1
+    updated_info = mock_async_zeroconf.async_update_service.await_args_list[-1].args[0]
+    assert _get_property(updated_info, "external_url") == hass.config.external_url
+    assert _get_property(updated_info, "base_url") == hass.config.external_url
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homeassistant_service_reregisters_on_location_change(
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
+) -> None:
+    """Ensure Zeroconf re-registers when the instance name changes."""
+    hass.config.location_name = "Maison"
+    assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    assert mock_async_zeroconf.async_register_service.await_count == 1
+    initial_info = mock_async_zeroconf.async_register_service.await_args_list[0].args[0]
+    assert _get_property(initial_info, "location_name") == "Maison"
+    assert initial_info.name.startswith("Maison")
+
+    hass.config.location_name = "Nouvelle Maison"
+    hass.bus.async_fire(EVENT_CORE_CONFIG_UPDATE, {})
+    await hass.async_block_till_done()
+
+    assert mock_async_zeroconf.async_unregister_service.await_count == 1
+    assert mock_async_zeroconf.async_register_service.await_count == 2
+    assert mock_async_zeroconf.async_update_service.await_count == 0
+
+    updated_info = mock_async_zeroconf.async_register_service.await_args_list[1].args[0]
+    assert _get_property(updated_info, "location_name") == "Nouvelle Maison"
+    assert updated_info.name.startswith("Nouvelle Maison")
+
+
+@pytest.mark.parametrize(
+    ("constant_name", "replacement_name", "replacement"),
+    [
+        (
+            "ATTR_PROPERTIES_ID",
+            "homeassistant.helpers.service_info.zeroconf.ATTR_PROPERTIES_ID",
+            ATTR_PROPERTIES_ID,
+        ),
+        (
+            "ZeroconfServiceInfo",
+            "homeassistant.helpers.service_info.zeroconf.ZeroconfServiceInfo",
+            ZeroconfServiceInfo,
+        ),
+    ],
+)
+def test_deprecated_constants(
+    caplog: pytest.LogCaptureFixture,
+    constant_name: str,
+    replacement_name: str,
+    replacement: Any,
+) -> None:
+    """Test deprecated automation constants."""
+    import_and_test_deprecated_constant(
+        caplog,
+        zeroconf,
+        constant_name,
+        replacement_name,
+        replacement,
+        "2026.2",
+    )

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1835,11 +1835,11 @@ async def test_homeassistant_service_updates_on_config_change(
 
 
 @pytest.mark.usefixtures("mock_async_zeroconf")
-async def test_homeassistant_service_reregisters_on_location_change(
+async def test_homeassistant_service_updates_on_location_change(
     hass: HomeAssistant, mock_async_zeroconf: MagicMock
 ) -> None:
-    """Ensure Zeroconf re-registers when the instance name changes."""
-    hass.config.location_name = "Maison"
+    """Ensure Zeroconf updates when the location name changes."""
+    hass.config.location_name = "Home"
     assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -1847,20 +1847,20 @@ async def test_homeassistant_service_reregisters_on_location_change(
 
     assert mock_async_zeroconf.async_register_service.await_count == 1
     initial_info = mock_async_zeroconf.async_register_service.await_args_list[0].args[0]
-    assert _get_property(initial_info, "location_name") == "Maison"
-    assert initial_info.name.startswith("Maison")
+    assert _get_property(initial_info, "location_name") == "Home"
+    assert initial_info.name.startswith("Home")
 
-    hass.config.location_name = "Nouvelle Maison"
+    hass.config.location_name = "New Home"
     hass.bus.async_fire(EVENT_CORE_CONFIG_UPDATE, {})
     await hass.async_block_till_done()
 
-    assert mock_async_zeroconf.async_unregister_service.await_count == 1
-    assert mock_async_zeroconf.async_register_service.await_count == 2
-    assert mock_async_zeroconf.async_update_service.await_count == 0
+    assert mock_async_zeroconf.async_unregister_service.await_count == 0
+    assert mock_async_zeroconf.async_register_service.await_count == 1
+    assert mock_async_zeroconf.async_update_service.await_count >= 1
 
-    updated_info = mock_async_zeroconf.async_register_service.await_args_list[1].args[0]
-    assert _get_property(updated_info, "location_name") == "Nouvelle Maison"
-    assert updated_info.name.startswith("Nouvelle Maison")
+    updated_info = mock_async_zeroconf.async_update_service.await_args_list[-1].args[0]
+    assert _get_property(updated_info, "location_name") == "New Home"
+    assert updated_info.name == initial_info.name
 
 
 @pytest.mark.parametrize(

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1461,6 +1461,63 @@ async def test_zeroconf_removed(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_zeroconf_removed_dismiss_protected(hass: HomeAssistant) -> None:
+    """Test dismiss-protected flows are not aborted when a PTR record is removed."""
+
+    def _device_removed_mock(zeroconf, services, handlers):
+        """Call service update handler."""
+        handlers[0](
+            zeroconf,
+            "_http._tcp.local.",
+            "Shelly108._http._tcp.local.",
+            ServiceStateChange.Removed,
+        )
+
+    with (
+        patch.dict(
+            zc_gen.ZEROCONF,
+            {
+                "_http._tcp.local.": [
+                    {
+                        "domain": "shelly",
+                        "name": "shelly*",
+                    }
+                ]
+            },
+            clear=True,
+        ),
+        patch.object(
+            hass.config_entries.flow,
+            "async_progress_by_init_data_type",
+            return_value=[
+                {
+                    "flow_id": "protected_flow_id",
+                    "context": {
+                        "dismiss_protected": True,
+                    },
+                },
+                {"flow_id": "unprotected_flow_id", "context": {}},
+            ],
+        ),
+        patch.object(hass.config_entries.flow, "async_abort") as mock_async_abort,
+        patch.object(
+            discovery, "AsyncServiceBrowser", side_effect=_device_removed_mock
+        ),
+        patch(
+            "homeassistant.components.zeroconf.discovery.AsyncServiceInfo",
+            side_effect=get_zeroconf_info_mock("FFAADDCC11DD"),
+        ),
+    ):
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    # Only the unprotected flow should be aborted
+    assert len(mock_async_abort.mock_calls) == 1
+    assert mock_async_abort.mock_calls[0][1][0] == "unprotected_flow_id"
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
 @pytest.mark.parametrize(
     (
         "entry_domain",

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -29,7 +29,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.generated import zeroconf as zc_gen
 from homeassistant.helpers.discovery_flow import DiscoveryKey
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.service_info.zeroconf import (
     ATTR_PROPERTIES_ID,
     ZeroconfServiceInfo,
@@ -1729,15 +1728,14 @@ async def test_homeassistant_service_updates_on_cloud_signal(
     external_url = "https://remote.example"
 
     fake_cloud = ModuleType("homeassistant.components.cloud")
-    fake_signal = "cloud_signal"
     connection = {"connected": False}
+    cloud_listener: Any = None
 
     class FakeCloudState(Enum):
         CLOUD_CONNECTED = "cloud_connected"
         CLOUD_DISCONNECTED = "cloud_disconnected"
 
     fake_cloud.CloudConnectionState = FakeCloudState
-    fake_cloud.SIGNAL_CLOUD_CONNECTION_STATE = fake_signal
 
     class FakeCloudNotAvailable(Exception):
         """Placeholder cloud error."""
@@ -1752,6 +1750,13 @@ async def test_homeassistant_service_updates_on_cloud_signal(
         return connection["connected"]
 
     fake_cloud.async_is_connected = fake_async_is_connected
+
+    def fake_async_listen_connection_change(_hass: HomeAssistant, target: Any) -> Any:
+        nonlocal cloud_listener
+        cloud_listener = target
+        return MagicMock()
+
+    fake_cloud.async_listen_connection_change = fake_async_listen_connection_change
 
     with (
         patch.dict(sys.modules, {"homeassistant.components.cloud": fake_cloud}),
@@ -1772,10 +1777,11 @@ async def test_homeassistant_service_updates_on_cloud_signal(
         assert _get_property(initial_info, "external_url") == ""
         assert _get_property(initial_info, "base_url") == hass.config.internal_url
         assert mock_async_zeroconf.async_update_service.await_count == 0
+        assert cloud_listener is not None
 
         connection["connected"] = True
         hass.config.external_url = external_url
-        async_dispatcher_send(hass, fake_signal, FakeCloudState.CLOUD_CONNECTED)
+        cloud_listener(FakeCloudState.CLOUD_CONNECTED)
         await hass.async_block_till_done()
 
         assert mock_async_zeroconf.async_update_service.await_count >= 1
@@ -1787,11 +1793,7 @@ async def test_homeassistant_service_updates_on_cloud_signal(
 
         connection["connected"] = False
         hass.config.external_url = None
-        async_dispatcher_send(
-            hass,
-            fake_signal,
-            FakeCloudState.CLOUD_DISCONNECTED,
-        )
+        cloud_listener(FakeCloudState.CLOUD_DISCONNECTED)
         await hass.async_block_till_done()
 
         assert mock_async_zeroconf.async_update_service.await_count >= 2

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -633,7 +633,20 @@ async def test_discovery_requirements_zeroconf(
     ) as mock_process:
         await async_get_integration_with_requirements(hass, "comp")
 
-    assert len(mock_process.mock_calls) == 2
+    assert len(mock_process.mock_calls) == 11
+    assert {call_args[1][0] for call_args in mock_process.mock_calls} == {
+        "assist_pipeline",
+        "backup",
+        "camera",
+        "cloud",
+        "conversation",
+        "ffmpeg",
+        "hassio",
+        "matter",
+        "network",
+        "tts",
+        "zeroconf",
+    }
     assert mock_process.mock_calls[0][1][1] == zeroconf.requirements
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update Zeroconf announcement when core config change to update external/internal URLs and location name as needed.
Also anounce when cloud is configured.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #100728
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
