### PR TITLE
check async_forward_entry_setups needs to be awaited

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1389,18 +1389,6 @@ class FlowCancelledError(Exception):
     """Error to indicate that a flow has been cancelled."""
 
 
-def _report_non_awaited_platform_forwards(entry: ConfigEntry, what: str) -> None:
-    """Report non awaited platform forwards."""
-    report_usage(
-        f"calls {what} for integration {entry.domain} with "
-        f"title: {entry.title} and entry_id: {entry.entry_id}, "
-        f"during setup without awaiting {what}, which can cause "
-        "the setup lock to be released before the setup is done",
-        core_behavior=ReportBehavior.LOG,
-        breaks_in_ha_version="2025.1",
-    )
-
-
 class ConfigEntriesFlowManager(
     data_entry_flow.FlowManager[ConfigFlowContext, ConfigFlowResult]
 ):
@@ -2680,10 +2668,6 @@ class ConfigEntries:
         in each integration. This is to ensure that all platforms are loaded
         before the entry is set up. This ensures that the config entry cannot
         be unloaded before all platforms are loaded.
-
-        This method is more efficient than async_forward_entry_setup as
-        it can load multiple platforms at once and does not require a separate
-        import executor job for each platform.
         """
         integration = await loader.async_get_integration(self.hass, entry.domain)
         if not integration.platforms_are_loaded(platforms):
@@ -2705,8 +2689,11 @@ class ConfigEntries:
             # If the lock was held when we stated, and it was released during
             # the platform setup, it means they did not await the setup call.
             if not entry.setup_lock.locked():
-                _report_non_awaited_platform_forwards(
-                    entry, "async_forward_entry_setups"
+                raise HomeAssistantError(
+                    f"Detected code that calls async_forward_entry_setups for integration "
+                    f"{entry.domain} with title: {entry.title} and entry_id: {entry.entry_id}, "
+                    f"during setup without awaiting async_forward_entry_setups, which can cause "
+                    "the setup lock to be released before the setup is done",
                 )
 
     async def _async_forward_entry_setups_locked(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -8044,15 +8044,15 @@ async def test_non_awaited_async_forward_entry_setups(
     await hass.async_block_till_done()
     forward_event.set()
     await hass.async_block_till_done()
-    await task
 
-    assert (
+    message = (
         "Detected code that calls async_forward_entry_setups for integration "
         "test with title: Mock Title and entry_id: test2, during setup without "
         "awaiting async_forward_entry_setups, which can cause the setup lock "
-        "to be released before the setup is done. This will stop working in "
-        "Home Assistant 2025.1, please report this issue"
-    ) in caplog.text
+        "to be released before the setup is done"
+    )
+    with pytest.raises(HomeAssistantError, match=message):
+        await task
 
 
 async def test_config_entry_unloaded_during_platform_setup(


### PR DESCRIPTION
## Breaking change
Using `async_forward_entry_setups` without awaiting it was previously deprecated and is now failing.

## Proposed change
See breaking

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 