### PR TITLE
Fix missing Ecovacs station actions

### DIFF
--- a/homeassistant/components/ecovacs/button.py
+++ b/homeassistant/components/ecovacs/button.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import EcovacsConfigEntry
-from .const import SUPPORTED_LIFESPANS
+from .const import SUPPORTED_LIFESPANS, SUPPORTED_STATION_ACTIONS
 from .entity import (
     EcovacsCapabilityEntityDescription,
     EcovacsDescriptionEntity,
@@ -62,7 +62,7 @@ STATION_ENTITY_DESCRIPTIONS = tuple(
         key=f"station_action_{action.name.lower()}",
         translation_key=f"station_action_{action.name.lower()}",
     )
-    for action in StationAction
+    for action in SUPPORTED_STATION_ACTIONS
 )
 
 

--- a/homeassistant/components/ecovacs/const.py
+++ b/homeassistant/components/ecovacs/const.py
@@ -23,7 +23,11 @@ SUPPORTED_LIFESPANS = (
     LifeSpan.STATION_FILTER,
 )
 
-SUPPORTED_STATION_ACTIONS = (StationAction.EMPTY_DUSTBIN,)
+SUPPORTED_STATION_ACTIONS = (
+    StationAction.EMPTY_DUSTBIN,
+    StationAction.DRY_MOP,
+    StationAction.CLEAN_BASE,
+)
 
 LEGACY_SUPPORTED_LIFESPANS = (
     "main_brush",

--- a/homeassistant/components/ecovacs/const.py
+++ b/homeassistant/components/ecovacs/const.py
@@ -24,9 +24,9 @@ SUPPORTED_LIFESPANS = (
 )
 
 SUPPORTED_STATION_ACTIONS = (
-    StationAction.EMPTY_DUSTBIN,
-    StationAction.DRY_MOP,
     StationAction.CLEAN_BASE,
+    StationAction.DRY_MOP,
+    StationAction.EMPTY_DUSTBIN,
 )
 
 LEGACY_SUPPORTED_LIFESPANS = (

--- a/homeassistant/components/ecovacs/icons.json
+++ b/homeassistant/components/ecovacs/icons.json
@@ -36,14 +36,14 @@
       "reset_lifespan_round_mop": {
         "default": "mdi:broom"
       },
-      "station_action_empty_dustbin": {
-        "default": "mdi:delete-restore"
+      "station_action_clean_base": {
+        "default": "mdi:home"
       },
       "station_action_dry_mop": {
         "default": "mdi:broom"
       },
-      "station_action_clean_base": {
-        "default": "mdi:home"
+      "station_action_empty_dustbin": {
+        "default": "mdi:delete-restore"
       }
     },
     "event": {

--- a/homeassistant/components/ecovacs/icons.json
+++ b/homeassistant/components/ecovacs/icons.json
@@ -38,6 +38,12 @@
       },
       "station_action_empty_dustbin": {
         "default": "mdi:delete-restore"
+      },
+      "station_action_dry_mop": {
+        "default": "mdi:broom"
+      },
+      "station_action_clean_base": {
+        "default": "mdi:home"
       }
     },
     "event": {

--- a/homeassistant/components/ecovacs/strings.json
+++ b/homeassistant/components/ecovacs/strings.json
@@ -72,6 +72,12 @@
       },
       "station_action_empty_dustbin": {
         "name": "Empty dustbin"
+      },
+      "station_action_dry_mop": {
+        "name": "Dry mop"
+      },
+      "station_action_clean_base": {
+        "name": "Clean base"
       }
     },
     "event": {

--- a/homeassistant/components/ecovacs/strings.json
+++ b/homeassistant/components/ecovacs/strings.json
@@ -70,14 +70,14 @@
       "reset_lifespan_side_brush": {
         "name": "Reset side brush lifespan"
       },
-      "station_action_empty_dustbin": {
-        "name": "Empty dustbin"
+      "station_action_clean_base": {
+        "name": "Clean base"
       },
       "station_action_dry_mop": {
         "name": "Dry mop"
       },
-      "station_action_clean_base": {
-        "name": "Clean base"
+      "station_action_empty_dustbin": {
+        "name": "Empty dustbin"
       }
     },
     "event": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix missing Ecovacs station actions and use again the supported constant to avoid missing translations in the future

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
