### PR TITLE
Allow configuring ignored Kuler Sky devices

### DIFF
--- a/homeassistant/components/kulersky/config_flow.py
+++ b/homeassistant/components/kulersky/config_flow.py
@@ -106,7 +106,7 @@ class KulerskyConfigFlow(ConfigFlow, domain=DOMAIN):
         if discovery := self._discovery_info:
             self._discovered_devices[discovery.address] = discovery
         else:
-            current_addresses = self._async_current_ids()
+            current_addresses = self._async_current_ids(include_ignore=False)
             for discovery in async_discovered_service_info(self.hass):
                 if (
                     discovery.address in current_addresses

--- a/tests/components/kulersky/test_config_flow.py
+++ b/tests/components/kulersky/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.components.kulersky.config_flow import DOMAIN
 from homeassistant.config_entries import (
     SOURCE_BLUETOOTH,
+    SOURCE_IGNORE,
     SOURCE_INTEGRATION_DISCOVERY,
     SOURCE_USER,
 )
@@ -15,6 +16,7 @@ from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from tests.common import MockConfigEntry
 from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 KULERSKY_SERVICE_INFO = BluetoothServiceInfoBleak(
@@ -180,3 +182,44 @@ async def test_unexpected_error(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"]["base"] == "unknown"
+
+
+async def test_user_setup_replaces_ignored_device(hass: HomeAssistant) -> None:
+    """Test the user flow can replace an ignored device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="AA:BB:CC:DD:EE:FF",
+        source=SOURCE_IGNORE,
+        data={},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.kulersky.config_flow.async_discovered_service_info",
+        return_value=[KULERSKY_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Verify the ignored device is in the dropdown
+    assert "AA:BB:CC:DD:EE:FF" in result["data_schema"].schema[CONF_ADDRESS].container
+
+    with patch("pykulersky.Light", Mock(return_value=AsyncMock())):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "KulerLight (EEFF)"
+    assert result2["data"] == {
+        CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
+    }
+    assert result2["result"].unique_id == "AA:BB:CC:DD:EE:FF"


### PR DESCRIPTION
## Proposed change

This PR fixes a UX issue where users who previously ignored a Kuler Sky device during discovery cannot configure it later through the UI without manually removing the ignored config entry.

The fix ensures that ignored devices appear in the device selection dropdown during manual setup by passing `include_ignore=False` to `_async_current_ids()`. When a user selects an ignored device, the ignored entry is automatically replaced with a properly configured one.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Part of #137114

- Added test coverage for the ignored device replacement scenario
- This change allows users to configure previously ignored devices without manual intervention

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repo]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
  Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
  Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] If this PR addresses an issue, I have linked the issue in the "Additional information" section above

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest
[perfect-pr]: https://developers.home-assistant.io/docs/review-process#perfect-pr
[docs-repo]: https://github.com/home-assistant/home-assistant.io
