### PR TITLE
Bump Pooldose API to 0.7.8

### DIFF
--- a/homeassistant/components/pooldose/icons.json
+++ b/homeassistant/components/pooldose/icons.json
@@ -4,13 +4,19 @@
       "orp": {
         "default": "mdi:water-check"
       },
+      "cl": {
+        "default": "mdi:pool"
+      },
+      "flow_rate": {
+        "default": "mdi:pipe-valve"
+      },
       "ph_type_dosing": {
         "default": "mdi:flask"
       },
       "peristaltic_ph_dosing": {
         "default": "mdi:pump"
       },
-      "ofa_ph_value": {
+      "ofa_ph_time": {
         "default": "mdi:clock"
       },
       "orp_type_dosing": {
@@ -19,7 +25,13 @@
       "peristaltic_orp_dosing": {
         "default": "mdi:pump"
       },
-      "ofa_orp_value": {
+      "cl_type_dosing": {
+        "default": "mdi:flask"
+      },
+      "peristaltic_cl_dosing": {
+        "default": "mdi:pump"
+      },
+      "ofa_orp_time": {
         "default": "mdi:clock"
       },
       "ph_calibration_type": {

--- a/homeassistant/components/pooldose/manifest.json
+++ b/homeassistant/components/pooldose/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/pooldose",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["python-pooldose==0.7.0"]
+  "requirements": ["python-pooldose==0.7.7"]
 }

--- a/homeassistant/components/pooldose/manifest.json
+++ b/homeassistant/components/pooldose/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/pooldose",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["python-pooldose==0.7.7"]
+  "requirements": ["python-pooldose==0.7.8"]
 }

--- a/homeassistant/components/pooldose/sensor.py
+++ b/homeassistant/components/pooldose/sensor.py
@@ -10,7 +10,12 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import EntityCategory, UnitOfElectricPotential, UnitOfTime
+from homeassistant.const import (
+    CONCENTRATION_PARTS_PER_MILLION,
+    EntityCategory,
+    UnitOfElectricPotential,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -33,6 +38,17 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
     ),
     SensorEntityDescription(
+        key="cl",
+        translation_key="cl",
+        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+    ),
+    SensorEntityDescription(
+        key="flow_rate",
+        translation_key="flow_rate",
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        # Unit dynamically determined via API
+    ),
+    SensorEntityDescription(
         key="ph_type_dosing",
         translation_key="ph_type_dosing",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -48,8 +64,8 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         options=["proportional", "on_off", "timed"],
     ),
     SensorEntityDescription(
-        key="ofa_ph_value",
-        translation_key="ofa_ph_value",
+        key="ofa_ph_time",
+        translation_key="ofa_ph_time",
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.DURATION,
         entity_registry_enabled_default=False,
@@ -72,8 +88,24 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         options=["off", "proportional", "on_off", "timed"],
     ),
     SensorEntityDescription(
-        key="ofa_orp_value",
-        translation_key="ofa_orp_value",
+        key="cl_type_dosing",
+        translation_key="cl_type_dosing",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        device_class=SensorDeviceClass.ENUM,
+        options=["low", "high"],
+    ),
+    SensorEntityDescription(
+        key="peristaltic_cl_dosing",
+        translation_key="peristaltic_cl_dosing",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        device_class=SensorDeviceClass.ENUM,
+        options=["off", "proportional", "on_off", "timed"],
+    ),
+    SensorEntityDescription(
+        key="ofa_orp_time",
+        translation_key="ofa_orp_time",
         device_class=SensorDeviceClass.DURATION,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -179,5 +211,11 @@ class PooldoseSensor(PooldoseEntity, SensorEntity):
             and (data := self.get_data()) is not None
         ):
             return data["unit"]  # °C or °F
+
+        if (
+            self.entity_description.key == "flow_rate"
+            and (data := self.get_data()) is not None
+        ):
+            return data.get("unit")  # m³/s or L/s
 
         return super().native_unit_of_measurement

--- a/homeassistant/components/pooldose/sensor.py
+++ b/homeassistant/components/pooldose/sensor.py
@@ -216,6 +216,6 @@ class PooldoseSensor(PooldoseEntity, SensorEntity):
             self.entity_description.key == "flow_rate"
             and (data := self.get_data()) is not None
         ):
-            return data.get("unit")  # m³/s or L/s
+            return data.get("unit")  # m3/h or L/s
 
         return super().native_unit_of_measurement

--- a/homeassistant/components/pooldose/strings.json
+++ b/homeassistant/components/pooldose/strings.json
@@ -37,6 +37,12 @@
       "orp": {
         "name": "ORP"
       },
+      "cl": {
+        "name": "Chlorine"
+      },
+      "flow_rate": {
+        "name": "Flow rate"
+      },
       "ph_type_dosing": {
         "name": "pH dosing type",
         "state": {
@@ -53,7 +59,7 @@
           "timed": "Timed"
         }
       },
-      "ofa_ph_value": {
+      "ofa_ph_time": {
         "name": "pH overfeed alert time"
       },
       "orp_type_dosing": {
@@ -72,7 +78,23 @@
           "timed": "[%key:component::pooldose::entity::sensor::peristaltic_ph_dosing::state::timed%]"
         }
       },
-      "ofa_orp_value": {
+      "cl_type_dosing": {
+        "name": "Chlorine dosing type",
+        "state": {
+          "low": "[%key:common::state::low%]",
+          "high": "[%key:common::state::high%]"
+        }
+      },
+      "peristaltic_cl_dosing": {
+        "name": "Chlorine peristaltic dosing",
+        "state": {
+          "off": "[%key:common::state::off%]",
+          "proportional": "[%key:component::pooldose::entity::sensor::peristaltic_ph_dosing::state::proportional%]",
+          "on_off": "[%key:component::pooldose::entity::sensor::peristaltic_ph_dosing::state::on_off%]",
+          "timed": "[%key:component::pooldose::entity::sensor::peristaltic_ph_dosing::state::timed%]"
+        }
+      },
+      "ofa_orp_time": {
         "name": "ORP overfeed alert time"
       },
       "ph_calibration_type": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2556,7 +2556,7 @@ python-overseerr==0.7.1
 python-picnic-api2==1.3.1
 
 # homeassistant.components.pooldose
-python-pooldose==0.7.7
+python-pooldose==0.7.8
 
 # homeassistant.components.rabbitair
 python-rabbitair==0.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2556,7 +2556,7 @@ python-overseerr==0.7.1
 python-picnic-api2==1.3.1
 
 # homeassistant.components.pooldose
-python-pooldose==0.7.0
+python-pooldose==0.7.7
 
 # homeassistant.components.rabbitair
 python-rabbitair==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2129,7 +2129,7 @@ python-overseerr==0.7.1
 python-picnic-api2==1.3.1
 
 # homeassistant.components.pooldose
-python-pooldose==0.7.0
+python-pooldose==0.7.7
 
 # homeassistant.components.rabbitair
 python-rabbitair==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2129,7 +2129,7 @@ python-overseerr==0.7.1
 python-picnic-api2==1.3.1
 
 # homeassistant.components.pooldose
-python-pooldose==0.7.7
+python-pooldose==0.7.8
 
 # homeassistant.components.rabbitair
 python-rabbitair==0.0.8

--- a/tests/components/pooldose/fixtures/instantvalues.json
+++ b/tests/components/pooldose/fixtures/instantvalues.json
@@ -12,6 +12,14 @@
       "value": 718,
       "unit": "mV"
     },
+    "cl": {
+      "value": 1.2,
+      "unit": "ppm"
+    },
+    "flow_rate": {
+      "value": 150,
+      "unit": "L/s"
+    },
     "ph_type_dosing": {
       "value": "alcalyne",
       "unit": null
@@ -20,7 +28,7 @@
       "value": "proportional",
       "unit": null
     },
-    "ofa_ph_value": {
+    "ofa_ph_time": {
       "value": 0,
       "unit": "min"
     },
@@ -32,7 +40,7 @@
       "value": "proportional",
       "unit": null
     },
-    "ofa_orp_value": {
+    "ofa_orp_time": {
       "value": 0,
       "unit": "min"
     },
@@ -62,25 +70,25 @@
     }
   },
   "binary_sensor": {
-    "pump_running": {
+    "pump_alarm": {
       "value": true
     },
-    "ph_level_ok": {
+    "ph_level_alarm": {
       "value": false
     },
-    "orp_level_ok": {
+    "orp_level_alarm": {
       "value": false
     },
-    "flow_rate_ok": {
+    "flow_rate_alarm": {
       "value": false
     },
     "alarm_relay": {
       "value": true
     },
-    "relay_aux1_ph": {
+    "relay_aux1": {
       "value": false
     },
-    "relay_aux2_orpcl": {
+    "relay_aux2": {
       "value": false
     }
   },
@@ -108,10 +116,10 @@
     }
   },
   "switch": {
-    "stop_pool_dosing": {
+    "pause_dosing": {
       "value": false
     },
-    "pump_detection": {
+    "pump_monitoring": {
       "value": true
     },
     "frequency_input": {

--- a/tests/components/pooldose/snapshots/test_sensor.ambr
+++ b/tests/components/pooldose/snapshots/test_sensor.ambr
@@ -1,4 +1,261 @@
 # serializer version: 1
+# name: test_all_sensors[sensor.pool_device_chlorine-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pool_device_chlorine',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Chlorine',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'cl',
+    'unique_id': 'TEST123456789_cl',
+    'unit_of_measurement': 'ppm',
+  })
+# ---
+# name: test_all_sensors[sensor.pool_device_chlorine-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pool Device Chlorine',
+      'unit_of_measurement': 'ppm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pool_device_chlorine',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.2',
+  })
+# ---
+# name: test_all_sensors[sensor.pool_device_duration-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.pool_device_duration',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Duration',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ofa_ph_time',
+    'unique_id': 'TEST123456789_ofa_ph_time',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_sensors[sensor.pool_device_duration-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Pool Device Duration',
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pool_device_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_all_sensors[sensor.pool_device_duration_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.pool_device_duration_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Duration',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ofa_orp_time',
+    'unique_id': 'TEST123456789_ofa_orp_time',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_sensors[sensor.pool_device_duration_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Pool Device Duration',
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pool_device_duration_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_all_sensors[sensor.pool_device_flow_rate-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pool_device_flow_rate',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLUME_FLOW_RATE: 'volume_flow_rate'>,
+    'original_icon': None,
+    'original_name': 'Flow rate',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'flow_rate',
+    'unique_id': 'TEST123456789_flow_rate',
+    'unit_of_measurement': 'L/s',
+  })
+# ---
+# name: test_all_sensors[sensor.pool_device_flow_rate-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'volume_flow_rate',
+      'friendly_name': 'Pool Device Flow rate',
+      'unit_of_measurement': 'L/s',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pool_device_flow_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '150',
+  })
+# ---
+# name: test_all_sensors[sensor.pool_device_none-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pool_device_none',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'cl',
+    'unique_id': 'TEST123456789_cl',
+    'unit_of_measurement': 'ppm',
+  })
+# ---
+# name: test_all_sensors[sensor.pool_device_none-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pool Device None',
+      'unit_of_measurement': 'ppm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pool_device_none',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.2',
+  })
+# ---
 # name: test_all_sensors[sensor.pool_device_orp-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -309,8 +566,8 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'ofa_orp_value',
-    'unique_id': 'TEST123456789_ofa_orp_value',
+    'translation_key': 'ofa_orp_time',
+    'unique_id': 'TEST123456789_ofa_orp_time',
     'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
   })
 # ---
@@ -699,8 +956,8 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'ofa_ph_value',
-    'unique_id': 'TEST123456789_ofa_ph_value',
+    'translation_key': 'ofa_ph_time',
+    'unique_id': 'TEST123456789_ofa_ph_time',
     'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
   })
 # ---
@@ -830,5 +1087,58 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
+  })
+# ---
+# name: test_all_sensors[sensor.pool_device_volume_flow_rate-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pool_device_volume_flow_rate',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLUME_FLOW_RATE: 'volume_flow_rate'>,
+    'original_icon': None,
+    'original_name': 'Volume flow rate',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'flow_rate',
+    'unique_id': 'TEST123456789_flow_rate',
+    'unit_of_measurement': 'L/s',
+  })
+# ---
+# name: test_all_sensors[sensor.pool_device_volume_flow_rate-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'volume_flow_rate',
+      'friendly_name': 'Pool Device Volume flow rate',
+      'unit_of_measurement': 'L/s',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pool_device_volume_flow_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '150',
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
bump to python-pooldose 0.7.8, added additional sensor desc with strings/icons and updated fixture/testcases

### API-Changes **Version: 0.7.0 - 0.7.8**
#### New Features
- CLI Debug Flag: `--print-payload` for HTTP payload debugging
- Payload Inspection: Added `debug_payload` parameter and `get_last_payload()` method
- Client Convenience Methods: Direct `set_switch`, `set_number`, `set_select` methods

#### Improvements
- Fixed strict datatypes for all API calls (latest 0.7.8 change)
- Array-Based Payloads: Consistent format for all operations: `[{"value": 7, "type": "NUMBER"}]`
- New Device Support: VA DOS EXACT (Model PDPR1H1HAR1V1, FW FW539224) --- **RELEVANT for HA integration**
- Bug Fix: Removed unsupported Chlorine Sensor from PDPR1H1HAR1V0 --- **RELEVANT for HA integration**

Full changelog: https://github.com/lmaertin/python-pooldose/compare/0.7.0...0.7.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
