### PR TITLE
Bump ZHA to 0.0.75

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["zha==0.0.73"],
+  "requirements": ["zha==0.0.75"],
   "usb": [
     {
       "description": "*2652*",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -179,6 +179,7 @@
       "left": "Left",
       "open": "[%key:common::action::open%]",
       "right": "Right",
+      "rotary_knob": "Rotary knob",
       "turn_off": "[%key:common::action::turn_off%]",
       "turn_on": "[%key:common::action::turn_on%]"
     },
@@ -206,7 +207,10 @@
       "remote_button_quintuple_press": "\"{subtype}\" quintuple clicked",
       "remote_button_short_press": "\"{subtype}\" pressed",
       "remote_button_short_release": "\"{subtype}\" released",
-      "remote_button_triple_press": "\"{subtype}\" triple clicked"
+      "remote_button_triple_press": "\"{subtype}\" triple clicked",
+      "rotary_knob_continued_rotating": "Rotary knob continued rotating \"{subtype}\"",
+      "rotary_knob_started_rotating": "Rotary knob started rotating \"{subtype}\"",
+      "rotary_knob_stopped_rotating": "\"{subtype}\" stopped rotating"
     }
   },
   "entity": {

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -305,6 +305,9 @@
       "calibrate_valve": {
         "name": "Calibrate valve"
       },
+      "calibrate_z_axis": {
+        "name": "Calibrate Z axis"
+      },
       "feed": {
         "name": "Feed"
       },
@@ -322,6 +325,12 @@
       },
       "reset_summation_delivered": {
         "name": "Reset summation delivered"
+      },
+      "reset_summation_delivered_left": {
+        "name": "Reset left summation delivered"
+      },
+      "reset_summation_delivered_right": {
+        "name": "Reset right summation delivered"
       },
       "restart_device": {
         "name": "Restart device"
@@ -463,6 +472,9 @@
       },
       "comfort_temperature_min": {
         "name": "Comfort temperature min"
+      },
+      "compensation_speed": {
+        "name": "Compensation speed"
       },
       "deadzone_temperature": {
         "name": "Deadzone temperature"
@@ -623,6 +635,9 @@
       "lift_drive_up_time": {
         "name": "Lift drive up time"
       },
+      "limit_position": {
+        "name": "Limit position"
+      },
       "liquid_depth_max": {
         "name": "Height from sensor to liquid level"
       },
@@ -719,6 +734,9 @@
       "on_transition_time": {
         "name": "On transition time"
       },
+      "open_delay_time": {
+        "name": "Open delay time"
+      },
       "open_window_detection_guard_period": {
         "name": "Open window detection guard period"
       },
@@ -745,6 +763,9 @@
       },
       "presence_timeout": {
         "name": "Fade time"
+      },
+      "pulse_configuration": {
+        "name": "Pulse configuration"
       },
       "quantitative_watering": {
         "name": "Quantitative watering"
@@ -853,6 +874,24 @@
       },
       "transmit_power": {
         "name": "Transmit power"
+      },
+      "turn_off_delay": {
+        "name": "Turn off delay"
+      },
+      "turn_off_delay_left": {
+        "name": "Turn off delay left"
+      },
+      "turn_off_delay_right": {
+        "name": "Turn off delay right"
+      },
+      "turn_on_delay": {
+        "name": "Turn on delay"
+      },
+      "turn_on_delay_left": {
+        "name": "Turn on delay left"
+      },
+      "turn_on_delay_right": {
+        "name": "Turn on delay right"
       },
       "up_movement": {
         "name": "Up movement"
@@ -1590,6 +1629,9 @@
       },
       "double_up_full": {
         "name": "Double tap on - full"
+      },
+      "enable_pir_mode": {
+        "name": "Enable PIR remote"
       },
       "enable_siren": {
         "name": "Enable siren"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3262,7 +3262,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.73
+zha==0.0.75
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2709,7 +2709,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.73
+zha==0.0.75
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.67.1

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -170,11 +170,6 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
         # pyhive-integration > unasync > setuptools
         "unasync": {"setuptools"}
     },
-    "homeassistant_hardware": {
-        # https://github.com/zigpy/zigpy/issues/1604
-        # universal-silabs-flasher > zigpy > pyserial-asyncio
-        "zigpy": {"pyserial-asyncio"},
-    },
     "homewizard": {"python-homewizard-energy": {"async-timeout"}},
     "imeon_inverter": {"imeon-inverter-api": {"async-timeout"}},
     "influxdb": {
@@ -267,9 +262,6 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
         # https://github.com/waveform80/colorzero/issues/9
         # zha > zigpy-zigate > gpiozero > colorzero > setuptools
         "colorzero": {"setuptools"},
-        # https://github.com/zigpy/zigpy/issues/1604
-        # zha > zigpy > pyserial-asyncio
-        "zigpy": {"pyserial-asyncio"},
     },
 }
 

--- a/tests/components/zha/snapshots/test_diagnostics.ambr
+++ b/tests/components/zha/snapshots/test_diagnostics.ambr
@@ -41,6 +41,8 @@
         'nwk_manager_id': 0,
         'nwk_update_id': 0,
         'pan_id': 4660,
+        'route_table': dict({
+        }),
         'security_level': 0,
         'source': None,
         'stack_specific': dict({
@@ -69,6 +71,7 @@
           'seq': 0,
           'tx_counter': 0,
         }),
+        'tx_power': None,
       }),
       'node_info': dict({
         'ieee': '**REDACTED**',
@@ -276,6 +279,7 @@
             'state_class': None,
             'supported_features': 15,
             'translation_key': 'alarm_control_panel',
+            'translation_placeholders': None,
             'unique_id': '**REDACTED**',
           }),
           'state': dict({
@@ -321,6 +325,7 @@
             'primary': True,
             'state_class': None,
             'translation_key': 'ias_zone',
+            'translation_placeholders': None,
             'unique_id': '**REDACTED**',
           }),
           'state': dict({


### PR DESCRIPTION
## Proposed change

This bumps ZHA to [0.0.75](https://github.com/zigpy/zha/releases/tag/0.0.75) (full diff: https://github.com/zigpy/zha/compare/0.0.73...0.0.75).
These dependency upgrades are bundled with it: 

- `zha-quirks` [0.0.147](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.147)
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.146...0.0.147

- `zigpy` [0.86.0](https://github.com/zigpy/zigpy/releases/tag/0.86.0), including [0.85.0](https://github.com/zigpy/zigpy/releases/tag/0.85.0) changes, including [0.84.0](https://github.com/zigpy/zigpy/releases/tag/0.84.0) changes
full diff: https://github.com/zigpy/zigpy/compare/0.83.0...0.86.0

- `bellows` [0.47.0](https://github.com/zigpy/bellows/releases/tag/0.47.0), including [0.46.2](https://github.com/zigpy/bellows/releases/tag/0.46.2) changes
full diff: https://github.com/zigpy/bellows/compare/0.46.1...0.47.0

- `zigpy-deconz` [0.25.3](https://github.com/zigpy/zigpy-deconz/releases/tag/0.25.3)
full diff: https://github.com/zigpy/zigpy-deconz/compare/0.25.2...0.25.3

This zha-quirks release also adds a few entities via the quirks v2 API. The entity names are added to `strings.json`.

`homeassistant_hardware` and `zha/zigpy` were also dropped from hassfest's `FORBIDDEN_PACKAGE_EXCEPTIONS`, as zigpy removed the requirement for `pyserial-asyncio` (`pyserial-asyncio-fast` was used when available before).


### ZHA release text

To highlight a few of the main changes across all libraries:
- an issue where devices can get stuck during joining is fixed when the identify option is on (thanks @abmantis)
- an issue where IAS sensors do not get the correct zone type after joining is fixed
- an issue where attributes used for quirks v2 entities aren't read during joining is fixed
- an issue where new networks on deCONZ coordinators with old firmware couldn't be created is fixed
- support for translation placeholders is prepared (thanks @epenet)
  (https://github.com/home-assistant/core/pull/155254 should be merged after this)
- the network backup format was expanded to include TX power info and the route table
- Python 3.9 and 3.10 support was dropped by zigpy and its radio libraries
- zigpy dropped the `pyserial-asyncio` requirement (`pyserial-asyncio-fast` was already used before)
- for quirks (device support):
  - newer IKEA plugs now add support for disabling the buttons and turning off the LED
  - a bunch of Third Reality devices support new configuration options
  - support for Candeo devices was massively improved
  - Frient electricity meter LED now allows for configuring pulses per kWh
  - Frient electricity meter Norwegian HAN now no longer shows invalid values due to a changing divisor
  - a bunch of new Tuya device variants are supported as well


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
