### PR TITLE
Allow ignored sensorpro devices to be set up from the user flow

### DIFF
--- a/homeassistant/components/sensorpro/config_flow.py
+++ b/homeassistant/components/sensorpro/config_flow.py
@@ -72,7 +72,7 @@ class SensorProConfigFlow(ConfigFlow, domain=DOMAIN):
                 title=self._discovered_devices[address], data={}
             )
 
-        current_addresses = self._async_current_ids()
+        current_addresses = self._async_current_ids(include_ignore=False)
         for discovery_info in async_discovered_service_info(self.hass, False):
             address = discovery_info.address
             if address in current_addresses or address in self._discovered_devices:

--- a/tests/components/sensorpro/test_config_flow.py
+++ b/tests/components/sensorpro/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.sensorpro.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IGNORE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -203,3 +204,39 @@ async def test_async_step_user_takes_precedence_over_discovery(
 
     # Verify the original one was aborted
     assert not hass.config_entries.flow.async_progress(DOMAIN)
+
+
+async def test_user_setup_replaces_ignored_device(hass: HomeAssistant) -> None:
+    """Test the user initiated form can replace an ignored device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="aa:bb:cc:dd:ee:ff",
+        source=SOURCE_IGNORE,
+        data={},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.sensorpro.config_flow.async_discovered_service_info",
+        return_value=[SENSORPRO_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Verify the ignored device is in the dropdown
+    assert "aa:bb:cc:dd:ee:ff" in result["data_schema"].schema["address"].container
+
+    with patch(
+        "homeassistant.components.sensorpro.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"address": "aa:bb:cc:dd:ee:ff"},
+        )
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "T201 EEFF"
+    assert result2["data"] == {}
+    assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"


### PR DESCRIPTION
## Proposed change

This PR addresses a recurring UX issue where users who previously ignored SensorPro (Bluetooth temperature and humidity sensor) devices during discovery cannot later set them up through the user configuration flow.

Previously, when a user ignored a discovered device, it would be permanently excluded from the device selection dropdown. This meant that if a user changed their mind later, they had no way to configure that device through the UI without manually removing the ignored config entry first.

This change modifies the user flow to include ignored devices in the selection dropdown by passing `include_ignore=False` to `_async_current_ids()`. This allows users to select previously ignored devices and replace the ignored entry with a proper configuration.

This follows the same pattern established in #137056 (govee_ble), #137102 (airthings_ble), #155611 (bluemaestro), #155613 (eufylife_ble), #155614 (kegtron), #155616 (keymitt_ble), #155618 (ld2410_ble), #155619 (leaone), #155620 (led_ble), #155622 (medcom_ble), #155623 (melnor), #155624 (moat), #155625 (ruuvitag_ble), and other related PRs addressing the same design issue across multiple integrations.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: Part of #137114
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
