### PR TITLE
Add grace period configuration to Wake-On-LAN switch

### DIFF
--- a/homeassistant/components/wake_on_lan/const.py
+++ b/homeassistant/components/wake_on_lan/const.py
@@ -6,6 +6,8 @@ DOMAIN = "wake_on_lan"
 PLATFORMS = [Platform.BUTTON]
 
 CONF_OFF_ACTION = "turn_off"
+CONF_ON_GRACE_PERIOD = "on_grace_period"
+CONF_OFF_GRACE_PERIOD = "off_grace_period"
 
 DEFAULT_NAME = "Wake on LAN"
 DEFAULT_PING_TIMEOUT = 1

--- a/tests/components/wake_on_lan/conftest.py
+++ b/tests/components/wake_on_lan/conftest.py
@@ -26,9 +26,9 @@ def mock_send_magic_packet() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def subprocess_call_return_value() -> int | None:
+def subprocess_call_return_value(request: pytest.FixtureRequest) -> int | None:
     """Return value for subprocess."""
-    return 1
+    return getattr(request, "param", 1)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add optional parameters to control `on` and `off` grace periods to the state of Wake-On-LAN switch, as discussed in issue #86735: 
- `on_grace_period`: The amount of time (in seconds) the state is set to `on` after `turn_on` has been triggered. The state is set to `on` for this time, irrespective of the actual device status. The `on_grace_period` reflects the amount of time it takes the system to boot. If no grace period is set, the system might show as `off` while it is actually in the process of starting up. `on_grace_period` requires `host` to be configured.
- `off_grace_period`: The amount of time (in seconds) the state is set to `off` after `turn_off` has been triggered. The state is set to `off` for this time, irrespective of the actual device status. The `off_grace_period` reflects the amount of time it takes the system to shutdown. If no grace period is set, the system might show as `on` while it is actually in the process of shutting down. `off_grace_period` requires `host` and `turn_off` to be configured.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86735
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41487
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
