### PR TITLE
Fix potentially flaky tests in multiple integrations

### DIFF
--- a/tests/components/knx/test_init.py
+++ b/tests/components/knx/test_init.py
@@ -290,14 +290,12 @@ async def _init_switch_and_wait_for_first_state_updater_run(
 
     freezer.tick(timedelta(minutes=59))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     await knx.assert_no_telegram()
 
     freezer.tick(timedelta(minutes=1))  # 60 minutes passed
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def test_default_state_updater_enabled(

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -1644,8 +1644,7 @@ async def test_remove_stale_media(
     point_in_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
     with freeze_time(point_in_time):
         async_fire_time_changed(hass, point_in_time)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     # Verify that the event media is still present and that the extra files
     # are removed. Newer media is not removed.

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -246,8 +246,7 @@ async def test_reconnection_on_update_failure(
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     # Verify that disconnect and connect were called (reconnection happened)
     mock_openrgb_client.disconnect.assert_called_once()
@@ -295,9 +294,7 @@ async def test_reconnection_fails_second_attempt(
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     # Verify that the light became unavailable after failed reconnection
     state = hass.states.get("light.ene_dram")
@@ -340,8 +337,7 @@ async def test_normal_update_without_errors(
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     # Verify that disconnect and connect were NOT called (no reconnection needed)
     mock_openrgb_client.disconnect.assert_not_called()

--- a/tests/components/playstation_network/test_image.py
+++ b/tests/components/playstation_network/test_image.py
@@ -75,8 +75,7 @@ async def test_image_platform(
 
     freezer.tick(timedelta(seconds=30))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     assert (state := hass.states.get("image.testuser_avatar"))
     assert state.state == "2025-06-16T00:00:30+00:00"

--- a/tests/components/rflink/test_binary_sensor.py
+++ b/tests/components/rflink/test_binary_sensor.py
@@ -176,8 +176,7 @@ async def test_off_delay(hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch) -
     future = now + timedelta(seconds=35)
     with freeze_time(future):
         async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
     state = hass.states.get("binary_sensor.test2")
     assert state.state == STATE_ON
     assert len(events) == 2
@@ -186,8 +185,7 @@ async def test_off_delay(hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch) -
     future = now + timedelta(seconds=45)
     with freeze_time(future):
         async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
     state = hass.states.get("binary_sensor.test2")
     assert state.state == STATE_OFF
     assert len(events) == 3

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -148,8 +148,7 @@ async def test_state_change(
     caplog.clear()
     with freeze_time(patched_time):
         async_fire_time_changed(hass, patched_time)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert caplog.text.count("sun phase_update") == 1
     # Called once by time listener, once from Sun.update_events

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -1005,8 +1005,7 @@ async def test_self_referencing_entity_picture_loop(
         "homeassistant.helpers.ratelimit.time.time", return_value=next_time.timestamp()
     ):
         async_fire_time_changed(hass, next_time)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert "Template loop detected" in caplog_setup_text
 

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -882,22 +882,19 @@ async def test_if_fires_on_time_change(
     second_time = start_time.replace(minute=4, second=0)
     freezer.move_to(second_time)
     async_fire_time_changed(hass, second_time)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert len(calls) == 1
 
     # Trigger again (do not match template)
     third_time = start_time.replace(minute=5, second=0)
     freezer.move_to(third_time)
     async_fire_time_changed(hass, third_time)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert len(calls) == 1
 
     # Trigger again (match template)
     forth_time = start_time.replace(minute=8, second=0)
     freezer.move_to(forth_time)
     async_fire_time_changed(hass, forth_time)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert len(calls) == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace multiple consecutive async_block_till_done() calls with single async_block_till_done(wait_background_tasks=True) calls after async_fire_time_changed() in test files.

This pattern is more reliable and predictable than calling async_block_till_done() multiple times, which doesn't guarantee proper handling of all async operations and can lead to flaky tests.

Affected integrations:
- nest: 1 instance in test_media_source.py
- openrgb: 3 instances in test_init.py (including one with 3 consecutive calls)
- playstation_network: 1 instance in test_image.py
- rflink: 2 instances in test_binary_sensor.py
- sun: 1 instance in test_init.py
- template: 4 instances (1 in test_sensor.py, 3 in test_trigger.py)

Total: 14 instances fixed across 7 integrations.

Follows the same fix pattern from PR #155095 which addressed similar issues in the openrgb light tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
