### PR TITLE
Use a config entry migration instead of migrating in async_setup in Ping

### DIFF
--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -23,6 +23,28 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER, Platform.SENSOR]
 DATA_PRIVILEGED_KEY: HassKey[bool | None] = HassKey(DOMAIN)
 
 
+async def async_migrate_entry(hass: HomeAssistant, entry: PingConfigEntry) -> bool:
+    """Migrate old config entries."""
+    if entry.minor_version == 1:
+        _LOGGER.debug("Migrating to minor version 2")
+
+        # Migrate device registry identifiers from homeassistant domain to ping domain
+        registry = dr.async_get(hass)
+        if (
+            device := registry.async_get_device(
+                identifiers={(HOMEASSISTANT_DOMAIN, entry.entry_id)}
+            )
+        ) is not None and entry.entry_id in device.config_entries:
+            registry.async_update_device(
+                device_id=device.id,
+                new_identifiers={(DOMAIN, entry.entry_id)},
+            )
+
+        hass.config_entries.async_update_entry(entry, minor_version=2)
+
+    return True
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the ping integration."""
     hass.data[DATA_PRIVILEGED_KEY] = await _can_use_icmp_lib_with_privilege()
@@ -32,19 +54,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: PingConfigEntry) -> bool:
     """Set up Ping (ICMP) from a config entry."""
-
-    # Migrate device registry identifiers from homeassistant domain to ping domain
-    registry = dr.async_get(hass)
-    if (
-        device := registry.async_get_device(
-            identifiers={(HOMEASSISTANT_DOMAIN, entry.entry_id)}
-        )
-    ) is not None and entry.entry_id in device.config_entries:
-        registry.async_update_device(
-            device_id=device.id,
-            new_identifiers={(DOMAIN, entry.entry_id)},
-        )
-
     privileged = hass.data[DATA_PRIVILEGED_KEY]
 
     host: str = entry.options[CONF_HOST]

--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -25,7 +25,7 @@ DATA_PRIVILEGED_KEY: HassKey[bool | None] = HassKey(DOMAIN)
 
 async def async_migrate_entry(hass: HomeAssistant, entry: PingConfigEntry) -> bool:
     """Migrate old config entries."""
-    if entry.minor_version == 1:
+    if entry.version == 1 and entry.minor_version == 1:
         _LOGGER.debug("Migrating to minor version 2")
 
         # Migrate device registry identifiers from homeassistant domain to ping domain

--- a/homeassistant/components/ping/config_flow.py
+++ b/homeassistant/components/ping/config_flow.py
@@ -37,6 +37,7 @@ class PingConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ping."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/tests/components/ping/test_init.py
+++ b/tests/components/ping/test_init.py
@@ -33,6 +33,8 @@ async def test_device_migration(
         identifiers={(HOMEASSISTANT_DOMAIN, config_entry.entry_id)},
     )
 
+    assert config_entry.minor_version == 1
+
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -44,3 +46,4 @@ async def test_device_migration(
     assert device is not None
     assert device.id == old_device.id
     assert device.config_entries == {config_entry.entry_id}
+    assert config_entry.minor_version == 2


### PR DESCRIPTION
## Proposed change
Use a config entry migration instead of migrating in async_setup in Ping as requested in https://github.com/home-assistant/core/pull/155343

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
