### PR TITLE
Allow configuring ignored Steamist devices

### DIFF
--- a/homeassistant/components/steamist/config_flow.py
+++ b/homeassistant/components/steamist/config_flow.py
@@ -137,7 +137,7 @@ class SteamistConfigFlow(ConfigFlow, domain=DOMAIN):
             device = self._discovered_devices[mac]
             return self._async_create_entry_from_device(device)
 
-        current_unique_ids = self._async_current_ids()
+        current_unique_ids = self._async_current_ids(include_ignore=False)
         current_hosts = {
             entry.data[CONF_HOST]
             for entry in self._async_current_entries(include_ignore=False)


### PR DESCRIPTION
## Proposed change

This PR fixes a UX issue where users who previously ignored a Steamist device during discovery cannot configure it later through the UI without manually removing the ignored config entry.

The fix ensures that ignored devices appear in the device selection dropdown during manual setup by passing `include_ignore=False` to `_async_current_ids()`. When a user selects an ignored device, the ignored entry is automatically replaced with a properly configured one.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Part of #137114

- Added test coverage for the ignored device replacement scenario
- This change allows users to configure previously ignored devices without manual intervention

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repo]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
  Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
  Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] If this PR addresses an issue, I have linked the issue in the "Additional information" section above

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest
[perfect-pr]: https://developers.home-assistant.io/docs/review-process#perfect-pr
[docs-repo]: https://github.com/home-assistant/home-assistant.io
