### PR TITLE
Add REST API endpoint for usage prediction

### DIFF
--- a/homeassistant/components/usage_prediction/__init__.py
+++ b/homeassistant/components/usage_prediction/__init__.py
@@ -98,6 +98,7 @@ class UsagePredictionCommonControlView(HomeAssistantView):
 
     url = "/api/usage_prediction/common_control"
     name = "api:usage_prediction:common_control"
+    requires_auth = True
 
     async def get(self, request: web.Request) -> web.Response:
         """Handle GET request for usage prediction common control."""

--- a/homeassistant/components/usage_prediction/__init__.py
+++ b/homeassistant/components/usage_prediction/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
-from http import HTTPStatus
 from typing import Any
 
 from aiohttp import web
@@ -111,6 +110,5 @@ class UsagePredictionCommonControlView(HomeAssistantView):
         return self.json(
             {
                 "entities": getattr(result, time_category),
-            },
-            status=HTTPStatus.OK,
+            }
         )

--- a/homeassistant/components/usage_prediction/__init__.py
+++ b/homeassistant/components/usage_prediction/__init__.py
@@ -105,7 +105,16 @@ class UsagePredictionCommonControlView(HomeAssistantView):
         hass: HomeAssistant = request.app[KEY_HASS]
         user = request[KEY_HASS_USER]
 
-        result = await get_cached_common_control(hass, user.id)
+        try:
+            result = await get_cached_common_control(hass, user.id)
+        except Exception as err:
+            return self.json(
+                {
+                    "error": "Could not fetch usage prediction common control.",
+                    "details": str(err),
+                },
+                status_code=500,
+            )
         time_category = common_control.time_category(dt_util.now().hour)
 
         return self.json(

--- a/homeassistant/components/usage_prediction/__init__.py
+++ b/homeassistant/components/usage_prediction/__init__.py
@@ -107,7 +107,7 @@ class UsagePredictionCommonControlView(HomeAssistantView):
 
         try:
             result = await get_cached_common_control(hass, user.id)
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001
             return self.json(
                 {
                     "error": "Could not fetch usage prediction common control.",

--- a/tests/components/usage_prediction/test_http_api.py
+++ b/tests/components/usage_prediction/test_http_api.py
@@ -3,11 +3,10 @@
 import asyncio
 from collections.abc import Generator
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import timedelta
 from http import HTTPStatus
 from unittest.mock import Mock, patch
 
-from freezegun import freeze_time
 import pytest
 
 from homeassistant.components.usage_prediction.models import EntityUsagePredictions

--- a/tests/components/usage_prediction/test_http_api.py
+++ b/tests/components/usage_prediction/test_http_api.py
@@ -162,29 +162,6 @@ async def test_different_time_categories(
 
 
 @pytest.mark.usefixtures("recorder_mock")
-async def test_unauthorized_access(
-    hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
-    hass_admin_user: MockUser,
-    mock_predict_common_control: Mock,
-) -> None:
-    """Test that unauthenticated requests are rejected."""
-    assert await async_setup_component(hass, "usage_prediction", {})
-
-    # Create a client without authentication
-    client = await hass_client()
-
-    # Remove authentication by making request without auth
-    # Note: hass_client already provides authenticated client,
-    # so this test verifies the endpoint requires authentication
-    with freeze_time(NOW):
-        resp = await client.get("/api/usage_prediction/common_control")
-
-    # Should succeed because hass_client provides authentication
-    assert resp.status == HTTPStatus.OK
-
-
-@pytest.mark.usefixtures("recorder_mock")
 async def test_concurrent_requests(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/usage_prediction/test_http_api.py
+++ b/tests/components/usage_prediction/test_http_api.py
@@ -117,51 +117,6 @@ async def test_caching_behavior(
 
 
 @pytest.mark.usefixtures("recorder_mock")
-async def test_different_time_categories(
-    hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
-    mock_predict_common_control: Mock,
-) -> None:
-    """Test that different time categories return different results."""
-    assert await async_setup_component(hass, "usage_prediction", {})
-
-    client = await hass_client()
-
-    # Test morning (6-11)
-    with freeze_time(datetime(2026, 8, 26, 10, 0, 0, tzinfo=dt_util.UTC)):
-        resp = await client.get("/api/usage_prediction/common_control")
-        data = await resp.json()
-        assert data == {"entities": ["light.kitchen"]}
-
-    # Clear cache for next test
-    hass.data["usage_prediction"] = {}
-
-    # Test afternoon (12-17)
-    with freeze_time(datetime(2026, 8, 26, 15, 0, 0, tzinfo=dt_util.UTC)):
-        resp = await client.get("/api/usage_prediction/common_control")
-        data = await resp.json()
-        assert data == {"entities": ["climate.thermostat"]}
-
-    # Clear cache for next test
-    hass.data["usage_prediction"] = {}
-
-    # Test evening (18-21)
-    with freeze_time(datetime(2026, 8, 26, 20, 0, 0, tzinfo=dt_util.UTC)):
-        resp = await client.get("/api/usage_prediction/common_control")
-        data = await resp.json()
-        assert data == {"entities": ["light.bedroom"]}
-
-    # Clear cache for next test
-    hass.data["usage_prediction"] = {}
-
-    # Test night (22-5)
-    with freeze_time(datetime(2026, 8, 26, 23, 0, 0, tzinfo=dt_util.UTC)):
-        resp = await client.get("/api/usage_prediction/common_control")
-        data = await resp.json()
-        assert data == {"entities": ["lock.front_door"]}
-
-
-@pytest.mark.usefixtures("recorder_mock")
 async def test_concurrent_requests(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/usage_prediction/test_http_api.py
+++ b/tests/components/usage_prediction/test_http_api.py
@@ -1,0 +1,213 @@
+"""Test usage_prediction HTTP API."""
+
+import asyncio
+from collections.abc import Generator
+from copy import deepcopy
+from datetime import datetime, timedelta
+from http import HTTPStatus
+from unittest.mock import Mock, patch
+
+from freezegun import freeze_time
+import pytest
+
+from homeassistant.components.usage_prediction.models import EntityUsagePredictions
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockUser
+from tests.typing import ClientSessionGenerator
+
+NOW = datetime(2026, 8, 26, 15, 0, 0, tzinfo=dt_util.UTC)
+
+
+@pytest.fixture
+def mock_predict_common_control() -> Generator[Mock]:
+    """Return a mock result for common control."""
+    with patch(
+        "homeassistant.components.usage_prediction.common_control.async_predict_common_control",
+        return_value=EntityUsagePredictions(
+            morning=["light.kitchen"],
+            afternoon=["climate.thermostat"],
+            evening=["light.bedroom"],
+            night=["lock.front_door"],
+        ),
+    ) as mock_predict:
+        yield mock_predict
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_common_control(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+    mock_predict_common_control: Mock,
+) -> None:
+    """Test usage_prediction common control HTTP API."""
+    assert await async_setup_component(hass, "usage_prediction", {})
+
+    client = await hass_client()
+
+    with freeze_time(NOW):
+        resp = await client.get("/api/usage_prediction/common_control")
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    assert data == {
+        "entities": [
+            "light.kitchen",
+        ]
+    }
+    assert mock_predict_common_control.call_count == 1
+    assert mock_predict_common_control.mock_calls[0][1][1] == hass_admin_user.id
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_caching_behavior(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_predict_common_control: Mock,
+) -> None:
+    """Test that results are cached for 24 hours."""
+    assert await async_setup_component(hass, "usage_prediction", {})
+
+    client = await hass_client()
+
+    # First call should fetch from database
+    with freeze_time(NOW):
+        resp = await client.get("/api/usage_prediction/common_control")
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+    assert data == {
+        "entities": [
+            "light.kitchen",
+        ]
+    }
+    assert mock_predict_common_control.call_count == 1
+
+    new_result = deepcopy(mock_predict_common_control.return_value)
+    new_result.morning.append("light.bla")
+    mock_predict_common_control.return_value = new_result
+
+    # Second call within 24 hours should use cache
+    with freeze_time(NOW + timedelta(hours=23)):
+        resp = await client.get("/api/usage_prediction/common_control")
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+    assert data == {
+        "entities": [
+            "light.kitchen",
+        ]
+    }
+    # Should still be 1 (no new database call)
+    assert mock_predict_common_control.call_count == 1
+
+    # Third call after 24 hours should fetch from database again
+    with freeze_time(NOW + timedelta(hours=25)):
+        resp = await client.get("/api/usage_prediction/common_control")
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+    assert data == {"entities": ["light.kitchen", "light.bla"]}
+    # Should now be 2 (new database call)
+    assert mock_predict_common_control.call_count == 2
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_different_time_categories(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_predict_common_control: Mock,
+) -> None:
+    """Test that different time categories return different results."""
+    assert await async_setup_component(hass, "usage_prediction", {})
+
+    client = await hass_client()
+
+    # Test morning (6-11)
+    with freeze_time(datetime(2026, 8, 26, 10, 0, 0, tzinfo=dt_util.UTC)):
+        resp = await client.get("/api/usage_prediction/common_control")
+        data = await resp.json()
+        assert data == {"entities": ["light.kitchen"]}
+
+    # Clear cache for next test
+    hass.data["usage_prediction"] = {}
+
+    # Test afternoon (12-17)
+    with freeze_time(datetime(2026, 8, 26, 15, 0, 0, tzinfo=dt_util.UTC)):
+        resp = await client.get("/api/usage_prediction/common_control")
+        data = await resp.json()
+        assert data == {"entities": ["climate.thermostat"]}
+
+    # Clear cache for next test
+    hass.data["usage_prediction"] = {}
+
+    # Test evening (18-21)
+    with freeze_time(datetime(2026, 8, 26, 20, 0, 0, tzinfo=dt_util.UTC)):
+        resp = await client.get("/api/usage_prediction/common_control")
+        data = await resp.json()
+        assert data == {"entities": ["light.bedroom"]}
+
+    # Clear cache for next test
+    hass.data["usage_prediction"] = {}
+
+    # Test night (22-5)
+    with freeze_time(datetime(2026, 8, 26, 23, 0, 0, tzinfo=dt_util.UTC)):
+        resp = await client.get("/api/usage_prediction/common_control")
+        data = await resp.json()
+        assert data == {"entities": ["lock.front_door"]}
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_unauthorized_access(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+    mock_predict_common_control: Mock,
+) -> None:
+    """Test that unauthenticated requests are rejected."""
+    assert await async_setup_component(hass, "usage_prediction", {})
+
+    # Create a client without authentication
+    client = await hass_client()
+
+    # Remove authentication by making request without auth
+    # Note: hass_client already provides authenticated client,
+    # so this test verifies the endpoint requires authentication
+    with freeze_time(NOW):
+        resp = await client.get("/api/usage_prediction/common_control")
+
+    # Should succeed because hass_client provides authentication
+    assert resp.status == HTTPStatus.OK
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_concurrent_requests(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_predict_common_control: Mock,
+) -> None:
+    """Test that concurrent requests don't cause multiple database calls."""
+    assert await async_setup_component(hass, "usage_prediction", {})
+
+    client = await hass_client()
+
+    # Make multiple concurrent requests
+    with freeze_time(NOW):
+        responses = await asyncio.gather(
+            client.get("/api/usage_prediction/common_control"),
+            client.get("/api/usage_prediction/common_control"),
+            client.get("/api/usage_prediction/common_control"),
+        )
+
+    # All requests should succeed
+    for resp in responses:
+        assert resp.status == HTTPStatus.OK
+        data = await resp.json()
+        assert data == {"entities": ["light.kitchen"]}
+
+    # Should only call the prediction function once due to task caching
+    assert mock_predict_common_control.call_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a REST endpoint (`GET /api/usage_prediction/common_control`) for fetching commonly used entities in addition to the existing WebSocket API.

**Motivation:** I am currently thinking of re-making the Home Assistant app for Pebble, and thought it would be neat if the app could surface relevant entities so that a user wouldn't have to go through menus (especially important for smartwatch apps). I saw the announcement of Usage Prediction, but saw that it only exposes a WebSocket API, so I decided to add a regular REST endpoint too.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
