### PR TITLE
Add RSSI signal strength sensor to incomfort boiler

### DIFF
--- a/homeassistant/components/incomfort/icons.json
+++ b/homeassistant/components/incomfort/icons.json
@@ -20,6 +20,11 @@
         }
       }
     },
+    "sensor": {
+      "rf_message_rssi": {
+        "default": "mdi:signal"
+      }
+    },
     "water_heater": {
       "boiler": {
         "state": {

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -32,7 +32,6 @@ class IncomfortSensorEntityDescription(SensorEntityDescription):
     value_key: str
     extra_key: str | None = None
     entity_category = EntityCategory.DIAGNOSTIC
-    value_fn: Callable[[float], float] | None = None
 
 
 SENSOR_TYPES: tuple[IncomfortSensorEntityDescription, ...] = (

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -110,10 +110,6 @@ class IncomfortSensor(IncomfortBoilerEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
-        if self.entity_description.value_fn is not None:
-            return self.entity_description.value_fn(
-                self._heater.status[self.entity_description.value_key]
-            )
         return self._heater.status[self.entity_description.value_key]  # type: ignore [no-any-return]
 
     @property

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -14,12 +14,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import (
-    SIGNAL_STRENGTH_DECIBELS,
-    EntityCategory,
-    UnitOfPressure,
-    UnitOfTemperature,
-)
+from homeassistant.const import EntityCategory, UnitOfPressure, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -68,17 +63,14 @@ SENSOR_TYPES: tuple[IncomfortSensorEntityDescription, ...] = (
         value_key="tap_temp",
         entity_registry_enabled_default=False,
     ),
-    # https://onlinedocs.microchip.com/oxy/GUID-04F68A6F-ABC7-4210-8B16-0AEE59C530AF-en-US-1/GUID-D9118600-8ED5-4DA3-8689-056D54CFF
     # A lower RSSI value is better
-    # An RSSI value of 28 calculates to -78 dB
+    # A typical RSSI value is 28 for connection just in range
     IncomfortSensorEntityDescription(
         key="rf_message_rssi",
-        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        translation_key="rf_message_rssi",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         value_key="rf_message_rssi",
         extra_key="rfstatus_cntr",
-        value_fn=lambda value: -50 - value,
         entity_registry_enabled_default=False,
     ),
 )

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -76,6 +76,9 @@
       }
     },
     "sensor": {
+      "rf_message_rssi": {
+        "name": "RSSI"
+      },
       "tap_temperature": {
         "name": "Tap temperature"
       }

--- a/tests/components/incomfort/snapshots/test_sensor.ambr
+++ b/tests/components/incomfort/snapshots/test_sensor.ambr
@@ -55,7 +55,7 @@
     'state': '1.86',
   })
 # ---
-# name: test_setup_platform[sensor.boiler_signal_strength-entry]
+# name: test_setup_platform[sensor.boiler_rssi-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -70,7 +70,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.boiler_signal_strength',
+    'entity_id': 'sensor.boiler_rssi',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -80,33 +80,31 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Signal strength',
+    'original_name': 'RSSI',
     'platform': 'incomfort',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'rf_message_rssi',
     'unique_id': 'c0ffeec0ffee_rf_message_rssi',
-    'unit_of_measurement': 'dB',
+    'unit_of_measurement': None,
   })
 # ---
-# name: test_setup_platform[sensor.boiler_signal_strength-state]
+# name: test_setup_platform[sensor.boiler_rssi-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'signal_strength',
-      'friendly_name': 'Boiler Signal strength',
+      'friendly_name': 'Boiler RSSI',
       'rfstatus_cntr': 0,
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'dB',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.boiler_signal_strength',
+    'entity_id': 'sensor.boiler_rssi',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '-80',
+    'state': '30',
   })
 # ---
 # name: test_setup_platform[sensor.boiler_tap_temperature-entry]

--- a/tests/components/incomfort/snapshots/test_sensor.ambr
+++ b/tests/components/incomfort/snapshots/test_sensor.ambr
@@ -55,6 +55,60 @@
     'state': '1.86',
   })
 # ---
+# name: test_setup_platform[sensor.boiler_signal_strength-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.boiler_signal_strength',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Signal strength',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'c0ffeec0ffee_rf_message_rssi',
+    'unit_of_measurement': 'dB',
+  })
+# ---
+# name: test_setup_platform[sensor.boiler_signal_strength-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'signal_strength',
+      'friendly_name': 'Boiler Signal strength',
+      'rfstatus_cntr': 0,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'dB',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.boiler_signal_strength',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-80',
+  })
+# ---
 # name: test_setup_platform[sensor.boiler_tap_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add RSSI signal strength sensor to incomfort/Intergas boiler.

The PCB of the Intergas gateway is a Microchip type. As the RSSI number is a positive value, that gets lower when the signal improves.

We do know the exact meaning of the sensor, so it is not assigned a device class nor native unit of measurement.

The sensor will be disabled by default.

<img width="334" height="557" alt="afbeelding" src="https://github.com/user-attachments/assets/f029fa66-fbcb-4427-9e4d-a1a44262fc57" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
