### PR TITLE
Deprecate TemperatureConverter.convert_interval

### DIFF
--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -58,7 +58,10 @@ from homeassistant.const import (
 from homeassistant.helpers import network
 from homeassistant.util import color as color_util, dt as dt_util
 from homeassistant.util.decorator import Registry
-from homeassistant.util.unit_conversion import TemperatureConverter
+from homeassistant.util.unit_conversion import (
+    TemperatureConverter,
+    TemperatureDeltaConverter,
+)
 
 from .config import AbstractConfig
 from .const import (
@@ -844,7 +847,7 @@ def temperature_from_object(
         temp -= 273.15
 
     if interval:
-        return TemperatureConverter.convert_interval(temp, from_unit, to_unit)
+        return TemperatureDeltaConverter.convert(temp, from_unit, to_unit)
     return TemperatureConverter.convert(temp, from_unit, to_unit)
 
 

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -38,6 +38,7 @@ from homeassistant.const import (
     UnitOfVolumetricFlux,
 )
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.deprecation import deprecated_function
 
 # Distance conversion constants
 _MM_TO_M = 0.001  # 1 mm = 0.001 m
@@ -707,6 +708,9 @@ class TemperatureConverter(BaseUnitConverter):
         )
 
     @classmethod
+    @deprecated_function(
+        "Use TemperatureDeltaConverter instead", breaks_in_ha_version="2026.6.0"
+    )
     def convert_interval(cls, interval: float, from_unit: str, to_unit: str) -> float:
         """Convert a temperature interval from one unit to another.
 

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -709,7 +709,7 @@ class TemperatureConverter(BaseUnitConverter):
 
     @classmethod
     @deprecated_function(
-        "Use TemperatureDeltaConverter.convert instead", breaks_in_ha_version="2026.6.0"
+        "Use TemperatureDeltaConverter.convert instead", breaks_in_ha_version="2026.12.0"
     )
     def convert_interval(cls, interval: float, from_unit: str, to_unit: str) -> float:
         """Convert a temperature interval from one unit to another.

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -709,7 +709,7 @@ class TemperatureConverter(BaseUnitConverter):
 
     @classmethod
     @deprecated_function(
-        "Use TemperatureDeltaConverter.convert instead", breaks_in_ha_version="2026.12.0"
+        "TemperatureDeltaConverter.convert", breaks_in_ha_version="2026.12.0"
     )
     def convert_interval(cls, interval: float, from_unit: str, to_unit: str) -> float:
         """Convert a temperature interval from one unit to another.

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -709,7 +709,7 @@ class TemperatureConverter(BaseUnitConverter):
 
     @classmethod
     @deprecated_function(
-        "Use TemperatureDeltaConverter instead", breaks_in_ha_version="2026.6.0"
+        "Use TemperatureDeltaConverter.convert instead", breaks_in_ha_version="2026.6.0"
     )
     def convert_interval(cls, interval: float, from_unit: str, to_unit: str) -> float:
         """Convert a temperature interval from one unit to another.

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -1293,25 +1293,6 @@ def test_unit_conversion_factory_allow_none(
 @pytest.mark.parametrize(
     ("value", "from_unit", "expected", "to_unit"),
     [
-        (100, UnitOfTemperature.CELSIUS, 180, UnitOfTemperature.FAHRENHEIT),
-        (100, UnitOfTemperature.CELSIUS, 100, UnitOfTemperature.KELVIN),
-        (100, UnitOfTemperature.FAHRENHEIT, 55.5556, UnitOfTemperature.CELSIUS),
-        (100, UnitOfTemperature.FAHRENHEIT, 55.5556, UnitOfTemperature.KELVIN),
-        (100, UnitOfTemperature.KELVIN, 100, UnitOfTemperature.CELSIUS),
-        (100, UnitOfTemperature.KELVIN, 180, UnitOfTemperature.FAHRENHEIT),
-    ],
-)
-def test_temperature_convert_with_interval(
-    value: float, from_unit: str, expected: float, to_unit: str
-) -> None:
-    """Test conversion to other units."""
-    expected = pytest.approx(expected)
-    assert TemperatureConverter.convert_interval(value, from_unit, to_unit) == expected
-
-
-@pytest.mark.parametrize(
-    ("value", "from_unit", "expected", "to_unit"),
-    [
         (
             100,
             UnitOfTemperature.CELSIUS,

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -1311,7 +1311,6 @@ def test_temperature_convert_with_interval(
     """Test conversion to other units."""
     expected = pytest.approx(expected)
     assert TemperatureConverter.convert_interval(value, from_unit, to_unit) == expected
-    assert "The deprecated function 
     assert (
         "The deprecated function convert_interval was called. It will be removed "
         "in HA Core 2026.12.0. Use TemperatureDeltaConverter.convert instead"

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -1302,11 +1302,20 @@ def test_unit_conversion_factory_allow_none(
     ],
 )
 def test_temperature_convert_with_interval(
-    value: float, from_unit: str, expected: float, to_unit: str
+    value: float,
+    from_unit: str,
+    expected: float,
+    to_unit: str,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test conversion to other units."""
     expected = pytest.approx(expected)
     assert TemperatureConverter.convert_interval(value, from_unit, to_unit) == expected
+    assert "The deprecated function 
+    assert (
+        "The deprecated function convert_interval was called. It will be removed "
+        "in HA Core 2026.12.0. Use TemperatureDeltaConverter.convert instead"
+    ) in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -1293,6 +1293,25 @@ def test_unit_conversion_factory_allow_none(
 @pytest.mark.parametrize(
     ("value", "from_unit", "expected", "to_unit"),
     [
+        (100, UnitOfTemperature.CELSIUS, 180, UnitOfTemperature.FAHRENHEIT),
+        (100, UnitOfTemperature.CELSIUS, 100, UnitOfTemperature.KELVIN),
+        (100, UnitOfTemperature.FAHRENHEIT, 55.5556, UnitOfTemperature.CELSIUS),
+        (100, UnitOfTemperature.FAHRENHEIT, 55.5556, UnitOfTemperature.KELVIN),
+        (100, UnitOfTemperature.KELVIN, 100, UnitOfTemperature.CELSIUS),
+        (100, UnitOfTemperature.KELVIN, 180, UnitOfTemperature.FAHRENHEIT),
+    ],
+)
+def test_temperature_convert_with_interval(
+    value: float, from_unit: str, expected: float, to_unit: str
+) -> None:
+    """Test conversion to other units."""
+    expected = pytest.approx(expected)
+    assert TemperatureConverter.convert_interval(value, from_unit, to_unit) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "from_unit", "expected", "to_unit"),
+    [
         (
             100,
             UnitOfTemperature.CELSIUS,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following #147358 the `convert_interval` member function in `TemperatureConverter` is now obsolete and superseeded by the new converter. This PR then, updates existing code and starts deprecating the aforementioned function.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
