### PR TITLE
Add ZHA migration retry steps for unplugged adapters

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -496,14 +496,23 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
         config_entry = config_entries[0]
         old_device_path = config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH]
 
-        # user confirmed, try again
-        if user_input is not None:
-            return await self.async_step_maybe_reset_old_radio()
-
-        return self.async_show_form(
+        return self.async_show_menu(
             step_id="plug_in_old_radio",
+            menu_options=["retry", "skip_reset"],
             description_placeholders={"device_path": old_device_path},
         )
+
+    async def async_step_retry(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Retry connecting to the old radio."""
+        return await self.async_step_maybe_reset_old_radio()
+
+    async def async_step_skip_reset(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Skip resetting the old radio and continue with migration."""
+        return await self.async_step_maybe_confirm_ezsp_restore()
 
     async def async_step_migration_strategy_advanced(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -498,17 +498,17 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
 
         return self.async_show_menu(
             step_id="plug_in_old_radio",
-            menu_options=["retry", "skip_reset"],
+            menu_options=["retry_old_radio", "skip_reset_old_radio"],
             description_placeholders={"device_path": old_device_path},
         )
 
-    async def async_step_retry(
+    async def async_step_retry_old_radio(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Retry connecting to the old radio."""
         return await self.async_step_maybe_reset_old_radio()
 
-    async def async_step_skip_reset(
+    async def async_step_skip_reset_old_radio(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Skip resetting the old radio and continue with migration."""

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -489,7 +489,8 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
             DOMAIN, include_ignore=False
         )
 
-        # config entry should always exist here, skip if not
+        # Unless the user removes the config entry whilst we try to reset the old radio
+        # for a few seconds and then also unplugs it, we will basically never hit this
         if not config_entries:
             return await self.async_step_maybe_confirm_ezsp_restore()
 

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -118,12 +118,12 @@
       "plug_in_old_radio": {
         "description": "Your old adapter at `{device_path}` was not found. You can retry after plugging it back in, or skip resetting the old adapter.\n\nIf you skip resetting the old adapter, please make sure it is permanently unavailable, as plugging it back in later will cause network issues.",
         "menu_option_descriptions": {
-          "retry": "Retry connecting to the old adapter to reset it as part of the migration.",
-          "skip_reset": "Skip resetting the old adapter and continue with the migration."
+          "retry_old_radio": "Retry connecting to the old adapter to reset it as part of the migration.",
+          "skip_reset_old_radio": "Skip resetting the old adapter and continue with the migration."
         },
         "menu_options": {
-          "retry": "Retry",
-          "skip_reset": "Skip reset"
+          "retry_old_radio": "Retry",
+          "skip_reset_old_radio": "Skip reset"
         },
         "title": "Old adapter not found"
       },
@@ -1968,12 +1968,12 @@
       "plug_in_old_radio": {
         "description": "[%key:component::zha::config::step::plug_in_old_radio::description%]",
         "menu_option_descriptions": {
-          "retry": "[%key:component::zha::config::step::plug_in_old_radio::menu_option_descriptions::retry%]",
-          "skip_reset": "[%key:component::zha::config::step::plug_in_old_radio::menu_option_descriptions::skip_reset%]"
+          "retry_old_radio": "[%key:component::zha::config::step::plug_in_old_radio::menu_option_descriptions::retry_old_radio%]",
+          "skip_reset_old_radio": "[%key:component::zha::config::step::plug_in_old_radio::menu_option_descriptions::skip_reset_old_radio%]"
         },
         "menu_options": {
-          "retry": "[%key:component::zha::config::step::plug_in_old_radio::menu_options::retry%]",
-          "skip_reset": "[%key:component::zha::config::step::plug_in_old_radio::menu_options::skip_reset%]"
+          "retry_old_radio": "[%key:component::zha::config::step::plug_in_old_radio::menu_options::retry_old_radio%]",
+          "skip_reset_old_radio": "[%key:component::zha::config::step::plug_in_old_radio::menu_options::skip_reset_old_radio%]"
         },
         "title": "[%key:component::zha::config::step::plug_in_old_radio::title%]"
       },

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -111,6 +111,10 @@
         "description": "A backup was created earlier and your old adapter is being reset as part of the migration.",
         "title": "Resetting old adapter"
       },
+      "plug_in_old_radio": {
+        "description": "Your old adapter at `{device_path}` was not found. Please plug it back in and click Submit to continue.\n\nOnce plugged in, your old adapter will be reset as part of the migration.",
+        "title": "Old adapter not found"
+      },
       "upload_manual_backup": {
         "data": {
           "uploaded_backup_file": "Upload a file"
@@ -1944,6 +1948,10 @@
         },
         "description": "[%key:component::zha::config::step::maybe_confirm_ezsp_restore::description%]",
         "title": "[%key:component::zha::config::step::maybe_confirm_ezsp_restore::title%]"
+      },
+      "plug_in_old_radio": {
+        "description": "[%key:component::zha::config::step::plug_in_old_radio::description%]",
+        "title": "[%key:component::zha::config::step::plug_in_old_radio::title%]"
       },
       "prompt_migrate_or_reconfigure": {
         "description": "Are you migrating to a new adapter or re-configuring the current adapter?",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -116,7 +116,7 @@
         "title": "New adapter not found"
       },
       "plug_in_old_radio": {
-        "description": "Your old adapter at `{device_path}` was not found. You can retry after plugging it back in, or skip resetting the old adapter.\n\nIf you skip resetting the old adapter, please make sure it is permanently unavailable, as plugging it back in later will cause network issues.",
+        "description": "Your old adapter at `{device_path}` was not found. You can retry after plugging it back in, or skip resetting the old adapter.\n\n**Warning:** If you skip resetting the old adapter, ensure it remains permanently disconnected. Plugging it back in later will cause network issues.",
         "menu_option_descriptions": {
           "retry_old_radio": "Retry connecting to the old adapter to reset it as part of the migration.",
           "skip_reset_old_radio": "Skip resetting the old adapter and continue with the migration."

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -112,7 +112,15 @@
         "title": "Resetting old adapter"
       },
       "plug_in_old_radio": {
-        "description": "Your old adapter at `{device_path}` was not found. Please plug it back in and click Submit to continue.\n\nOnce plugged in, your old adapter will be reset as part of the migration.",
+        "description": "Your old adapter at `{device_path}` was not found. You can retry after plugging it back in, or skip resetting the old adapter.\n\nIf you skip resetting the old adapter, please make sure it is permanently unavailable, as plugging it back in later will cause network issues.",
+        "menu_option_descriptions": {
+          "retry": "Retry connecting to the old adapter to reset it as part of the migration.",
+          "skip_reset": "Skip resetting the old adapter and continue with the migration."
+        },
+        "menu_options": {
+          "retry": "Retry",
+          "skip_reset": "Skip reset"
+        },
         "title": "Old adapter not found"
       },
       "upload_manual_backup": {
@@ -1951,6 +1959,14 @@
       },
       "plug_in_old_radio": {
         "description": "[%key:component::zha::config::step::plug_in_old_radio::description%]",
+        "menu_option_descriptions": {
+          "retry": "[%key:component::zha::config::step::plug_in_old_radio::menu_option_descriptions::retry%]",
+          "skip_reset": "[%key:component::zha::config::step::plug_in_old_radio::menu_option_descriptions::skip_reset%]"
+        },
+        "menu_options": {
+          "retry": "[%key:component::zha::config::step::plug_in_old_radio::menu_options::retry%]",
+          "skip_reset": "[%key:component::zha::config::step::plug_in_old_radio::menu_options::skip_reset%]"
+        },
         "title": "[%key:component::zha::config::step::plug_in_old_radio::title%]"
       },
       "prompt_migrate_or_reconfigure": {

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -111,6 +111,10 @@
         "description": "A backup was created earlier and your old adapter is being reset as part of the migration.",
         "title": "Resetting old adapter"
       },
+      "plug_in_new_radio": {
+        "description": "Your new adapter at `{device_path}` was not found.\nPlease plug it in and click Submit to continue.",
+        "title": "New adapter not found"
+      },
       "plug_in_old_radio": {
         "description": "Your old adapter at `{device_path}` was not found. You can retry after plugging it back in, or skip resetting the old adapter.\n\nIf you skip resetting the old adapter, please make sure it is permanently unavailable, as plugging it back in later will cause network issues.",
         "menu_option_descriptions": {
@@ -1956,6 +1960,10 @@
         },
         "description": "[%key:component::zha::config::step::maybe_confirm_ezsp_restore::description%]",
         "title": "[%key:component::zha::config::step::maybe_confirm_ezsp_restore::title%]"
+      },
+      "plug_in_new_radio": {
+        "description": "[%key:component::zha::config::step::plug_in_new_radio::description%]",
+        "title": "[%key:component::zha::config::step::plug_in_new_radio::title%]"
       },
       "plug_in_old_radio": {
         "description": "[%key:component::zha::config::step::plug_in_old_radio::description%]",

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -3011,3 +3011,98 @@ async def test_plug_in_new_radio_retry(
     # Verify restore was attempted four times:
     # first fail + retry for destructive dialog + failed destructive + successful retry
     assert mock_restore_backup.call_count == 4
+
+
+@patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
+@patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
+async def test_plug_in_old_radio_retry(hass: HomeAssistant, backup, mock_app) -> None:
+    """Test plug_in_old_radio step when reset fails due to unplugged adapter."""
+    entry = MockConfigEntry(
+        version=config_flow.ZhaConfigFlowHandler.VERSION,
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE: {
+                CONF_DEVICE_PATH: "/dev/ttyUSB0",
+                CONF_BAUDRATE: 115200,
+                CONF_FLOW_CONTROL: None,
+            },
+            CONF_RADIO_TYPE: "ezsp",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    discovery_info = UsbServiceInfo(
+        device="/dev/ttyZIGBEE",
+        pid="AAAA",
+        vid="AAAA",
+        serial_number="1234",
+        description="zigbee radio",
+        manufacturer="test",
+    )
+
+    mock_temp_radio_mgr = AsyncMock()
+    mock_temp_radio_mgr.async_reset_adapter = AsyncMock(
+        side_effect=HomeAssistantError(
+            "Failed to connect to Zigbee adapter: [Errno 2] No such file or directory"
+        )
+    )
+
+    with (
+        patch(
+            "homeassistant.components.zha.radio_manager.ZhaRadioManager._async_read_backups_from_database",
+            return_value=[backup],
+        ),
+        patch(
+            "homeassistant.components.zha.config_flow.ZhaRadioManager",
+            side_effect=[ZhaRadioManager(), mock_temp_radio_mgr, mock_temp_radio_mgr],
+        ),
+    ):
+        result_init = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USB}, data=discovery_info
+        )
+
+        result_confirm = await hass.config_entries.flow.async_configure(
+            result_init["flow_id"], user_input={}
+        )
+
+        assert result_confirm["step_id"] == "choose_migration_strategy"
+
+        result_recommended = await hass.config_entries.flow.async_configure(
+            result_confirm["flow_id"],
+            user_input={"next_step_id": config_flow.MIGRATION_STRATEGY_RECOMMENDED},
+        )
+
+        # Prompt user to plug old adapter back in when reset fails
+        assert result_recommended["type"] is FlowResultType.MENU
+        assert result_recommended["step_id"] == "plug_in_old_radio"
+        assert (
+            result_recommended["description_placeholders"]["device_path"]
+            == "/dev/ttyUSB0"
+        )
+        assert result_recommended["menu_options"] == [
+            "retry_old_radio",
+            "skip_reset_old_radio",
+        ]
+
+        # Retry with unplugged adapter
+        result_retry = await hass.config_entries.flow.async_configure(
+            result_recommended["flow_id"],
+            user_input={"next_step_id": "retry_old_radio"},
+        )
+
+        # Prompt user again to plug old adapter back in
+        assert result_retry["type"] is FlowResultType.MENU
+        assert result_retry["step_id"] == "plug_in_old_radio"
+
+        # Skip resetting the old adapter
+        result_skip = await hass.config_entries.flow.async_configure(
+            result_retry["flow_id"],
+            user_input={"next_step_id": "skip_reset_old_radio"},
+        )
+
+    # Entry created successfully after skipping reset
+    assert result_skip["type"] is FlowResultType.ABORT
+    assert result_skip["reason"] == "reconfigure_successful"
+
+    # Verify reset was attempted twice: initial + retry
+    assert mock_temp_radio_mgr.async_reset_adapter.call_count == 2

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -51,6 +51,7 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_MANUFACTURER_URL,
     ATTR_UPNP_SERIAL,
@@ -2925,3 +2926,88 @@ async def test_migrate_setup_options_with_ignored_discovery(
         "setup_strategy_recommended",
         "setup_strategy_advanced",
     ]
+
+
+@patch("homeassistant.components.zha.radio_manager._allow_overwrite_ezsp_ieee")
+async def test_plug_in_new_radio_retry(
+    allow_overwrite_ieee_mock,
+    advanced_pick_radio: RadioPicker,
+    mock_app: AsyncMock,
+    backup,
+    hass: HomeAssistant,
+) -> None:
+    """Test plug_in_new_radio step when restore fails due to unplugged adapter."""
+    result = await advanced_pick_radio(RadioType.ezsp)
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": config_flow.FORMATION_UPLOAD_MANUAL_BACKUP},
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "upload_manual_backup"
+
+    with (
+        patch(
+            "homeassistant.components.zha.config_flow.ZhaConfigFlowHandler._parse_uploaded_backup",
+            return_value=backup,
+        ),
+        patch(
+            "homeassistant.components.zha.radio_manager.ZhaRadioManager.restore_backup",
+            side_effect=[
+                HomeAssistantError(
+                    "Failed to connect to Zigbee adapter: [Errno 2] No such file or directory"
+                ),
+                DestructiveWriteNetworkSettings("Radio IEEE change is permanent"),
+                HomeAssistantError(
+                    "Failed to connect to Zigbee adapter: [Errno 2] No such file or directory"
+                ),
+                None,
+            ],
+        ) as mock_restore_backup,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            user_input={config_flow.UPLOADED_BACKUP_FILE: str(uuid.uuid4())},
+        )
+
+        # Prompt user to plug old adapter back in when restore fails
+        assert result3["type"] is FlowResultType.FORM
+        assert result3["step_id"] == "plug_in_new_radio"
+        assert result3["description_placeholders"] == {"device_path": "/dev/ttyUSB1234"}
+
+        # Submit retry attempt with plugged in adapter
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            user_input={},
+        )
+
+        # This adapter requires user confirmation for restore
+        assert result4["type"] is FlowResultType.FORM
+        assert result4["step_id"] == "maybe_confirm_ezsp_restore"
+
+        # Confirm destructive rewrite, but adapter is unplugged again
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            user_input={config_flow.OVERWRITE_COORDINATOR_IEEE: True},
+        )
+
+        # Prompt user to plug old adapter back in again
+        assert result4["type"] is FlowResultType.FORM
+        assert result4["step_id"] == "plug_in_new_radio"
+        assert result4["description_placeholders"] == {"device_path": "/dev/ttyUSB1234"}
+
+        # User confirms they plugged in the adapter
+        result5 = await hass.config_entries.flow.async_configure(
+            result4["flow_id"],
+            user_input={},
+        )
+
+    # Entry created successfully
+    assert result5["type"] is FlowResultType.CREATE_ENTRY
+    assert result5["data"][CONF_RADIO_TYPE] == "ezsp"
+
+    # Verify restore was attempted four times:
+    # first fail + retry for destructive dialog + failed destructive + successful retry
+    assert mock_restore_backup.call_count == 4

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -3090,15 +3090,15 @@ async def test_plug_in_old_radio_retry(hass: HomeAssistant, backup, mock_app) ->
             user_input={"next_step_id": "retry_old_radio"},
         )
 
-        # Prompt user again to plug old adapter back in
-        assert result_retry["type"] is FlowResultType.MENU
-        assert result_retry["step_id"] == "plug_in_old_radio"
+    # Prompt user again to plug old adapter back in
+    assert result_retry["type"] is FlowResultType.MENU
+    assert result_retry["step_id"] == "plug_in_old_radio"
 
-        # Skip resetting the old adapter
-        result_skip = await hass.config_entries.flow.async_configure(
-            result_retry["flow_id"],
-            user_input={"next_step_id": "skip_reset_old_radio"},
-        )
+    # Skip resetting the old adapter
+    result_skip = await hass.config_entries.flow.async_configure(
+        result_retry["flow_id"],
+        user_input={"next_step_id": "skip_reset_old_radio"},
+    )
 
     # Entry created successfully after skipping reset
     assert result_skip["type"] is FlowResultType.ABORT

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -2988,25 +2988,25 @@ async def test_plug_in_new_radio_retry(
         assert result4["step_id"] == "maybe_confirm_ezsp_restore"
 
         # Confirm destructive rewrite, but adapter is unplugged again
-        result4 = await hass.config_entries.flow.async_configure(
+        result5 = await hass.config_entries.flow.async_configure(
             result3["flow_id"],
             user_input={config_flow.OVERWRITE_COORDINATOR_IEEE: True},
         )
 
         # Prompt user to plug old adapter back in again
-        assert result4["type"] is FlowResultType.FORM
-        assert result4["step_id"] == "plug_in_new_radio"
-        assert result4["description_placeholders"] == {"device_path": "/dev/ttyUSB1234"}
+        assert result5["type"] is FlowResultType.FORM
+        assert result5["step_id"] == "plug_in_new_radio"
+        assert result5["description_placeholders"] == {"device_path": "/dev/ttyUSB1234"}
 
         # User confirms they plugged in the adapter
-        result5 = await hass.config_entries.flow.async_configure(
+        result6 = await hass.config_entries.flow.async_configure(
             result4["flow_id"],
             user_input={},
         )
 
     # Entry created successfully
-    assert result5["type"] is FlowResultType.CREATE_ENTRY
-    assert result5["data"][CONF_RADIO_TYPE] == "ezsp"
+    assert result6["type"] is FlowResultType.CREATE_ENTRY
+    assert result6["data"][CONF_RADIO_TYPE] == "ezsp"
 
     # Verify restore was attempted four times:
     # first fail + retry for destructive dialog + failed destructive + successful retry

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -3137,7 +3137,6 @@ async def test_plug_in_old_radio_config_entry_removed(
         manufacturer="test",
     )
 
-    # Mock radio manager for the old radio that is unplugged during reset
     mock_temp_radio_mgr = AsyncMock()
     mock_temp_radio_mgr.async_reset_adapter = AsyncMock(
         side_effect=HomeAssistantError(


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where the ZHA migration completely fails if the user unplugs the old or new radio in between steps.
New dialogs are added in the config/options flow to allow the user to plug back in the old or new adapter respectively.

Initial implementation of puddly's suggestion here: https://github.com/zigpy/backlog/issues/59#issuecomment-3459473645

### No user-facing changes with old + new adapters plugged in

If both adapters are plugged in during the entire migration (which we expected when it was rewritten), nothing changes!
These dialogs are only shown if the user unplugged the old or new adapter during the migration, when we need to communicate with it to (1) reset or (2) restore the backup.


### Images of new dialogs

Old adapter not found for reset | New adapter not found for restore
--- | ---
<img width="582" height="348" alt="image" src="https://github.com/user-attachments/assets/62ae2fab-0a45-4a4c-9148-b4c97f783dab" /> | <img width="534" height="209" alt="Bildschirmfoto 2025-10-31 um 04 09 20" src="https://github.com/user-attachments/assets/4aba5a38-1fd9-471e-b8c4-edf460f0cbcb" />


<details><summary>Previous dialog for old adapter being unplugged without the warning (click to view) </summary>
<p>

This is the initial version of the dialog, before the change introduced in this commit: [`f594696` (#155537)](https://github.com/home-assistant/core/pull/155537/commits/f594696a6eb587ef70622ea45e98ffa4ad88d145)

<img width="584" height="347" alt="Bildschirmfoto 2025-10-31 um 04 09 03" src="https://github.com/user-attachments/assets/5d7dba4d-d97a-4a64-aa45-6ac6616b9139" /> 

</p>
</details> 





### Config flow steps

When migrating adapters, something like this happens in the background:
1. Old adapter: Take fresh backup (optional, uses existing backup otherwise)
2. New adapter: List in serial port selector
3. New adapter: Probe to test
4. Old adapter: Resetting
5. New adapter: Restoring backup

Currently, if the old adapter is unplugged for step 4, the whole migration blows up.
The same also applies if the new adapter is unplugged for step 5.

#### Why do users do this?

Sometimes, users have a valid reason to unplug the old adapter at that point: they have a device with only one (free) USB port for their Zigbee adapter. So, we should not catastrophically fail anymore.

With this PR, retry steps are added to step 4 and 5:
- For step 4, the retry dialog also allows the option to skip the reset, as this needs to be done when the user uses the "Migrate" option, but no longer has their old adapter (e.g. if it's broken/lost).
- For step 5, the retry dialog only allows you to retry, not skip restoring the backup, as that would obviously defeat the purpose of the whole migration. This dialog needs to be added, as users may unplug the new adapter to reset their old adapter in step 4.


### Allowing migration with one USB port

Theoretically, this also allows the user to perform a migration with just one free USB port for the Zigbee adapter.
Mostly, you just need to follow the instructions. There are two new main possibilities for this:

<details><summary>Detailed(!) steps for doing migration with one USB port (CLICK TO OPEN)</summary>
<p>


#### 'Live' migration

1. Have old/active adapter plugged in
7. Start migration flow: backup will be taken of old adapter
8. Before choosing to re-configure or migrate in first step:
9. Unplug the old adapter
10. Plug in the new adapter
11. Choose "Migration", NOT "Re-configure current radio"
12. Choose new adapter from serial port selector (-> it's probed)
13. Choose "Migrate automatically" strategy
14. User will get a prompt to plug in old adapter for resetting it. **(New! Failed before)**
  This reset can also be skipped (continue with step 17), otherwise proceed normally:
15. Unplug new adapter
16. Plug in old adapter
17. Click "Retry" to retry reset
18. After successful reset, the user gets a prompt about plugging in the new adapter again. **(New! Failed before)**
19. Unplug old adapter
20. Plug in new adapter
21. Click "Submit" to try restoring backup to new adapter again
22. Success: Migration completed with one USB port

#### Old backup migration

1. Unplug old adapter
2. Plug in new adapter
3. Start migration flow: no backup can be taken of old adapter, as it's not plugged in, so an existing one is used
4. Choose "Migration", NOT "Re-configure current radio" in first step
5. Choose new adapter from serial port selector
6. Choose "Migrate automatically" strategy
7. User will get a prompt to plug in the old adapter to reset OR skip reset. **(New! Failed before)**
8. User skips resetting old adapter, as they won't plug it in*.
9. Success: Migration continued normally, as new adapter is plugged in the entire time

*: It is also possible to reset the old adapter at this point. It just needs to be plugged in briefly. The new adapter can be unplugged during that time. Another dialog will ask to plug in the new adapter afterwards.
This is very similar to steps 10 to 16 from the "Live migration".

</p>
</details> 



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/zigpy/backlog/issues/59
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
