### PR TITLE
Improve code formatting in System monitor

### DIFF
--- a/homeassistant/components/systemmonitor/coordinator.py
+++ b/homeassistant/components/systemmonitor/coordinator.py
@@ -30,44 +30,44 @@ _LOGGER = logging.getLogger(__name__)
 class SensorData:
     """Sensor data."""
 
-    disk_usage: dict[str, sdiskusage]
-    swap: sswap
-    memory: VirtualMemory
-    io_counters: dict[str, snetio]
     addresses: dict[str, list[snicaddr]]
-    load: tuple[float, float, float]
-    cpu_percent: float | None
     boot_time: datetime
-    processes: list[Process]
-    temperatures: dict[str, list[shwtemp]]
+    cpu_percent: float | None
+    disk_usage: dict[str, sdiskusage]
+    io_counters: dict[str, snetio]
+    load: tuple[float, float, float]
+    memory: VirtualMemory
     process_fds: dict[str, int]
+    processes: list[Process]
+    swap: sswap
+    temperatures: dict[str, list[shwtemp]]
 
     def as_dict(self) -> dict[str, Any]:
         """Return as dict."""
+        addresses = None
+        if self.addresses:
+            addresses = {k: str(v) for k, v in self.addresses.items()}
         disk_usage = None
         if self.disk_usage:
             disk_usage = {k: str(v) for k, v in self.disk_usage.items()}
         io_counters = None
         if self.io_counters:
             io_counters = {k: str(v) for k, v in self.io_counters.items()}
-        addresses = None
-        if self.addresses:
-            addresses = {k: str(v) for k, v in self.addresses.items()}
         temperatures = None
         if self.temperatures:
             temperatures = {k: str(v) for k, v in self.temperatures.items()}
         return {
-            "disk_usage": disk_usage,
-            "swap": str(self.swap),
-            "memory": str(self.memory),
-            "io_counters": io_counters,
             "addresses": addresses,
-            "load": str(self.load),
-            "cpu_percent": str(self.cpu_percent),
             "boot_time": str(self.boot_time),
-            "processes": str(self.processes),
-            "temperatures": temperatures,
+            "cpu_percent": str(self.cpu_percent),
+            "disk_usage": disk_usage,
+            "io_counters": io_counters,
+            "load": str(self.load),
+            "memory": str(self.memory),
             "process_fds": self.process_fds,
+            "processes": str(self.processes),
+            "swap": str(self.swap),
+            "temperatures": temperatures,
         }
 
 
@@ -124,14 +124,14 @@ class SystemMonitorCoordinator(TimestampDataUpdateCoordinator[SensorData]):
             _disk_defaults[("disks", argument)] = set()
         return {
             **_disk_defaults,
-            ("swap", ""): set(),
-            ("memory", ""): set(),
-            ("io_counters", ""): set(),
             ("addresses", ""): set(),
-            ("load", ""): set(),
-            ("cpu_percent", ""): set(),
             ("boot", ""): set(),
+            ("cpu_percent", ""): set(),
+            ("io_counters", ""): set(),
+            ("load", ""): set(),
+            ("memory", ""): set(),
             ("processes", ""): set(),
+            ("swap", ""): set(),
             ("temperatures", ""): set(),
         }
 
@@ -153,17 +153,17 @@ class SystemMonitorCoordinator(TimestampDataUpdateCoordinator[SensorData]):
 
         self._initial_update = False
         return SensorData(
-            disk_usage=_data["disks"],
-            swap=_data["swap"],
-            memory=_data["memory"],
-            io_counters=_data["io_counters"],
             addresses=_data["addresses"],
-            load=load,
-            cpu_percent=cpu_percent,
             boot_time=_data["boot_time"],
-            processes=_data["processes"],
-            temperatures=_data["temperatures"],
+            cpu_percent=cpu_percent,
+            disk_usage=_data["disks"],
+            io_counters=_data["io_counters"],
+            load=load,
+            memory=_data["memory"],
             process_fds=_data["process_fds"],
+            processes=_data["processes"],
+            swap=_data["swap"],
+            temperatures=_data["temperatures"],
         )
 
     def update_data(self) -> dict[str, Any]:
@@ -256,13 +256,13 @@ class SystemMonitorCoordinator(TimestampDataUpdateCoordinator[SensorData]):
                 _LOGGER.debug("OS does not provide temperature sensors")
 
         return {
-            "disks": disks,
-            "swap": swap,
-            "memory": memory,
-            "io_counters": io_counters,
             "addresses": addresses,
             "boot_time": self.boot_time,
-            "processes": selected_processes,
-            "temperatures": temps,
+            "disks": disks,
+            "io_counters": io_counters,
+            "memory": memory,
             "process_fds": process_fds,
+            "processes": selected_processes,
+            "swap": swap,
+            "temperatures": temps,
         }

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -55,12 +55,18 @@ SENSOR_TYPE_MANDATORY_ARG = 4
 
 SIGNAL_SYSTEMMONITOR_UPDATE = "systemmonitor_update"
 
-SENSORS_NO_ARG = ("load_", "memory_", "processor_use", "swap_", "last_boot")
+SENSORS_NO_ARG = (
+    "last_boot",
+    "load_",
+    "memory_",
+    "processor_use",
+    "swap_",
+)
 SENSORS_WITH_ARG = {
     "disk_": "disk_arguments",
     "ipv": "network_arguments",
-    **dict.fromkeys(NET_IO_TYPES, "network_arguments"),
     "process_num_fds": "processes",
+    **dict.fromkeys(NET_IO_TYPES, "network_arguments"),
 }
 
 
@@ -152,11 +158,13 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription] = {
         native_unit_of_measurement=UnitOfInformation.GIBIBYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda entity: round(
-            entity.coordinator.data.disk_usage[entity.argument].free / 1024**3, 1
-        )
-        if entity.argument in entity.coordinator.data.disk_usage
-        else None,
+        value_fn=(
+            lambda entity: round(
+                entity.coordinator.data.disk_usage[entity.argument].free / 1024**3, 1
+            )
+            if entity.argument in entity.coordinator.data.disk_usage
+            else None
+        ),
         none_is_unavailable=True,
         add_to_update=lambda entity: ("disks", entity.argument),
     ),
@@ -167,11 +175,13 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription] = {
         native_unit_of_measurement=UnitOfInformation.GIBIBYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda entity: round(
-            entity.coordinator.data.disk_usage[entity.argument].used / 1024**3, 1
-        )
-        if entity.argument in entity.coordinator.data.disk_usage
-        else None,
+        value_fn=(
+            lambda entity: round(
+                entity.coordinator.data.disk_usage[entity.argument].used / 1024**3, 1
+            )
+            if entity.argument in entity.coordinator.data.disk_usage
+            else None
+        ),
         none_is_unavailable=True,
         add_to_update=lambda entity: ("disks", entity.argument),
     ),
@@ -181,11 +191,11 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription] = {
         placeholder="mount_point",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda entity: entity.coordinator.data.disk_usage[
-            entity.argument
-        ].percent
-        if entity.argument in entity.coordinator.data.disk_usage
-        else None,
+        value_fn=(
+            lambda entity: entity.coordinator.data.disk_usage[entity.argument].percent
+            if entity.argument in entity.coordinator.data.disk_usage
+            else None
+        ),
         none_is_unavailable=True,
         add_to_update=lambda entity: ("disks", entity.argument),
     ),
@@ -212,14 +222,6 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription] = {
         value_fn=lambda entity: entity.coordinator.data.boot_time,
         add_to_update=lambda entity: ("boot", ""),
     ),
-    "load_15m": SysMonitorSensorEntityDescription(
-        key="load_15m",
-        translation_key="load_15m",
-        icon=get_cpu_icon(),
-        state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda entity: round(entity.coordinator.data.load[2], 2),
-        add_to_update=lambda entity: ("load", ""),
-    ),
     "load_1m": SysMonitorSensorEntityDescription(
         key="load_1m",
         translation_key="load_1m",
@@ -234,6 +236,14 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription] = {
         icon=get_cpu_icon(),
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda entity: round(entity.coordinator.data.load[1], 2),
+        add_to_update=lambda entity: ("load", ""),
+    ),
+    "load_15m": SysMonitorSensorEntityDescription(
+        key="load_15m",
+        translation_key="load_15m",
+        icon=get_cpu_icon(),
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda entity: round(entity.coordinator.data.load[2], 2),
         add_to_update=lambda entity: ("load", ""),
     ),
     "memory_free": SysMonitorSensorEntityDescription(
@@ -253,13 +263,15 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription] = {
         native_unit_of_measurement=UnitOfInformation.MEBIBYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda entity: round(
-            (
-                entity.coordinator.data.memory.total
-                - entity.coordinator.data.memory.available
+        value_fn=(
+            lambda entity: round(
+                (
+                    entity.coordinator.data.memory.total
+                    - entity.coordinator.data.memory.available
+                )
+                / 1024**2,
+                1,
             )
-            / 1024**2,
-            1,
         ),
         add_to_update=lambda entity: ("memory", ""),
     ),
@@ -311,27 +323,15 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription] = {
         value_fn=get_packets,
         add_to_update=lambda entity: ("io_counters", ""),
     ),
-    "throughput_network_in": SysMonitorSensorEntityDescription(
-        key="throughput_network_in",
-        translation_key="throughput_network_in",
-        placeholder="interface",
-        native_unit_of_measurement=UnitOfDataRate.MEGABYTES_PER_SECOND,
-        device_class=SensorDeviceClass.DATA_RATE,
+    "process_num_fds": SysMonitorSensorEntityDescription(
+        key="process_num_fds",
+        translation_key="process_num_fds",
+        placeholder="process",
         state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
         mandatory_arg=True,
-        value_fn=get_throughput,
-        add_to_update=lambda entity: ("io_counters", ""),
-    ),
-    "throughput_network_out": SysMonitorSensorEntityDescription(
-        key="throughput_network_out",
-        translation_key="throughput_network_out",
-        placeholder="interface",
-        native_unit_of_measurement=UnitOfDataRate.MEGABYTES_PER_SECOND,
-        device_class=SensorDeviceClass.DATA_RATE,
-        state_class=SensorStateClass.MEASUREMENT,
-        mandatory_arg=True,
-        value_fn=get_throughput,
-        add_to_update=lambda entity: ("io_counters", ""),
+        value_fn=get_process_num_fds,
+        add_to_update=lambda entity: ("processes", ""),
     ),
     "processor_use": SysMonitorSensorEntityDescription(
         key="processor_use",
@@ -339,10 +339,12 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription] = {
         native_unit_of_measurement=PERCENTAGE,
         icon=get_cpu_icon(),
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda entity: (
-            round(entity.coordinator.data.cpu_percent)
-            if entity.coordinator.data.cpu_percent
-            else None
+        value_fn=(
+            lambda entity: (
+                round(entity.coordinator.data.cpu_percent)
+                if entity.coordinator.data.cpu_percent
+                else None
+            )
         ),
         add_to_update=lambda entity: ("cpu_percent", ""),
     ),
@@ -352,8 +354,8 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription] = {
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda entity: read_cpu_temperature(
-            entity.coordinator.data.temperatures
+        value_fn=(
+            lambda entity: read_cpu_temperature(entity.coordinator.data.temperatures)
         ),
         none_is_unavailable=True,
         add_to_update=lambda entity: ("temperatures", ""),
@@ -384,15 +386,27 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription] = {
         value_fn=lambda entity: entity.coordinator.data.swap.percent,
         add_to_update=lambda entity: ("swap", ""),
     ),
-    "process_num_fds": SysMonitorSensorEntityDescription(
-        key="process_num_fds",
-        translation_key="process_num_fds",
-        placeholder="process",
+    "throughput_network_in": SysMonitorSensorEntityDescription(
+        key="throughput_network_in",
+        translation_key="throughput_network_in",
+        placeholder="interface",
+        native_unit_of_measurement=UnitOfDataRate.MEGABYTES_PER_SECOND,
+        device_class=SensorDeviceClass.DATA_RATE,
         state_class=SensorStateClass.MEASUREMENT,
-        entity_registry_enabled_default=False,
         mandatory_arg=True,
-        value_fn=get_process_num_fds,
-        add_to_update=lambda entity: ("processes", ""),
+        value_fn=get_throughput,
+        add_to_update=lambda entity: ("io_counters", ""),
+    ),
+    "throughput_network_out": SysMonitorSensorEntityDescription(
+        key="throughput_network_out",
+        translation_key="throughput_network_out",
+        placeholder="interface",
+        native_unit_of_measurement=UnitOfDataRate.MEGABYTES_PER_SECOND,
+        device_class=SensorDeviceClass.DATA_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
+        mandatory_arg=True,
+        value_fn=get_throughput,
+        add_to_update=lambda entity: ("io_counters", ""),
     ),
 }
 
@@ -409,14 +423,17 @@ def check_legacy_resource(resource: str, resources: set[str]) -> bool:
 
 
 IO_COUNTER = {
-    "network_out": 0,
     "network_in": 1,
-    "packets_out": 2,
+    "network_out": 0,
     "packets_in": 3,
-    "throughput_network_out": 0,
+    "packets_out": 2,
     "throughput_network_in": 1,
+    "throughput_network_out": 0,
 }
-IF_ADDRS_FAMILY = {"ipv4_address": socket.AF_INET, "ipv6_address": socket.AF_INET6}
+IF_ADDRS_FAMILY = {
+    "ipv4_address": socket.AF_INET,
+    "ipv6_address": socket.AF_INET6,
+}
 
 
 async def async_setup_entry(


### PR DESCRIPTION
## Breaking change


## Proposed change
Improves code formatting and sorting in System monitor.
Prel PR for #151066

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 