### PR TITLE
Add bronze quality scale for NINA

### DIFF
--- a/homeassistant/components/nina/manifest.json
+++ b/homeassistant/components/nina/manifest.json
@@ -6,6 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/nina",
   "iot_class": "cloud_polling",
   "loggers": ["pynina"],
+  "quality_scale": "bronze",
   "requirements": ["pynina==0.3.6"],
   "single_config_entry": true
 }

--- a/homeassistant/components/nina/quality_scale.yaml
+++ b/homeassistant/components/nina/quality_scale.yaml
@@ -7,17 +7,8 @@ rules:
   appropriate-polling: done
   brands: done
   common-modules: done
-  config-flow-test-coverage:
-    status: done
-    comment: |
-      Fix typo in DUMMY_RESPONSE_WARNIGNS
-      Never initialize the flow with data directly
-      Use fixture for mock_setup_entry
-      Use mock config entry in test_step_user_already_configured
-  config-flow:
-    status: done
-    comment: |
-      Fix typo in removed_entites_area
+  config-flow-test-coverage: done
+  config-flow: done
   dependency-transparency: done
   docs-actions:
     status: exempt

--- a/homeassistant/components/nina/quality_scale.yaml
+++ b/homeassistant/components/nina/quality_scale.yaml
@@ -27,3 +27,66 @@ rules:
   test-before-configure: done
   test-before-setup: done
   unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: |
+      This integration does not services that need authentication.
+  test-coverage: done
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery-update-info:
+    status: exempt
+    comment: |
+      This integration does use a cloud service.
+  discovery:
+    status: exempt
+    comment: |
+      This integration does use a cloud service.
+  docs-data-update: done
+  docs-examples: todo
+  docs-known-limitations: done
+  docs-supported-devices:
+    status: exempt
+    comment: |
+      This integration does not used devices.
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: done
+  entity-category: todo
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations:
+    status: exempt
+    comment: |
+      This integration does not custom icons.
+  reconfiguration-flow: todo
+  repair-issues:
+    status: exempt
+    comment: |
+      This integration does not use issues.
+  stale-devices:
+    status: exempt
+    comment: |
+      This integration does not used devices.
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/nina/quality_scale.yaml
+++ b/homeassistant/components/nina/quality_scale.yaml
@@ -1,0 +1,29 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: |
+      Entities of this integration does not explicitly subscribe to events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done

--- a/homeassistant/components/nina/quality_scale.yaml
+++ b/homeassistant/components/nina/quality_scale.yaml
@@ -7,8 +7,18 @@ rules:
   appropriate-polling: done
   brands: done
   common-modules: done
-  config-flow-test-coverage: done
-  config-flow: done
+  config-flow-test-coverage:
+    status: done
+    comment: |
+      Fix typo in DUMMY_RESPONSE_WARNIGNS
+      Flow tests should end in ABORT or CREATE_ENTRY
+      Never initialize the flow with data directly
+      Use fixture for mock_setup_entry
+      Use mock config entry in test_step_user_already_configured
+  config-flow:
+    status: done
+    comment: |
+      Fix typo in removed_entites_area
   dependency-transparency: done
   docs-actions:
     status: exempt
@@ -43,8 +53,17 @@ rules:
   reauthentication-flow:
     status: exempt
     comment: |
-      This integration does not services that need authentication.
-  test-coverage: done
+      This integration does not use services that need authentication.
+  test-coverage:
+    status: todo
+    comment: |
+      Use load_json_object_fixture in tests
+      Patch the library instead of the HTTP requests
+      Create a shared fixture for the mock config entry
+      Use snapshots for binary sensor tests
+      Use init_integration in tests
+      Evaluate the need of test_config_entry_not_ready
+
   # Gold
   devices: done
   diagnostics: done
@@ -62,7 +81,7 @@ rules:
   docs-supported-devices:
     status: exempt
     comment: |
-      This integration does not used devices.
+      This integration does not use devices.
   docs-supported-functions: todo
   docs-troubleshooting: todo
   docs-use-cases: todo
@@ -84,7 +103,7 @@ rules:
   stale-devices:
     status: exempt
     comment: |
-      This integration does not used devices.
+      This integration does not use devices.
 
   # Platinum
   async-dependency: todo

--- a/homeassistant/components/nina/quality_scale.yaml
+++ b/homeassistant/components/nina/quality_scale.yaml
@@ -11,7 +11,6 @@ rules:
     status: done
     comment: |
       Fix typo in DUMMY_RESPONSE_WARNIGNS
-      Flow tests should end in ABORT or CREATE_ENTRY
       Never initialize the flow with data directly
       Use fixture for mock_setup_entry
       Use mock config entry in test_step_user_already_configured
@@ -87,7 +86,10 @@ rules:
   docs-use-cases: todo
   dynamic-devices: done
   entity-category: todo
-  entity-device-class: done
+  entity-device-class:
+    status: todo
+    comment: |
+      Extract attributes into own entities.
   entity-disabled-by-default: done
   entity-translations: todo
   exception-translations: todo

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -691,7 +691,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "nice_go",
     "nightscout",
     "nilu",
-    "nina",
     "nissan_leaf",
     "nmap_tracker",
     "nmbs",

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1726,7 +1726,6 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "nightscout",
     "niko_home_control",
     "nilu",
-    "nina",
     "nissan_leaf",
     "nmap_tracker",
     "nmbs",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pr adds the bronze quality scale to nina.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Quality checklist:
### Bronze
- [x] `action-setup` - Service actions are registered in async_setup
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [x] `brands` - Has branding assets available for the integration
- [x] `common-modules` - Place common patterns in common modules
- [x] `config-flow-test-coverage` - Full test coverage for the config flow (https://github.com/home-assistant/core/pull/156664, https://github.com/home-assistant/core/pull/160435, https://github.com/home-assistant/core/pull/160323, https://github.com/home-assistant/core/pull/160324)
- [x] `config-flow` - Integration needs to be able to be set up via the UI (https://github.com/home-assistant/core/pull/160523)
    - [x] Uses `data_description` to give context to fields (https://github.com/home-assistant/core/pull/155192)
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `dependency-transparency` - Dependency transparency
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [x] `entity-event-setup` - Entity events are subscribed in the correct lifecycle methods
- [x] `entity-unique-id` - Entities have a unique ID
- [x] `has-entity-name` - Entities use has_entity_name = True
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
- [x] `test-before-configure` - Test a connection in the config flow
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
