### PR TITLE
Add labels to selector in Brother config flow

### DIFF
--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -33,7 +33,7 @@ DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_TYPE, default=PRINTER_TYPE_LASER): SelectSelector(
             SelectSelectorConfig(
                 options=PRINTER_TYPES,
-                translation_key=CONF_TYPE,
+                translation_key="printer_type",
             )
         ),
         vol.Required(SECTION_ADVANCED_SETTINGS): section(
@@ -52,7 +52,7 @@ ZEROCONF_SCHEMA = vol.Schema(
         vol.Required(CONF_TYPE, default=PRINTER_TYPE_LASER): SelectSelector(
             SelectSelectorConfig(
                 options=PRINTER_TYPES,
-                translation_key=CONF_TYPE,
+                translation_key="printer_type",
             )
         ),
         vol.Required(SECTION_ADVANCED_SETTINGS): section(

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -13,6 +13,11 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import section
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+)
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.util.network import is_host_valid
 
@@ -21,6 +26,7 @@ from .const import (
     DEFAULT_COMMUNITY,
     DEFAULT_PORT,
     DOMAIN,
+    PRINTER_TYPE_LASER,
     PRINTER_TYPES,
     SECTION_ADVANCED_SETTINGS,
 )
@@ -28,7 +34,14 @@ from .const import (
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
-        vol.Optional(CONF_TYPE, default="laser"): vol.In(PRINTER_TYPES),
+        vol.Required(CONF_TYPE, default=PRINTER_TYPE_LASER): SelectSelector(
+            SelectSelectorConfig(
+                options=[
+                    SelectOptionDict(value=k, label=v) for k, v in PRINTER_TYPES.items()
+                ],
+                translation_key=CONF_TYPE,
+            )
+        ),
         vol.Required(SECTION_ADVANCED_SETTINGS): section(
             vol.Schema(
                 {
@@ -42,7 +55,14 @@ DATA_SCHEMA = vol.Schema(
 )
 ZEROCONF_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_TYPE, default="laser"): vol.In(PRINTER_TYPES),
+        vol.Required(CONF_TYPE, default=PRINTER_TYPE_LASER): SelectSelector(
+            SelectSelectorConfig(
+                options=[
+                    SelectOptionDict(value=k, label=v) for k, v in PRINTER_TYPES.items()
+                ],
+                translation_key=CONF_TYPE,
+            )
+        ),
         vol.Required(SECTION_ADVANCED_SETTINGS): section(
             vol.Schema(
                 {

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -13,11 +13,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import section
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.selector import (
-    SelectOptionDict,
-    SelectSelector,
-    SelectSelectorConfig,
-)
+from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.util.network import is_host_valid
 
@@ -36,9 +32,7 @@ DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_TYPE, default=PRINTER_TYPE_LASER): SelectSelector(
             SelectSelectorConfig(
-                options=[
-                    SelectOptionDict(value=k, label=v) for k, v in PRINTER_TYPES.items()
-                ],
+                options=PRINTER_TYPES,
                 translation_key=CONF_TYPE,
             )
         ),
@@ -57,9 +51,7 @@ ZEROCONF_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_TYPE, default=PRINTER_TYPE_LASER): SelectSelector(
             SelectSelectorConfig(
-                options=[
-                    SelectOptionDict(value=k, label=v) for k, v in PRINTER_TYPES.items()
-                ],
+                options=PRINTER_TYPES,
                 translation_key=CONF_TYPE,
             )
         ),

--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -7,7 +7,13 @@ from typing import Final
 
 DOMAIN: Final = "brother"
 
-PRINTER_TYPES: Final = ["laser", "ink"]
+PRINTER_TYPE_LASER = "laser"
+PRINTER_TYPE_INK = "ink"
+
+PRINTER_TYPES: Final = {
+    PRINTER_TYPE_LASER: "laser",
+    PRINTER_TYPE_INK: "ink",
+}
 
 UPDATE_INTERVAL = timedelta(seconds=30)
 

--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -10,10 +10,7 @@ DOMAIN: Final = "brother"
 PRINTER_TYPE_LASER = "laser"
 PRINTER_TYPE_INK = "ink"
 
-PRINTER_TYPES: Final = {
-    PRINTER_TYPE_LASER: "laser",
-    PRINTER_TYPE_INK: "ink",
-}
+PRINTER_TYPES: Final = [PRINTER_TYPE_LASER, PRINTER_TYPE_INK]
 
 UPDATE_INTERVAL = timedelta(seconds=30)
 

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -212,7 +212,7 @@
     }
   },
   "selectors": {
-    "type": {
+    "printer_type": {
       "options": {
         "ink": "ink",
         "laser": "laser"

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -38,11 +38,11 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "type": "Type of the printer"
+          "type": "Type"
         },
         "data_description": {
           "host": "The hostname or IP address of the Brother printer to control.",
-          "type": "Brother printer type: ink or laser."
+          "type": "The type of the printer."
         },
         "sections": {
           "advanced_settings": {
@@ -209,6 +209,14 @@
     },
     "update_error": {
       "message": "An error occurred while retrieving data from the {device} printer: {error}"
+    }
+  },
+  "selectors": {
+    "type": {
+      "options": {
+        "ink": "ink",
+        "laser": "laser"
+      }
     }
   }
 }

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -212,7 +212,7 @@
     }
   },
   "selector": {
-    "type": {
+    "printer_type": {
       "options": {
         "ink": "ink",
         "laser": "laser"

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -38,11 +38,11 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "type": "Type"
+          "type": "Printer type"
         },
         "data_description": {
           "host": "The hostname or IP address of the Brother printer to control.",
-          "type": "The type of the printer."
+          "type": "The type of the Brother printer."
         },
         "sections": {
           "advanced_settings": {

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -211,8 +211,8 @@
       "message": "An error occurred while retrieving data from the {device} printer: {error}"
     }
   },
-  "selectors": {
-    "printer_type": {
+  "selector": {
+    "type": {
       "options": {
         "ink": "ink",
         "laser": "laser"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enables translation for the labels `ink` and `laser` in the config flow.

<img width="418" height="484" alt="Bildschirmfoto 2025-11-02 um 10 21 58" src="https://github.com/user-attachments/assets/6ba26772-078e-40da-b4eb-fff73b5ba042" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
