### PR TITLE
Correct serial number for Zigbee devices in ViCare integration

### DIFF
--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -65,5 +65,5 @@ class ViCareEntity(Entity):
                     self._attr_device_info["serial_number"] = "-".join(
                         ieee.upper()[i : i + 2] for i in range(0, 16, 2)
                     )
-            else:
-                self._attr_device_info["serial_number"] = device_serial
+        else:
+            self._attr_device_info["serial_number"] = device_serial

--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -59,9 +59,12 @@ class ViCareEntity(Entity):
                     DOMAIN,
                     f"{gateway_serial}_zigbee_{zigbee_ieee}",
                 )
-            elif len(parts) == 2 and len((ieee := device_serial.removeprefix("zigbee-"))) == 16:
-			    self._attr_device_info["serial_number"] = "-".join(
-			        ieee.upper()[i:i + 2] for i in range(0, 16, 2)
-			    )
+            elif (
+                len(parts) == 2
+                and len(zigbee_ieee := device_serial.removeprefix("zigbee-")) == 16
+            ):
+                self._attr_device_info["serial_number"] = "-".join(
+                    zigbee_ieee.upper()[i : i + 2] for i in range(0, 16, 2)
+                )
         else:
             self._attr_device_info["serial_number"] = device_serial

--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -59,11 +59,9 @@ class ViCareEntity(Entity):
                     DOMAIN,
                     f"{gateway_serial}_zigbee_{zigbee_ieee}",
                 )
-            elif len(parts) == 2:
-                ieee = device_serial.replace("zigbee-", "")
-                if len(ieee) == 16:
-                    self._attr_device_info["serial_number"] = "-".join(
-                        ieee.upper()[i : i + 2] for i in range(0, 16, 2)
-                    )
+            elif len(parts) == 2 and len((ieee := device_serial.removeprefix("zigbee-"))) == 16:
+			    self._attr_device_info["serial_number"] = "-".join(
+			        ieee.upper()[i:i + 2] for i in range(0, 16, 2)
+			    )
         else:
             self._attr_device_info["serial_number"] = device_serial

--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -43,17 +43,8 @@ class ViCareEntity(Entity):
         if component:
             self._attr_unique_id += f"-{component.id}"
 
-        formatted_serial = device_serial
-        if device_serial and device_serial.startswith("zigbee-"):
-            ieee = device_serial.replace("zigbee-", "")
-            if len(ieee) == 16:
-                formatted_serial = "-".join(
-                    ieee.upper()[i : i + 2] for i in range(0, 16, 2)
-                )
-
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, identifier)},
-            serial_number=formatted_serial,
             name=model,
             manufacturer="Viessmann",
             model=model,
@@ -68,3 +59,11 @@ class ViCareEntity(Entity):
                     DOMAIN,
                     f"{gateway_serial}_zigbee_{zigbee_ieee}",
                 )
+            elif len(parts) == 2:
+                ieee = device_serial.replace("zigbee-", "")
+                if len(ieee) == 16:
+                    self._attr_device_info["serial_number"] = "-".join(
+                        ieee.upper()[i : i + 2] for i in range(0, 16, 2)
+                    )
+            else:
+                self._attr_device_info["serial_number"] = device_serial

--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -49,9 +49,17 @@ class ViCareEntity(Entity):
         if component:
             self._attr_unique_id += f"-{component.id}"
 
+        formatted_serial = device_serial
+        if device_serial and device_serial.startswith("zigbee-"):
+            ieee = device_serial.replace("zigbee-", "")
+            if len(ieee) == 16:
+                formatted_serial = "-".join(
+                    ieee.upper()[i : i + 2] for i in range(0, 16, 2)
+                )
+
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, identifier)},
-            serial_number=device_serial,
+            serial_number=formatted_serial,
             name=model,
             manufacturer="Viessmann",
             model=model,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
Display the serial number for ViCare Zigbee devices as it is done the the ViCare App.


<img width="300" alt="IMG_41259484A5E7-1" src="https://github.com/user-attachments/assets/3e7ecc98-86b9-487b-87c0-6144b209bca9" />
<img width="334" height="286" alt="Bildschirmfoto 2025-10-06 um 00 22 25" src="https://github.com/user-attachments/assets/2c313a02-6244-4c58-99b2-31b90db6c67f" />

Replaces https://github.com/home-assistant/core/pull/153786


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
