### PR TITLE
Fix double reloading in esphome

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -31,7 +31,7 @@ from homeassistant.config_entries import (
     ConfigFlow,
     ConfigFlowResult,
     FlowType,
-    OptionsFlow,
+    OptionsFlowWithReload,
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import callback
@@ -397,7 +397,6 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 "name": conflict_entry.data.get(CONF_DEVICE_NAME, "unknown"),
                 "mac": format_mac(conflict_entry.unique_id),
             },
-            reload_on_update=False,
         )
 
     async def async_step_mqtt(
@@ -522,7 +521,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle creating a new entry by removing the old one and creating new."""
         assert self._entry_with_name_conflict is not None
         if self.source in (SOURCE_REAUTH, SOURCE_RECONFIGURE):
-            return self.async_update_and_abort(
+            return self.async_update_reload_and_abort(
                 self._entry_with_name_conflict,
                 title=self._name,
                 unique_id=self.unique_id,
@@ -919,7 +918,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         return OptionsFlowHandler()
 
 
-class OptionsFlowHandler(OptionsFlow):
+class OptionsFlowHandler(OptionsFlowWithReload):
     """Handle a option flow for esphome."""
 
     async def async_step_init(

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -397,6 +397,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 "name": conflict_entry.data.get(CONF_DEVICE_NAME, "unknown"),
                 "mac": format_mac(conflict_entry.unique_id),
             },
+            reload_on_update=False,
         )
 
     async def async_step_mqtt(
@@ -521,7 +522,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle creating a new entry by removing the old one and creating new."""
         assert self._entry_with_name_conflict is not None
         if self.source in (SOURCE_REAUTH, SOURCE_RECONFIGURE):
-            return self.async_update_reload_and_abort(
+            return self.async_update_and_abort(
                 self._entry_with_name_conflict,
                 title=self._name,
                 unique_id=self.unique_id,

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -442,12 +442,6 @@ class RuntimeEntryData:
             # save delay has passed.
             await self.store.async_save(self._pending_storage())
 
-    async def async_update_listener(
-        self, hass: HomeAssistant, entry: ESPHomeConfigEntry
-    ) -> None:
-        """Handle options update."""
-        hass.config_entries.async_schedule_reload(entry.entry_id)
-
     @callback
     def async_on_disconnect(self) -> None:
         """Call when the entry has been disconnected.

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -446,9 +446,7 @@ class RuntimeEntryData:
         self, hass: HomeAssistant, entry: ESPHomeConfigEntry
     ) -> None:
         """Handle options update."""
-        if self.original_options == entry.options:
-            return
-        hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+        hass.config_entries.async_schedule_reload(entry.entry_id)
 
     @callback
     def async_on_disconnect(self) -> None:

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -983,10 +983,6 @@ class ESPHomeManager:
 
         await reconnect_logic.start()
 
-        entry.async_on_unload(
-            entry.add_update_listener(entry_data.async_update_listener)
-        )
-
 
 @callback
 def _async_setup_device_registry(


### PR DESCRIPTION
## Breaking change


## Proposed change
Remove config entry listener in `esphome` to manage the reloading from the config flows

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 