### PR TITLE
Fix manifest URL requirement install check

### DIFF
--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -86,6 +86,10 @@ def is_installed(requirement_str: str) -> bool:
                 "Installed version for %s resolved to None", req.name
             )
             return False
+        if req.url:
+            # If requirement is a URL, we cannot verify versions, so let
+            # the package manager handle it
+            return False
         return req.specifier.contains(installed_version, prereleases=True)
     except PackageNotFoundError:
         return False

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -400,6 +400,11 @@ def test_get_is_installed() -> None:
     assert package.is_installed(f"{installed_package}<={installed_version}")
     assert not package.is_installed(f"{installed_package}<{installed_version}")
 
+    # URL-based requirements should always return False, as no version check is possible
+    assert not package.is_installed(
+        "homeassistant@git+https://github.com/home-assistant/core.git@dev"
+    )
+
 
 def test_check_package_previous_failed_install() -> None:
     """Test for when a previously install package failed and left cruft behind."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR forces the `is_installed()` check of the HA package utils to `False` if a requirement is given as URL instead of a package version (as suggested in [Developer Docs - Custom requirements during development & testing](https://developers.home-assistant.io/docs/creating_integration_manifest/#custom-requirements-during-development--testing)).

This will pass a requirement to the package manager (in our case uv) which will then install or update if required, based on the contents of the VCS repo.

Previously, the version check only works if
- the requested package was not installed at all
- using the deprecated fragment URLs (i.e. `git+https://github.com/pypa/pip#pip>=1`) as `is_installed()` only checks against the requirement string itself (in this case: the URL fragment), not the actual package version in the repo

For "valid" requirements, `SpecifierSet()` is empty, meaning any installed version is acceptable (without knowing if the VCS version actually differs).

Reproducer for `SpecifierSet().contains()`:
```py
>>> from importlib.metadata import version
>>> from urllib.parse import urlparse
>>> from packaging.requirements import Requirement
>>>
>>> installed_version = version("homeassistant")
>>> installed_version
'2025.12.0.dev0'
>>>
>>> # deprecated URL
>>> r = Requirement(urlparse("git+https://github.com/home-assistant/core.git#homeassistant<2025.12.0").fragment)
>>> r.specifier
<SpecifierSet('<2025.12.0')>
>>> r.url
>>> r.specifier.contains(installed_version, prereleases=True)
False
>>>
>>> # valid URL, doesn't parse a version and therefore assumes "any installed version is ok"
>>> r = Requirement("homeassistant@git+https://github.com/home-assistant/core.git@dev")
>>> r.specifier
<SpecifierSet('')>
>>> r.url
'git+https://github.com/home-assistant/core.git@dev'
>>> r.specifier.contains(installed_version, prereleases=True)
True
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #149833, fixes #153142
- This PR is related to issue: https://github.com/orgs/home-assistant/discussions/1226
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
