### PR TITLE
Bump librehardwaremonitor-api to 1.5.0

### DIFF
--- a/homeassistant/components/libre_hardware_monitor/manifest.json
+++ b/homeassistant/components/libre_hardware_monitor/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/libre_hardware_monitor",
   "iot_class": "local_polling",
   "quality_scale": "silver",
-  "requirements": ["librehardwaremonitor-api==1.4.0"]
+  "requirements": ["librehardwaremonitor-api==1.5.0"]
 }

--- a/homeassistant/components/libre_hardware_monitor/sensor.py
+++ b/homeassistant/components/libre_hardware_monitor/sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from librehardwaremonitor_api.model import LibreHardwareMonitorSensorData
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
@@ -51,10 +53,10 @@ class LibreHardwareMonitorSensor(
         super().__init__(coordinator)
 
         self._attr_name: str = sensor_data.name
-        self.value: str | None = sensor_data.value
-        self._attr_extra_state_attributes: dict[str, str] = {
-            STATE_MIN_VALUE: self._format_number_value(sensor_data.min),
-            STATE_MAX_VALUE: self._format_number_value(sensor_data.max),
+        self._attr_native_value: str | None = sensor_data.value
+        self._attr_extra_state_attributes: dict[str, Any] = {
+            STATE_MIN_VALUE: sensor_data.min,
+            STATE_MAX_VALUE: sensor_data.max,
         }
         self._attr_native_unit_of_measurement = sensor_data.unit
         self._attr_unique_id: str = f"{entry_id}_{sensor_data.sensor_id}"
@@ -72,23 +74,12 @@ class LibreHardwareMonitorSensor(
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if sensor_data := self.coordinator.data.sensor_data.get(self._sensor_id):
-            self.value = sensor_data.value
+            self._attr_native_value = sensor_data.value
             self._attr_extra_state_attributes = {
-                STATE_MIN_VALUE: self._format_number_value(sensor_data.min),
-                STATE_MAX_VALUE: self._format_number_value(sensor_data.max),
+                STATE_MIN_VALUE: sensor_data.min,
+                STATE_MAX_VALUE: sensor_data.max,
             }
         else:
-            self.value = None
+            self._attr_native_value = None
 
         super()._handle_coordinator_update()
-
-    @property
-    def native_value(self) -> str | None:
-        """Return the formatted sensor value or None if no value is available."""
-        if self.value is not None and self.value != "-":
-            return self._format_number_value(self.value)
-        return None
-
-    @staticmethod
-    def _format_number_value(number_str: str) -> str:
-        return number_str.replace(",", ".")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1359,7 +1359,7 @@ libpyfoscamcgi==0.0.8
 libpyvivotek==0.6.1
 
 # homeassistant.components.libre_hardware_monitor
-librehardwaremonitor-api==1.4.0
+librehardwaremonitor-api==1.5.0
 
 # homeassistant.components.mikrotik
 librouteros==3.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1178,7 +1178,7 @@ letpot==0.6.3
 libpyfoscamcgi==0.0.8
 
 # homeassistant.components.libre_hardware_monitor
-librehardwaremonitor-api==1.4.0
+librehardwaremonitor-api==1.5.0
 
 # homeassistant.components.mikrotik
 librouteros==3.2.0

--- a/tests/components/libre_hardware_monitor/snapshots/test_sensor.ambr
+++ b/tests/components/libre_hardware_monitor/snapshots/test_sensor.ambr
@@ -634,8 +634,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
-      'max_value': '-',
-      'min_value': '-',
+      'max_value': None,
+      'min_value': None,
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
@@ -1458,8 +1458,8 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
-        'max_value': '-',
-        'min_value': '-',
+        'max_value': None,
+        'min_value': None,
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       }),
       'context': <ANY>,
@@ -1836,8 +1836,8 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
-        'max_value': '-',
-        'min_value': '-',
+        'max_value': None,
+        'min_value': None,
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       }),
       'context': <ANY>,

--- a/tests/components/libre_hardware_monitor/test_sensor.py
+++ b/tests/components/libre_hardware_monitor/test_sensor.py
@@ -100,7 +100,7 @@ async def test_sensors_are_updated(
 
     updated_data = dict(mock_lhm_client.get_data.return_value.sensor_data)
     updated_data["amdcpu-0-temperature-3"] = replace(
-        updated_data["amdcpu-0-temperature-3"], value="42,1"
+        updated_data["amdcpu-0-temperature-3"], value="42.1"
     )
     mock_lhm_client.get_data.return_value = replace(
         mock_lhm_client.get_data.return_value,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes TimeSpan and NaN values.

1) TimeSpans (e.g. remaining time for laptop battery) are reported by the Libre Hardware Monitor API in the format h:mm:ss which causes errors in HA:

<code>ValueError: Sensor sensor.dell_g8vcf6c_remaining_time_estimated_timespan has device class 'None', state class 'measurement' unit 'None' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-numeric value: '4:48:20' (<class 'str'>)</code>

For LHM versions <=0.9.4 the library will convert timestamps to seconds, for versions > 0.9.4 (to be released) a `raw_value` is available in the LHM API that will be used. More formatting options and/or user configurable unit conversion is planned for a future update.

2) The same error could occur if LHM reports a value as `NaN` in rare cases. Now the library will handle any absence of a numerical value and return `None` instead. Therefore, the previous custom handling in the integration for the `-` string which previously indicated "no value" is removed.

3) Locale handling has been moved to the library, values will always use a dot as decimal separator now independent of locale. The formatting has therefore been removed from the integration.

Diff: https://github.com/Sab44/librehardwaremonitor-api/compare/v1.4.0...v1.5.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
