### PR TITLE
Bump PSNAWP to 3.0.1

### DIFF
--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
-import json
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -175,10 +174,6 @@ class PlaystationNetworkGroupsUpdateCoordinator(
                 }
             )
         except PSNAWPForbiddenError as e:
-            try:
-                error = json.loads(e.args[0])
-            except json.JSONDecodeError as err:
-                raise PSNAWPServerError from err
             ir.async_create_issue(
                 self.hass,
                 DOMAIN,
@@ -189,7 +184,7 @@ class PlaystationNetworkGroupsUpdateCoordinator(
                 translation_key="group_chat_forbidden",
                 translation_placeholders={
                     CONF_NAME: self.config_entry.title,
-                    "error_message": error["error"]["message"],
+                    "error_message": e.message or "",
                 },
             )
             await self.async_shutdown()

--- a/homeassistant/components/playstation_network/manifest.json
+++ b/homeassistant/components/playstation_network/manifest.json
@@ -81,5 +81,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
-  "requirements": ["PSNAWP==3.0.0", "pyrate-limiter==3.9.0"]
+  "requirements": ["PSNAWP==3.0.1", "pyrate-limiter==3.9.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -25,7 +25,7 @@ HATasmota==0.10.1
 Mastodon.py==2.1.2
 
 # homeassistant.components.playstation_network
-PSNAWP==3.0.0
+PSNAWP==3.0.1
 
 # homeassistant.components.doods
 # homeassistant.components.generic

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -25,7 +25,7 @@ HATasmota==0.10.1
 Mastodon.py==2.1.2
 
 # homeassistant.components.playstation_network
-PSNAWP==3.0.0
+PSNAWP==3.0.1
 
 # homeassistant.components.doods
 # homeassistant.components.generic

--- a/tests/components/playstation_network/test_config_flow.py
+++ b/tests/components/playstation_network/test_config_flow.py
@@ -119,9 +119,9 @@ async def test_form_already_configured_as_subentry(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("raise_error", "text_error"),
     [
-        (PSNAWPNotFoundError(), "invalid_account"),
-        (PSNAWPAuthenticationError(), "invalid_auth"),
-        (PSNAWPError(), "cannot_connect"),
+        (PSNAWPNotFoundError("error msg"), "invalid_account"),
+        (PSNAWPAuthenticationError("error msg"), "invalid_auth"),
+        (PSNAWPError("error msg"), "cannot_connect"),
         (Exception(), "unknown"),
     ],
 )
@@ -169,7 +169,7 @@ async def test_parse_npsso_token_failures(
     mock_psnawp_npsso: MagicMock,
 ) -> None:
     """Test parse_npsso_token raises the correct exceptions during config flow."""
-    mock_psnawp_npsso.side_effect = PSNAWPInvalidTokenError
+    mock_psnawp_npsso.side_effect = PSNAWPInvalidTokenError("error msg")
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -221,9 +221,9 @@ async def test_flow_reauth(
 @pytest.mark.parametrize(
     ("raise_error", "text_error"),
     [
-        (PSNAWPNotFoundError(), "invalid_account"),
-        (PSNAWPAuthenticationError(), "invalid_auth"),
-        (PSNAWPError(), "cannot_connect"),
+        (PSNAWPNotFoundError("error msg"), "invalid_account"),
+        (PSNAWPAuthenticationError("error msg"), "invalid_auth"),
+        (PSNAWPError("error msg"), "cannot_connect"),
         (Exception(), "unknown"),
     ],
 )
@@ -287,7 +287,7 @@ async def test_flow_reauth_token_error(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    mock_psnawp_npsso.side_effect = PSNAWPInvalidTokenError
+    mock_psnawp_npsso.side_effect = PSNAWPInvalidTokenError("error msg")
     result = await config_entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -49,7 +49,7 @@ async def test_config_entry_auth_failed(
 ) -> None:
     """Test config entry auth failed setup error."""
 
-    mock_psnawpapi.user.side_effect = PSNAWPAuthenticationError
+    mock_psnawpapi.user.side_effect = PSNAWPAuthenticationError("error msg")
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -95,7 +95,7 @@ async def test_coordinator_update_auth_failed(
     """Test coordinator update auth failed setup error."""
 
     mock_psnawpapi.user.return_value.get_presence.side_effect = (
-        PSNAWPAuthenticationError
+        PSNAWPAuthenticationError("error msg")
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -152,7 +152,7 @@ async def test_trophy_title_coordinator_auth_failed(
     assert config_entry.state is ConfigEntryState.LOADED
 
     mock_psnawpapi.user.return_value.trophy_titles.side_effect = (
-        PSNAWPAuthenticationError
+        PSNAWPAuthenticationError("error msg")
     )
 
     freezer.tick(timedelta(days=1))
@@ -300,10 +300,10 @@ async def test_friends_coordinator_update_data_failed(
 @pytest.mark.parametrize(
     ("exception", "state"),
     [
-        (PSNAWPNotFoundError, ConfigEntryState.SETUP_ERROR),
-        (PSNAWPAuthenticationError, ConfigEntryState.SETUP_ERROR),
-        (PSNAWPServerError, ConfigEntryState.SETUP_RETRY),
-        (PSNAWPClientError, ConfigEntryState.SETUP_RETRY),
+        (PSNAWPNotFoundError("error msg"), ConfigEntryState.SETUP_ERROR),
+        (PSNAWPAuthenticationError("error msg"), ConfigEntryState.SETUP_ERROR),
+        (PSNAWPServerError("error msg"), ConfigEntryState.SETUP_RETRY),
+        (PSNAWPClientError("error msg"), ConfigEntryState.SETUP_RETRY),
     ],
 )
 async def test_friends_coordinator_setup_failed(
@@ -332,7 +332,7 @@ async def test_friends_coordinator_auth_failed(
     """Test friends coordinator starts reauth on authentication error."""
 
     mock = mock_psnawpapi.user.return_value.friends_list.return_value[0]
-    mock.profile.side_effect = PSNAWPAuthenticationError
+    mock.profile.side_effect = PSNAWPAuthenticationError("error msg")
 
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/playstation_network/test_notify.py
+++ b/tests/components/playstation_network/test_notify.py
@@ -101,7 +101,12 @@ async def test_send_message(
 
 @pytest.mark.parametrize(
     "exception",
-    [PSNAWPClientError, PSNAWPForbiddenError, PSNAWPNotFoundError, PSNAWPServerError],
+    [
+        PSNAWPClientError("error msg"),
+        PSNAWPForbiddenError("error msg"),
+        PSNAWPNotFoundError("error msg"),
+        PSNAWPServerError("error msg"),
+    ],
 )
 async def test_send_message_exceptions(
     hass: HomeAssistant,


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Release notes: https://codeberg.org/YoshikageKira/psnawp/releases/tag/v3.0.1
Diff: https://codeberg.org/YoshikageKira/psnawp/compare/v3.0.0...v3.0.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #151987
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
