### PR TITLE
Allow multiple config entries for Satel Integra

### DIFF
--- a/homeassistant/components/satel_integra/config_flow.py
+++ b/homeassistant/components/satel_integra/config_flow.py
@@ -121,6 +121,8 @@ class SatelConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+
             valid = await self.test_connection(
                 user_input[CONF_HOST], user_input[CONF_PORT]
             )

--- a/homeassistant/components/satel_integra/manifest.json
+++ b/homeassistant/components/satel_integra/manifest.json
@@ -1,17 +1,11 @@
 {
   "domain": "satel_integra",
   "name": "Satel Integra",
-  "codeowners": [
-    "@Tommatheussen"
-  ],
+  "codeowners": ["@Tommatheussen"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/satel_integra",
   "integration_type": "device",
   "iot_class": "local_push",
-  "loggers": [
-    "satel_integra"
-  ],
-  "requirements": [
-    "satel-integra==0.3.7"
-  ]
+  "loggers": ["satel_integra"],
+  "requirements": ["satel-integra==0.3.7"]
 }

--- a/homeassistant/components/satel_integra/manifest.json
+++ b/homeassistant/components/satel_integra/manifest.json
@@ -1,12 +1,17 @@
 {
   "domain": "satel_integra",
   "name": "Satel Integra",
-  "codeowners": ["@Tommatheussen"],
+  "codeowners": [
+    "@Tommatheussen"
+  ],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/satel_integra",
   "integration_type": "device",
   "iot_class": "local_push",
-  "loggers": ["satel_integra"],
-  "requirements": ["satel-integra==0.3.7"],
-  "single_config_entry": true
+  "loggers": [
+    "satel_integra"
+  ],
+  "requirements": [
+    "satel-integra==0.3.7"
+  ]
 }

--- a/homeassistant/components/satel_integra/strings.json
+++ b/homeassistant/components/satel_integra/strings.json
@@ -4,6 +4,9 @@
     "code_input_description": "Code to toggle switchable outputs"
   },
   "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5749,8 +5749,7 @@
       "name": "Satel Integra",
       "integration_type": "device",
       "config_flow": true,
-      "iot_class": "local_push",
-      "single_config_entry": true
+      "iot_class": "local_push"
     },
     "schlage": {
       "name": "Schlage",

--- a/tests/components/satel_integra/test_config_flow.py
+++ b/tests/components/satel_integra/test_config_flow.py
@@ -399,7 +399,7 @@ async def test_cannot_create_same_subentry(
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_one_config_allowed(
+async def test_same_host_config_disallowed(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test that only one Satel Integra configuration is allowed."""
@@ -409,5 +409,14 @@ async def test_one_config_allowed(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        MOCK_CONFIG_DATA,
+    )
+
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "single_instance_allowed"
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Coming from YAML, only 1 entry was supported. When adding the config flow we decided to keep this (and the unique ID migration) for another PR. My previous PR https://github.com/home-assistant/core/pull/154187 made sure the entities got unique IDs, this PR enabled multiple config entries to be configured

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
