### PR TITLE
Use satellite area in fuzzy matcher

### DIFF
--- a/homeassistant/components/assist_satellite/manifest.json
+++ b/homeassistant/components/assist_satellite/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/assist_satellite",
   "integration_type": "entity",
   "quality_scale": "internal",
-  "requirements": ["hassil==3.3.0"]
+  "requirements": ["hassil==3.4.0"]
 }

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -1249,15 +1249,14 @@ class DefaultAgent(ConversationEntity):
             intent_slot_list_names=self._fuzzy_config.slot_list_names,
             slot_combinations={
                 intent_name: {
-                    combo_key: [
-                        SlotCombinationInfo(
-                            name_domains=(
-                                set(combo_info.name_domains)
-                                if combo_info.name_domains
-                                else None
-                            )
-                        )
-                    ]
+                    combo_key: SlotCombinationInfo(
+                        context_area=combo_info.context_area,
+                        name_domains=(
+                            set(combo_info.name_domains)
+                            if combo_info.name_domains
+                            else None
+                        ),
+                    )
                     for combo_key, combo_info in intent_combos.items()
                 }
                 for intent_name, intent_combos in self._fuzzy_config.slot_combinations.items()

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -768,7 +768,16 @@ class DefaultAgent(ConversationEntity):
         if lang_intents.fuzzy_matcher is None:
             return None
 
-        fuzzy_result = lang_intents.fuzzy_matcher.match(user_input.text)
+        context_area: str | None = None
+        satellite_area, _ = self._get_satellite_area_and_device(
+            user_input.satellite_id, user_input.device_id
+        )
+        if satellite_area:
+            context_area = satellite_area.name
+
+        fuzzy_result = lang_intents.fuzzy_matcher.match(
+            user_input.text, context_area=context_area
+        )
         if fuzzy_result is None:
             return None
 

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "integration_type": "entity",
   "quality_scale": "internal",
-  "requirements": ["hassil==3.3.0", "home-assistant-intents==2025.10.28"]
+  "requirements": ["hassil==3.4.0", "home-assistant-intents==2025.10.28"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -37,7 +37,7 @@ go2rtc-client==0.2.1
 ha-ffmpeg==3.2.2
 habluetooth==5.7.0
 hass-nabucasa==1.4.0
-hassil==3.3.0
+hassil==3.4.0
 home-assistant-bluetooth==1.13.1
 home-assistant-frontend==20251001.4
 home-assistant-intents==2025.10.28

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1167,7 +1167,7 @@ hass-splunk==0.1.1
 
 # homeassistant.components.assist_satellite
 # homeassistant.components.conversation
-hassil==3.3.0
+hassil==3.4.0
 
 # homeassistant.components.jewish_calendar
 hdate[astral]==1.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1025,7 +1025,7 @@ hass-nabucasa==1.4.0
 
 # homeassistant.components.assist_satellite
 # homeassistant.components.conversation
-hassil==3.3.0
+hassil==3.4.0
 
 # homeassistant.components.jewish_calendar
 hdate[astral]==1.1.2

--- a/script/hassfest/docker/Dockerfile
+++ b/script/hassfest/docker/Dockerfile
@@ -31,7 +31,7 @@ RUN --mount=from=ghcr.io/astral-sh/uv:0.9.5,source=/uv,target=/bin/uv \
         PyTurboJPEG==1.8.0 \
         go2rtc-client==0.2.1 \
         ha-ffmpeg==3.2.2 \
-        hassil==3.3.0 \
+        hassil==3.4.0 \
         home-assistant-intents==2025.10.28 \
         mutagen==1.47.0 \
         pymicro-vad==1.0.1 \

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -3343,6 +3343,11 @@ async def test_language_with_alternative_code(
             "HassLightSet",
             {"name": "office light", "brightness": "50%"},
         ),
+        (
+            "turn on the lights in the spaceship",
+            "HassTurnOn",
+            {"domain": "lights", "area": "office"},  # context area
+        ),
     ],
 )
 async def test_fuzzy_matching(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use the area of the voice satellite in fuzzy matcher, so sentences like "turn on the lights in X" (where X is an unknown/misspelled area) do not turn off lights in the whole house.
Instead, any fuzzy match that targets an entire domain (lights, fans, etc.) is automatically redirected to the area of the voice satellite only.

Requires a bump to hassil 3.4.0: https://github.com/OHF-Voice/hassil/compare/v3.3.0...v3.4.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/155024
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
