### PR TITLE
Allow control on missing izone thermometer

### DIFF
--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -31,7 +31,7 @@ class DiscoveryService(pizone.Listener):
 
     # Listener interface
     def controller_discovered(self, ctrl: pizone.Controller) -> None:
-        """Handle new controller discoverery."""
+        """Handle new controller discovery."""
         async_dispatcher_send(self.hass, DISPATCH_CONTROLLER_DISCOVERED, ctrl)
 
     def controller_disconnected(self, ctrl: pizone.Controller, ex: Exception) -> None:

--- a/tests/components/izone/__init__.py
+++ b/tests/components/izone/__init__.py
@@ -1,1 +1,32 @@
 """IZone tests."""
+
+from unittest.mock import AsyncMock
+
+import pizone
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Mock integration setup."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def setup_controller(
+    hass: HomeAssistant, mock_discovery: AsyncMock, mock_controller: AsyncMock
+) -> None:
+    """Mock integration setup."""
+    get_discovery_service(mock_discovery).controller_discovered(mock_controller)
+    await hass.async_block_till_done()
+
+
+def get_discovery_service(mock_discovery: AsyncMock) -> pizone.Listener:
+    """Get the DiscoveryService instance from the mock discovery."""
+    return mock_discovery.mock_calls[0][1][0]

--- a/tests/components/izone/conftest.py
+++ b/tests/components/izone/conftest.py
@@ -1,0 +1,139 @@
+"""Fixtures for iZone integration tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, Mock, patch
+
+from pizone import Controller, Zone
+import pytest
+
+from homeassistant.components.izone.const import (
+    DATA_DISCOVERY_SERVICE,
+    DISPATCH_CONTROLLER_DISCOVERED,
+    IZONE,
+)
+from homeassistant.components.izone.discovery import DiscoveryService
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Create a mock config entry for iZone."""
+    return MockConfigEntry(
+        domain=IZONE,
+        title="iZone",
+        data={},
+        entry_id="test_entry_id",
+    )
+
+
+@pytest.fixture
+def mock_pizone_discovery_service() -> Mock:
+    """Create a mock pizone discovery service."""
+    disco = Mock()
+    disco.controllers = {}
+    disco.start_discovery = AsyncMock()
+    disco.close = AsyncMock()
+    return disco
+
+
+def create_mock_controller(
+    device_uid: str = "test_controller_123",
+    sys_type: str = "iZone310",
+    zones_total: int = 4,
+    zone_ctrl: int = 1,
+    ras_mode: str = "master",
+    free_air_enabled: bool = False,
+    zones: list[Zone] | None = None,
+) -> Mock:
+    """Create a mock Controller with configurable parameters."""
+    controller = Mock(spec=Controller)
+    controller.device_uid = device_uid
+    controller.sys_type = sys_type
+    controller.zones_total = zones_total
+    controller.zone_ctrl = zone_ctrl
+    controller.ras_mode = ras_mode
+    controller.free_air_enabled = free_air_enabled
+    controller.free_air = False
+    controller.is_on = True
+    controller.mode = Controller.Mode.COOL
+    controller.temp_setpoint = 24.0
+    controller.temp_return = 22.0
+    controller.temp_supply = 16.0
+    controller.temp_min = 15.0
+    controller.temp_max = 30.0
+    controller.fan = Controller.Fan.MED
+    controller.fan_modes = [
+        Controller.Fan.LOW,
+        Controller.Fan.MED,
+        Controller.Fan.HIGH,
+        Controller.Fan.AUTO,
+    ]
+    controller.zones = zones if zones is not None else []
+    return controller
+
+
+def create_mock_zone(
+    index: int = 0,
+    name: str = "Zone",
+    temp_current: float | None = 22.5,
+    temp_setpoint: float = 24.0,
+) -> Mock:
+    """Create a mock Zone with configurable parameters."""
+    zone = Mock(spec=Zone)
+    zone.index = index
+    zone.name = name
+    zone.type = Zone.Type.AUTO
+    zone.mode = Zone.Mode.AUTO
+    zone.temp_current = temp_current
+    zone.temp_setpoint = temp_setpoint
+    zone.airflow_min = 0
+    zone.airflow_max = 100
+    zone.is_on = True
+    return zone
+
+
+@pytest.fixture
+async def setup_integration(
+    hass: HomeAssistant,
+) -> Generator[callable]:
+    """Set up iZone integration with mocked discovery service."""
+
+    async def _setup(
+        config_entry: MockConfigEntry,
+        mock_pizone_disco: Mock,
+    ) -> Mock:
+        """Set up the integration with provided mocks."""
+
+        async def mock_start_discovery(hass: HomeAssistant) -> DiscoveryService:
+            # Create a real DiscoveryService but inject mock pizone disco
+            disco = DiscoveryService(hass)
+            disco.pi_disco = mock_pizone_disco
+            hass.data[DATA_DISCOVERY_SERVICE] = disco
+            return disco
+
+        with (
+            patch(
+                "homeassistant.components.izone.async_start_discovery_service",
+                side_effect=mock_start_discovery,
+            ),
+            patch(
+                "homeassistant.components.izone.discovery.pizone.discovery",
+                return_value=mock_pizone_disco,
+            ),
+        ):
+            config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            # Trigger controller discovered for each controller in the mock disco
+            for controller in mock_pizone_disco.controllers.values():
+                async_dispatcher_send(hass, DISPATCH_CONTROLLER_DISCOVERED, controller)
+
+            await hass.async_block_till_done()
+
+        return mock_pizone_disco
+
+    return _setup

--- a/tests/components/izone/snapshots/test_climate.ambr
+++ b/tests/components/izone/snapshots/test_climate.ambr
@@ -1,0 +1,165 @@
+# serializer version: 1
+# name: test_basic_controller_properties[climate.izone_controller_test_controller_123-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'fan_modes': list([
+        'low',
+        'medium',
+        'high',
+        'auto',
+      ]),
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': 30.0,
+      'min_temp': 15.0,
+      'target_temp_step': 0.5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.izone_controller_test_controller_123',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'izone',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 392>,
+    'translation_key': None,
+    'unique_id': 'test_controller_123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_basic_controller_properties[climate.izone_controller_test_controller_123-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'control_zone': 1,
+      'control_zone_name': None,
+      'control_zone_setpoint': None,
+      'current_temperature': 22.0,
+      'fan_mode': 'medium',
+      'fan_modes': list([
+        'low',
+        'medium',
+        'high',
+        'auto',
+      ]),
+      'friendly_name': 'iZone Controller test_controller_123',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': 30.0,
+      'min_temp': 15.0,
+      'supply_temperature': 16.0,
+      'supported_features': <ClimateEntityFeature: 392>,
+      'target_temp_step': 0.5,
+      'temp_setpoint': 24.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.izone_controller_test_controller_123',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
+# name: test_basic_controller_properties[climate.living_room-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 30.0,
+      'min_temp': 15.0,
+      'target_temp_step': 0.5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.living_room',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'izone',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 385>,
+    'translation_key': None,
+    'unique_id': 'test_controller_123_z1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_basic_controller_properties[climate.living_room-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'airflow_max': 100,
+      'airflow_min': 0,
+      'current_temperature': 22.5,
+      'friendly_name': 'Living Room',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 30.0,
+      'min_temp': 15.0,
+      'supported_features': <ClimateEntityFeature: 385>,
+      'target_temp_step': 0.5,
+      'temperature': 24.0,
+      'zone_index': 0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.living_room',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -1,63 +1,61 @@
 """Tests for iZone climate platform."""
 
-from collections.abc import Awaitable, Callable
-from unittest.mock import Mock
+from unittest.mock import AsyncMock
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.climate import ClimateEntityFeature
 from homeassistant.core import HomeAssistant
+import homeassistant.helpers.entity_registry as er
 
+from . import setup_controller, setup_integration
 from .conftest import create_mock_controller, create_mock_zone
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 
 async def test_basic_controller_properties(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_pizone_discovery_service: Mock,
-    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test basic properties of ControllerDevice."""
-    zone = create_mock_zone(index=0, name="Living Room")
-    controller = create_mock_controller(
-        device_uid="test_controller_123",
-        ras_mode="master",
-        zone_ctrl=1,
-        zones_total=1,
-        zones=[zone],
-    )
-    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
 
-    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     entity_id = "climate.izone_controller_test_controller_123"
     entity = hass.states.get(entity_id)
 
     assert entity is not None
-    # Verify basic entity properties via state machine
-    assert entity.attributes.get("friendly_name") is not None
-    # Device info can't be directly accessed via state machine,
-    # but we can verify the entity exists and has the expected entity_id
-    assert entity.entity_id == entity_id
+    assert (
+        entity.attributes["supported_features"]
+        & ClimateEntityFeature.TARGET_TEMPERATURE
+    ) != ClimateEntityFeature.TARGET_TEMPERATURE
 
 
+@pytest.mark.parametrize(
+    "mock_controller",
+    [
+        create_mock_controller(
+            ras_mode="RAS",
+        )
+    ],
+)
 async def test_target_temperature_feature_ras_mode(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_pizone_discovery_service: Mock,
-    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
 ) -> None:
     """Test TARGET_TEMPERATURE feature enabled in RAS mode."""
-    # Scenario 1: Controller in RAS mode
-    zone = create_mock_zone(index=0, name="Living Room")
-    controller = create_mock_controller(
-        device_uid="test_controller_123",
-        ras_mode="RAS",
-        zones=[zone],
-    )
-    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
-
-    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
 
     entity_id = "climate.izone_controller_test_controller_123"
     entity = hass.states.get(entity_id)
@@ -69,25 +67,24 @@ async def test_target_temperature_feature_ras_mode(
     ) == ClimateEntityFeature.TARGET_TEMPERATURE
 
 
+@pytest.mark.parametrize(
+    "mock_controller",
+    [
+        create_mock_controller(
+            zone_ctrl=13,  # Greater than zones_total (4)
+            zones_total=4,
+        )
+    ],
+)
 async def test_target_temperature_feature_master_mode_invalid_zone(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_pizone_discovery_service: Mock,
-    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
 ) -> None:
     """Test TARGET_TEMPERATURE feature enabled when control zone is invalid."""
-    # Scenario 2: Controller in master mode with control zone > zones_total
-    zone = create_mock_zone(index=0, name="Living Room")
-    controller = create_mock_controller(
-        device_uid="test_controller_123",
-        ras_mode="master",
-        zone_ctrl=13,  # Greater than zones_total (4)
-        zones_total=4,
-        zones=[zone],
-    )
-    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
-
-    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
 
     entity_id = "climate.izone_controller_test_controller_123"
     entity = hass.states.get(entity_id)
@@ -99,29 +96,32 @@ async def test_target_temperature_feature_master_mode_invalid_zone(
     ) == ClimateEntityFeature.TARGET_TEMPERATURE
 
 
+@pytest.mark.parametrize(
+    ("mock_controller", "mock_zones"),
+    [
+        (
+            create_mock_controller(
+                zone_ctrl=1,  # Valid zone
+                zones_total=2,
+            ),
+            [
+                create_mock_zone(index=0, name="Living Room", temp_current=22.5),
+                create_mock_zone(
+                    index=1, name="Bedroom", temp_current=None
+                ),  # No sensor
+            ],
+        )
+    ],
+)
 async def test_target_temperature_feature_zone_without_sensor(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_pizone_discovery_service: Mock,
-    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
 ) -> None:
     """Test TARGET_TEMPERATURE feature enabled when any zone lacks temperature sensor."""
-    # Scenario 3: At least one zone without temperature sensor
-    zone_with_temp = create_mock_zone(index=0, name="Living Room", temp_current=22.5)
-    zone_without_temp = create_mock_zone(
-        index=1, name="Bedroom", temp_current=None
-    )  # No sensor
-
-    controller = create_mock_controller(
-        device_uid="test_controller_123",
-        ras_mode="master",
-        zone_ctrl=1,  # Valid zone
-        zones_total=2,
-        zones=[zone_with_temp, zone_without_temp],
-    )
-    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
-
-    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
 
     entity_id = "climate.izone_controller_test_controller_123"
     entity = hass.states.get(entity_id)
@@ -133,59 +133,30 @@ async def test_target_temperature_feature_zone_without_sensor(
     ) == ClimateEntityFeature.TARGET_TEMPERATURE
 
 
-async def test_target_temperature_feature_not_enabled_normal_master(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_pizone_discovery_service: Mock,
-    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
-) -> None:
-    """Test TARGET_TEMPERATURE feature NOT enabled in normal master mode."""
-    # Normal master mode with valid control zone and all zones have sensors
-    zone = create_mock_zone(index=0, name="Living Room")
-    controller = create_mock_controller(
-        device_uid="test_controller_123",
-        ras_mode="master",
-        zone_ctrl=1,  # Valid zone (less than zones_total)
-        zones_total=4,
-        zones=[zone],  # All zones have temp sensors
-    )
-    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
-
-    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
-
-    entity_id = "climate.izone_controller_test_controller_123"
-    entity = hass.states.get(entity_id)
-
-    assert entity is not None
-    # Should NOT have TARGET_TEMPERATURE feature
-    assert (
-        entity.attributes["supported_features"]
-        & ClimateEntityFeature.TARGET_TEMPERATURE
-    ) != ClimateEntityFeature.TARGET_TEMPERATURE
-
-
+@pytest.mark.parametrize(
+    ("mock_controller", "mock_zones"),
+    [
+        (
+            create_mock_controller(
+                zones_total=3,
+            ),
+            [
+                create_mock_zone(index=0, name="Zone 1", temp_current=22.5),
+                create_mock_zone(index=1, name="Zone 2", temp_current=23.0),
+                create_mock_zone(index=2, name="Zone 3", temp_current=21.5),
+            ],
+        )
+    ],
+)
 async def test_target_temperature_feature_all_zones_with_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_pizone_discovery_service: Mock,
-    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
 ) -> None:
     """Test TARGET_TEMPERATURE feature NOT enabled when all zones have sensors."""
-    # Create multiple zones, all with temperature sensors
-    zone1 = create_mock_zone(index=0, name="Zone 1", temp_current=22.5)
-    zone2 = create_mock_zone(index=1, name="Zone 2", temp_current=23.0)
-    zone3 = create_mock_zone(index=2, name="Zone 3", temp_current=21.5)
-
-    controller = create_mock_controller(
-        device_uid="test_controller_123",
-        ras_mode="master",
-        zone_ctrl=1,
-        zones_total=3,
-        zones=[zone1, zone2, zone3],
-    )
-    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
-
-    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
 
     entity_id = "climate.izone_controller_test_controller_123"
     entity = hass.states.get(entity_id)
@@ -198,28 +169,30 @@ async def test_target_temperature_feature_all_zones_with_sensors(
     ) != ClimateEntityFeature.TARGET_TEMPERATURE
 
 
+@pytest.mark.parametrize(
+    ("mock_controller", "mock_zones"),
+    [
+        (
+            create_mock_controller(
+                zones_total=3,
+            ),
+            [
+                create_mock_zone(index=0, name="Zone 1", temp_current=22.5),
+                create_mock_zone(index=1, name="Zone 2", temp_current=None),
+                create_mock_zone(index=2, name="Zone 3", temp_current=21.5),
+            ],
+        )
+    ],
+)
 async def test_target_temperature_feature_multiple_zones_one_without_sensor(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_pizone_discovery_service: Mock,
-    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
 ) -> None:
     """Test TARGET_TEMPERATURE feature enabled with multiple zones when one lacks sensor."""
-    # Create multiple zones, one without temperature sensor
-    zone1 = create_mock_zone(index=0, name="Zone 1", temp_current=22.5)
-    zone2 = create_mock_zone(index=1, name="Zone 2", temp_current=None)  # No sensor
-    zone3 = create_mock_zone(index=2, name="Zone 3", temp_current=21.5)
-
-    controller = create_mock_controller(
-        device_uid="test_controller_123",
-        ras_mode="master",
-        zone_ctrl=1,
-        zones_total=3,
-        zones=[zone1, zone2, zone3],
-    )
-    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
-
-    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
 
     entity_id = "climate.izone_controller_test_controller_123"
     entity = hass.states.get(entity_id)
@@ -231,25 +204,23 @@ async def test_target_temperature_feature_multiple_zones_one_without_sensor(
     ) == ClimateEntityFeature.TARGET_TEMPERATURE
 
 
+@pytest.mark.parametrize(
+    "mock_controller",
+    [
+        create_mock_controller(
+            ras_mode="slave",
+        )
+    ],
+)
 async def test_target_temperature_feature_slave_mode(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_pizone_discovery_service: Mock,
-    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
 ) -> None:
     """Test TARGET_TEMPERATURE feature NOT enabled in slave mode."""
-    # Slave mode should not enable TARGET_TEMPERATURE
-    zone = create_mock_zone(index=0, name="Living Room")
-    controller = create_mock_controller(
-        device_uid="test_controller_123",
-        ras_mode="slave",
-        zone_ctrl=1,
-        zones_total=4,
-        zones=[zone],
-    )
-    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
-
-    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
 
     entity_id = "climate.izone_controller_test_controller_123"
     entity = hass.states.get(entity_id)
@@ -262,25 +233,24 @@ async def test_target_temperature_feature_slave_mode(
     ) != ClimateEntityFeature.TARGET_TEMPERATURE
 
 
+@pytest.mark.parametrize(
+    "mock_controller",
+    [
+        create_mock_controller(
+            zone_ctrl=13,
+            zones_total=4,
+        )
+    ],
+)
 async def test_target_temperature_feature_master_mode_zone_13(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_pizone_discovery_service: Mock,
-    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
 ) -> None:
     """Test TARGET_TEMPERATURE feature enabled when control zone is 13 (master unit)."""
-    # Master mode with zone_ctrl = 13 (the master unit itself)
-    zone = create_mock_zone(index=0, name="Living Room")
-    controller = create_mock_controller(
-        device_uid="test_controller_123",
-        ras_mode="master",
-        zone_ctrl=13,
-        zones_total=4,
-        zones=[zone],
-    )
-    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
-
-    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
 
     entity_id = "climate.izone_controller_test_controller_123"
     entity = hass.states.get(entity_id)

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -1,274 +1,292 @@
 """Tests for iZone climate platform."""
 
+from collections.abc import Awaitable, Callable
 from unittest.mock import Mock
 
-from pizone import Controller, Zone
-import pytest
-
 from homeassistant.components.climate import ClimateEntityFeature
-from homeassistant.components.izone.climate import ControllerDevice
-from homeassistant.components.izone.const import IZONE
+from homeassistant.core import HomeAssistant
+
+from .conftest import create_mock_controller, create_mock_zone
+
+from tests.common import MockConfigEntry
 
 
-@pytest.fixture
-def mock_controller() -> Mock:
-    """Create a mock Controller."""
-    controller = Mock(spec=Controller)
-    controller.device_uid = "test_controller_123"
-    controller.sys_type = "iZone310"
-    controller.zones_total = 4
-    controller.zone_ctrl = 1
-    controller.ras_mode = "master"
-    controller.free_air_enabled = False
-    controller.free_air = False
-    controller.is_on = True
-    controller.mode = Controller.Mode.COOL
-    controller.temp_setpoint = 24.0
-    controller.temp_return = 22.0
-    controller.fan_modes = [
-        Controller.Fan.LOW,
-        Controller.Fan.MED,
-        Controller.Fan.HIGH,
-        Controller.Fan.AUTO,
-    ]
-    return controller
+async def test_basic_controller_properties(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pizone_discovery_service: Mock,
+    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
+) -> None:
+    """Test basic properties of ControllerDevice."""
+    zone = create_mock_zone(index=0, name="Living Room")
+    controller = create_mock_controller(
+        device_uid="test_controller_123",
+        ras_mode="master",
+        zone_ctrl=1,
+        zones_total=1,
+        zones=[zone],
+    )
+    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
 
+    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
 
-@pytest.fixture
-def mock_zone_with_temp() -> Mock:
-    """Create a mock Zone with temperature sensor."""
-    zone = Mock(spec=Zone)
-    zone.index = 0
-    zone.name = "Living Room"
-    zone.type = Zone.Type.AUTO
-    zone.mode = Zone.Mode.AUTO
-    zone.temp_current = 22.5
-    zone.temp_setpoint = 24.0
-    zone.airflow_min = 0
-    zone.airflow_max = 100
-    return zone
+    entity_id = "climate.izone_controller_test_controller_123"
+    entity = hass.states.get(entity_id)
 
-
-@pytest.fixture
-def mock_zone_without_temp() -> Mock:
-    """Create a mock Zone without temperature sensor."""
-    zone = Mock(spec=Zone)
-    zone.index = 1
-    zone.name = "Bedroom"
-    zone.type = Zone.Type.AUTO
-    zone.mode = Zone.Mode.AUTO
-    zone.temp_current = None  # No temperature sensor
-    zone.temp_setpoint = 24.0
-    zone.airflow_min = 0
-    zone.airflow_max = 100
-    return zone
+    assert entity is not None
+    # Verify basic entity properties via state machine
+    assert entity.attributes.get("friendly_name") is not None
+    # Device info can't be directly accessed via state machine,
+    # but we can verify the entity exists and has the expected entity_id
+    assert entity.entity_id == entity_id
 
 
 async def test_target_temperature_feature_ras_mode(
-    mock_controller: Mock,
-    mock_zone_with_temp: Mock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pizone_discovery_service: Mock,
+    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
 ) -> None:
     """Test TARGET_TEMPERATURE feature enabled in RAS mode."""
     # Scenario 1: Controller in RAS mode
-    mock_controller.ras_mode = "RAS"
-    mock_controller.zones = [mock_zone_with_temp]
+    zone = create_mock_zone(index=0, name="Living Room")
+    controller = create_mock_controller(
+        device_uid="test_controller_123",
+        ras_mode="RAS",
+        zones=[zone],
+    )
+    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
 
-    device = ControllerDevice(mock_controller)
+    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
 
+    entity_id = "climate.izone_controller_test_controller_123"
+    entity = hass.states.get(entity_id)
+
+    assert entity is not None
     assert (
-        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+        entity.attributes["supported_features"]
+        & ClimateEntityFeature.TARGET_TEMPERATURE
     ) == ClimateEntityFeature.TARGET_TEMPERATURE
 
 
 async def test_target_temperature_feature_master_mode_invalid_zone(
-    mock_controller: Mock,
-    mock_zone_with_temp: Mock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pizone_discovery_service: Mock,
+    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
 ) -> None:
     """Test TARGET_TEMPERATURE feature enabled when control zone is invalid."""
     # Scenario 2: Controller in master mode with control zone > zones_total
-    mock_controller.ras_mode = "master"
-    mock_controller.zone_ctrl = 13  # Greater than zones_total (4)
-    mock_controller.zones_total = 4
-    mock_controller.zones = [mock_zone_with_temp]
+    zone = create_mock_zone(index=0, name="Living Room")
+    controller = create_mock_controller(
+        device_uid="test_controller_123",
+        ras_mode="master",
+        zone_ctrl=13,  # Greater than zones_total (4)
+        zones_total=4,
+        zones=[zone],
+    )
+    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
 
-    device = ControllerDevice(mock_controller)
+    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
 
+    entity_id = "climate.izone_controller_test_controller_123"
+    entity = hass.states.get(entity_id)
+
+    assert entity is not None
     assert (
-        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+        entity.attributes["supported_features"]
+        & ClimateEntityFeature.TARGET_TEMPERATURE
     ) == ClimateEntityFeature.TARGET_TEMPERATURE
 
 
 async def test_target_temperature_feature_zone_without_sensor(
-    mock_controller: Mock,
-    mock_zone_with_temp: Mock,
-    mock_zone_without_temp: Mock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pizone_discovery_service: Mock,
+    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
 ) -> None:
     """Test TARGET_TEMPERATURE feature enabled when any zone lacks temperature sensor."""
     # Scenario 3: At least one zone without temperature sensor
-    mock_controller.ras_mode = "master"
-    mock_controller.zone_ctrl = 1  # Valid zone
-    mock_controller.zones_total = 2
-    mock_controller.zones = [
-        mock_zone_with_temp,
-        mock_zone_without_temp,  # This zone has no temp sensor
-    ]
+    zone_with_temp = create_mock_zone(index=0, name="Living Room", temp_current=22.5)
+    zone_without_temp = create_mock_zone(
+        index=1, name="Bedroom", temp_current=None
+    )  # No sensor
 
-    device = ControllerDevice(mock_controller)
+    controller = create_mock_controller(
+        device_uid="test_controller_123",
+        ras_mode="master",
+        zone_ctrl=1,  # Valid zone
+        zones_total=2,
+        zones=[zone_with_temp, zone_without_temp],
+    )
+    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
 
+    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
+
+    entity_id = "climate.izone_controller_test_controller_123"
+    entity = hass.states.get(entity_id)
+
+    assert entity is not None
     assert (
-        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+        entity.attributes["supported_features"]
+        & ClimateEntityFeature.TARGET_TEMPERATURE
     ) == ClimateEntityFeature.TARGET_TEMPERATURE
 
 
 async def test_target_temperature_feature_not_enabled_normal_master(
-    mock_controller: Mock,
-    mock_zone_with_temp: Mock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pizone_discovery_service: Mock,
+    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
 ) -> None:
     """Test TARGET_TEMPERATURE feature NOT enabled in normal master mode."""
     # Normal master mode with valid control zone and all zones have sensors
-    mock_controller.ras_mode = "master"
-    mock_controller.zone_ctrl = 1  # Valid zone (less than zones_total)
-    mock_controller.zones_total = 4
-    mock_controller.zones = [mock_zone_with_temp]  # All zones have temp sensors
+    zone = create_mock_zone(index=0, name="Living Room")
+    controller = create_mock_controller(
+        device_uid="test_controller_123",
+        ras_mode="master",
+        zone_ctrl=1,  # Valid zone (less than zones_total)
+        zones_total=4,
+        zones=[zone],  # All zones have temp sensors
+    )
+    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
 
-    device = ControllerDevice(mock_controller)
+    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
 
+    entity_id = "climate.izone_controller_test_controller_123"
+    entity = hass.states.get(entity_id)
+
+    assert entity is not None
     # Should NOT have TARGET_TEMPERATURE feature
     assert (
-        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+        entity.attributes["supported_features"]
+        & ClimateEntityFeature.TARGET_TEMPERATURE
     ) != ClimateEntityFeature.TARGET_TEMPERATURE
 
 
 async def test_target_temperature_feature_all_zones_with_sensors(
-    mock_controller: Mock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pizone_discovery_service: Mock,
+    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
 ) -> None:
     """Test TARGET_TEMPERATURE feature NOT enabled when all zones have sensors."""
     # Create multiple zones, all with temperature sensors
-    zone1 = Mock(spec=Zone)
-    zone1.index = 0
-    zone1.type = Zone.Type.AUTO
-    zone1.mode = Zone.Mode.AUTO
-    zone1.temp_current = 22.5
-    zone1.airflow_min = 0
-    zone1.airflow_max = 100
-    zone2 = Mock(spec=Zone)
-    zone2.index = 1
-    zone2.type = Zone.Type.AUTO
-    zone2.mode = Zone.Mode.AUTO
-    zone2.temp_current = 23.0
-    zone2.airflow_min = 0
-    zone2.airflow_max = 100
-    zone3 = Mock(spec=Zone)
-    zone3.index = 2
-    zone3.type = Zone.Type.AUTO
-    zone3.mode = Zone.Mode.AUTO
-    zone3.temp_current = 21.5
-    zone3.airflow_min = 0
-    zone3.airflow_max = 100
+    zone1 = create_mock_zone(index=0, name="Zone 1", temp_current=22.5)
+    zone2 = create_mock_zone(index=1, name="Zone 2", temp_current=23.0)
+    zone3 = create_mock_zone(index=2, name="Zone 3", temp_current=21.5)
 
-    mock_controller.ras_mode = "master"
-    mock_controller.zone_ctrl = 1
-    mock_controller.zones_total = 3
-    mock_controller.zones = [zone1, zone2, zone3]
+    controller = create_mock_controller(
+        device_uid="test_controller_123",
+        ras_mode="master",
+        zone_ctrl=1,
+        zones_total=3,
+        zones=[zone1, zone2, zone3],
+    )
+    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
 
-    device = ControllerDevice(mock_controller)
+    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
 
+    entity_id = "climate.izone_controller_test_controller_123"
+    entity = hass.states.get(entity_id)
+
+    assert entity is not None
     # Should NOT have TARGET_TEMPERATURE feature
     assert (
-        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+        entity.attributes["supported_features"]
+        & ClimateEntityFeature.TARGET_TEMPERATURE
     ) != ClimateEntityFeature.TARGET_TEMPERATURE
 
 
 async def test_target_temperature_feature_multiple_zones_one_without_sensor(
-    mock_controller: Mock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pizone_discovery_service: Mock,
+    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
 ) -> None:
     """Test TARGET_TEMPERATURE feature enabled with multiple zones when one lacks sensor."""
     # Create multiple zones, one without temperature sensor
-    zone1 = Mock(spec=Zone)
-    zone1.index = 0
-    zone1.type = Zone.Type.AUTO
-    zone1.mode = Zone.Mode.AUTO
-    zone1.temp_current = 22.5
-    zone1.airflow_min = 0
-    zone1.airflow_max = 100
-    zone2 = Mock(spec=Zone)
-    zone2.index = 1
-    zone2.type = Zone.Type.AUTO
-    zone2.mode = Zone.Mode.AUTO
-    zone2.temp_current = None  # No sensor
-    zone2.airflow_min = 0
-    zone2.airflow_max = 100
-    zone3 = Mock(spec=Zone)
-    zone3.index = 2
-    zone3.type = Zone.Type.AUTO
-    zone3.mode = Zone.Mode.AUTO
-    zone3.temp_current = 21.5
-    zone3.airflow_min = 0
-    zone3.airflow_max = 100
+    zone1 = create_mock_zone(index=0, name="Zone 1", temp_current=22.5)
+    zone2 = create_mock_zone(index=1, name="Zone 2", temp_current=None)  # No sensor
+    zone3 = create_mock_zone(index=2, name="Zone 3", temp_current=21.5)
 
-    mock_controller.ras_mode = "master"
-    mock_controller.zone_ctrl = 1
-    mock_controller.zones_total = 3
-    mock_controller.zones = [zone1, zone2, zone3]
+    controller = create_mock_controller(
+        device_uid="test_controller_123",
+        ras_mode="master",
+        zone_ctrl=1,
+        zones_total=3,
+        zones=[zone1, zone2, zone3],
+    )
+    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
 
-    device = ControllerDevice(mock_controller)
+    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
 
+    entity_id = "climate.izone_controller_test_controller_123"
+    entity = hass.states.get(entity_id)
+
+    assert entity is not None
     assert (
-        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+        entity.attributes["supported_features"]
+        & ClimateEntityFeature.TARGET_TEMPERATURE
     ) == ClimateEntityFeature.TARGET_TEMPERATURE
 
 
 async def test_target_temperature_feature_slave_mode(
-    mock_controller: Mock,
-    mock_zone_with_temp: Mock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pizone_discovery_service: Mock,
+    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
 ) -> None:
     """Test TARGET_TEMPERATURE feature NOT enabled in slave mode."""
     # Slave mode should not enable TARGET_TEMPERATURE
-    mock_controller.ras_mode = "slave"
-    mock_controller.zone_ctrl = 1
-    mock_controller.zones_total = 4
-    mock_controller.zones = [mock_zone_with_temp]
+    zone = create_mock_zone(index=0, name="Living Room")
+    controller = create_mock_controller(
+        device_uid="test_controller_123",
+        ras_mode="slave",
+        zone_ctrl=1,
+        zones_total=4,
+        zones=[zone],
+    )
+    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
 
-    device = ControllerDevice(mock_controller)
+    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
 
+    entity_id = "climate.izone_controller_test_controller_123"
+    entity = hass.states.get(entity_id)
+
+    assert entity is not None
     # Should NOT have TARGET_TEMPERATURE feature
     assert (
-        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+        entity.attributes["supported_features"]
+        & ClimateEntityFeature.TARGET_TEMPERATURE
     ) != ClimateEntityFeature.TARGET_TEMPERATURE
 
 
 async def test_target_temperature_feature_master_mode_zone_13(
-    mock_controller: Mock,
-    mock_zone_with_temp: Mock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pizone_discovery_service: Mock,
+    setup_integration: Callable[[MockConfigEntry, Mock], Awaitable[Mock]],
 ) -> None:
     """Test TARGET_TEMPERATURE feature enabled when control zone is 13 (master unit)."""
     # Master mode with zone_ctrl = 13 (the master unit itself)
-    mock_controller.ras_mode = "master"
-    mock_controller.zone_ctrl = 13
-    mock_controller.zones_total = 4
-    mock_controller.zones = [mock_zone_with_temp]
+    zone = create_mock_zone(index=0, name="Living Room")
+    controller = create_mock_controller(
+        device_uid="test_controller_123",
+        ras_mode="master",
+        zone_ctrl=13,
+        zones_total=4,
+        zones=[zone],
+    )
+    mock_pizone_discovery_service.controllers = {"test_controller_123": controller}
 
-    device = ControllerDevice(mock_controller)
+    await setup_integration(mock_config_entry, mock_pizone_discovery_service)
 
+    entity_id = "climate.izone_controller_test_controller_123"
+    entity = hass.states.get(entity_id)
+
+    assert entity is not None
     assert (
-        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+        entity.attributes["supported_features"]
+        & ClimateEntityFeature.TARGET_TEMPERATURE
     ) == ClimateEntityFeature.TARGET_TEMPERATURE
-
-
-async def test_basic_controller_properties(
-    mock_controller: Mock,
-    mock_zone_with_temp: Mock,
-) -> None:
-    """Test basic properties of ControllerDevice."""
-    mock_controller.ras_mode = "master"
-    mock_controller.zone_ctrl = 1
-    mock_controller.zones_total = 1
-    mock_controller.zones = [mock_zone_with_temp]
-
-    device = ControllerDevice(mock_controller)
-
-    assert device.unique_id == "test_controller_123"
-    assert device.name is None  # Should be None with has_entity_name
-    assert device._attr_has_entity_name is True
-    assert device.device_info is not None
-    assert (IZONE, "test_controller_123") in device.device_info["identifiers"]

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -1,0 +1,274 @@
+"""Tests for iZone climate platform."""
+
+from unittest.mock import Mock
+
+from pizone import Controller, Zone
+import pytest
+
+from homeassistant.components.climate import ClimateEntityFeature
+from homeassistant.components.izone.climate import ControllerDevice
+from homeassistant.components.izone.const import IZONE
+
+
+@pytest.fixture
+def mock_controller() -> Mock:
+    """Create a mock Controller."""
+    controller = Mock(spec=Controller)
+    controller.device_uid = "test_controller_123"
+    controller.sys_type = "iZone310"
+    controller.zones_total = 4
+    controller.zone_ctrl = 1
+    controller.ras_mode = "master"
+    controller.free_air_enabled = False
+    controller.free_air = False
+    controller.is_on = True
+    controller.mode = Controller.Mode.COOL
+    controller.temp_setpoint = 24.0
+    controller.temp_return = 22.0
+    controller.fan_modes = [
+        Controller.Fan.LOW,
+        Controller.Fan.MED,
+        Controller.Fan.HIGH,
+        Controller.Fan.AUTO,
+    ]
+    return controller
+
+
+@pytest.fixture
+def mock_zone_with_temp() -> Mock:
+    """Create a mock Zone with temperature sensor."""
+    zone = Mock(spec=Zone)
+    zone.index = 0
+    zone.name = "Living Room"
+    zone.type = Zone.Type.AUTO
+    zone.mode = Zone.Mode.AUTO
+    zone.temp_current = 22.5
+    zone.temp_setpoint = 24.0
+    zone.airflow_min = 0
+    zone.airflow_max = 100
+    return zone
+
+
+@pytest.fixture
+def mock_zone_without_temp() -> Mock:
+    """Create a mock Zone without temperature sensor."""
+    zone = Mock(spec=Zone)
+    zone.index = 1
+    zone.name = "Bedroom"
+    zone.type = Zone.Type.AUTO
+    zone.mode = Zone.Mode.AUTO
+    zone.temp_current = None  # No temperature sensor
+    zone.temp_setpoint = 24.0
+    zone.airflow_min = 0
+    zone.airflow_max = 100
+    return zone
+
+
+async def test_target_temperature_feature_ras_mode(
+    mock_controller: Mock,
+    mock_zone_with_temp: Mock,
+) -> None:
+    """Test TARGET_TEMPERATURE feature enabled in RAS mode."""
+    # Scenario 1: Controller in RAS mode
+    mock_controller.ras_mode = "RAS"
+    mock_controller.zones = [mock_zone_with_temp]
+
+    device = ControllerDevice(mock_controller)
+
+    assert (
+        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+    ) == ClimateEntityFeature.TARGET_TEMPERATURE
+
+
+async def test_target_temperature_feature_master_mode_invalid_zone(
+    mock_controller: Mock,
+    mock_zone_with_temp: Mock,
+) -> None:
+    """Test TARGET_TEMPERATURE feature enabled when control zone is invalid."""
+    # Scenario 2: Controller in master mode with control zone > zones_total
+    mock_controller.ras_mode = "master"
+    mock_controller.zone_ctrl = 13  # Greater than zones_total (4)
+    mock_controller.zones_total = 4
+    mock_controller.zones = [mock_zone_with_temp]
+
+    device = ControllerDevice(mock_controller)
+
+    assert (
+        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+    ) == ClimateEntityFeature.TARGET_TEMPERATURE
+
+
+async def test_target_temperature_feature_zone_without_sensor(
+    mock_controller: Mock,
+    mock_zone_with_temp: Mock,
+    mock_zone_without_temp: Mock,
+) -> None:
+    """Test TARGET_TEMPERATURE feature enabled when any zone lacks temperature sensor."""
+    # Scenario 3: At least one zone without temperature sensor
+    mock_controller.ras_mode = "master"
+    mock_controller.zone_ctrl = 1  # Valid zone
+    mock_controller.zones_total = 2
+    mock_controller.zones = [
+        mock_zone_with_temp,
+        mock_zone_without_temp,  # This zone has no temp sensor
+    ]
+
+    device = ControllerDevice(mock_controller)
+
+    assert (
+        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+    ) == ClimateEntityFeature.TARGET_TEMPERATURE
+
+
+async def test_target_temperature_feature_not_enabled_normal_master(
+    mock_controller: Mock,
+    mock_zone_with_temp: Mock,
+) -> None:
+    """Test TARGET_TEMPERATURE feature NOT enabled in normal master mode."""
+    # Normal master mode with valid control zone and all zones have sensors
+    mock_controller.ras_mode = "master"
+    mock_controller.zone_ctrl = 1  # Valid zone (less than zones_total)
+    mock_controller.zones_total = 4
+    mock_controller.zones = [mock_zone_with_temp]  # All zones have temp sensors
+
+    device = ControllerDevice(mock_controller)
+
+    # Should NOT have TARGET_TEMPERATURE feature
+    assert (
+        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+    ) != ClimateEntityFeature.TARGET_TEMPERATURE
+
+
+async def test_target_temperature_feature_all_zones_with_sensors(
+    mock_controller: Mock,
+) -> None:
+    """Test TARGET_TEMPERATURE feature NOT enabled when all zones have sensors."""
+    # Create multiple zones, all with temperature sensors
+    zone1 = Mock(spec=Zone)
+    zone1.index = 0
+    zone1.type = Zone.Type.AUTO
+    zone1.mode = Zone.Mode.AUTO
+    zone1.temp_current = 22.5
+    zone1.airflow_min = 0
+    zone1.airflow_max = 100
+    zone2 = Mock(spec=Zone)
+    zone2.index = 1
+    zone2.type = Zone.Type.AUTO
+    zone2.mode = Zone.Mode.AUTO
+    zone2.temp_current = 23.0
+    zone2.airflow_min = 0
+    zone2.airflow_max = 100
+    zone3 = Mock(spec=Zone)
+    zone3.index = 2
+    zone3.type = Zone.Type.AUTO
+    zone3.mode = Zone.Mode.AUTO
+    zone3.temp_current = 21.5
+    zone3.airflow_min = 0
+    zone3.airflow_max = 100
+
+    mock_controller.ras_mode = "master"
+    mock_controller.zone_ctrl = 1
+    mock_controller.zones_total = 3
+    mock_controller.zones = [zone1, zone2, zone3]
+
+    device = ControllerDevice(mock_controller)
+
+    # Should NOT have TARGET_TEMPERATURE feature
+    assert (
+        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+    ) != ClimateEntityFeature.TARGET_TEMPERATURE
+
+
+async def test_target_temperature_feature_multiple_zones_one_without_sensor(
+    mock_controller: Mock,
+) -> None:
+    """Test TARGET_TEMPERATURE feature enabled with multiple zones when one lacks sensor."""
+    # Create multiple zones, one without temperature sensor
+    zone1 = Mock(spec=Zone)
+    zone1.index = 0
+    zone1.type = Zone.Type.AUTO
+    zone1.mode = Zone.Mode.AUTO
+    zone1.temp_current = 22.5
+    zone1.airflow_min = 0
+    zone1.airflow_max = 100
+    zone2 = Mock(spec=Zone)
+    zone2.index = 1
+    zone2.type = Zone.Type.AUTO
+    zone2.mode = Zone.Mode.AUTO
+    zone2.temp_current = None  # No sensor
+    zone2.airflow_min = 0
+    zone2.airflow_max = 100
+    zone3 = Mock(spec=Zone)
+    zone3.index = 2
+    zone3.type = Zone.Type.AUTO
+    zone3.mode = Zone.Mode.AUTO
+    zone3.temp_current = 21.5
+    zone3.airflow_min = 0
+    zone3.airflow_max = 100
+
+    mock_controller.ras_mode = "master"
+    mock_controller.zone_ctrl = 1
+    mock_controller.zones_total = 3
+    mock_controller.zones = [zone1, zone2, zone3]
+
+    device = ControllerDevice(mock_controller)
+
+    assert (
+        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+    ) == ClimateEntityFeature.TARGET_TEMPERATURE
+
+
+async def test_target_temperature_feature_slave_mode(
+    mock_controller: Mock,
+    mock_zone_with_temp: Mock,
+) -> None:
+    """Test TARGET_TEMPERATURE feature NOT enabled in slave mode."""
+    # Slave mode should not enable TARGET_TEMPERATURE
+    mock_controller.ras_mode = "slave"
+    mock_controller.zone_ctrl = 1
+    mock_controller.zones_total = 4
+    mock_controller.zones = [mock_zone_with_temp]
+
+    device = ControllerDevice(mock_controller)
+
+    # Should NOT have TARGET_TEMPERATURE feature
+    assert (
+        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+    ) != ClimateEntityFeature.TARGET_TEMPERATURE
+
+
+async def test_target_temperature_feature_master_mode_zone_13(
+    mock_controller: Mock,
+    mock_zone_with_temp: Mock,
+) -> None:
+    """Test TARGET_TEMPERATURE feature enabled when control zone is 13 (master unit)."""
+    # Master mode with zone_ctrl = 13 (the master unit itself)
+    mock_controller.ras_mode = "master"
+    mock_controller.zone_ctrl = 13
+    mock_controller.zones_total = 4
+    mock_controller.zones = [mock_zone_with_temp]
+
+    device = ControllerDevice(mock_controller)
+
+    assert (
+        device.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+    ) == ClimateEntityFeature.TARGET_TEMPERATURE
+
+
+async def test_basic_controller_properties(
+    mock_controller: Mock,
+    mock_zone_with_temp: Mock,
+) -> None:
+    """Test basic properties of ControllerDevice."""
+    mock_controller.ras_mode = "master"
+    mock_controller.zone_ctrl = 1
+    mock_controller.zones_total = 1
+    mock_controller.zones = [mock_zone_with_temp]
+
+    device = ControllerDevice(mock_controller)
+
+    assert device.unique_id == "test_controller_123"
+    assert device.name is None  # Should be None with has_entity_name
+    assert device._attr_has_entity_name is True
+    assert device.device_info is not None
+    assert (IZONE, "test_controller_123") in device.device_info["identifiers"]


### PR DESCRIPTION
## Proposed change

### What

Enable the `TARGET_TEMPERATURE` feature of the iZone controller if any of the zone's `temp_curent` is `None`.

### Why

If an iZone zone does not have a thermometer, then iZone will not adjust the target temperature of the controller. In such cases, Home Assistant needs to be able to set the target temperature based on non-iZone thermometers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #155823
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41615

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
