### PR TITLE
Fix sentence casing in smhi

### DIFF
--- a/homeassistant/components/smhi/strings.json
+++ b/homeassistant/components/smhi/strings.json
@@ -27,19 +27,19 @@
   "entity": {
     "sensor": {
       "build_up_index": {
-        "name": "Build Up Index"
+        "name": "Build up index"
       },
       "drought_code": {
-        "name": "Drought Code"
+        "name": "Drought code"
       },
       "duff_moisture_code": {
-        "name": "Duff Moisture Code"
+        "name": "Duff moisture code"
       },
       "fine_fuel_moisture_code": {
-        "name": "Fine Fuel Moisture Code"
+        "name": "Fine fuel moisture code"
       },
       "fire_weather_index": {
-        "name": "Fire Weather Index"
+        "name": "Fire weather index"
       },
       "forestdry": {
         "name": "Fuel drying",
@@ -56,10 +56,10 @@
         "name": "Frozen precipitation"
       },
       "fwi": {
-        "name": "Fire Weather Index"
+        "name": "Fire weather index"
       },
       "fwiindex": {
-        "name": "FWI-index",
+        "name": "FWI index",
         "state": {
           "extreme": "Extremely high risk",
           "high": "High risk",
@@ -84,7 +84,7 @@
         "name": "High cloud coverage"
       },
       "initial_spread_index": {
-        "name": "Initial Spread Index"
+        "name": "Initial spread index"
       },
       "low_cloud": {
         "name": "Low cloud coverage"

--- a/tests/components/smhi/snapshots/test_sensor.ambr
+++ b/tests/components/smhi/snapshots/test_sensor.ambr
@@ -26,7 +26,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Build Up Index',
+    'original_name': 'Build up index',
     'platform': 'smhi',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -40,7 +40,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Swedish weather institute (SMHI)',
-      'friendly_name': 'Test Build Up Index',
+      'friendly_name': 'Test Build up index',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
@@ -78,7 +78,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Drought Code',
+    'original_name': 'Drought code',
     'platform': 'smhi',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -92,7 +92,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Swedish weather institute (SMHI)',
-      'friendly_name': 'Test Drought Code',
+      'friendly_name': 'Test Drought code',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
@@ -130,7 +130,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Duff Moisture Code',
+    'original_name': 'Duff moisture code',
     'platform': 'smhi',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -144,7 +144,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Swedish weather institute (SMHI)',
-      'friendly_name': 'Test Duff Moisture Code',
+      'friendly_name': 'Test Duff moisture code',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
@@ -182,7 +182,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Fine Fuel Moisture Code',
+    'original_name': 'Fine fuel moisture code',
     'platform': 'smhi',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -196,7 +196,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Swedish weather institute (SMHI)',
-      'friendly_name': 'Test Fine Fuel Moisture Code',
+      'friendly_name': 'Test Fine fuel moisture code',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
@@ -234,7 +234,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Fire Weather Index',
+    'original_name': 'Fire weather index',
     'platform': 'smhi',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -248,7 +248,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Swedish weather institute (SMHI)',
-      'friendly_name': 'Test Fire Weather Index',
+      'friendly_name': 'Test Fire weather index',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
@@ -410,7 +410,7 @@
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
-    'original_name': 'FWI-index',
+    'original_name': 'FWI index',
     'platform': 'smhi',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -425,7 +425,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Swedish weather institute (SMHI)',
       'device_class': 'enum',
-      'friendly_name': 'Test FWI-index',
+      'friendly_name': 'Test FWI index',
       'options': list([
         'very_low',
         'low',
@@ -587,7 +587,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Initial Spread Index',
+    'original_name': 'Initial spread index',
     'platform': 'smhi',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -601,7 +601,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Swedish weather institute (SMHI)',
-      'friendly_name': 'Test Initial Spread Index',
+      'friendly_name': 'Test Initial spread index',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,


### PR DESCRIPTION
## Proposed change
SSIA
https://github.com/home-assistant/core/pull/153224#discussion_r2493205357

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 