### PR TITLE
Fix ZBT-2 Thread to Zigbee migration discovery failing

### DIFF
--- a/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
@@ -75,6 +75,7 @@ class ZBT2FirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
 
     context: ConfigFlowContext
     BOOTLOADER_RESET_METHODS = [ResetTarget.RTS_DTR]
+    ZIGBEE_BAUDRATE = 460800
 
     async def async_step_install_zigbee_firmware(
         self, user_input: dict[str, Any] | None = None
@@ -112,7 +113,6 @@ class HomeAssistantConnectZBT2ConfigFlow(
 
     VERSION = 1
     MINOR_VERSION = 1
-    ZIGBEE_BAUDRATE = 460800
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the config flow."""

--- a/tests/components/homeassistant_connect_zbt2/test_config_flow.py
+++ b/tests/components/homeassistant_connect_zbt2/test_config_flow.py
@@ -128,6 +128,26 @@ async def test_config_flow_zigbee(
     assert zha_flow["context"]["source"] == "hardware"
     assert zha_flow["step_id"] == "confirm"
 
+    progress_zha_flows = hass.config_entries.flow._async_progress_by_handler(
+        handler="zha",
+        match_context=None,
+    )
+
+    assert len(progress_zha_flows) == 1
+
+    # Ensure correct baudrate
+    progress_zha_flow = progress_zha_flows[0]
+    assert progress_zha_flow.init_data == {
+        "flow_strategy": "recommended",
+        "name": model,
+        "port": {
+            "path": usb_data.device,
+            "baudrate": 460800,
+            "flow_control": "hardware",
+        },
+        "radio_type": fw_type.value,
+    }
+
 
 @pytest.mark.usefixtures("addon_installed", "supervisor")
 async def test_config_flow_thread(
@@ -334,6 +354,35 @@ async def test_options_flow(
     # Verify async_flash_silabs_firmware was called with ZBT-2's reset methods
     assert flash_mock.call_count == 1
     assert flash_mock.mock_calls[0].kwargs["bootloader_reset_methods"] == ["rts_dtr"]
+
+    flows = hass.config_entries.flow.async_progress()
+
+    # Ensure a ZHA discovery flow has been created
+    assert len(flows) == 1
+    zha_flow = flows[0]
+    assert zha_flow["handler"] == "zha"
+    assert zha_flow["context"]["source"] == "hardware"
+    assert zha_flow["step_id"] == "confirm"
+
+    progress_zha_flows = hass.config_entries.flow._async_progress_by_handler(
+        handler="zha",
+        match_context=None,
+    )
+
+    assert len(progress_zha_flows) == 1
+
+    # Ensure correct baudrate
+    progress_zha_flow = progress_zha_flows[0]
+    assert progress_zha_flow.init_data == {
+        "flow_strategy": "recommended",
+        "name": model,
+        "port": {
+            "path": usb_data.device,
+            "baudrate": 460800,
+            "flow_control": "hardware",
+        },
+        "radio_type": "ezsp",
+    }
 
 
 async def test_duplicate_discovery(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where the ZHA discovery entry set up after migrating from Thread to Zigbee using the options flow in the ZBT-2 hardware integration did not use the correct baudrate, causing ZHA setup to always fail with a helpful "Unknown error occurred" message.

### Code changes

This is done by setting `ZIGBEE_BAUDRATE` inside of the `ZBT2FirmwareMixin`, where the bootloader reset methods are set as well. 

Prior to these changes, it was only set in `HomeAssistantConnectZBT2ConfigFlow` for the config flow, but not in `HomeAssistantConnectZBT2OptionsFlowHandler` for the options flow, which is used for the migration.

### Tests

Tests in the ZBT-2 integration now also verify that the baudrate set in the discovery (new ZHA flow) is correct both in the config flow (where it was correct before) as well as in the options flow (where it was incorrect before).

The changed tests are similar to an existing test for the base `homeassistant_hardware` integration. 


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/zigpy/backlog/issues/63
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
