### PR TITLE
Add setting aux maxtemp threshold to ecobee

### DIFF
--- a/homeassistant/components/ecobee/number.py
+++ b/homeassistant/components/ecobee/number.py
@@ -69,14 +69,12 @@ async def async_setup_entry(
 
     _LOGGER.debug("Adding compressor min temp number and aux heat")
     for index, thermostat in enumerate(data.ecobee.thermostats):
-        if thermostat["settings"]["hasHeatPump"]:
+        thermostat_settings = thermostat["settings"]
+        if thermostat_settings["hasHeatPump"]:
             compressor_entity = EcobeeCompressorMinTemp(data, index)
             entities.append(compressor_entity)
 
-            if (
-                thermostat["settings"]["hasForcedAir"]
-                or thermostat["settings"]["hasBoiler"]
-            ):
+            if thermostat_settings["hasForcedAir"] or thermostat_settings["hasBoiler"]:
                 aux_entity = EcobeeAuxMaxOutdoorTemp(data, index, compressor_entity)
                 compressor_entity.aux_entity = aux_entity
                 entities.append(aux_entity)

--- a/homeassistant/components/ecobee/number.py
+++ b/homeassistant/components/ecobee/number.py
@@ -204,7 +204,7 @@ class EcobeeAuxMaxOutdoorTemp(EcobeeBaseEntity, NumberEntity):
         data: EcobeeData,
         thermostat_index: int,
     ) -> None:
-        """Initialize ecobee compressor min temperature."""
+        """Initialize ecobee auxiliary maximum outdoor temperature."""
         super().__init__(data, thermostat_index)
         self._attr_unique_id = f"{self.base_unique_id}_aux_max_outdoor_temp"
         self.update_without_throttle = False
@@ -222,6 +222,6 @@ class EcobeeAuxMaxOutdoorTemp(EcobeeBaseEntity, NumberEntity):
         )
 
     def set_native_value(self, value: float) -> None:
-        """Set new aux max outdoor max temp."""
+        """Set new auxiliary maximum outdoor temperature."""
         self.data.ecobee.set_aux_maxtemp_threshold(self.thermostat_index, int(value))
         self.update_without_throttle = True

--- a/homeassistant/components/ecobee/number.py
+++ b/homeassistant/components/ecobee/number.py
@@ -81,11 +81,14 @@ async def async_setup_entry(
         (
             EcobeeAuxMaxOutdoorTemp(data, index)
             for index, thermostat in enumerate(data.ecobee.thermostats)
-            if thermostat["settings"]["hasHeatPump"] and 
-                (thermostat["settings"]["hasForcedAir"] or thermostat["settings"]["hasBoiler"])
+            if thermostat["settings"]["hasHeatPump"]
+            and (
+                thermostat["settings"]["hasForcedAir"]
+                or thermostat["settings"]["hasBoiler"]
+            )
         )
     )
-    
+
     async_add_entities(entities, True)
 
 
@@ -178,6 +181,7 @@ class EcobeeCompressorMinTemp(EcobeeBaseEntity, NumberEntity):
         self.data.ecobee.set_aux_cutover_threshold(self.thermostat_index, value)
         self.update_without_throttle = True
 
+
 class EcobeeAuxMaxOutdoorTemp(EcobeeBaseEntity, NumberEntity):
     """Maximum outdoor temperature at which aux heat will operate.
 
@@ -219,5 +223,5 @@ class EcobeeAuxMaxOutdoorTemp(EcobeeBaseEntity, NumberEntity):
 
     def set_native_value(self, value: float) -> None:
         """Set new aux max outdoor max temp."""
-        self.data.ecobee.set_aux_maxtemp_threshold(self.thermostat_index, value)
+        self.data.ecobee.set_aux_maxtemp_threshold(self.thermostat_index, int(value))
         self.update_without_throttle = True

--- a/homeassistant/components/ecobee/number.py
+++ b/homeassistant/components/ecobee/number.py
@@ -67,27 +67,19 @@ async def async_setup_entry(
         for numbers in VENTILATOR_NUMBERS
     ]
 
-    _LOGGER.debug("Adding compressor min temp number (if present)")
-    entities.extend(
-        (
-            EcobeeCompressorMinTemp(data, index)
-            for index, thermostat in enumerate(data.ecobee.thermostats)
-            if thermostat["settings"]["hasHeatPump"]
-        )
-    )
+    _LOGGER.debug("Adding compressor min temp number and aux heat")
+    for index, thermostat in enumerate(data.ecobee.thermostats):
+        if thermostat["settings"]["hasHeatPump"]:
+            compressor_entity = EcobeeCompressorMinTemp(data, index)
+            entities.append(compressor_entity)
 
-    _LOGGER.debug("Adding auxiliary max outdoor temp (if present)")
-    entities.extend(
-        (
-            EcobeeAuxMaxOutdoorTemp(data, index)
-            for index, thermostat in enumerate(data.ecobee.thermostats)
-            if thermostat["settings"]["hasHeatPump"]
-            and (
+            if (
                 thermostat["settings"]["hasForcedAir"]
                 or thermostat["settings"]["hasBoiler"]
-            )
-        )
-    )
+            ):
+                aux_entity = EcobeeAuxMaxOutdoorTemp(data, index, compressor_entity)
+                compressor_entity.aux_entity = aux_entity
+                entities.append(aux_entity)
 
     async_add_entities(entities, True)
 
@@ -163,6 +155,7 @@ class EcobeeCompressorMinTemp(EcobeeBaseEntity, NumberEntity):
         super().__init__(data, thermostat_index)
         self._attr_unique_id = f"{self.base_unique_id}_compressor_protection_min_temp"
         self.update_without_throttle = False
+        self.aux_entity: EcobeeAuxMaxOutdoorTemp | None = None
 
     async def async_update(self) -> None:
         """Get the latest state from the thermostat."""
@@ -178,7 +171,26 @@ class EcobeeCompressorMinTemp(EcobeeBaseEntity, NumberEntity):
 
     def set_native_value(self, value: float) -> None:
         """Set new compressor minimum temperature."""
-        self.data.ecobee.set_aux_cutover_threshold(self.thermostat_index, value)
+        if self.aux_entity is not None:
+            # We need to ensure there is at least a difference of 5 degrees between
+            # the auxiliary max outdoor temp and the compressor min temp.
+            difference = (
+                self.aux_entity.native_value - int(value)
+                if self.aux_entity.native_value is not None
+                else None
+            )
+            if difference is not None and difference < 5:
+                # Subtract 5 from our current value, round down to nearest 5 and ensure
+                # it is 0 or higher.
+                new_aux_value = max(int(value) + 5, 0)
+                _LOGGER.debug(
+                    "Adjusting auxiliary max outdoor temp to %s°F to maintain 5°F "
+                    "difference",
+                    new_aux_value,
+                )
+                self.aux_entity.set_native_value(new_aux_value)
+
+        self.data.ecobee.set_aux_cutover_threshold(self.thermostat_index, int(value))
         self.update_without_throttle = True
 
 
@@ -203,11 +215,13 @@ class EcobeeAuxMaxOutdoorTemp(EcobeeBaseEntity, NumberEntity):
         self,
         data: EcobeeData,
         thermostat_index: int,
+        compressor_entity: EcobeeCompressorMinTemp,
     ) -> None:
         """Initialize ecobee auxiliary maximum outdoor temperature."""
         super().__init__(data, thermostat_index)
         self._attr_unique_id = f"{self.base_unique_id}_aux_max_outdoor_temp"
         self.update_without_throttle = False
+        self._compressor_entity = compressor_entity
 
     async def async_update(self) -> None:
         """Get the latest state from the thermostat."""
@@ -223,5 +237,24 @@ class EcobeeAuxMaxOutdoorTemp(EcobeeBaseEntity, NumberEntity):
 
     def set_native_value(self, value: float) -> None:
         """Set new auxiliary maximum outdoor temperature."""
+        # We need to ensure there is at least a difference of 5 degrees between
+        # the auxiliary max outdoor temp and the compressor min temp.
+        difference = (
+            value - self._compressor_entity.native_value
+            if self._compressor_entity.native_value is not None
+            else None
+        )
+        if difference is not None and difference < 5:
+            # Subtract 5 from our current value, round down to nearest 5 as
+            # compressor protection min temp only supports steps of 5, maximum is 65.
+            new_compressor_value = min(((value - 5) // 5) * 5, 65)
+
+            _LOGGER.debug(
+                "Adjusting compressor protection min temp to %s°F to maintain 5°F "
+                "difference",
+                new_compressor_value,
+            )
+            self._compressor_entity.set_native_value(new_compressor_value)
+
         self.data.ecobee.set_aux_maxtemp_threshold(self.thermostat_index, int(value))
         self.update_without_throttle = True

--- a/homeassistant/components/ecobee/number.py
+++ b/homeassistant/components/ecobee/number.py
@@ -188,7 +188,10 @@ class EcobeeCompressorMinTemp(EcobeeBaseEntity, NumberEntity):
                     "difference",
                     new_aux_value,
                 )
-                self.aux_entity.set_native_value(new_aux_value)
+                self.data.ecobee.set_aux_maxtemp_threshold(
+                    self.thermostat_index, int(new_aux_value)
+                )
+                self.aux_entity.update_without_throttle = True
 
         self.data.ecobee.set_aux_cutover_threshold(self.thermostat_index, int(value))
         self.update_without_throttle = True
@@ -239,6 +242,7 @@ class EcobeeAuxMaxOutdoorTemp(EcobeeBaseEntity, NumberEntity):
         """Set new auxiliary maximum outdoor temperature."""
         # We need to ensure there is at least a difference of 5 degrees between
         # the auxiliary max outdoor temp and the compressor min temp.
+
         difference = (
             value - self._compressor_entity.native_value
             if self._compressor_entity.native_value is not None
@@ -254,7 +258,10 @@ class EcobeeAuxMaxOutdoorTemp(EcobeeBaseEntity, NumberEntity):
                 "difference",
                 new_compressor_value,
             )
-            self._compressor_entity.set_native_value(new_compressor_value)
+            self.data.ecobee.set_aux_cutover_threshold(
+                self.thermostat_index, int(new_compressor_value)
+            )
+            self._compressor_entity.update_without_throttle = True
 
         self.data.ecobee.set_aux_maxtemp_threshold(self.thermostat_index, int(value))
         self.update_without_throttle = True

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -32,6 +32,9 @@
       }
     },
     "number": {
+      "aux_max_outdoor_temp": {
+        "name": "Auxiliary maximum outdoor temperature"
+      },
       "compressor_protection_min_temp": {
         "name": "Compressor minimum temperature"
       },
@@ -40,9 +43,6 @@
       },
       "ventilator_min_type_home": {
         "name": "Ventilator minimum time home"
-      },
-      "aux_max_outdoor_temp": {
-        "name": "Auxiliary maximum outdoor temperature"
       }
     },
     "switch": {

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -40,6 +40,9 @@
       },
       "ventilator_min_type_home": {
         "name": "Ventilator minimum time home"
+      },
+      "aux_max_outdoor_temp": {
+        "name": "Auxiliary maximum outdoor temperature"
       }
     },
     "switch": {

--- a/tests/components/ecobee/fixtures/ecobee-data.json
+++ b/tests/components/ecobee/fixtures/ecobee-data.json
@@ -161,6 +161,7 @@
         "humidifierMode": "manual",
         "hasHeatPump": true,
         "compressorProtectionMinTemp": 100,
+        "auxMaxOutdoorTemp": 410,
         "humidity": "30"
       },
       "equipmentStatus": "fan",

--- a/tests/components/ecobee/fixtures/ecobee-data.json
+++ b/tests/components/ecobee/fixtures/ecobee-data.json
@@ -65,6 +65,8 @@
         "hasHumidifier": true,
         "humidifierMode": "manual",
         "hasHeatPump": false,
+        "hasForcedAir": true,
+        "hasBoiler": false,
         "humidity": "30"
       },
       "equipmentStatus": "fan,humidifier",
@@ -160,6 +162,8 @@
         "hasHumidifier": true,
         "humidifierMode": "manual",
         "hasHeatPump": true,
+        "hasForcedAir": true,
+        "hasBoiler": false,
         "compressorProtectionMinTemp": 100,
         "auxMaxOutdoorTemp": 410,
         "humidity": "30"
@@ -257,6 +261,8 @@
         "hasHumidifier": true,
         "humidifierMode": "manual",
         "hasHeatPump": false,
+        "hasForcedAir": true,
+        "hasBoiler": false,
         "humidity": "30"
       },
       "equipmentStatus": "fan",

--- a/tests/components/ecobee/test_number.py
+++ b/tests/components/ecobee/test_number.py
@@ -143,7 +143,7 @@ async def test_auxiliary_max_outdoor_temp_attributes(hass: HomeAssistant) -> Non
 async def test_set_auxiliary_max_outdoor_temp(hass: HomeAssistant) -> None:
     """Test the number can set aux max outdoor temp.
 
-    Ecobee runs in Fahrenheit; the test rig runs in Celsius. Conversions are necessary
+    Ecobee runs in Fahrenheit; the test rig runs in Celsius. Conversions are necessary.
     """
     target_value = 0
     with patch(

--- a/tests/components/ecobee/test_number.py
+++ b/tests/components/ecobee/test_number.py
@@ -107,6 +107,8 @@ async def test_set_compressor_protection_min_temp(hass: HomeAssistant) -> None:
     Ecobee runs in Fahrenheit; the test rig runs in Celsius. Conversions are necessary
     """
     target_value = 10
+    await setup_platform(hass, NUMBER_DOMAIN)
+
     with (
         patch(
             "homeassistant.components.ecobee.Ecobee.set_aux_cutover_threshold"
@@ -115,15 +117,13 @@ async def test_set_compressor_protection_min_temp(hass: HomeAssistant) -> None:
             "homeassistant.components.ecobee.Ecobee.set_aux_maxtemp_threshold"
         ) as mock_set_aux_max_temp_threshold,
     ):
-        await setup_platform(hass, NUMBER_DOMAIN)
-
         await hass.services.async_call(
             NUMBER_DOMAIN,
             SERVICE_SET_VALUE,
             {ATTR_ENTITY_ID: COMPRESSOR_MIN_TEMP_ID, ATTR_VALUE: target_value},
             blocking=True,
         )
-        await hass.async_block_till_done()
+
         mock_set_compressor_min_temp.assert_called_once_with(1, 50)
         mock_set_aux_max_temp_threshold.assert_called_once_with(1, 55)
 
@@ -134,7 +134,7 @@ async def test_set_compressor_protection_min_temp(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: COMPRESSOR_MIN_TEMP_ID, ATTR_VALUE: target_value},
             blocking=True,
         )
-        await hass.async_block_till_done()
+
         assert mock_set_compressor_min_temp.call_count == 2
         calls = mock_set_compressor_min_temp.call_args_list
         assert calls[1].args == (1, 64)
@@ -168,6 +168,7 @@ async def test_set_auxiliary_max_outdoor_temp(hass: HomeAssistant) -> None:
     Ecobee runs in Fahrenheit; the test rig runs in Celsius. Conversions are necessary.
     """
     target_value = -14
+    await setup_platform(hass, NUMBER_DOMAIN)
     with (
         patch(
             "homeassistant.components.ecobee.Ecobee.set_aux_cutover_threshold"
@@ -176,15 +177,13 @@ async def test_set_auxiliary_max_outdoor_temp(hass: HomeAssistant) -> None:
             "homeassistant.components.ecobee.Ecobee.set_aux_maxtemp_threshold"
         ) as mock_set_aux_max_temp_threshold,
     ):
-        await setup_platform(hass, NUMBER_DOMAIN)
-
         await hass.services.async_call(
             NUMBER_DOMAIN,
             SERVICE_SET_VALUE,
             {ATTR_ENTITY_ID: AUX_MAX_OUTDOOR_TEMP_ID, ATTR_VALUE: target_value},
             blocking=True,
         )
-        await hass.async_block_till_done()
+
         mock_set_aux_max_temp_threshold.assert_called_once_with(1, 6)
         mock_set_compressor_min_temp.assert_called_once_with(1, 0)
 
@@ -195,7 +194,7 @@ async def test_set_auxiliary_max_outdoor_temp(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: AUX_MAX_OUTDOOR_TEMP_ID, ATTR_VALUE: target_value},
             blocking=True,
         )
-        await hass.async_block_till_done()
+
         assert mock_set_aux_max_temp_threshold.call_count == 2
         calls = mock_set_aux_max_temp_threshold.call_args_list
         assert calls[1].args == (1, 77)

--- a/tests/components/ecobee/test_number.py
+++ b/tests/components/ecobee/test_number.py
@@ -120,3 +120,42 @@ async def test_set_compressor_protection_min_temp(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
         mock_set_compressor_min_temp.assert_called_once_with(1, 32)
+
+
+AUX_MAX_OUTDOOR_TEMP_ID = "number.ecobee2_auxiliary_maximum_outdoor_temperature"
+
+
+async def test_auxiliary_max_outdoor_temp_attributes(hass: HomeAssistant) -> None:
+    """Test the aux max outdoor temp value is correct.
+
+    Ecobee runs in Fahrenheit; the test rig runs in Celsius. Conversions are necessary.
+    """
+    await setup_platform(hass, NUMBER_DOMAIN)
+
+    state = hass.states.get(AUX_MAX_OUTDOOR_TEMP_ID)
+    assert state.state == "5"
+    assert (
+        state.attributes.get("friendly_name")
+        == "ecobee2 Auxiliary maximum outdoor temperature"
+    )
+
+
+async def test_set_compressor_protection_min_temp(hass: HomeAssistant) -> None:
+    """Test the number can set aux max outdoor temp.
+
+    Ecobee runs in Fahrenheit; the test rig runs in Celsius. Conversions are necessary
+    """
+    target_value = 0
+    with patch(
+        "homeassistant.components.ecobee.Ecobee.set_aux_maxtemp_threshold"
+    ) as mock_set_aux_max_temp_threshold:
+        await setup_platform(hass, NUMBER_DOMAIN)
+
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: AUX_MAX_OUTDOOR_TEMP_ID, ATTR_VALUE: target_value},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_set_aux_max_temp_threshold.assert_called_once_with(1, 32)

--- a/tests/components/ecobee/test_number.py
+++ b/tests/components/ecobee/test_number.py
@@ -14,6 +14,7 @@ from .common import setup_platform
 
 VENTILATOR_MIN_HOME_ID = "number.ecobee_ventilator_minimum_time_home"
 VENTILATOR_MIN_AWAY_ID = "number.ecobee_ventilator_minimum_time_away"
+AUX_MAX_OUTDOOR_TEMP_ID = "number.ecobee2_auxiliary_maximum_outdoor_temperature"
 THERMOSTAT_ID = 0
 
 
@@ -144,9 +145,6 @@ async def test_set_compressor_protection_min_temp(hass: HomeAssistant) -> None:
         assert calls[1].args == (1, 69)
 
 
-AUX_MAX_OUTDOOR_TEMP_ID = "number.ecobee2_auxiliary_maximum_outdoor_temperature"
-
-
 async def test_auxiliary_max_outdoor_temp_attributes(hass: HomeAssistant) -> None:
     """Test the aux max outdoor temp value is correct.
 
@@ -183,6 +181,7 @@ async def test_set_auxiliary_max_outdoor_temp(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: AUX_MAX_OUTDOOR_TEMP_ID, ATTR_VALUE: target_value},
             blocking=True,
         )
+        await hass.async_block_till_done()
 
         mock_set_aux_max_temp_threshold.assert_called_once_with(1, 6)
         mock_set_compressor_min_temp.assert_called_once_with(1, 0)
@@ -194,6 +193,7 @@ async def test_set_auxiliary_max_outdoor_temp(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: AUX_MAX_OUTDOOR_TEMP_ID, ATTR_VALUE: target_value},
             blocking=True,
         )
+        await hass.async_block_till_done()
 
         assert mock_set_aux_max_temp_threshold.call_count == 2
         calls = mock_set_aux_max_temp_threshold.call_args_list

--- a/tests/components/ecobee/test_number.py
+++ b/tests/components/ecobee/test_number.py
@@ -181,7 +181,6 @@ async def test_set_auxiliary_max_outdoor_temp(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: AUX_MAX_OUTDOOR_TEMP_ID, ATTR_VALUE: target_value},
             blocking=True,
         )
-        await hass.async_block_till_done()
 
         mock_set_aux_max_temp_threshold.assert_called_once_with(1, 6)
         mock_set_compressor_min_temp.assert_called_once_with(1, 0)
@@ -193,7 +192,6 @@ async def test_set_auxiliary_max_outdoor_temp(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: AUX_MAX_OUTDOOR_TEMP_ID, ATTR_VALUE: target_value},
             blocking=True,
         )
-        await hass.async_block_till_done()
 
         assert mock_set_aux_max_temp_threshold.call_count == 2
         calls = mock_set_aux_max_temp_threshold.call_args_list

--- a/tests/components/ecobee/test_number.py
+++ b/tests/components/ecobee/test_number.py
@@ -140,7 +140,7 @@ async def test_auxiliary_max_outdoor_temp_attributes(hass: HomeAssistant) -> Non
     )
 
 
-async def test_set_compressor_protection_min_temp(hass: HomeAssistant) -> None:
+async def test_set_auxiliary_max_outdoor_temp(hass: HomeAssistant) -> None:
     """Test the number can set aux max outdoor temp.
 
     Ecobee runs in Fahrenheit; the test rig runs in Celsius. Conversions are necessary

--- a/tests/components/ecobee/test_number.py
+++ b/tests/components/ecobee/test_number.py
@@ -133,7 +133,7 @@ async def test_auxiliary_max_outdoor_temp_attributes(hass: HomeAssistant) -> Non
     await setup_platform(hass, NUMBER_DOMAIN)
 
     state = hass.states.get(AUX_MAX_OUTDOOR_TEMP_ID)
-    assert state.state == "5"
+    assert state.state == "5.0"
     assert (
         state.attributes.get("friendly_name")
         == "ecobee2 Auxiliary maximum outdoor temperature"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Add auxiliary maximum temp threshold for Ecobee.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Added a new number entity to be able to change the auxiliary maximum temperature threshold.
Locally tested and confirmed to be working. Checked on thermostat as well.
Added two new tests similar to the compressor threshold tests.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41526
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository] https://www.home-assistant.io/integrations/ecobee

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
