### PR TITLE
Fix double reloading in unifi

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -176,7 +176,7 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
                 ):
                     return self.async_abort(reason="already_configured")
 
-                return self.async_update_reload_and_abort(
+                return self.async_update_and_abort(
                     config_entry, data=self.config, reason=abort_reason
                 )
 
@@ -230,7 +230,7 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({CONF_HOST: self.config[CONF_HOST]})
 
         await self.async_set_unique_id(mac_address)
-        self._abort_if_unique_id_configured(updates=self.config)
+        self._abort_if_unique_id_configured(updates=self.config, reload_on_update=False)
 
         self.context["title_placeholders"] = {
             CONF_HOST: self.config[CONF_HOST],

--- a/homeassistant/components/unifi/hub/hub.py
+++ b/homeassistant/components/unifi/hub/hub.py
@@ -7,6 +7,13 @@ from typing import TYPE_CHECKING
 
 import aiounifi
 
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import (
@@ -131,6 +138,19 @@ class UnifiHub:
         the entry might already have been reset and thus is not available.
         """
         hub = config_entry.runtime_data
+        check_keys = {
+            CONF_HOST: "host",
+            CONF_PORT: "port",
+            CONF_USERNAME: "username",
+            CONF_PASSWORD: "password",
+            CONF_SITE_ID: "site",
+            CONF_VERIFY_SSL: "ssl_context",
+        }
+        for key, value in check_keys.items():
+            if config_entry.data[key] != getattr(hub.config, value):
+                hass.config_entries.async_schedule_reload(config_entry.entry_id)
+                return
+
         hub.config = UnifiConfig.from_config_entry(config_entry)
         async_dispatcher_send(hass, hub.signal_options_update)
 

--- a/homeassistant/components/unifi/hub/hub.py
+++ b/homeassistant/components/unifi/hub/hub.py
@@ -147,6 +147,13 @@ class UnifiHub:
             CONF_VERIFY_SSL: "ssl_context",
         }
         for key, value in check_keys.items():
+            if key == CONF_VERIFY_SSL:
+                # ssl_context is either False or a SSLContext object, so we need to compare it differently
+                if config_entry.data[CONF_VERIFY_SSL] != bool(
+                    getattr(hub.config, value)
+                ):
+                    hass.config_entries.async_schedule_reload(config_entry.entry_id)
+                    return
             if config_entry.data[key] != getattr(hub.config, value):
                 hass.config_entries.async_schedule_reload(config_entry.entry_id)
                 return

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -460,14 +460,17 @@ async def test_simple_option_flow(
     assert result["step_id"] == "simple_options"
     assert result["last_step"]
 
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_TRACK_CLIENTS: False,
-            CONF_TRACK_DEVICES: False,
-            CONF_BLOCK_CLIENT: [CLIENTS[0]["mac"]],
-        },
-    )
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_schedule_reload"
+    ) as mock_reload:
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_TRACK_CLIENTS: False,
+                CONF_TRACK_DEVICES: False,
+                CONF_BLOCK_CLIENT: [CLIENTS[0]["mac"]],
+            },
+        )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
@@ -475,6 +478,8 @@ async def test_simple_option_flow(
         CONF_TRACK_DEVICES: False,
         CONF_BLOCK_CLIENT: [CLIENTS[0]["mac"]],
     }
+    # Check there is no reload on updating these options
+    assert mock_reload.call_count == 0
 
 
 async def test_form_ssdp(hass: HomeAssistant) -> None:

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -471,6 +471,7 @@ async def test_simple_option_flow(
                 CONF_BLOCK_CLIENT: [CLIENTS[0]["mac"]],
             },
         )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {


### PR DESCRIPTION
## Breaking change


## Proposed change
No reloading in methods from config flow, reloading managed by the config entry listener.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 