### PR TITLE
Update Switcher actions exceptions

### DIFF
--- a/homeassistant/components/switcher_kis/button.py
+++ b/homeassistant/components/switcher_kis/button.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, cast
 
-from aioswitcher.api import SwitcherApi
-from aioswitcher.api.messages import SwitcherBaseResponse
 from aioswitcher.api.remotes import SwitcherBreezeRemote
 from aioswitcher.device import DeviceCategory, DeviceState, ThermostatSwing
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -26,15 +23,14 @@ from .utils import get_breeze_remote_manager
 
 PARALLEL_UPDATES = 1
 
+API_CONTROL_BREEZE_DEVICE = "control_breeze_device"
+
 
 @dataclass(frozen=True, kw_only=True)
 class SwitcherThermostatButtonEntityDescription(ButtonEntityDescription):
     """Class to describe a Switcher Thermostat Button entity."""
 
-    press_fn: Callable[
-        [SwitcherApi, SwitcherBreezeRemote],
-        Coroutine[Any, Any, SwitcherBaseResponse],
-    ]
+    press_args: dict[str, Any]
     supported: Callable[[SwitcherBreezeRemote], bool]
 
 
@@ -43,34 +39,26 @@ THERMOSTAT_BUTTONS = [
         key="assume_on",
         translation_key="assume_on",
         entity_category=EntityCategory.CONFIG,
-        press_fn=lambda api, remote: api.control_breeze_device(
-            remote, state=DeviceState.ON, update_state=True
-        ),
+        press_args={"state": DeviceState.ON, "update_state": True},
         supported=lambda _: True,
     ),
     SwitcherThermostatButtonEntityDescription(
         key="assume_off",
         translation_key="assume_off",
         entity_category=EntityCategory.CONFIG,
-        press_fn=lambda api, remote: api.control_breeze_device(
-            remote, state=DeviceState.OFF, update_state=True
-        ),
+        press_args={"state": DeviceState.OFF, "update_state": True},
         supported=lambda _: True,
     ),
     SwitcherThermostatButtonEntityDescription(
         key="vertical_swing_on",
         translation_key="vertical_swing_on",
-        press_fn=lambda api, remote: api.control_breeze_device(
-            remote, swing=ThermostatSwing.ON
-        ),
+        press_args={"swing": ThermostatSwing.ON},
         supported=lambda remote: bool(remote.separated_swing_command),
     ),
     SwitcherThermostatButtonEntityDescription(
         key="vertical_swing_off",
         translation_key="vertical_swing_off",
-        press_fn=lambda api, remote: api.control_breeze_device(
-            remote, swing=ThermostatSwing.OFF
-        ),
+        press_args={"swing": ThermostatSwing.OFF},
         supported=lambda remote: bool(remote.separated_swing_command),
     ),
 ]
@@ -121,23 +109,8 @@ class SwitcherThermostatButtonEntity(SwitcherEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Press the button."""
-        response: SwitcherBaseResponse | None = None
-        error = None
-
-        try:
-            async with SwitcherApi(
-                self.coordinator.data.device_type,
-                self.coordinator.data.ip_address,
-                self.coordinator.data.device_id,
-                self.coordinator.data.device_key,
-            ) as swapi:
-                response = await self.entity_description.press_fn(swapi, self._remote)
-        except (TimeoutError, OSError, RuntimeError) as err:
-            error = repr(err)
-
-        if error or not response or not response.successful:
-            self.coordinator.last_update_success = False
-            self.async_write_ha_state()
-            raise HomeAssistantError(
-                f"Call api for {self.name} failed, response/error: {response or error}"
-            )
+        await self._async_call_api(
+            API_CONTROL_BREEZE_DEVICE,
+            self._remote,
+            **self.entity_description.press_args,
+        )

--- a/homeassistant/components/switcher_kis/button.py
+++ b/homeassistant/components/switcher_kis/button.py
@@ -16,14 +16,12 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import SwitcherConfigEntry
-from .const import SIGNAL_DEVICE_ADD
+from .const import API_CONTROL_BREEZE_DEVICE, SIGNAL_DEVICE_ADD
 from .coordinator import SwitcherDataUpdateCoordinator
 from .entity import SwitcherEntity
 from .utils import get_breeze_remote_manager
 
 PARALLEL_UPDATES = 1
-
-API_CONTROL_BREEZE_DEVICE = "control_breeze_device"
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/switcher_kis/climate.py
+++ b/homeassistant/components/switcher_kis/climate.py
@@ -32,14 +32,12 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import SwitcherConfigEntry
-from .const import SIGNAL_DEVICE_ADD
+from .const import API_CONTROL_BREEZE_DEVICE, SIGNAL_DEVICE_ADD
 from .coordinator import SwitcherDataUpdateCoordinator
 from .entity import SwitcherEntity
 from .utils import get_breeze_remote_manager
 
 PARALLEL_UPDATES = 1
-
-API_CONTROL_BREEZE_DEVICE = "control_breeze_device"
 
 DEVICE_MODE_TO_HA = {
     ThermostatMode.COOL: HVACMode.COOL,

--- a/homeassistant/components/switcher_kis/climate.py
+++ b/homeassistant/components/switcher_kis/climate.py
@@ -160,7 +160,7 @@ class SwitcherClimateEntity(SwitcherEntity, ClimateEntity):
         data = cast(SwitcherThermostat, self.coordinator.data)
         if not self._remote.modes_features[data.mode]["temperature_control"]:
             raise ServiceValidationError(
-                "Current mode doesn't support setting Target Temperature"
+                "Current mode does not support setting 'Target temperature'."
             )
 
         await self._async_control_breeze_device(

--- a/homeassistant/components/switcher_kis/const.py
+++ b/homeassistant/components/switcher_kis/const.py
@@ -2,6 +2,8 @@
 
 DOMAIN = "switcher_kis"
 
+API_CONTROL_BREEZE_DEVICE = "control_breeze_device"
+
 DISCOVERY_TIME_SEC = 12
 
 SIGNAL_DEVICE_ADD = "switcher_device_add"

--- a/homeassistant/components/switcher_kis/quality_scale.yaml
+++ b/homeassistant/components/switcher_kis/quality_scale.yaml
@@ -28,7 +28,7 @@ rules:
     comment: The integration only supports a single config entry.
 
   # Silver
-  action-exceptions: todo
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Update the `button` platform to use common method from base entity to control the device so all actions are using the same method.
- Remove stale exceptions that are handled by the base `climate` entity
- Use `ServiceValidationError` instead of `HomeAssistantError` when setting temperature in modes that does not allow it. This is to align with [action-exceptions](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/action-exceptions) for when to raise each error.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
