### PR TITLE
Postpone updating when prices are final in Nord Pool

### DIFF
--- a/homeassistant/components/nordpool/sensor.py
+++ b/homeassistant/components/nordpool/sensor.py
@@ -54,7 +54,7 @@ def get_prices(
     current_price_entries: dict[str, float] = {}
     next_price_entries: dict[str, float] = {}
     current_time = dt_util.utcnow()
-    LOGGER.debug("Price data: %s", data)
+    # LOGGER.debug("Price data: %s", data)
     for entry in data:
         resolution = entry.end - entry.start
         previous_time = current_time - resolution

--- a/tests/components/nordpool/fixtures/delivery_period_today.json
+++ b/tests/components/nordpool/fixtures/delivery_period_today.json
@@ -831,7 +831,7 @@
   "exchangeRate": 11.05186,
   "areaStates": [
     {
-      "state": "Final",
+      "state": "Preliminary",
       "areas": ["SE3", "SE4"]
     }
   ],

--- a/tests/components/nordpool/fixtures/delivery_period_tomorrow.json
+++ b/tests/components/nordpool/fixtures/delivery_period_tomorrow.json
@@ -831,7 +831,7 @@
   "exchangeRate": 11.03362,
   "areaStates": [
     {
-      "state": "Final",
+      "state": "Preliminary",
       "areas": ["SE3", "SE4"]
     }
   ],

--- a/tests/components/nordpool/snapshots/test_diagnostics.ambr
+++ b/tests/components/nordpool/snapshots/test_diagnostics.ambr
@@ -297,7 +297,7 @@
               'SE3',
               'SE4',
             ]),
-            'state': 'Final',
+            'state': 'Preliminary',
           }),
         ]),
         'blockPriceAggregates': list([
@@ -1151,7 +1151,7 @@
               'SE3',
               'SE4',
             ]),
-            'state': 'Final',
+            'state': 'Preliminary',
           }),
         ]),
         'blockPriceAggregates': list([


### PR DESCRIPTION
## Breaking change


## Proposed change
Postpone updating to next day when prices are final and tomorrow prices exist.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 