### PR TITLE
Add sidebar default visible flag to panels

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -263,6 +263,9 @@ class Panel:
     # Title to show in the sidebar
     sidebar_title: str | None = None
 
+    # If the panel should be visible by default in the sidebar
+    sidebar_default_visible: bool = True
+
     # Url to show the panel in the frontend
     frontend_url_path: str
 
@@ -280,6 +283,7 @@ class Panel:
         component_name: str,
         sidebar_title: str | None,
         sidebar_icon: str | None,
+        sidebar_default_visible: bool,
         frontend_url_path: str | None,
         config: dict[str, Any] | None,
         require_admin: bool,
@@ -293,6 +297,7 @@ class Panel:
         self.config = config
         self.require_admin = require_admin
         self.config_panel_domain = config_panel_domain
+        self.sidebar_default_visible = sidebar_default_visible
 
     @callback
     def to_response(self) -> PanelResponse:
@@ -301,6 +306,7 @@ class Panel:
             "component_name": self.component_name,
             "icon": self.sidebar_icon,
             "title": self.sidebar_title,
+            "default_visible": self.sidebar_default_visible,
             "config": self.config,
             "url_path": self.frontend_url_path,
             "require_admin": self.require_admin,
@@ -315,6 +321,7 @@ def async_register_built_in_panel(
     component_name: str,
     sidebar_title: str | None = None,
     sidebar_icon: str | None = None,
+    sidebar_default_visible: bool = True,
     frontend_url_path: str | None = None,
     config: dict[str, Any] | None = None,
     require_admin: bool = False,
@@ -327,6 +334,7 @@ def async_register_built_in_panel(
         component_name,
         sidebar_title,
         sidebar_icon,
+        sidebar_default_visible,
         frontend_url_path,
         config,
         require_admin,
@@ -879,6 +887,7 @@ class PanelResponse(TypedDict):
     component_name: str
     icon: str | None
     title: str | None
+    default_visible: bool
     config: dict[str, Any] | None
     url_path: str
     require_admin: bool

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -645,6 +645,7 @@ async def test_get_panels(
     assert msg["result"]["map"]["icon"] == "mdi:tooltip-account"
     assert msg["result"]["map"]["title"] == "Map"
     assert msg["result"]["map"]["require_admin"] is True
+    assert msg["result"]["map"]["default_visible"] is True
 
     async_remove_panel(hass, "map")
 
@@ -683,6 +684,39 @@ async def test_get_panels_non_admin(
     assert msg["success"]
     assert "history" in msg["result"]
     assert "map" not in msg["result"]
+
+
+async def test_panel_sidebar_default_visible(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_http_client: TestClient,
+) -> None:
+    """Test sidebar_default_visible property in panels."""
+    async_register_built_in_panel(
+        hass,
+        "visible_panel",
+        "Visible Panel",
+        "mdi:eye",
+        sidebar_default_visible=True,
+    )
+    async_register_built_in_panel(
+        hass,
+        "hidden_panel",
+        "Hidden Panel",
+        "mdi:eye-off",
+        sidebar_default_visible=False,
+    )
+
+    client = await hass_ws_client(hass)
+    await client.send_json({"id": 5, "type": "get_panels"})
+
+    msg = await client.receive_json()
+
+    assert msg["id"] == 5
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+    assert msg["result"]["visible_panel"]["default_visible"] is True
+    assert msg["result"]["hidden_panel"]["default_visible"] is False
 
 
 async def test_get_translations(ws_client: MockHAClientWebSocket) -> None:

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -694,6 +694,11 @@ async def test_panel_sidebar_default_visible(
     """Test sidebar_default_visible property in panels."""
     async_register_built_in_panel(
         hass,
+        "default_panel",
+        "Default Panel",
+    )
+    async_register_built_in_panel(
+        hass,
         "visible_panel",
         "Visible Panel",
         "mdi:eye",
@@ -715,6 +720,7 @@ async def test_panel_sidebar_default_visible(
     assert msg["id"] == 5
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
+    assert msg["result"]["default_panel"]["default_visible"] is True
     assert msg["result"]["visible_panel"]["default_visible"] is True
     assert msg["result"]["hidden_panel"]["default_visible"] is False
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -253,9 +253,7 @@ async def test_setup_api_panel(
         "component_name": "custom",
         "icon": None,
         "title": None,
-        "url_path": "hassio",
-        "require_admin": True,
-        "config_panel_domain": None,
+        "default_visible": True,
         "config": {
             "_panel_custom": {
                 "embed_iframe": True,
@@ -264,6 +262,9 @@ async def test_setup_api_panel(
                 "trust_external": False,
             }
         },
+        "url_path": "hassio",
+        "require_admin": True,
+        "config_panel_domain": None,
     }
 
 


### PR DESCRIPTION
## Proposed change

Following https://github.com/home-assistant/core/pull/155047.

For now, all the panels are visible by default in the sidebar. This PR adds a flag to panel to not show a panel by default in the sidebar. Then the user can add it manual (requires frontend).

It will be used for the new "domain" dashboards (https://github.com/home-assistant/core/pull/153261). We want them available but not displayed by default to not clutter the sidebar by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
