### PR TITLE
Fix Shelly irrigation zone ID retrieval with Sleepy devices

### DIFF
--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -417,7 +417,7 @@ def get_rpc_sub_device_name(
     """Get name based on device and channel name."""
     if key in device.config and key != "em:0":
         # workaround for Pro 3EM, we don't want to get name for em:0
-        if (zone_id := get_irrigation_zone_id(device.config, key)) is not None:
+        if (zone_id := get_irrigation_zone_id(device, key)) is not None:
             # workaround for Irrigation controller, name stored in "service:0"
             if zone_name := device.config["service:0"]["zones"][zone_id]["name"]:
                 return cast(str, zone_name)
@@ -792,9 +792,13 @@ async def get_rpc_scripts_event_types(
     return script_events
 
 
-def get_irrigation_zone_id(config: dict[str, Any], key: str) -> int | None:
+def get_irrigation_zone_id(device: RpcDevice, key: str) -> int | None:
     """Return the zone id if the component is an irrigation zone."""
-    if key in config and (zone := get_rpc_role_by_key(config, key)).startswith("zone"):
+    if (
+        device.initialized
+        and key in device.config
+        and (zone := get_rpc_role_by_key(device.config, key)).startswith("zone")
+    ):
         return int(zone[4:])
     return None
 
@@ -837,7 +841,7 @@ def get_rpc_device_info(
     if (
         (
             component not in (*All_LIGHT_TYPES, "cover", "em1", "switch")
-            and get_irrigation_zone_id(device.config, key) is None
+            and get_irrigation_zone_id(device, key) is None
         )
         or idx is None
         or len(get_rpc_key_instances(device.status, component, all_lights=True)) < 2

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1,9 +1,10 @@
 """Tests for Shelly sensor platform."""
 
 from copy import deepcopy
-from unittest.mock import Mock
+from unittest.mock import Mock, PropertyMock
 
 from aioshelly.const import MODEL_BLU_GATEWAY_G3
+from aioshelly.exceptions import NotInitialized
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -52,6 +53,7 @@ from . import (
     register_device,
     register_entity,
 )
+from .conftest import MOCK_CONFIG, MOCK_SHELLY_RPC, MOCK_STATUS_RPC
 
 from tests.common import (
     async_fire_time_changed,
@@ -632,6 +634,9 @@ async def test_rpc_restored_sleeping_sensor(
     extra_data = {"native_value": "21.0", "native_unit_of_measurement": "°C"}
 
     mock_restore_cache_with_extra_data(hass, ((State(entity_id, ""), extra_data),))
+    type(mock_rpc_device).shelly = PropertyMock(side_effect=NotInitialized())
+    type(mock_rpc_device).config = PropertyMock(side_effect=NotInitialized())
+    type(mock_rpc_device).status = PropertyMock(side_effect=NotInitialized())
     monkeypatch.setattr(mock_rpc_device, "initialized", False)
 
     await hass.config_entries.async_setup(entry.entry_id)
@@ -641,6 +646,9 @@ async def test_rpc_restored_sleeping_sensor(
     assert state.state == "21.0"
 
     # Make device online
+    type(mock_rpc_device).shelly = PropertyMock(return_value=MOCK_SHELLY_RPC)
+    type(mock_rpc_device).config = PropertyMock(return_value=MOCK_CONFIG)
+    type(mock_rpc_device).status = PropertyMock(return_value=MOCK_STATUS_RPC)
     monkeypatch.setattr(mock_rpc_device, "initialized", True)
     mock_rpc_device.mock_online()
     await hass.async_block_till_done(wait_background_tasks=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix https://github.com/home-assistant/core/issues/155466 - do not access device data for Non-initialized devices (sleepy devices).
Modified one of the tests to fail when accessing properties of the device to simulate the issue, without this fix the test fails

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/155466
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
