### PR TITLE
Add new sensor and attributes to Xbox integration

### DIFF
--- a/homeassistant/components/xbox/binary_sensor.py
+++ b/homeassistant/components/xbox/binary_sensor.py
@@ -43,7 +43,7 @@ class XboxBinarySensorEntityDescription(
     deprecated: bool | None = None
 
 
-def profile_pic(person: Person) -> str | None:
+def profile_pic(person: Person, _: Title | None) -> str | None:
     """Return the gamer pic."""
 
     # Xbox sometimes returns a domain that uses a wrong certificate which
@@ -159,13 +159,3 @@ class XboxBinarySensorEntity(XboxBaseEntity, BinarySensorEntity):
         """Return the status of the requested attribute."""
 
         return self.entity_description.is_on_fn(self.data)
-
-    @property
-    def entity_picture(self) -> str | None:
-        """Return the gamer pic."""
-
-        return (
-            fn(self.data)
-            if (fn := self.entity_description.entity_picture_fn) is not None
-            else super().entity_picture
-        )

--- a/homeassistant/components/xbox/coordinator.py
+++ b/homeassistant/components/xbox/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import timedelta
+from http import HTTPStatus
 import logging
 
 from httpx import HTTPStatusError, RequestError, TimeoutException
@@ -15,6 +16,7 @@ from xbox.webapi.api.provider.smartglass.models import (
     SmartglassConsoleList,
     SmartglassConsoleStatus,
 )
+from xbox.webapi.api.provider.titlehub.models import Title
 from xbox.webapi.common.signed_session import SignedSession
 
 from homeassistant.config_entries import ConfigEntry
@@ -45,6 +47,7 @@ class XboxData:
 
     consoles: dict[str, ConsoleData] = field(default_factory=dict)
     presence: dict[str, Person] = field(default_factory=dict)
+    title_info: dict[str, Title] = field(default_factory=dict)
 
 
 class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
@@ -199,6 +202,42 @@ class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
                 {friend.xuid: friend for friend in friends.people if friend.is_favorite}
             )
 
+        # retrieve title details
+        title_data: dict[str, Title] = {}
+        for person in presence_data.values():
+            if presence_detail := next(
+                (
+                    d
+                    for d in person.presence_details or []
+                    if d.state == "Active" and d.title_id and d.is_game and d.is_primary
+                ),
+                None,
+            ):
+                try:
+                    title = await self.client.titlehub.get_title_info(
+                        presence_detail.title_id
+                    )
+                except TimeoutException as e:
+                    raise UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="timeout_exception",
+                    ) from e
+                except HTTPStatusError as e:
+                    _LOGGER.debug("Xbox exception:", exc_info=True)
+                    if e.response.status_code == HTTPStatus.NOT_FOUND:
+                        continue
+                    raise UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="request_exception",
+                    ) from e
+                except RequestError as e:
+                    _LOGGER.debug("Xbox exception:", exc_info=True)
+                    raise UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="request_exception",
+                    ) from e
+                title_data[person.xuid] = title.titles[0]
+
         if (
             self.current_friends - (new_friends := set(presence_data))
             or not self.current_friends
@@ -206,7 +245,7 @@ class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
             self.remove_stale_devices(new_friends)
         self.current_friends = new_friends
 
-        return XboxData(new_console_data, presence_data)
+        return XboxData(new_console_data, presence_data, title_data)
 
     def remove_stale_devices(self, xuids: set[str]) -> None:
         """Remove stale devices from registry."""

--- a/homeassistant/components/xbox/icons.json
+++ b/homeassistant/components/xbox/icons.json
@@ -24,15 +24,15 @@
       "last_online": {
         "default": "mdi:account-clock"
       },
-      "status": {
-        "default": "mdi:message-text-outline"
-      },
       "now_playing": {
         "default": "mdi:microsoft-xbox-controller",
         "state": {
-          "unknown": "mdi:microsoft-xbox-controller-off",
-          "unavailable": "mdi:microsoft-xbox-controller-off"
+          "unavailable": "mdi:microsoft-xbox-controller-off",
+          "unknown": "mdi:microsoft-xbox-controller-off"
         }
+      },
+      "status": {
+        "default": "mdi:message-text-outline"
       }
     }
   }

--- a/homeassistant/components/xbox/icons.json
+++ b/homeassistant/components/xbox/icons.json
@@ -26,6 +26,13 @@
       },
       "status": {
         "default": "mdi:message-text-outline"
+      },
+      "now_playing": {
+        "default": "mdi:microsoft-xbox-controller",
+        "state": {
+          "unknown": "mdi:microsoft-xbox-controller-off",
+          "unavailable": "mdi:microsoft-xbox-controller-off"
+        }
       }
     }
   }

--- a/homeassistant/components/xbox/sensor.py
+++ b/homeassistant/components/xbox/sensor.py
@@ -99,6 +99,7 @@ def title_logo(_: Person, title: Title | None) -> str | None:
 
     return (
         next((i.url for i in title.images if i.type == "Tile"), None)
+        or next((i.url for i in title.images if i.type == "Logo"), None)
         if title and title.images
         else None
     )

--- a/homeassistant/components/xbox/sensor.py
+++ b/homeassistant/components/xbox/sensor.py
@@ -48,31 +48,48 @@ class XboxSensorEntityDescription(XboxBaseEntityDescription, SensorEntityDescrip
 
 def now_playing_attributes(_: Person, title: Title | None) -> dict[str, Any]:
     """Attributes of the currently played title."""
-    attributes: dict[str, Any] = {}
+    attributes: dict[str, Any] = {
+        "short_description": None,
+        "genres": None,
+        "developer": None,
+        "publisher": None,
+        "release_date": None,
+        "min_age": None,
+        "achievements": None,
+        "gamerscore": None,
+        "progress": None,
+    }
     if not title:
         return attributes
     if title.detail is not None:
-        attributes["short_description"] = title.detail.short_description
-        attributes["genres"] = (
-            ", ".join(title.detail.genres) if title.detail.genres else None
+        attributes.update(
+            {
+                "short_description": title.detail.short_description,
+                "genres": (
+                    ", ".join(title.detail.genres) if title.detail.genres else None
+                ),
+                "developer": title.detail.developer_name,
+                "publisher": title.detail.publisher_name,
+                "release_date": (
+                    title.detail.release_date.replace(tzinfo=UTC).date()
+                    if title.detail.release_date
+                    else None
+                ),
+                "min_age": title.detail.min_age,
+            }
         )
-        attributes["developer"] = title.detail.developer_name
-        attributes["publisher"] = title.detail.publisher_name
-        attributes["min_age"] = title.detail.min_age
-        attributes["release_date"] = (
-            title.detail.release_date.replace(tzinfo=UTC).date()
-            if title.detail.release_date
-            else None
-        )
-        attributes["min_age"] = title.detail.min_age
     if (achievement := title.achievement) is not None:
-        attributes["achievements"] = (
-            f"{achievement.current_achievements} / {achievement.total_achievements}"
+        attributes.update(
+            {
+                "achievements": (
+                    f"{achievement.current_achievements} / {achievement.total_achievements}"
+                ),
+                "gamerscore": (
+                    f"{achievement.current_gamerscore} / {achievement.total_gamerscore}"
+                ),
+                "progress": f"{int(achievement.progress_percentage)} %",
+            }
         )
-        attributes["gamerscore"] = (
-            f"{achievement.current_gamerscore} / {achievement.total_gamerscore}"
-        )
-        attributes["progress"] = f"{int(achievement.progress_percentage)} %"
 
     return attributes
 
@@ -81,7 +98,7 @@ def title_logo(_: Person, title: Title | None) -> str | None:
     """Get the game logo."""
 
     return (
-        next((i.url for i in title.images if i.type == "Logo"), None)
+        next((i.url for i in title.images if i.type == "Tile"), None)
         if title and title.images
         else None
     )

--- a/homeassistant/components/xbox/sensor.py
+++ b/homeassistant/components/xbox/sensor.py
@@ -6,8 +6,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Any
 
 from xbox.webapi.api.provider.people.models import Person
+from xbox.webapi.api.provider.titlehub.models import Title
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -20,7 +22,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .coordinator import XboxConfigEntry
-from .entity import XboxBaseEntity, check_deprecated_entity
+from .entity import XboxBaseEntity, XboxBaseEntityDescription, check_deprecated_entity
 
 
 class XboxSensor(StrEnum):
@@ -33,42 +35,74 @@ class XboxSensor(StrEnum):
     LAST_ONLINE = "last_online"
     FOLLOWING = "following"
     FOLLOWER = "follower"
+    NOW_PLAYING = "now_playing"
 
 
 @dataclass(kw_only=True, frozen=True)
-class XboxSensorEntityDescription(SensorEntityDescription):
+class XboxSensorEntityDescription(XboxBaseEntityDescription, SensorEntityDescription):
     """Xbox sensor description."""
 
-    value_fn: Callable[[Person], StateType | datetime]
+    value_fn: Callable[[Person, Title | None], StateType | datetime]
     deprecated: bool | None = None
+
+
+def now_playing_attributes(_: Person, title: Title | None) -> dict[str, Any]:
+    """Attributes of the currently played title."""
+    attributes: dict[str, Any] = {}
+    if not title:
+        return attributes
+    if title.detail is not None:
+        attributes["short_description"] = title.detail.short_description
+        attributes["genres"] = (
+            ", ".join(title.detail.genres) if title.detail.genres else None
+        )
+        attributes["developer"] = title.detail.developer_name
+        attributes["publisher"] = title.detail.publisher_name
+        attributes["min_age"] = title.detail.min_age
+        attributes["release_date"] = (
+            title.detail.release_date.replace(tzinfo=UTC).date()
+            if title.detail.release_date
+            else None
+        )
+        attributes["min_age"] = title.detail.min_age
+    if (achievement := title.achievement) is not None:
+        attributes["achievements"] = (
+            f"{achievement.current_achievements} / {achievement.total_achievements}"
+        )
+        attributes["gamerscore"] = (
+            f"{achievement.current_gamerscore} / {achievement.total_gamerscore}"
+        )
+        attributes["progress"] = f"{int(achievement.progress_percentage)} %"
+
+    return attributes
 
 
 SENSOR_DESCRIPTIONS: tuple[XboxSensorEntityDescription, ...] = (
     XboxSensorEntityDescription(
         key=XboxSensor.STATUS,
         translation_key=XboxSensor.STATUS,
-        value_fn=lambda x: x.presence_text,
+        value_fn=lambda x, _: x.presence_text,
     ),
     XboxSensorEntityDescription(
         key=XboxSensor.GAMER_SCORE,
         translation_key=XboxSensor.GAMER_SCORE,
-        value_fn=lambda x: x.gamer_score,
+        value_fn=lambda x, _: x.gamer_score,
     ),
     XboxSensorEntityDescription(
         key=XboxSensor.ACCOUNT_TIER,
-        value_fn=lambda _: None,
+        value_fn=lambda _, __: None,
         deprecated=True,
     ),
     XboxSensorEntityDescription(
         key=XboxSensor.GOLD_TENURE,
-        value_fn=lambda _: None,
+        value_fn=lambda _, __: None,
         deprecated=True,
     ),
     XboxSensorEntityDescription(
         key=XboxSensor.LAST_ONLINE,
         translation_key=XboxSensor.LAST_ONLINE,
         value_fn=(
-            lambda x: x.last_seen_date_time_utc.replace(tzinfo=UTC)
+            lambda x, _: x.last_seen_date_time_utc.replace(tzinfo=UTC)
             if x.last_seen_date_time_utc
             else None
         ),
@@ -77,12 +111,18 @@ SENSOR_DESCRIPTIONS: tuple[XboxSensorEntityDescription, ...] = (
     XboxSensorEntityDescription(
         key=XboxSensor.FOLLOWING,
         translation_key=XboxSensor.FOLLOWING,
-        value_fn=lambda x: x.detail.following_count if x.detail else None,
+        value_fn=lambda x, _: x.detail.following_count if x.detail else None,
     ),
     XboxSensorEntityDescription(
         key=XboxSensor.FOLLOWER,
         translation_key=XboxSensor.FOLLOWER,
-        value_fn=lambda x: x.detail.follower_count if x.detail else None,
+        value_fn=lambda x, _: x.detail.follower_count if x.detail else None,
+    ),
+    XboxSensorEntityDescription(
+        key=XboxSensor.NOW_PLAYING,
+        translation_key=XboxSensor.NOW_PLAYING,
+        value_fn=lambda _, title: title.name if title else None,
+        attributes_fn=now_playing_attributes,
     ),
 )
 
@@ -127,4 +167,4 @@ class XboxSensorEntity(XboxBaseEntity, SensorEntity):
     @property
     def native_value(self) -> StateType | datetime:
         """Return the state of the requested attribute."""
-        return self.entity_description.value_fn(self.data)
+        return self.entity_description.value_fn(self.data, self.title_info)

--- a/homeassistant/components/xbox/sensor.py
+++ b/homeassistant/components/xbox/sensor.py
@@ -77,6 +77,16 @@ def now_playing_attributes(_: Person, title: Title | None) -> dict[str, Any]:
     return attributes
 
 
+def title_logo(_: Person, title: Title | None) -> str | None:
+    """Get the game logo."""
+
+    return (
+        next((i.url for i in title.images if i.type == "Logo"), None)
+        if title and title.images
+        else None
+    )
+
+
 SENSOR_DESCRIPTIONS: tuple[XboxSensorEntityDescription, ...] = (
     XboxSensorEntityDescription(
         key=XboxSensor.STATUS,
@@ -123,6 +133,7 @@ SENSOR_DESCRIPTIONS: tuple[XboxSensorEntityDescription, ...] = (
         translation_key=XboxSensor.NOW_PLAYING,
         value_fn=lambda _, title: title.name if title else None,
         attributes_fn=now_playing_attributes,
+        entity_picture_fn=title_logo,
     ),
 )
 

--- a/homeassistant/components/xbox/strings.json
+++ b/homeassistant/components/xbox/strings.json
@@ -30,6 +30,13 @@
   },
   "entity": {
     "binary_sensor": {
+      "online": {
+        "state_attributes": {
+          "display_name": { "name": "Display name" },
+          "real_name": { "name": "Real name" },
+          "bio": { "name": "Bio" }
+        }
+      },
       "has_game_pass": {
         "name": "Subscribed to Xbox Game Pass"
       },

--- a/homeassistant/components/xbox/strings.json
+++ b/homeassistant/components/xbox/strings.json
@@ -55,6 +55,22 @@
       },
       "status": {
         "name": "Status"
+      },
+      "now_playing": {
+        "name": "Now playing",
+        "state_attributes": {
+          "short_description": { "name": "Short description" },
+          "publisher": { "name": "Publisher" },
+          "genres": { "name": "Genres" },
+          "developer": { "name": "Developer" },
+          "release_date": { "name": "Release date" },
+          "min_age": { "name": "Minimum age" },
+          "achievements": { "name": "Achievements" },
+          "gamerscore": {
+            "name": "[%key:component::xbox::entity::sensor::gamer_score::name%]"
+          },
+          "progress": { "name": "Progress" }
+        }
       }
     }
   },

--- a/homeassistant/components/xbox/strings.json
+++ b/homeassistant/components/xbox/strings.json
@@ -30,18 +30,18 @@
   },
   "entity": {
     "binary_sensor": {
-      "online": {
-        "state_attributes": {
-          "display_name": { "name": "Display name" },
-          "real_name": { "name": "Real name" },
-          "bio": { "name": "Bio" }
-        }
-      },
       "has_game_pass": {
         "name": "Subscribed to Xbox Game Pass"
       },
       "in_game": {
         "name": "In game"
+      },
+      "online": {
+        "state_attributes": {
+          "bio": { "name": "Bio" },
+          "display_name": { "name": "Display name" },
+          "real_name": { "name": "Real name" }
+        }
       }
     },
     "sensor": {
@@ -60,24 +60,24 @@
       "last_online": {
         "name": "Last online"
       },
-      "status": {
-        "name": "Status"
-      },
       "now_playing": {
         "name": "Now playing",
         "state_attributes": {
-          "short_description": { "name": "Short description" },
-          "publisher": { "name": "Publisher" },
-          "genres": { "name": "Genres" },
-          "developer": { "name": "Developer" },
-          "release_date": { "name": "Release date" },
-          "min_age": { "name": "Minimum age" },
           "achievements": { "name": "Achievements" },
+          "developer": { "name": "Developer" },
           "gamerscore": {
             "name": "[%key:component::xbox::entity::sensor::gamer_score::name%]"
           },
-          "progress": { "name": "Progress" }
+          "genres": { "name": "Genres" },
+          "min_age": { "name": "Minimum age" },
+          "progress": { "name": "Progress" },
+          "publisher": { "name": "Publisher" },
+          "release_date": { "name": "Release date" },
+          "short_description": { "name": "Short description" }
         }
+      },
+      "status": {
+        "name": "Status"
       }
     }
   },

--- a/tests/components/xbox/conftest.py
+++ b/tests/components/xbox/conftest.py
@@ -1,3 +1,4 @@
+# type: ignore[reportArgumentType] # ignore JsonValueType assignment to pydantic model
 """Common fixtures for the Xbox tests."""
 
 from collections.abc import Generator
@@ -10,6 +11,7 @@ from xbox.webapi.api.provider.smartglass.models import (
     SmartglassConsoleList,
     SmartglassConsoleStatus,
 )
+from xbox.webapi.api.provider.titlehub.models import TitleHubResponse
 
 from homeassistant.components.application_credentials import (
     ClientCredential,
@@ -133,6 +135,11 @@ def mock_xbox_live_client(signed_session) -> Generator[AsyncMock]:
         )
         client.people.get_friends_own.return_value = PeopleResponse(
             **load_json_object_fixture("people_friends_own.json", DOMAIN)
+        )
+
+        client.titlehub = AsyncMock()
+        client.titlehub.get_title_info.return_value = TitleHubResponse(
+            **load_json_object_fixture("titlehub_titleinfo.json", DOMAIN)
         )
 
         client.xuid = "271958441785640"

--- a/tests/components/xbox/fixtures/people_batch.json
+++ b/tests/components/xbox/fixtures/people_batch.json
@@ -7,7 +7,7 @@
       "isFollowedByCaller": false,
       "isIdentityShared": false,
       "addedDateTimeUtc": null,
-      "displayName": null,
+      "displayName": "GSR Ae",
       "realName": "Test Test",
       "displayPicRaw": "https://images-eds-ssl.xboxlive.com/image?url=wHwbXKif8cus8csoZ03RW_ES.ojiJijNBGRVUbTnZKsoCCCkjlsEJrrMqDkYqs3M0aLOK2kxE9mbLm9M2.R0stAQYoDsGCDJxqDzG9WF3oa4rOCjEK7DbZXdBmBWnMrfErA3M_Q4y_mUTEQLqSAEeYFGlGeCXYsccnQMvEecxRg-&format=png",
       "showUserAsAvatar": "0",
@@ -17,7 +17,7 @@
       "modernGamertagSuffix": "",
       "uniqueModernGamertag": "GSR Ae",
       "xboxOneRep": "GoodPlayer",
-      "presenceState": "Offline",
+      "presenceState": "Online",
       "presenceText": "Last seen 49m ago: Xbox App",
       "presenceDevices": null,
       "isBroadcasting": false,
@@ -43,13 +43,13 @@
       "presenceDetails": [
         {
           "IsBroadcasting": false,
-          "Device": "iOS",
-          "PresenceText": "Last seen 49m ago: Xbox App",
-          "State": "LastSeen",
-          "TitleId": "328178078",
+          "Device": "Xbox360",
+          "PresenceText": "Blue Dragon",
+          "State": "Active",
+          "TitleId": "1297287135",
           "TitleType": null,
           "IsPrimary": true,
-          "IsGame": false,
+          "IsGame": true,
           "RichPresenceText": null
         }
       ],
@@ -58,7 +58,7 @@
       "presenceTitleIds": null,
       "detail": {
         "accountTier": "Gold",
-        "bio": null,
+        "bio": "My mind is a swirling miasma of scintillating thoughts and turgid ideas.",
         "isVerified": false,
         "location": null,
         "tenure": null,

--- a/tests/components/xbox/fixtures/titlehub_titleinfo.json
+++ b/tests/components/xbox/fixtures/titlehub_titleinfo.json
@@ -56,6 +56,11 @@
           "caption": ""
         },
         {
+          "url": "http://store-images.s-microsoft.com/image/apps.35072.13670972585585116.70570f0d-17aa-4f97-b692-5412fa183673.25a97451-9369-4f6b-b66b-3427913235eb",
+          "type": "Logo",
+          "caption": ""
+        },
+        {
           "url": "http://store-images.s-microsoft.com/image/apps.45451.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.3abf2cc3-00cc-417d-a93d-97110cdfb261",
           "type": "FeaturePromotionalSquareArt",
           "caption": ""

--- a/tests/components/xbox/fixtures/titlehub_titleinfo.json
+++ b/tests/components/xbox/fixtures/titlehub_titleinfo.json
@@ -1,0 +1,181 @@
+{
+  "xuid": "2535446026190660",
+  "titles": [
+    {
+      "titleId": "1297287135",
+      "pfn": null,
+      "bingId": "66acd000-77fe-1000-9115-d8024d5307df",
+      "serviceConfigId": "7f2e0100-2f8c-4b64-b2be-675b266ec2cd",
+      "windowsPhoneProductId": null,
+      "name": "Blue Dragon",
+      "type": "Game",
+      "devices": ["Xbox360", "XboxOne", "XboxSeries"],
+      "displayImage": "http://store-images.s-microsoft.com/image/apps.45451.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.3abf2cc3-00cc-417d-a93d-97110cdfb261",
+      "mediaItemType": "Xbox360Game",
+      "modernTitleId": "644793037",
+      "isBundle": false,
+      "achievement": {
+        "currentAchievements": 2,
+        "totalAchievements": 43,
+        "currentGamerscore": 10,
+        "totalGamerscore": 1000,
+        "progressPercentage": 1.0,
+        "sourceVersion": 1
+      },
+      "stats": null,
+      "gamePass": null,
+      "images": [
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.35725.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.c4bf34f8-ad40-4af3-914e-a85e75a76bed",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.64736.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.6491fb2f-52e7-4129-bcbd-d23a67117ae0",
+          "type": "BrandedKeyArt",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.55545.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.4c2daefb-fbf6-4b90-b392-bf8ecc39a92e",
+          "type": "TitledHeroArt",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.22570.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.bf29284d-808a-4e4a-beaa-6621c9898d0e",
+          "type": "Poster",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.55545.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.4c2daefb-fbf6-4b90-b392-bf8ecc39a92e",
+          "type": "SuperHeroArt",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.45451.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.3abf2cc3-00cc-417d-a93d-97110cdfb261",
+          "type": "BoxArt",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.45451.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.3abf2cc3-00cc-417d-a93d-97110cdfb261",
+          "type": "FeaturePromotionalSquareArt",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.38628.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.c2a205af-5146-405b-b2b7-56845351f1f3",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.22150.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.b147895c-e947-424d-a731-faefc8c9906a",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.37559.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.479d2dc1-db2d-4ffa-8c54-a2bebb093ec6",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.32737.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.6a16ae3e-2918-46e9-90d9-232c79cb9d9d",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.57046.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.0c0dd072-aa27-4e83-9010-474dfbb42277",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.19315.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.6293a7b7-07ca-4df0-9eea-6018285a0a8d",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.23374.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.66498a73-52f5-4247-a1e2-d3c84b9b315d",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.64646.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.83182b76-4294-496d-90a7-f4e31e7aa80a",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.24470.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.72d2abc3-aa69-4aeb-960b-6f6d25f498e4",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.15604.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.27cee011-660b-49a4-bd33-38db6fff5226",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.39987.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.be285efe-78f8-4984-9d28-9159881bacd4",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.38206.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.2409803d-7378-4a69-a10b-1574ac42b98b",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.14938.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.ef6ee72c-4beb-45ec-bd10-6235bd6a7c7f",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.12835.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.6165ee24-df01-44f5-80fe-7411f9366d1c",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.40786.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.b7607a0d-0101-4864-9bf8-ad889f820489",
+          "type": "Screenshot",
+          "caption": ""
+        },
+        {
+          "url": "http://store-images.s-microsoft.com/image/apps.55686.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.ecbb0e91-36a9-4f76-ab1e-5a5de009840e",
+          "type": "Screenshot",
+          "caption": ""
+        }
+      ],
+      "titleHistory": null,
+      "titleRecord": null,
+      "detail": {
+        "attributes": [],
+        "availabilities": [
+          {
+            "Actions": [
+              "Details",
+              "Fulfill",
+              "Purchase",
+              "Browse",
+              "Curate",
+              "Redeem"
+            ],
+            "AvailabilityId": "9TWPXS4C28K1",
+            "Platforms": ["Xbox"],
+            "SkuId": "0001",
+            "ProductId": "C2HGK9J5367F"
+          }
+        ],
+        "capabilities": [],
+        "description": "Hironobu Sakaguchi, the Father of the Final Fantasy series, and Artoon present the world of Blue Dragon on Xbox 360. Featuring the character design of Akira Toriyama, the Father of \"Dragon Ball Z\", and music by Nobuo Uematsu, the composer for Final Fantasy, Blue Dragon is an epic role-playing game (RPG) centered on five youngsters who possess miraculous strength and magical power to control shadow creatures that mirror the actions of their masters.",
+        "developerName": "Mistwalker / Artoon",
+        "genres": ["Role Playing"],
+        "minAge": 13,
+        "publisherName": "Microsoft",
+        "releaseDate": "2016-12-14T09:00:00Z",
+        "shortDescription": "Hironobu Sakaguchi, the Father of the Final Fantasy series, and Artoon present the world of Blue Dragon on Xbox 360. Featuring the character design of Akira Toriyama, the Father of \"Dragon Ball Z\", and music by Nobuo Uematsu, the composer for Final Fantasy, Blue Dragon is an epic role-playing game (RPG) centered on five youngsters who possess miraculous strength and magical power to control shadow creatures that mirror the actions of their masters.",
+        "vuiDisplayName": "Blue Dragon",
+        "xboxLiveGoldRequired": false
+      },
+      "friendsWhoPlayed": null,
+      "alternateTitleIds": [],
+      "contentBoards": null,
+      "xboxLiveTier": "Full"
+    }
+  ]
+}

--- a/tests/components/xbox/snapshots/test_binary_sensor.ambr
+++ b/tests/components/xbox/snapshots/test_binary_sensor.ambr
@@ -37,8 +37,11 @@
 # name: test_binary_sensors[binary_sensor.erics273-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'bio': '',
+      'display_name': 'erics273',
       'entity_picture': 'https://images-eds-ssl.xboxlive.com/image?url=rwljod2fPqLqGP3DBV9F_yK9iuxAt3_MH6tcOnQXTc8LY1LO8JeulzCEFHaqqItKdg9oJ84qjO.VNwvUWuq_iR5iTyx1gQsqHSvWLbqIrRI-&background=0xababab&format=png',
       'friendly_name': 'erics273',
+      'real_name': None,
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.erics273',
@@ -182,15 +185,18 @@
 # name: test_binary_sensors[binary_sensor.gsr_ae-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'bio': 'My mind is a swirling miasma of scintillating thoughts and turgid ideas.',
+      'display_name': 'GSR Ae',
       'entity_picture': 'https://images-eds-ssl.xboxlive.com/image?url=wHwbXKif8cus8csoZ03RW_ES.ojiJijNBGRVUbTnZKsoCCCkjlsEJrrMqDkYqs3M0aLOK2kxE9mbLm9M2.R0stAQYoDsGCDJxqDzG9WF3oa4rOCjEK7DbZXdBmBWnMrfErA3M_Q4y_mUTEQLqSAEeYFGlGeCXYsccnQMvEecxRg-&format=png',
       'friendly_name': 'GSR Ae',
+      'real_name': 'Test Test',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.gsr_ae',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'on',
   })
 # ---
 # name: test_binary_sensors[binary_sensor.gsr_ae_in_game-entry]
@@ -238,7 +244,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'on',
   })
 # ---
 # name: test_binary_sensors[binary_sensor.gsr_ae_subscribed_to_xbox_game_pass-entry]
@@ -327,8 +333,11 @@
 # name: test_binary_sensors[binary_sensor.ikken_hissatsuu-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'bio': 'Bio',
+      'display_name': 'Ikken Hissatsuu',
       'entity_picture': 'https://images-eds-ssl.xboxlive.com/image?url=7OTVnZUMVj4OV2zUUGecWvn3U00nQQLfK7_kwpANogj9vJpb.t4ZQMMLIWOuBZBBZs5MjD7okwh5Zwnit1SAtO3OAsFXxJc1ALIbaVoRo7gsiun9FdcaTpzkM60nqzT8ip1659eQpB1SLyupscP.ec_wAGvXwkhCcTKCNHQMrxg-&format=png',
       'friendly_name': 'Ikken Hissatsuu',
+      'real_name': None,
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.ikken_hissatsuu',

--- a/tests/components/xbox/snapshots/test_sensor.ambr
+++ b/tests/components/xbox/snapshots/test_sensor.ambr
@@ -195,6 +195,54 @@
     'state': '2020-10-08T04:19:58+00:00',
   })
 # ---
+# name: test_sensors[sensor.erics273_now_playing-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.erics273_now_playing',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Now playing',
+    'platform': 'xbox',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <XboxSensor.NOW_PLAYING: 'now_playing'>,
+    'unique_id': '2533274913657542_now_playing',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.erics273_now_playing-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'erics273 Now playing',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.erics273_now_playing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_sensors[sensor.erics273_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -439,6 +487,63 @@
     'state': '2020-10-09T00:12:27+00:00',
   })
 # ---
+# name: test_sensors[sensor.gsr_ae_now_playing-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.gsr_ae_now_playing',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Now playing',
+    'platform': 'xbox',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <XboxSensor.NOW_PLAYING: 'now_playing'>,
+    'unique_id': '271958441785640_now_playing',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.gsr_ae_now_playing-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'achievements': '2 / 43',
+      'developer': 'Mistwalker / Artoon',
+      'friendly_name': 'GSR Ae Now playing',
+      'gamerscore': '10 / 1000',
+      'genres': 'Role Playing',
+      'min_age': 13,
+      'progress': '1 %',
+      'publisher': 'Microsoft',
+      'release_date': datetime.date(2016, 12, 14),
+      'short_description': 'Hironobu Sakaguchi, the Father of the Final Fantasy series, and Artoon present the world of Blue Dragon on Xbox 360. Featuring the character design of Akira Toriyama, the Father of "Dragon Ball Z", and music by Nobuo Uematsu, the composer for Final Fantasy, Blue Dragon is an epic role-playing game (RPG) centered on five youngsters who possess miraculous strength and magical power to control shadow creatures that mirror the actions of their masters.',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.gsr_ae_now_playing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Blue Dragon',
+  })
+# ---
 # name: test_sensors[sensor.gsr_ae_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -677,6 +782,54 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.ikken_hissatsuu_last_online',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.ikken_hissatsuu_now_playing-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ikken_hissatsuu_now_playing',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Now playing',
+    'platform': 'xbox',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <XboxSensor.NOW_PLAYING: 'now_playing'>,
+    'unique_id': '2533274838782903_now_playing',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.ikken_hissatsuu_now_playing-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Ikken Hissatsuu Now playing',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ikken_hissatsuu_now_playing',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/xbox/snapshots/test_sensor.ambr
+++ b/tests/components/xbox/snapshots/test_sensor.ambr
@@ -536,6 +536,7 @@
     'attributes': ReadOnlyDict({
       'achievements': '2 / 43',
       'developer': 'Mistwalker / Artoon',
+      'entity_picture': 'http://store-images.s-microsoft.com/image/apps.35072.13670972585585116.70570f0d-17aa-4f97-b692-5412fa183673.25a97451-9369-4f6b-b66b-3427913235eb',
       'friendly_name': 'GSR Ae Now playing',
       'gamerscore': '10 / 1000',
       'genres': 'Role Playing',

--- a/tests/components/xbox/snapshots/test_sensor.ambr
+++ b/tests/components/xbox/snapshots/test_sensor.ambr
@@ -233,7 +233,16 @@
 # name: test_sensors[sensor.erics273_now_playing-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'achievements': None,
+      'developer': None,
       'friendly_name': 'erics273 Now playing',
+      'gamerscore': None,
+      'genres': None,
+      'min_age': None,
+      'progress': None,
+      'publisher': None,
+      'release_date': None,
+      'short_description': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.erics273_now_playing',
@@ -527,7 +536,6 @@
     'attributes': ReadOnlyDict({
       'achievements': '2 / 43',
       'developer': 'Mistwalker / Artoon',
-      'entity_picture': 'http://store-images.s-microsoft.com/image/apps.35072.13670972585585116.70570f0d-17aa-4f97-b692-5412fa183673.25a97451-9369-4f6b-b66b-3427913235eb',
       'friendly_name': 'GSR Ae Now playing',
       'gamerscore': '10 / 1000',
       'genres': 'Role Playing',
@@ -827,7 +835,16 @@
 # name: test_sensors[sensor.ikken_hissatsuu_now_playing-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'achievements': None,
+      'developer': None,
       'friendly_name': 'Ikken Hissatsuu Now playing',
+      'gamerscore': None,
+      'genres': None,
+      'min_age': None,
+      'progress': None,
+      'publisher': None,
+      'release_date': None,
+      'short_description': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.ikken_hissatsuu_now_playing',

--- a/tests/components/xbox/snapshots/test_sensor.ambr
+++ b/tests/components/xbox/snapshots/test_sensor.ambr
@@ -527,6 +527,7 @@
     'attributes': ReadOnlyDict({
       'achievements': '2 / 43',
       'developer': 'Mistwalker / Artoon',
+      'entity_picture': 'http://store-images.s-microsoft.com/image/apps.35072.13670972585585116.70570f0d-17aa-4f97-b692-5412fa183673.25a97451-9369-4f6b-b66b-3427913235eb',
       'friendly_name': 'GSR Ae Now playing',
       'gamerscore': '10 / 1000',
       'genres': 'Role Playing',


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a new sensor `Now playing` that displays the currently played game including some metadata and the players progress info in the state attributes (Short description, Publisher, Genres, Developer, Release date, Minimum age, Achievements, Gamerscore, and Progress percentage. 
The entity picture will also show the Logo of the game if available. The logo is usually used as icon on the Xbox. There is also a box art available which I will add as image entity in a future PR

Attributes have also been added for the profile (Display name, real name, bio)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io/pull/41454
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
