### PR TITLE
Fix Nord Pool sensor resolution for next/previous price

### DIFF
--- a/homeassistant/components/nordpool/sensor.py
+++ b/homeassistant/components/nordpool/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from homeassistant.components.sensor import (
     EntityCategory,
@@ -54,10 +54,11 @@ def get_prices(
     current_price_entries: dict[str, float] = {}
     next_price_entries: dict[str, float] = {}
     current_time = dt_util.utcnow()
-    previous_time = current_time - timedelta(hours=1)
-    next_time = current_time + timedelta(hours=1)
     LOGGER.debug("Price data: %s", data)
     for entry in data:
+        resolution = entry.end - entry.start
+        previous_time = current_time - resolution
+        next_time = current_time + resolution
         if entry.start <= current_time <= entry.end:
             current_price_entries = entry.entry
         if entry.start <= previous_time <= entry.end:

--- a/tests/components/nordpool/snapshots/test_sensor.ambr
+++ b/tests/components/nordpool/snapshots/test_sensor.ambr
@@ -414,7 +414,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '1.21814',
+    'state': '1.42403',
   })
 # ---
 # name: test_sensor[sensor.nord_pool_se3_off_peak_1_average-entry]
@@ -1255,7 +1255,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '3.82803',
+    'state': '2.30807',
   })
 # ---
 # name: test_sensor[sensor.nord_pool_se4_currency-entry]
@@ -1673,7 +1673,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '1.40502',
+    'state': '1.64617',
   })
 # ---
 # name: test_sensor[sensor.nord_pool_se4_off_peak_1_average-entry]
@@ -2514,6 +2514,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '4.44274',
+    'state': '2.67764',
   })
 # ---

--- a/tests/components/nordpool/test_sensor.py
+++ b/tests/components/nordpool/test_sensor.py
@@ -59,8 +59,8 @@ async def test_sensor_no_next_price(hass: HomeAssistant, load_int: ConfigEntry) 
     assert last_price is not None
     assert next_price is not None
     assert current_price.state == "0.78568"  # SE3 2025-10-01T21:45:00Z
-    assert last_price.state == "0.82171"  # SE3 2025-10-01T21:30:00Z
-    assert next_price.state == "0.81174"  # SE3 2025-10-01T22:00:00Z
+    assert last_price.state == "0.82005"  # SE3 2025-10-01T21:30:00Z
+    assert next_price.state == "0.93322"  # SE3 2025-10-01T22:00:00Z
 
 
 @pytest.mark.freeze_time("2025-10-02T00:00:00+02:00")
@@ -78,8 +78,8 @@ async def test_sensor_no_previous_price(
     assert last_price is not None
     assert next_price is not None
     assert current_price.state == "0.93322"  # SE3 2025-10-01T22:00:00Z
-    assert last_price.state == "0.8605"  # SE3 2025-10-01T21:45:00Z
-    assert next_price.state == "0.83513"  # SE3 2025-10-01T22:15:00Z
+    assert last_price.state == "0.78568"  # SE3 2025-10-01T21:45:00Z
+    assert next_price.state == "0.85422"  # SE3 2025-10-01T22:15:00Z
 
 
 @pytest.mark.freeze_time("2025-10-01T11:00:01+01:00")
@@ -102,8 +102,8 @@ async def test_sensor_empty_response(
     assert last_price is not None
     assert next_price is not None
     assert current_price.state == "0.67405"
-    assert last_price.state == "0.8616"
-    assert next_price.state == "0.63736"
+    assert last_price.state == "0.60774"
+    assert next_price.state == "0.63858"
 
     aioclient_mock.clear_requests()
     aioclient_mock.request(
@@ -154,8 +154,8 @@ async def test_sensor_empty_response(
     assert last_price is not None
     assert next_price is not None
     assert current_price.state == "0.63736"
-    assert last_price.state == "0.67405"
-    assert next_price.state == "0.62233"
+    assert last_price.state == "0.63482"
+    assert next_price.state == "0.66068"
 
     aioclient_mock.clear_requests()
     aioclient_mock.request(
@@ -207,5 +207,5 @@ async def test_sensor_empty_response(
     assert last_price is not None
     assert next_price is not None
     assert current_price.state == "0.78568"
-    assert last_price.state == "0.82171"
+    assert last_price.state == "0.82005"
     assert next_price.state == STATE_UNKNOWN

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -149,6 +149,7 @@ async def test_state_change(
     with freeze_time(patched_time):
         async_fire_time_changed(hass, patched_time)
         await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     assert caplog.text.count("sun phase_update") == 1
     # Called once by time listener, once from Sun.update_events

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -149,7 +149,6 @@ async def test_state_change(
     with freeze_time(patched_time):
         async_fire_time_changed(hass, patched_time)
         await hass.async_block_till_done()
-        await hass.async_block_till_done()
 
     assert caplog.text.count("sun phase_update") == 1
     # Called once by time listener, once from Sun.update_events


### PR DESCRIPTION
## Breaking change


## Proposed change
Fixes the Nord Pool sensor so it handles the correct resolution for the pricing, previously hard coded to 1 hour.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #154779
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 