### PR TITLE
Create issue to warn against using http.server_host in supervised installs

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -214,7 +214,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             hass,
             DOMAIN,
             "server_host_may_break_hassio",
-            breaks_in_ha_version="2026.5.0",
             is_fixable=False,
             severity=ir.IssueSeverity.ERROR,
             translation_key=issue_id,

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -209,14 +209,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         conf = cast(ConfData, HTTP_SCHEMA({}))
 
     if CONF_SERVER_HOST in conf and is_hassio(hass):
-        issue_id = "server_host_may_break_hassio"
         ir.async_create_issue(
             hass,
             DOMAIN,
             "server_host_may_break_hassio",
             is_fixable=False,
             severity=ir.IssueSeverity.ERROR,
-            translation_key=issue_id,
+            translation_key="server_host_may_break_hassio",
         )
 
     server_host = conf.get(CONF_SERVER_HOST, _DEFAULT_BIND)

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -108,7 +108,6 @@ _DEFAULT_BIND = ["0.0.0.0", "::"] if _HAS_IPV6 else ["0.0.0.0"]
 
 HTTP_SCHEMA: Final = vol.All(
     cv.deprecated(CONF_BASE_URL),
-    cv.deprecated(CONF_SERVER_HOST),  # Deprecated in HA Core 2025.11
     vol.Schema(
         {
             vol.Optional(CONF_SERVER_HOST): vol.All(
@@ -209,20 +208,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if conf is None:
         conf = cast(ConfData, HTTP_SCHEMA({}))
 
-    if CONF_SERVER_HOST in conf:
-        if is_hassio(hass):
-            issue_id = "server_host_deprecated_hassio"
-            severity = ir.IssueSeverity.ERROR
-        else:
-            issue_id = "server_host_deprecated"
-            severity = ir.IssueSeverity.WARNING
+    if CONF_SERVER_HOST in conf and is_hassio(hass):
+        issue_id = "server_host_may_break_hassio"
         ir.async_create_issue(
             hass,
             DOMAIN,
-            issue_id,
+            "server_host_may_break_hassio",
             breaks_in_ha_version="2026.5.0",
             is_fixable=False,
-            severity=severity,
+            severity=ir.IssueSeverity.ERROR,
             translation_key=issue_id,
         )
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -38,6 +38,7 @@ from homeassistant.const import (
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, issue_registry as ir, storage
+from homeassistant.helpers.hassio import is_hassio
 from homeassistant.helpers.http import (
     KEY_ALLOW_CONFIGURED_CORS,
     KEY_AUTHENTICATED,  # noqa: F401
@@ -107,9 +108,10 @@ _DEFAULT_BIND = ["0.0.0.0", "::"] if _HAS_IPV6 else ["0.0.0.0"]
 
 HTTP_SCHEMA: Final = vol.All(
     cv.deprecated(CONF_BASE_URL),
+    cv.deprecated(CONF_SERVER_HOST),  # Deprecated in HA Core 2025.11
     vol.Schema(
         {
-            vol.Optional(CONF_SERVER_HOST, default=_DEFAULT_BIND): vol.All(
+            vol.Optional(CONF_SERVER_HOST): vol.All(
                 cv.ensure_list, vol.Length(min=1), [cv.string]
             ),
             vol.Optional(CONF_SERVER_PORT, default=SERVER_PORT): cv.port,
@@ -207,7 +209,24 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if conf is None:
         conf = cast(ConfData, HTTP_SCHEMA({}))
 
-    server_host = conf[CONF_SERVER_HOST]
+    if CONF_SERVER_HOST in conf:
+        if is_hassio(hass):
+            issue_id = "server_host_deprecated_hassio"
+            severity = ir.IssueSeverity.ERROR
+        else:
+            issue_id = "server_host_deprecated"
+            severity = ir.IssueSeverity.WARNING
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            breaks_in_ha_version="2026.5.0",
+            is_fixable=False,
+            severity=severity,
+            translation_key=issue_id,
+        )
+
+    server_host = conf.get(CONF_SERVER_HOST, _DEFAULT_BIND)
     server_port = conf[CONF_SERVER_PORT]
     ssl_certificate = conf.get(CONF_SSL_CERTIFICATE)
     ssl_peer_certificate = conf.get(CONF_SSL_PEER_CERTIFICATE)

--- a/homeassistant/components/http/strings.json
+++ b/homeassistant/components/http/strings.json
@@ -1,11 +1,7 @@
 {
   "issues": {
-    "server_host_deprecated": {
-      "description": "The `server_host` configuration option in the HTTP integration is deprecated and will be removed in a future release.\n\nIf you are using this option to bind Home Assistant to specific network interfaces, please remove it from your configuration. Home Assistant will automatically bind to all available interfaces by default.\n\nIf you have specific networking requirements, consider using firewall rules or other network configuration to control access to Home Assistant.",
-      "title": "The `server_host` HTTP configuration option is deprecated"
-    },
-    "server_host_deprecated_hassio": {
-      "description": "The deprecated `server_host` configuration option in the HTTP integration is prone to break the communication between Home Assistant Core and supervisor, and will be removed in a future release.\n\nIf you are using this option to bind Home Assistant to specific network interfaces, please remove it from your configuration. Home Assistant will automatically bind to all available interfaces by default.\n\nIf you have specific networking requirements, consider using firewall rules or other network configuration to control access to Home Assistant.",
+    "server_host_may_break_hassio": {
+      "description": "The `server_host` configuration option in the HTTP integration is prone to break the communication between Home Assistant Core and supervisor, and will be removed in a future release.\n\nIf you are using this option to bind Home Assistant to specific network interfaces, please remove it from your configuration. Home Assistant will automatically bind to all available interfaces by default.\n\nIf you have specific networking requirements, consider using firewall rules or other network configuration to control access to Home Assistant.",
       "title": "The `server_host` HTTP configuration may break Home Assistant Core - Supervisor communication"
     },
     "ssl_configured_without_configured_urls": {

--- a/homeassistant/components/http/strings.json
+++ b/homeassistant/components/http/strings.json
@@ -1,5 +1,13 @@
 {
   "issues": {
+    "server_host_deprecated": {
+      "description": "The `server_host` configuration option in the HTTP integration is deprecated and will be removed in a future release.\n\nIf you are using this option to bind Home Assistant to specific network interfaces, please remove it from your configuration. Home Assistant will automatically bind to all available interfaces by default.\n\nIf you have specific networking requirements, consider using firewall rules or other network configuration to control access to Home Assistant.",
+      "title": "The `server_host` HTTP configuration option is deprecated"
+    },
+    "server_host_deprecated_hassio": {
+      "description": "The deprecated `server_host` configuration option in the HTTP integration is prone to break the communication between Home Assistant Core and supervisor, and will be removed in a future release.\n\nIf you are using this option to bind Home Assistant to specific network interfaces, please remove it from your configuration. Home Assistant will automatically bind to all available interfaces by default.\n\nIf you have specific networking requirements, consider using firewall rules or other network configuration to control access to Home Assistant.",
+      "title": "The `server_host` HTTP configuration may break Home Assistant Core - Supervisor communication"
+    },
     "ssl_configured_without_configured_urls": {
       "description": "Home Assistant detected that SSL has been set up on your instance, however, no custom external internet URL has been set.\n\nThis may result in unexpected behavior. Text-to-speech may fail, and integrations may not be able to connect back to your instance correctly.\n\nTo address this issue, go to Settings > System > Network; under the \"Home Assistant URL\" section, configure your new \"Internet\" and \"Local network\" addresses that match your new SSL configuration.",
       "title": "SSL is configured without an external URL or internal URL"

--- a/homeassistant/components/http/strings.json
+++ b/homeassistant/components/http/strings.json
@@ -1,7 +1,7 @@
 {
   "issues": {
     "server_host_may_break_hassio": {
-      "description": "The `server_host` configuration option in the HTTP integration is prone to break the communication between Home Assistant Core and supervisor, and will be removed in a future release.\n\nIf you are using this option to bind Home Assistant to specific network interfaces, please remove it from your configuration. Home Assistant will automatically bind to all available interfaces by default.\n\nIf you have specific networking requirements, consider using firewall rules or other network configuration to control access to Home Assistant.",
+      "description": "The `server_host` configuration option in the HTTP integration is prone to break the communication between Home Assistant Core and Supervisor, and will be removed in a future release.\n\nIf you are using this option to bind Home Assistant to specific network interfaces, please remove it from your configuration. Home Assistant will automatically bind to all available interfaces by default.\n\nIf you have specific networking requirements, consider using firewall rules or other network configuration to control access to Home Assistant.",
       "title": "The `server_host` HTTP configuration may break Home Assistant Core - Supervisor communication"
     },
     "ssl_configured_without_configured_urls": {

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -674,27 +674,19 @@ async def test_ssl_issue_urls_configured(
         "hassio",
         "http_config",
         "expected_serverhost",
-        "expected_warning_count",
         "expected_issues",
     ),
     [
-        (False, {}, ["0.0.0.0", "::"], 0, set()),
-        (
-            False,
-            {"server_host": "0.0.0.0"},
-            ["0.0.0.0"],
-            1,
-            {("http", "server_host_deprecated")},
-        ),
-        (True, {}, ["0.0.0.0", "::"], 0, set()),
+        (False, {}, ["0.0.0.0", "::"], set()),
+        (False, {"server_host": "0.0.0.0"}, ["0.0.0.0"], set()),
+        (True, {}, ["0.0.0.0", "::"], set()),
         (
             True,
             {"server_host": "0.0.0.0"},
             [
                 "0.0.0.0",
             ],
-            1,
-            {("http", "server_host_deprecated_hassio")},
+            {("http", "server_host_may_break_hassio")},
         ),
     ],
 )
@@ -704,9 +696,7 @@ async def test_server_host(
     issue_registry: ir.IssueRegistry,
     http_config: dict,
     expected_serverhost: list,
-    expected_warning_count: int,
     expected_issues: set[tuple[str, str]],
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test server_host behavior."""
     mock_server = Mock()
@@ -732,13 +722,6 @@ async def test_server_host(
         backlog=128,
         reuse_address=None,
         reuse_port=None,
-    )
-
-    assert (
-        caplog.text.count(
-            "The 'server_host' option is deprecated, please remove it from your configuration"
-        )
-        == expected_warning_count
     )
 
     assert set(issue_registry.issues) == expected_issues

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -7,7 +7,7 @@ from http import HTTPStatus
 from ipaddress import ip_network
 import logging
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 
@@ -667,3 +667,78 @@ async def test_ssl_issue_urls_configured(
         "http",
         "ssl_configured_without_configured_urls",
     ) not in issue_registry.issues
+
+
+@pytest.mark.parametrize(
+    (
+        "hassio",
+        "http_config",
+        "expected_serverhost",
+        "expected_warning_count",
+        "expected_issues",
+    ),
+    [
+        (False, {}, ["0.0.0.0", "::"], 0, set()),
+        (
+            False,
+            {"server_host": "0.0.0.0"},
+            ["0.0.0.0"],
+            1,
+            {("http", "server_host_deprecated")},
+        ),
+        (True, {}, ["0.0.0.0", "::"], 0, set()),
+        (
+            True,
+            {"server_host": "0.0.0.0"},
+            [
+                "0.0.0.0",
+            ],
+            1,
+            {("http", "server_host_deprecated_hassio")},
+        ),
+    ],
+)
+async def test_server_host(
+    hass: HomeAssistant,
+    hassio: bool,
+    issue_registry: ir.IssueRegistry,
+    http_config: dict,
+    expected_serverhost: list,
+    expected_warning_count: int,
+    expected_issues: set[tuple[str, str]],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test server_host behavior."""
+    mock_server = Mock()
+    with (
+        patch("homeassistant.components.http.is_hassio", return_value=hassio),
+        patch(
+            "asyncio.BaseEventLoop.create_server", return_value=mock_server
+        ) as mock_create_server,
+    ):
+        assert await async_setup_component(
+            hass,
+            "http",
+            {"http": http_config},
+        )
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    mock_create_server.assert_called_once_with(
+        ANY,
+        expected_serverhost,
+        8123,
+        ssl=None,
+        backlog=128,
+        reuse_address=None,
+        reuse_port=None,
+    )
+
+    assert (
+        caplog.text.count(
+            "The 'server_host' option is deprecated, please remove it from your configuration"
+        )
+        == expected_warning_count
+    )
+
+    assert set(issue_registry.issues) == expected_issues

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -137,7 +137,6 @@ def test_secrets() -> None:
         "server_port": 8123,
         "ssl_profile": "modern",
         "use_x_frame_options": True,
-        "server_host": ["0.0.0.0", "::"],
     }
     assert res["secret_cache"] == {
         get_test_config_dir("secrets.yaml"): {"http_pw": "http://google.com"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Create issue to warn against using `http.server_host` in supervised installs

Background:
The HTTP integration's `server_host` configuration option is only supported for Home Assistant Core.
Users are using it in supervised installation methods, which is prone to breaking supervisor initiated communication with core, which among other things mean backups break.

Needs https://github.com/home-assistant/core/pull/155834

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
