### PR TITLE
Refactor Velux integration to use runtime_data

### DIFF
--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -11,16 +11,33 @@ from .const import DOMAIN, LOGGER, PLATFORMS
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the velux component."""
-    module = VeluxModule(hass, entry.data)
-    try:
-        module.setup()
-        await module.async_start()
+    host = entry.data[CONF_HOST]
+    password = entry.data[CONF_PASSWORD]
+    pyvlx = PyVLX(host=host, password=password)
 
+    try:
+        LOGGER.debug("Velux interface started")
+        await pyvlx.load_scenes()
+        await pyvlx.load_nodes()
     except PyVLXException as ex:
         LOGGER.exception("Can't connect to velux interface: %s", ex)
         return False
 
-    entry.runtime_data = module
+    entry.runtime_data = pyvlx
+
+    async def on_hass_stop(event):
+        """Close connection when hass stops."""
+        LOGGER.debug("Velux interface terminated")
+        await pyvlx.disconnect()
+
+    async def async_reboot_gateway(service_call: ServiceCall) -> None:
+        await pyvlx.reboot_gateway()
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
+    )
+
+    hass.services.async_register(DOMAIN, "reboot_gateway", async_reboot_gateway)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -32,40 +49,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-class VeluxModule:
-    """Abstraction for velux component."""
-
-    def __init__(self, hass, domain_config):
-        """Initialize for velux component."""
-        self.pyvlx = None
-        self._hass = hass
-        self._domain_config = domain_config
-
-    def setup(self):
-        """Velux component setup."""
-
-        async def on_hass_stop(event):
-            """Close connection when hass stops."""
-            LOGGER.debug("Velux interface terminated")
-            await self.pyvlx.disconnect()
-
-        async def async_reboot_gateway(service_call: ServiceCall) -> None:
-            await self.pyvlx.reboot_gateway()
-
-        self._hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
-        host = self._domain_config.get(CONF_HOST)
-        password = self._domain_config.get(CONF_PASSWORD)
-        self.pyvlx = PyVLX(host=host, password=password)
-
-        self._hass.services.async_register(
-            DOMAIN, "reboot_gateway", async_reboot_gateway
-        )
-
-    async def async_start(self):
-        """Start velux component."""
-        LOGGER.debug("Velux interface started")
-        await self.pyvlx.load_scenes()
-        await self.pyvlx.load_nodes()
-
-
-type VeluxConfigEntry = ConfigEntry[VeluxModule]
+type VeluxConfigEntry = ConfigEntry[PyVLX]

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -8,6 +8,8 @@ from homeassistant.core import HomeAssistant, ServiceCall
 
 from .const import DOMAIN, LOGGER, PLATFORMS
 
+type VeluxConfigEntry = ConfigEntry[PyVLX]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the velux component."""
@@ -15,8 +17,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     password = entry.data[CONF_PASSWORD]
     pyvlx = PyVLX(host=host, password=password)
 
+    LOGGER.debug("Velux interface started")
     try:
-        LOGGER.debug("Velux interface started")
         await pyvlx.load_scenes()
         await pyvlx.load_nodes()
     except PyVLXException as ex:
@@ -47,6 +49,3 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-
-type VeluxConfigEntry = ConfigEntry[PyVLX]

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -20,7 +20,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         LOGGER.exception("Can't connect to velux interface: %s", ex)
         return False
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = module
+    entry.runtime_data = module
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -66,3 +66,6 @@ class VeluxModule:
         LOGGER.debug("Velux interface started")
         await self.pyvlx.load_scenes()
         await self.pyvlx.load_nodes()
+
+
+type VeluxConfigEntry = ConfigEntry[VeluxModule]

--- a/homeassistant/components/velux/binary_sensor.py
+++ b/homeassistant/components/velux/binary_sensor.py
@@ -28,11 +28,11 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up rain sensor(s) for Velux platform."""
-    module = config.runtime_data
+    pyvlx = config.runtime_data
 
     async_add_entities(
         VeluxRainSensor(node, config.entry_id)
-        for node in module.pyvlx.nodes
+        for node in pyvlx.nodes
         if isinstance(node, Window) and node.rain_sensor
     )
 

--- a/homeassistant/components/velux/binary_sensor.py
+++ b/homeassistant/components/velux/binary_sensor.py
@@ -11,11 +11,11 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, LOGGER
+from . import VeluxConfigEntry
+from .const import LOGGER
 from .entity import VeluxEntity
 
 PARALLEL_UPDATES = 1
@@ -24,11 +24,11 @@ SCAN_INTERVAL = timedelta(minutes=5)  # Use standard polling
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigEntry,
+    config: VeluxConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up rain sensor(s) for Velux platform."""
-    module = hass.data[DOMAIN][config.entry_id]
+    module = config.runtime_data
 
     async_add_entities(
         VeluxRainSensor(node, config.entry_id)

--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -36,10 +36,10 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up cover(s) for Velux platform."""
-    module = config.runtime_data
+    pyvlx = config.runtime_data
     async_add_entities(
         VeluxCover(node, config.entry_id)
-        for node in module.pyvlx.nodes
+        for node in pyvlx.nodes
         if isinstance(node, OpeningDevice)
     )
 

--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -21,11 +21,10 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from . import VeluxConfigEntry
 from .entity import VeluxEntity
 
 PARALLEL_UPDATES = 1
@@ -33,11 +32,11 @@ PARALLEL_UPDATES = 1
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigEntry,
+    config: VeluxConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up cover(s) for Velux platform."""
-    module = hass.data[DOMAIN][config.entry_id]
+    module = config.runtime_data
     async_add_entities(
         VeluxCover(node, config.entry_id)
         for node in module.pyvlx.nodes

--- a/homeassistant/components/velux/light.py
+++ b/homeassistant/components/velux/light.py
@@ -7,11 +7,10 @@ from typing import Any
 from pyvlx import Intensity, LighteningDevice
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from . import VeluxConfigEntry
 from .entity import VeluxEntity
 
 PARALLEL_UPDATES = 1
@@ -19,11 +18,11 @@ PARALLEL_UPDATES = 1
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigEntry,
+    config: VeluxConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up light(s) for Velux platform."""
-    module = hass.data[DOMAIN][config.entry_id]
+    module = config.runtime_data
 
     async_add_entities(
         VeluxLight(node, config.entry_id)

--- a/homeassistant/components/velux/light.py
+++ b/homeassistant/components/velux/light.py
@@ -22,11 +22,10 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up light(s) for Velux platform."""
-    module = config.runtime_data
-
+    pyvlx = config.runtime_data
     async_add_entities(
         VeluxLight(node, config.entry_id)
-        for node in module.pyvlx.nodes
+        for node in pyvlx.nodes
         if isinstance(node, LighteningDevice)
     )
 

--- a/homeassistant/components/velux/scene.py
+++ b/homeassistant/components/velux/scene.py
@@ -5,22 +5,21 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.scene import Scene
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from . import VeluxConfigEntry
 
 PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigEntry,
+    config: VeluxConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the scenes for Velux platform."""
-    module = hass.data[DOMAIN][config.entry_id]
+    module = config.runtime_data
 
     entities = [VeluxScene(scene) for scene in module.pyvlx.scenes]
     async_add_entities(entities)

--- a/homeassistant/components/velux/scene.py
+++ b/homeassistant/components/velux/scene.py
@@ -19,9 +19,9 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the scenes for Velux platform."""
-    module = config.runtime_data
+    pyvlx = config.runtime_data
 
-    entities = [VeluxScene(scene) for scene in module.pyvlx.scenes]
+    entities = [VeluxScene(scene) for scene in pyvlx.scenes]
     async_add_entities(entities)
 
 

--- a/tests/components/velux/conftest.py
+++ b/tests/components/velux/conftest.py
@@ -79,28 +79,16 @@ def mock_window() -> AsyncMock:
 
 
 @pytest.fixture
-def mock_pyvlx(mock_window: MagicMock) -> MagicMock:
-    """Create the library mock."""
+def mock_pyvlx(mock_window: MagicMock) -> Generator[MagicMock]:
+    """Create the library mock and patch PyVLX."""
     pyvlx = MagicMock()
     pyvlx.nodes = [mock_window]
     pyvlx.load_scenes = AsyncMock()
     pyvlx.load_nodes = AsyncMock()
     pyvlx.disconnect = AsyncMock()
-    return pyvlx
 
-
-@pytest.fixture
-def mock_module(mock_pyvlx: MagicMock) -> Generator[AsyncMock]:
-    """Create the Velux module mock."""
-    with (
-        patch(
-            "homeassistant.components.velux.VeluxModule",
-            autospec=True,
-        ) as mock_velux,
-    ):
-        module = mock_velux.return_value
-        module.pyvlx = mock_pyvlx
-        yield module
+    with patch("homeassistant.components.velux.PyVLX", return_value=pyvlx):
+        yield pyvlx
 
 
 @pytest.fixture

--- a/tests/components/velux/test_binary_sensor.py
+++ b/tests/components/velux/test_binary_sensor.py
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-@pytest.mark.usefixtures("mock_module")
+@pytest.mark.usefixtures("mock_pyvlx")
 async def test_rain_sensor_state(
     hass: HomeAssistant,
     mock_window: MagicMock,
@@ -62,7 +62,7 @@ async def test_rain_sensor_state(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-@pytest.mark.usefixtures("mock_module")
+@pytest.mark.usefixtures("mock_pyvlx")
 async def test_rain_sensor_device_association(
     hass: HomeAssistant,
     mock_window: MagicMock,

--- a/tests/components/velux/test_cover.py
+++ b/tests/components/velux/test_cover.py
@@ -13,7 +13,7 @@ from . import update_callback_entity
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.usefixtures("mock_module")
+@pytest.mark.usefixtures("mock_pyvlx")
 async def test_cover_closed(
     hass: HomeAssistant,
     mock_window: AsyncMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR refactors the integration to use config.runtime_data instead of hass.data when storing and accessing runtime data. This is one of the requirements of the bronze tier on the quality scale, which I hope to introduce with https://github.com/home-assistant/core/pull/154615 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/154615
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
