### PR TITLE
Add initial IQS to sfr_box

### DIFF
--- a/homeassistant/components/sfr_box/manifest.json
+++ b/homeassistant/components/sfr_box/manifest.json
@@ -6,6 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/sfr_box",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "quality_scale": "bronze",
   "requirements": ["sfrbox-api==0.1.0"]
 }

--- a/homeassistant/components/sfr_box/manifest.json
+++ b/homeassistant/components/sfr_box/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/sfr_box",
   "integration_type": "device",
   "iot_class": "local_polling",
+  "quality_scale": "bronze",
   "requirements": ["sfrbox-api==0.1.0"]
 }

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -1,9 +1,20 @@
 rules:
+  # Special note, doesn't fall in any of the categories below
+  # Why can the coordinator state be None? As in, I understand that it can be None if it doesn't support it, but wouldn't these coordinators not be created at all?
+
   ## Bronze
-  config-flow: done
+  config-flow:
+    status: todo
+    comment: |
+      SFRBoxFlowHandler has a classvar _config. This can be dangerous
+      self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]}) can be tested at the first if statement
   test-before-configure: done
   unique-config-entry: done
-  config-flow-test-coverage: done
+  config-flow-test-coverage:
+    status: todo
+    comment: |
+      - test_config_flow_skip_auth -> I'd split the happy from the not happy flows
+      - We should test created mac address
   runtime-data: done
   test-before-setup: done
   appropriate-polling: done
@@ -34,7 +45,13 @@ rules:
   parallel-updates: done
   test-coverage:
     status: todo
-    comment: 93% on diagnostics / 92% on sensors, need to improve overall coverage
+    comment: |
+      - 93% on diagnostics / 92% on sensors, need to improve overall coverage
+      - you can use load_json_object_fixture
+      - It would be nice to use the snapshot helper as currently it would just throw everything in a list
+      - We also test the devices in each platform, kinda overkill
+      - assert not hass.data.get(DOMAIN) not needed
+      - We should use entity_registry_enabled_by_default instead to enable entities
   integration-owner: done
   docs-installation-parameters:
     status: todo
@@ -45,8 +62,15 @@ rules:
 
   ## Gold
   entity-translations: done
-  entity-device-class: done
-  devices: done
+  entity-device-class:
+    status: todo
+    comment: |
+      What does DSL counter count?
+      What is the state of CRC?
+      line_status and training and net_infra and mode -> unknown shouldn't be an option and the entity should return None instead
+  devices:
+    status: todo
+    comment: MAC address can be set to the connections
   entity-category: done
   entity-disabled-by-default: done
   discovery:

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -31,9 +31,7 @@ rules:
   entity-unavailable: done
   action-exceptions: done
   reauthentication-flow: done
-  parallel-updates:
-    status: todo
-    comment: Updates are managed by the coordinator, actions need it
+  parallel-updates: done
   test-coverage:
     status: todo
     comment: 93% on diagnostics / 92% on sensors, need to improve overall coverage

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -14,7 +14,9 @@ rules:
   action-setup:
     status: exempt
     comment: There are no service actions
-  common-modules: done
+  common-modules:
+    status: todo
+    comment: https://github.com/home-assistant/core/pull/155418
   docs-high-level-description:
     status: todo
     comment: Under review

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -1,8 +1,6 @@
 rules:
   ## Bronze
-  config-flow:
-    status: todo
-    comment: https://github.com/home-assistant/core/pull/155420
+  config-flow: done
   test-before-configure: done
   unique-config-entry: done
   config-flow-test-coverage: done
@@ -19,15 +17,9 @@ rules:
     status: exempt
     comment: There are no service actions
   common-modules: done
-  docs-high-level-description:
-    status: todo
-    comment: Under review
-  docs-installation-instructions:
-    status: todo
-    comment: Under review
-  docs-removal-instructions:
-    status: todo
-    comment: Under review
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
   docs-actions:
     status: exempt
     comment: There are no service actions

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -11,7 +11,9 @@ rules:
   appropriate-polling: done
   entity-unique-id: done
   has-entity-name: done
-  entity-event-setup: done
+  entity-event-setup:
+    status: exempt
+    comment: local_polling without events
   dependency-transparency: done
   action-setup:
     status: exempt

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -46,48 +46,28 @@ rules:
     comment: Under review
 
   ## Gold
-  entity-translations:
-    status: todo
-    comment: Under review
-  entity-device-class:
-    status: todo
-    comment: Under review
-  devices:
-    status: todo
-    comment: Under review
-  entity-category:
-    status: todo
-    comment: Under review
-  entity-disabled-by-default:
-    status: todo
-    comment: Under review
+  entity-translations: done
+  entity-device-class: done
+  devices: done
+  entity-category: done
+  entity-disabled-by-default: done
   discovery:
     status: todo
-    comment: Under review
-  stale-devices:
-    status: todo
-    comment: Under review
-  diagnostics:
-    status: todo
-    comment: Under review
+    comment: Should be possible
+  stale-devices: done
+  diagnostics: done
   exception-translations:
     status: todo
-    comment: Under review
-  icon-translations:
-    status: todo
-    comment: Under review
+    comment: not yet done
+  icon-translations: done
   reconfiguration-flow:
     status: todo
-    comment: Under review
-  dynamic-devices:
-    status: todo
-    comment: Under review
+    comment: Need to be able to manually change the IP address
+  dynamic-devices: done
   discovery-update-info:
     status: todo
-    comment: Under review
-  repair-issues:
-    status: todo
-    comment: Under review
+    comment: Discovery is not yet implemented
+  repair-issues: done
   docs-use-cases:
     status: todo
     comment: Under review

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -18,9 +18,7 @@ rules:
   action-setup:
     status: exempt
     comment: There are no service actions
-  common-modules:
-    status: todo
-    comment: https://github.com/home-assistant/core/pull/155418
+  common-modules: done
   docs-high-level-description:
     status: todo
     comment: Under review

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -1,0 +1,138 @@
+rules:
+  ## Bronze
+  config-flow: done
+  test-before-configure: done
+  unique-config-entry: done
+  config-flow-test-coverage: done
+  runtime-data: done
+  test-before-setup: done
+  appropriate-polling: done
+  entity-unique-id: done
+  has-entity-name: done
+  entity-event-setup: done
+  dependency-transparency: done
+  action-setup:
+    status: exempt
+    comment: There are no service actions
+  common-modules: done
+  docs-high-level-description:
+    status: todo
+    comment: Under review
+  docs-installation-instructions:
+    status: todo
+    comment: Under review
+  docs-removal-instructions:
+    status: todo
+    comment: Under review
+  docs-actions:
+    status: todo
+    comment: Under review
+  brands: done
+
+  ## Silver
+  config-entry-unloading:
+    status: todo
+    comment: Under review
+  log-when-unavailable:
+    status: todo
+    comment: Under review
+  entity-unavailable:
+    status: todo
+    comment: Under review
+  action-exceptions:
+    status: todo
+    comment: Under review
+  reauthentication-flow:
+    status: todo
+    comment: Under review
+  parallel-updates:
+    status: todo
+    comment: Under review
+  test-coverage:
+    status: todo
+    comment: Under review
+  integration-owner:
+    status: todo
+    comment: Under review
+  docs-installation-parameters:
+    status: todo
+    comment: Under review
+  docs-configuration-parameters:
+    status: todo
+    comment: Under review
+
+  ## Gold
+  entity-translations:
+    status: todo
+    comment: Under review
+  entity-device-class:
+    status: todo
+    comment: Under review
+  devices:
+    status: todo
+    comment: Under review
+  entity-category:
+    status: todo
+    comment: Under review
+  entity-disabled-by-default:
+    status: todo
+    comment: Under review
+  discovery:
+    status: todo
+    comment: Under review
+  stale-devices:
+    status: todo
+    comment: Under review
+  diagnostics:
+    status: todo
+    comment: Under review
+  exception-translations:
+    status: todo
+    comment: Under review
+  icon-translations:
+    status: todo
+    comment: Under review
+  reconfiguration-flow:
+    status: todo
+    comment: Under review
+  dynamic-devices:
+    status: todo
+    comment: Under review
+  discovery-update-info:
+    status: todo
+    comment: Under review
+  repair-issues:
+    status: todo
+    comment: Under review
+  docs-use-cases:
+    status: todo
+    comment: Under review
+  docs-supported-devices:
+    status: todo
+    comment: Under review
+  docs-supported-functions:
+    status: todo
+    comment: Under review
+  docs-data-update:
+    status: todo
+    comment: Under review
+  docs-known-limitations:
+    status: todo
+    comment: Under review
+  docs-troubleshooting:
+    status: todo
+    comment: Under review
+  docs-examples:
+    status: todo
+    comment: Under review
+
+  ## Platinum
+  async-dependency:
+    status: done
+    comment: sfrbox-api is asynchronous
+  inject-websession:
+    status: done
+    comment: sfrbox-api uses injected aiohttp websession
+  strict-typing:
+    status: done
+    comment: sfrbox-api is fully typed, and integration uses strict typing

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -27,8 +27,8 @@ rules:
     status: todo
     comment: Under review
   docs-actions:
-    status: todo
-    comment: Under review
+    status: exempt
+    comment: There are no service actions
   brands: done
 
   ## Silver

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -40,10 +40,10 @@ rules:
   integration-owner: done
   docs-installation-parameters:
     status: todo
-    comment: Under review
+    comment: not yet documented
   docs-configuration-parameters:
-    status: todo
-    comment: Under review
+    status: exempt
+    comment: No options flow
 
   ## Gold
   entity-translations: done
@@ -58,7 +58,7 @@ rules:
   diagnostics: done
   exception-translations:
     status: todo
-    comment: not yet done
+    comment: not yet documented
   icon-translations: done
   reconfiguration-flow:
     status: todo
@@ -70,25 +70,21 @@ rules:
   repair-issues: done
   docs-use-cases:
     status: todo
-    comment: Under review
-  docs-supported-devices:
-    status: todo
-    comment: Under review
-  docs-supported-functions:
-    status: todo
-    comment: Under review
+    comment: not yet documented
+  docs-supported-devices: done
+  docs-supported-functions: done
   docs-data-update:
     status: todo
-    comment: Under review
+    comment: not yet documented
   docs-known-limitations:
     status: todo
-    comment: Under review
+    comment: not yet documented
   docs-troubleshooting:
     status: todo
-    comment: Under review
+    comment: not yet documented
   docs-examples:
     status: todo
-    comment: Under review
+    comment: not yet documented
 
   ## Platinum
   async-dependency:

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -1,6 +1,8 @@
 rules:
   ## Bronze
-  config-flow: done
+  config-flow:
+    status: todo
+    comment: Under review
   test-before-configure: done
   unique-config-entry: done
   config-flow-test-coverage: done

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -2,7 +2,7 @@ rules:
   ## Bronze
   config-flow:
     status: todo
-    comment: Under review
+    comment: https://github.com/home-assistant/core/pull/155420
   test-before-configure: done
   unique-config-entry: done
   config-flow-test-coverage: done

--- a/homeassistant/components/sfr_box/quality_scale.yaml
+++ b/homeassistant/components/sfr_box/quality_scale.yaml
@@ -26,30 +26,18 @@ rules:
   brands: done
 
   ## Silver
-  config-entry-unloading:
-    status: todo
-    comment: Under review
-  log-when-unavailable:
-    status: todo
-    comment: Under review
-  entity-unavailable:
-    status: todo
-    comment: Under review
-  action-exceptions:
-    status: todo
-    comment: Under review
-  reauthentication-flow:
-    status: todo
-    comment: Under review
+  config-entry-unloading: done
+  log-when-unavailable: done
+  entity-unavailable: done
+  action-exceptions: done
+  reauthentication-flow: done
   parallel-updates:
     status: todo
-    comment: Under review
+    comment: Updates are managed by the coordinator, actions need it
   test-coverage:
     status: todo
-    comment: Under review
-  integration-owner:
-    status: todo
-    comment: Under review
+    comment: 93% on diagnostics / 92% on sensors, need to improve overall coverage
+  integration-owner: done
   docs-installation-parameters:
     status: todo
     comment: Under review

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1879,7 +1879,6 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "sesame",
     "seven_segments",
     "seventeentrack",
-    "sfr_box",
     "sharkiq",
     "shell_command",
     "shodan",

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -857,7 +857,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "sesame",
     "seven_segments",
     "seventeentrack",
-    "sfr_box",
     "sharkiq",
     "shell_command",
     "shodan",

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1879,6 +1879,7 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "sesame",
     "seven_segments",
     "seventeentrack",
+    "sfr_box",
     "sharkiq",
     "shell_command",
     "shodan",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
## Bronze
- [x] `action-setup` - Service actions are registered in async_setup `=> Exempted - no actions`
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval https://github.com/home-assistant/core/blob/a6ba8fa69c5392d64290385df6c5d132daeda103/homeassistant/components/sfr_box/coordinator.py#L20
- [x] `brands` - Has branding assets available for the integration https://github.com/home-assistant/brands/tree/master/core_integrations/sfr_box
- [x] `common-modules` - Place common patterns in common modules #155418
- [ ] `config-flow-test-coverage` - Full test coverage for the config flow `homeassistant/components/sfr_box/config_flow.py 100%`
- [ ] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data_description` to give context to fields #155420
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `dependency-transparency` - Dependency transparency https://github.com/hacf-fr/sfrbox-api
- [x] `docs-actions` - The documentation describes the provided service actions that can be used `=> Exempted - no actions`
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [x] `entity-event-setup` - Entity events are subscribed in the correct lifecycle methods `=> Exempted - local polling with coordinator`
- [x] `entity-unique-id` - Entities have a unique ID https://github.com/home-assistant/core/blob/6c8dffd52180e74b86013ced02fb280108edf050/homeassistant/components/sfr_box/entity.py#L26
- [x] `has-entity-name` - Entities use has_entity_name = True https://github.com/home-assistant/core/blob/1ea534e40032a7d74e3fdb7e85e3c3112c2d22f9/homeassistant/components/sfr_box/binary_sensor.py#L97
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data #155410
- [x] `test-before-configure` - Test a connection in the config flow https://github.com/home-assistant/core/blob/6c8dffd52180e74b86013ced02fb280108edf050/homeassistant/components/sfr_box/config_flow.py#L55
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly https://github.com/home-assistant/core/blob/6c8dffd52180e74b86013ced02fb280108edf050/homeassistant/components/sfr_box/__init__.py#L29
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice https://github.com/home-assistant/core/blob/6c8dffd52180e74b86013ced02fb280108edf050/homeassistant/components/sfr_box/config_flow.py#L61

## Silver
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
- [x] `config-entry-unloading` - Support config entry unloading
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options
- [ ] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
- [x] `integration-owner` - Has an integration owner
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [x] `parallel-updates` - Number of parallel updates is specified
- [x] `reauthentication-flow` - Reauthentication needs to be available via the UI
- [ ] `test-coverage` - Above 95% test coverage for all integration modules

## Gold
- [ ] `devices` - The integration creates devices
- [x] `diagnostics` - Implements diagnostics
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [ ] `discovery` - Devices can be discovered
- [ ] `docs-data-update` - The documentation describes how data is updated
- [ ] `docs-examples` - The documentation provides automation examples the user can use.
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [x] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [x] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `dynamic-devices` - Devices added after integration setup
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
- [ ] `entity-device-class` - Entities use device classes where possible
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [x] `entity-translations` - Entities have translated names
- [ ] `exception-translations` - Exception messages are translatable
- [x] `icon-translations` - Entities implement icon translations
- [ ] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [x] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [x] `stale-devices` - Stale devices are removed

## Platinum
- [x] `async-dependency` - Dependency is async https://github.com/hacf-fr/sfrbox-api
- [x] `inject-websession` - The integration dependency supports passing in a websession https://github.com/home-assistant/core/blob/fbb07e16cb92736d82fe7b6d41e28556781fd459/homeassistant/components/sfr_box/__init__.py#L23
- [x] `strict-typing` - Strict typing https://github.com/home-assistant/core/blob/a6c1ce86d89ce8ad1ac085265c73f9fd63ff162b/.strict-typing#L468


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
