### PR TITLE
_abort_if_unique_id_configured no automatic reload in deconz

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -184,7 +184,8 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
                             CONF_HOST: self.host,
                             CONF_PORT: self.port,
                             CONF_API_KEY: self.api_key,
-                        }
+                        },
+                        reload_on_update=False,
                     )
 
             except TimeoutError:
@@ -231,7 +232,8 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
             updates={
                 CONF_HOST: self.host,
                 CONF_PORT: self.port,
-            }
+            },
+            reload_on_update=False,
         )
 
         self.context.update(
@@ -265,7 +267,8 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
                 CONF_HOST: self.host,
                 CONF_PORT: self.port,
                 CONF_API_KEY: self.api_key,
-            }
+            },
+            reload_on_update=False,
         )
 
         self.context["configuration_url"] = HASSIO_CONFIGURATION_URL

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -483,7 +483,7 @@ async def test_ssdp_discovery_update_configuration(
     with patch(
         "homeassistant.components.deconz.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry:
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             data=SsdpServiceInfo(
@@ -502,7 +502,6 @@ async def test_ssdp_discovery_update_configuration(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry_setup.data[CONF_HOST] == "2.3.4.5"
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_ssdp_discovery_dont_update_configuration(
@@ -607,7 +606,7 @@ async def test_hassio_discovery_update_configuration(
     with patch(
         "homeassistant.components.deconz.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry:
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             data=HassioServiceInfo(
@@ -630,7 +629,6 @@ async def test_hassio_discovery_update_configuration(
     assert config_entry_setup.data[CONF_HOST] == "2.3.4.5"
     assert config_entry_setup.data[CONF_PORT] == 8080
     assert config_entry_setup.data[CONF_API_KEY] == "updated"
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 @pytest.mark.usefixtures("config_entry_setup")

--- a/tests/components/deconz/test_hub.py
+++ b/tests/components/deconz/test_hub.py
@@ -76,7 +76,7 @@ async def test_update_address(
         patch(
             "homeassistant.components.deconz.async_setup_entry",
             return_value=True,
-        ) as mock_setup_entry,
+        ),
         patch("pydeconz.gateway.WSClient") as ws_mock,
     ):
         await hass.config_entries.flow.async_init(
@@ -97,4 +97,3 @@ async def test_update_address(
 
     assert ws_mock.call_args[0][1] == "2.3.4.5"
     assert config_entry_setup.data["host"] == "2.3.4.5"
-    assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
## Breaking change


## Proposed change
`deconz` uses a config entry listener and should not reload the integration using `_abort_if_unique_id_configured()`

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 