### PR TITLE
Bump pynordpool to 0.3.2

### DIFF
--- a/homeassistant/components/nordpool/manifest.json
+++ b/homeassistant/components/nordpool/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "loggers": ["pynordpool"],
   "quality_scale": "platinum",
-  "requirements": ["pynordpool==0.3.1"],
+  "requirements": ["pynordpool==0.3.2"],
   "single_config_entry": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2231,7 +2231,7 @@ pynintendoparental==1.1.2
 pynobo==1.8.1
 
 # homeassistant.components.nordpool
-pynordpool==0.3.1
+pynordpool==0.3.2
 
 # homeassistant.components.nuki
 pynuki==1.6.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1867,7 +1867,7 @@ pynintendoparental==1.1.2
 pynobo==1.8.1
 
 # homeassistant.components.nordpool
-pynordpool==0.3.1
+pynordpool==0.3.2
 
 # homeassistant.components.nuki
 pynuki==1.6.3


### PR DESCRIPTION
## Breaking change


## Proposed change
Bump pynordpool to 0.3.2
https://github.com/gjohansson-ST/pynordpool/compare/v0.3.1...v0.3.2

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 