### PR TITLE
Fix event entity state update for Telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -108,8 +108,8 @@ from .const import (
     SERVICE_SEND_STICKER,
     SERVICE_SEND_VIDEO,
     SERVICE_SEND_VOICE,
-    SIGNAL_UPDATE_EVENT,
 )
+from .helpers import signal
 
 _FILE_TYPES = ("animation", "document", "photo", "sticker", "video", "voice")
 _LOGGER = logging.getLogger(__name__)
@@ -169,7 +169,7 @@ class BaseTelegramBot:
 
         _LOGGER.debug("Firing event %s: %s", event_type, event_data)
         self.hass.bus.async_fire(event_type, event_data, context=event_context)
-        async_dispatcher_send(self.hass, SIGNAL_UPDATE_EVENT, event_type, event_data)
+        async_dispatcher_send(self.hass, signal(self._bot), event_type, event_data)
         return True
 
     @staticmethod
@@ -551,7 +551,7 @@ class TelegramNotificationService:
                     EVENT_TELEGRAM_SENT, event_data, context=context
                 )
                 async_dispatcher_send(
-                    self.hass, SIGNAL_UPDATE_EVENT, EVENT_TELEGRAM_SENT, event_data
+                    self.hass, signal(self.bot), EVENT_TELEGRAM_SENT, event_data
                 )
         except TelegramError as exc:
             if not suppress_error:

--- a/homeassistant/components/telegram_bot/event.py
+++ b/homeassistant/components/telegram_bot/event.py
@@ -14,9 +14,9 @@ from .const import (
     EVENT_TELEGRAM_COMMAND,
     EVENT_TELEGRAM_SENT,
     EVENT_TELEGRAM_TEXT,
-    SIGNAL_UPDATE_EVENT,
 )
 from .entity import TelegramBotEntity
+from .helpers import signal
 
 
 async def async_setup_entry(
@@ -55,7 +55,7 @@ class TelegramBotEventEntity(TelegramBotEntity, EventEntity):
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                SIGNAL_UPDATE_EVENT,
+                signal(self.config_entry.runtime_data.bot),
                 self._async_handle_event,
             )
         )

--- a/homeassistant/components/telegram_bot/helpers.py
+++ b/homeassistant/components/telegram_bot/helpers.py
@@ -1,0 +1,10 @@
+"""Helper functions for Telegram bot integration."""
+
+from telegram import Bot
+
+from .const import SIGNAL_UPDATE_EVENT
+
+
+def signal(bot: Bot) -> str:
+    """Define signal name."""
+    return f"{SIGNAL_UPDATE_EVENT}_{bot.id}"

--- a/tests/components/telegram_bot/test_event.py
+++ b/tests/components/telegram_bot/test_event.py
@@ -37,4 +37,5 @@ async def test_send_message(
     await hass.async_block_till_done()
 
     state = hass.states.get("event.mock_title_update_event")
+    assert state is not None
     assert state.attributes == snapshot(exclude=props("config_entry_id"))


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fix is for 2025.11.0 beta.

Events are associated with an config entry (telegram bot) and are fired when the bot sends or receives a message.
Currently, when an event is fired, all event entities are updated.
This is incorrect behavior, only the event entity associated with the bot should be updated.

This PR fixes the issue by renaming the signal to include the entity id so that the signal is processed only by the corresponding event entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #155486
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
