### PR TITLE
Add a regression test for airq integration stalling

### DIFF
--- a/tests/components/airq/test_integration_stalling_regression.py
+++ b/tests/components/airq/test_integration_stalling_regression.py
@@ -1,0 +1,83 @@
+"""Test that the coordinator does not hang with unresponding server.
+
+Users reported that the integration was stalling silently at random intervals.
+This was identified to be due to an incorrect timeout in aioairq and was fixed
+in aioairq==0.4.7 and homeassistant==2025.10.3.
+This is the regression test.
+"""
+
+import asyncio
+import time
+
+import pytest
+import pytest_asyncio
+
+from homeassistant.components.airq import AirQCoordinator
+from homeassistant.components.airq.const import DOMAIN
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+TIMEOUT_DEFAULT = 15
+TIMEOUT_HANGING = TIMEOUT_DEFAULT * 3
+TIMEOUT_SAFETY = TIMEOUT_DEFAULT * 2
+IP = "127.0.0.1"
+
+
+@pytest_asyncio.fixture
+async def hanging_server():
+    """TCP server that accepts connections but never sends data.
+
+    This makes HTTP clients wait forever for the status line / headers.
+    """
+
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        try:
+            # Keep the connection open; don't read or write HTTP data.
+            await asyncio.sleep(TIMEOUT_HANGING)
+        finally:
+            writer.close()
+
+    # pick any free ephemeral port on localhost and bind the server to it
+    server = await asyncio.start_server(handler, host=IP, port=0)
+    # get the actual selected port
+    port = server.sockets[0].getsockname()[1]
+    try:
+        yield (IP, port)
+    finally:
+        server.close()
+
+
+@pytest.mark.usefixtures("socket_enabled")
+async def test_coordinator_timeout_with_hanging_device(
+    hass: HomeAssistant,
+    hanging_server,
+) -> None:
+    """Test that AirQCoordinator times out by itself instead of getting stuck."""
+    host, port = hanging_server
+
+    # Create config entry with the actual hanging server address
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_IP_ADDRESS: f"{host}:{port}",  # Use actual port!
+            CONF_PASSWORD: "test_password",
+        },
+        unique_id="test_hanging_device",
+    )
+
+    # Create coordinator
+    coordinator = AirQCoordinator(hass, config_entry)
+
+    started = time.perf_counter()
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with asyncio.timeout(TIMEOUT_SAFETY):
+            await coordinator._async_update_data()
+
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < TIMEOUT_DEFAULT + 1, (
+        f"Expected ~{TIMEOUT_DEFAULT}s, got {elapsed:.1f}s (aioairq==0.4.6 behavior)"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The stalling was (hopefully) fixed in `homeassistant==2025.10.3` with the bump to `aioairq==0.4.7`.
This PR introduces a regression test that captures the stalling behaviour `<2025.10.3`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #82077
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
