### PR TITLE
Fix translation references to unverified translations

### DIFF
--- a/script/translations/develop.py
+++ b/script/translations/develop.py
@@ -3,12 +3,11 @@
 import argparse
 import json
 from pathlib import Path
-import re
 import sys
 
 from . import download, upload
 from .const import INTEGRATIONS_DIR
-from .util import flatten_translations, get_base_arg_parser
+from .util import flatten_translations, get_base_arg_parser, substitute_references
 
 
 def valid_integration(integration):
@@ -31,42 +30,6 @@ def get_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def substitute_translation_references(integration_strings, flattened_translations):
-    """Recursively processes all translation strings for the integration."""
-    result = {}
-    for key, value in integration_strings.items():
-        if isinstance(value, dict):
-            sub_dict = substitute_translation_references(value, flattened_translations)
-            result[key] = sub_dict
-        elif isinstance(value, str):
-            result[key] = substitute_reference(value, flattened_translations)
-
-    return result
-
-
-def substitute_reference(value, flattened_translations):
-    """Substitute localization key references in a translation string."""
-    matches = re.findall(r"\[\%key:([a-z0-9_]+(?:::(?:[a-z0-9-_])+)+)\%\]", value)
-    if not matches:
-        return value
-
-    new = value
-    for key in matches:
-        if key in flattened_translations:
-            new = new.replace(
-                f"[%key:{key}%]",
-                # New value can also be a substitution reference
-                substitute_reference(
-                    flattened_translations[key], flattened_translations
-                ),
-            )
-        else:
-            print(f"Invalid substitution key '{key}' found in string '{value}'")
-            sys.exit(1)
-
-    return new
-
-
 def run_single(translations, flattened_translations, integration):
     """Run the script for a single integration."""
     print(f"Generating translations for {integration}")
@@ -77,8 +40,8 @@ def run_single(translations, flattened_translations, integration):
 
     integration_strings = translations["component"][integration]
 
-    translations["component"][integration] = substitute_translation_references(
-        integration_strings, flattened_translations
+    translations["component"][integration] = substitute_references(
+        integration_strings, flattened_translations, fail_on_missing=True
     )
 
     if download.DOWNLOAD_DIR.is_dir():

--- a/script/translations/download.py
+++ b/script/translations/download.py
@@ -10,12 +10,17 @@ from typing import Any
 
 from .const import CLI_2_DOCKER_IMAGE, CORE_PROJECT_ID, INTEGRATIONS_DIR
 from .error import ExitApp
-from .util import get_lokalise_token, load_json_from_path
+from .util import (
+    flatten_translations,
+    get_lokalise_token,
+    load_json_from_path,
+    substitute_references,
+)
 
 DOWNLOAD_DIR = Path("build/translations-download").absolute()
 
 
-def run_download_docker():
+def run_download_docker() -> None:
     """Run the Docker image to download the translations."""
     print("Running Docker to download latest translations.")
     result = subprocess.run(
@@ -39,6 +44,7 @@ def run_download_docker():
             "--replace-breaks=false",
             "--filter-data",
             "nonfuzzy",
+            "--disable-references",
             "--export-empty-as",
             "skip",
             "--format",
@@ -76,9 +82,12 @@ def filter_translations(translations: dict[str, Any], strings: dict[str, Any]) -
                 continue
 
 
-def save_language_translations(lang, translations):
+def save_language_translations(lang: str, translations: dict[str, Any]) -> None:
     """Save translations for a single language."""
     components = translations.get("component", {})
+
+    flattened_all_translations = flatten_translations(translations)
+
     for component, component_translations in components.items():
         # Remove legacy platform translations
         component_translations.pop("platform", None)
@@ -104,12 +113,16 @@ def save_language_translations(lang, translations):
         path = component_path / "translations" / f"{lang}.json"
         path.parent.mkdir(parents=True, exist_ok=True)
 
+        component_translations = substitute_references(
+            component_translations, flattened_all_translations, fail_on_missing=False
+        )
+
         filter_translations(component_translations, strings)
 
         save_json(path, component_translations)
 
 
-def save_integrations_translations():
+def save_integrations_translations() -> None:
     """Save integrations translations."""
     for lang_file in DOWNLOAD_DIR.glob("*.json"):
         lang = lang_file.stem
@@ -117,13 +130,13 @@ def save_integrations_translations():
         save_language_translations(lang, translations)
 
 
-def delete_old_translations():
+def delete_old_translations() -> None:
     """Delete old translations."""
     for fil in INTEGRATIONS_DIR.glob("*/translations/*"):
         fil.unlink()
 
 
-def run():
+def run() -> None:
     """Run the script."""
     DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/script/translations/download.py
+++ b/script/translations/download.py
@@ -86,7 +86,7 @@ def save_language_translations(lang: str, translations: dict[str, Any]) -> None:
     """Save translations for a single language."""
     components = translations.get("component", {})
 
-    flattened_all_translations = flatten_translations(translations)
+    flattened_translations = flatten_translations(translations)
 
     for component, component_translations in components.items():
         # Remove legacy platform translations
@@ -114,7 +114,7 @@ def save_language_translations(lang: str, translations: dict[str, Any]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
 
         component_translations = substitute_references(
-            component_translations, flattened_all_translations, fail_on_missing=False
+            component_translations, flattened_translations, fail_on_missing=False
         )
 
         filter_translations(component_translations, strings)

--- a/script/translations/error.py
+++ b/script/translations/error.py
@@ -12,6 +12,15 @@ class ExitApp(Exception):
         self.exit_code = exit_code
 
 
+class MissingReference(Exception):
+    """Exception to indicate a missing reference in translations."""
+
+    def __init__(self, reference_key: str):
+        """Initialize the missing reference exception."""
+        self.reference_key = reference_key
+        super().__init__(f"Missing reference key: {reference_key}")
+
+
 class JSONDecodeErrorWithPath(json.JSONDecodeError):
     """Subclass of JSONDecodeError with additional properties.
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix translation references to unverified translations.

When a given translation key is unverified, we do not include it in translations since #114968.

Unfortunately if another key is verified, it is always included, even if it refers to an unverified key.

This PR fixes that problem, by first downloading all translations without automatic reference substitution and then doing it ourselves, properly filtering out all unverified translations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
