### PR TITLE
Make Google sheets datetime column optional

### DIFF
--- a/homeassistant/components/google_sheets/services.py
+++ b/homeassistant/components/google_sheets/services.py
@@ -31,11 +31,11 @@ from .const import DOMAIN
 if TYPE_CHECKING:
     from . import GoogleSheetsConfigEntry
 
+ADD_DATETIME = "add_datetime"
 DATA = "data"
 DATA_CONFIG_ENTRY = "config_entry"
 ROWS = "rows"
 WORKSHEET = "worksheet"
-ADD_DATETIME = "add_datetime"
 
 SERVICE_APPEND_SHEET = "append_sheet"
 SERVICE_GET_SHEET = "get_sheet"

--- a/homeassistant/components/google_sheets/services.py
+++ b/homeassistant/components/google_sheets/services.py
@@ -31,7 +31,7 @@ from .const import DOMAIN
 if TYPE_CHECKING:
     from . import GoogleSheetsConfigEntry
 
-ADD_DATETIME = "add_datetime"
+ADD_CREATED_COLUMN = "add_created_column"
 DATA = "data"
 DATA_CONFIG_ENTRY = "config_entry"
 ROWS = "rows"
@@ -44,7 +44,7 @@ SHEET_SERVICE_SCHEMA = vol.All(
     {
         vol.Required(DATA_CONFIG_ENTRY): ConfigEntrySelector({"integration": DOMAIN}),
         vol.Optional(WORKSHEET): cv.string,
-        vol.Optional(ADD_DATETIME, default=True): cv.boolean,
+        vol.Optional(ADD_CREATED_COLUMN, default=True): cv.boolean,
         vol.Required(DATA): vol.Any(cv.ensure_list, [dict]),
     },
 )
@@ -71,11 +71,11 @@ def _append_to_sheet(call: ServiceCall, entry: GoogleSheetsConfigEntry) -> None:
 
     worksheet = sheet.worksheet(call.data.get(WORKSHEET, sheet.sheet1.title))
     columns: list[str] = next(iter(worksheet.get_values("A1:ZZ1")), [])
-    add_timestamp = call.data[ADD_DATETIME]
+    add_created_column = call.data[ADD_CREATED_COLUMN]
     now = str(datetime.now())
     rows = []
     for d in call.data[DATA]:
-        row_data = ({"created": now} | d) if add_timestamp else d
+        row_data = ({"created": now} | d) if add_created_column else d
         row = [row_data.get(column, "") for column in columns]
         for key, value in row_data.items():
             if key not in columns:

--- a/homeassistant/components/google_sheets/services.py
+++ b/homeassistant/components/google_sheets/services.py
@@ -35,6 +35,7 @@ DATA = "data"
 DATA_CONFIG_ENTRY = "config_entry"
 ROWS = "rows"
 WORKSHEET = "worksheet"
+ADD_DATETIME = "add_datetime"
 
 SERVICE_APPEND_SHEET = "append_sheet"
 SERVICE_GET_SHEET = "get_sheet"
@@ -43,6 +44,7 @@ SHEET_SERVICE_SCHEMA = vol.All(
     {
         vol.Required(DATA_CONFIG_ENTRY): ConfigEntrySelector({"integration": DOMAIN}),
         vol.Optional(WORKSHEET): cv.string,
+        vol.Optional(ADD_DATETIME, default=True): cv.boolean,
         vol.Required(DATA): vol.Any(cv.ensure_list, [dict]),
     },
 )
@@ -69,10 +71,11 @@ def _append_to_sheet(call: ServiceCall, entry: GoogleSheetsConfigEntry) -> None:
 
     worksheet = sheet.worksheet(call.data.get(WORKSHEET, sheet.sheet1.title))
     columns: list[str] = next(iter(worksheet.get_values("A1:ZZ1")), [])
+    add_timestamp = call.data[ADD_DATETIME]
     now = str(datetime.now())
     rows = []
     for d in call.data[DATA]:
-        row_data = {"created": now} | d
+        row_data = ({"created": now} | d) if add_timestamp else d
         row = [row_data.get(column, "") for column in columns]
         for key, value in row_data.items():
             if key not in columns:

--- a/homeassistant/components/google_sheets/services.yaml
+++ b/homeassistant/components/google_sheets/services.yaml
@@ -9,7 +9,7 @@ append_sheet:
       example: "Sheet1"
       selector:
         text:
-    add_datetime:
+    add_created_column:
       required: false
       default: true
       selector:

--- a/homeassistant/components/google_sheets/services.yaml
+++ b/homeassistant/components/google_sheets/services.yaml
@@ -9,6 +9,11 @@ append_sheet:
       example: "Sheet1"
       selector:
         text:
+    add_datetime:
+      required: false
+      default: true
+      selector:
+        boolean:
     data:
       required: true
       example: '{"hello": world, "cool": True, "count": 5}'

--- a/homeassistant/components/google_sheets/strings.json
+++ b/homeassistant/components/google_sheets/strings.json
@@ -45,6 +45,10 @@
     "append_sheet": {
       "description": "Appends data to a worksheet in Google Sheets.",
       "fields": {
+        "add_datetime": {
+          "description": "Include date-time column to the data being appended.",
+          "name": "Add date-time"
+        },
         "config_entry": {
           "description": "The sheet to add data to.",
           "name": "Sheet"

--- a/homeassistant/components/google_sheets/strings.json
+++ b/homeassistant/components/google_sheets/strings.json
@@ -45,9 +45,9 @@
     "append_sheet": {
       "description": "Appends data to a worksheet in Google Sheets.",
       "fields": {
-        "add_datetime": {
-          "description": "Include date-time column to the data being appended.",
-          "name": "Add date-time"
+        "add_created_column": {
+          "description": "Include created column containing current date-time to the data being appended.",
+          "name": "Add created column"
         },
         "config_entry": {
           "description": "The sheet to add data to.",

--- a/homeassistant/components/google_sheets/strings.json
+++ b/homeassistant/components/google_sheets/strings.json
@@ -46,7 +46,7 @@
       "description": "Appends data to a worksheet in Google Sheets.",
       "fields": {
         "add_created_column": {
-          "description": "Include created column containing current date-time to the data being appended.",
+          "description": "Include \"created\" column containing current date-time to the data being appended.",
           "name": "Add created column"
         },
         "config_entry": {

--- a/homeassistant/components/google_sheets/strings.json
+++ b/homeassistant/components/google_sheets/strings.json
@@ -46,7 +46,7 @@
       "description": "Appends data to a worksheet in Google Sheets.",
       "fields": {
         "add_created_column": {
-          "description": "Include \"created\" column containing current date-time to the data being appended.",
+          "description": "Add a \"created\" column with the current date-time to the appended data.",
           "name": "Add created column"
         },
         "config_entry": {

--- a/tests/components/google_sheets/test_init.py
+++ b/tests/components/google_sheets/test_init.py
@@ -17,8 +17,11 @@ from homeassistant.components.application_credentials import (
 )
 from homeassistant.components.google_sheets.const import DOMAIN
 from homeassistant.components.google_sheets.services import (
+    ADD_CREATED_COLUMN,
+    DATA,
     DATA_CONFIG_ENTRY,
     ROWS,
+    SERVICE_APPEND_SHEET,
     SERVICE_GET_SHEET,
     WORKSHEET,
 )
@@ -209,11 +212,12 @@ async def test_append_sheet(
     with patch("homeassistant.components.google_sheets.services.Client") as mock_client:
         await hass.services.async_call(
             DOMAIN,
-            "append_sheet",
+            SERVICE_APPEND_SHEET,
             {
-                "config_entry": config_entry.entry_id,
-                "worksheet": "Sheet1",
-                "data": {"foo": "bar"},
+                DATA_CONFIG_ENTRY: config_entry.entry_id,
+                WORKSHEET: "Sheet1",
+                ADD_CREATED_COLUMN: True,
+                DATA: {"foo": "bar"},
             },
             blocking=True,
         )

--- a/tests/components/google_sheets/test_init.py
+++ b/tests/components/google_sheets/test_init.py
@@ -30,7 +30,6 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -199,33 +198,6 @@ async def test_expired_token_refresh_failure(
     assert entries[0].state is expected_state
 
 
-async def test_append_sheet(
-    hass: HomeAssistant,
-    setup_integration: ComponentSetup,
-    config_entry: MockConfigEntry,
-) -> None:
-    """Test service call appending to a sheet."""
-    await setup_integration()
-
-    entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(entries) == 1
-    assert entries[0].state is ConfigEntryState.LOADED
-
-    with patch("homeassistant.components.google_sheets.services.Client") as mock_client:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_APPEND_SHEET,
-            {
-                DATA_CONFIG_ENTRY: config_entry.entry_id,
-                WORKSHEET: "Sheet1",
-                ADD_CREATED_COLUMN: True,
-                DATA: {"foo": "bar"},
-            },
-            blocking=True,
-        )
-    assert len(mock_client.mock_calls) == 8
-
-
 @pytest.mark.parametrize(
     ("add_created_column_param", "expected_row"),
     [
@@ -236,7 +208,7 @@ async def test_append_sheet(
     ids=["created_column_true", "created_column_false", "created_column_default"],
 )
 @freeze_time("2024-01-15 12:30:45.123456")
-async def test_created_column(
+async def test_append_sheet(
     hass: HomeAssistant,
     setup_integration: ComponentSetup,
     config_entry: MockConfigEntry,

--- a/tests/components/google_sheets/test_init.py
+++ b/tests/components/google_sheets/test_init.py
@@ -262,7 +262,8 @@ async def test_created_column(
 
         mock_worksheet.append_rows.assert_called_once()
         rows_data = mock_worksheet.append_rows.call_args[0][0]
-        assert rows_data[0][1] == utcnow
+        created_ts = utcnow.strftime("%Y-%m-%d %H:%M:%S.%f")
+        assert rows_data[0][1] == created_ts
 
 
 async def test_get_sheet(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make Google sheets datetime column optional by introducing a bool in the action being `True` by default so there is no breaking change. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #97035
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41628
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [ X Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
