### PR TITLE
Remove `@progress_step` decorator from ZHA and Hardware integration

### DIFF
--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -193,10 +193,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
             return self.async_show_progress(
                 step_id=step_id,
                 progress_action="install_firmware",
-                description_placeholders={
-                    **self._get_translation_placeholders(),
-                    "firmware_name": firmware_name,
-                },
+                description_placeholders=self._get_translation_placeholders(),
                 progress_task=self.firmware_install_task,
             )
 

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -246,7 +246,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
                 _LOGGER.debug("Skipping firmware upgrade due to index download failure")
                 return
 
-            raise AbortFlow(reason="firmware_download_failed") from err
+            raise AbortFlow(reason="fw_download_failed") from err
 
         if not firmware_install_required:
             assert self._probed_firmware_info is not None
@@ -275,7 +275,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
                 return
 
             # Otherwise, fail
-            raise AbortFlow(reason="firmware_download_failed") from err
+            raise AbortFlow(reason="fw_download_failed") from err
 
         self._probed_firmware_info = await async_flash_silabs_firmware(
             hass=self.hass,
@@ -318,7 +318,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
 
         await otbr_manager.async_start_addon_waiting()
 
-    async def async_step_firmware_download_failed(
+    async def async_step_fw_download_failed(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Abort when firmware download failed."""

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -190,7 +190,8 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
 
         self._hass = None  # type: ignore[assignment]
         self._radio_mgr = ZhaRadioManager()
-        self._restore_backup_task: asyncio.Task[None] | None = None        self._reset_old_radio_task: asyncio.Task[ConfigFlowResult] | None = None
+        self._restore_backup_task: asyncio.Task[None] | None = None
+        self._reset_old_radio_task: asyncio.Task[ConfigFlowResult] | None = None
         self._form_network_task: asyncio.Task[None] | None = None
         self._extra_network_config: dict[str, Any] = {}
 
@@ -652,7 +653,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
 
     async def _async_form_new_network(self) -> None:
         """Do the work of forming a new network."""
-        await self._radio_mgr.async_form_network()
+        await self._radio_mgr.async_form_network(config=self._extra_network_config)
         # Load the newly formed network settings to get the network info
         await self._radio_mgr.async_load_network_settings()
 
@@ -662,9 +663,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
         """Form a brand-new network."""
         if self._form_network_task is None:
             self._form_network_task = self.hass.async_create_task(
-                self._async_form_new_network(
-                    config=self._extra_network_config
-                ),
+                self._async_form_new_network(),
                 "Form new network",
             )
 

--- a/tests/components/homeassistant_hardware/test_config_flow.py
+++ b/tests/components/homeassistant_hardware/test_config_flow.py
@@ -792,10 +792,11 @@ async def test_config_flow_thread(
         assert pick_result["type"] is FlowResultType.SHOW_PROGRESS
         assert pick_result["progress_action"] == "install_firmware"
         assert pick_result["step_id"] == "install_thread_firmware"
-        description_placeholders = pick_result["description_placeholders"]
-        assert description_placeholders is not None
-        assert description_placeholders["firmware_type"] == "ezsp"
-        assert description_placeholders["model"] == TEST_HARDWARE_NAME
+        assert pick_result["description_placeholders"] == {
+            "firmware_type": "ezsp",
+            "model": TEST_HARDWARE_NAME,
+            "firmware_name": "Thread",
+        }
 
         await hass.async_block_till_done(wait_background_tasks=True)
 
@@ -919,10 +920,11 @@ async def test_options_flow_zigbee_to_thread(
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
         assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "pick_firmware"
-        description_placeholders = result["description_placeholders"]
-        assert description_placeholders is not None
-        assert description_placeholders["firmware_type"] == "ezsp"
-        assert description_placeholders["model"] == TEST_HARDWARE_NAME
+        assert result["description_placeholders"] == {
+            "firmware_type": "ezsp",
+            "model": TEST_HARDWARE_NAME,
+            "firmware_name": "unknown",
+        }
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
@@ -995,10 +997,11 @@ async def test_options_flow_thread_to_zigbee(hass: HomeAssistant) -> None:
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "pick_firmware"
-    description_placeholders = result["description_placeholders"]
-    assert description_placeholders is not None
-    assert description_placeholders["firmware_type"] == "spinel"
-    assert description_placeholders["model"] == TEST_HARDWARE_NAME
+    assert result["description_placeholders"] == {
+        "firmware_type": "spinel",
+        "model": TEST_HARDWARE_NAME,
+        "firmware_name": "unknown",
+    }
 
     with mock_firmware_info(
         probe_app_type=ApplicationType.SPINEL,

--- a/tests/components/homeassistant_hardware/test_config_flow_failures.py
+++ b/tests/components/homeassistant_hardware/test_config_flow_failures.py
@@ -69,6 +69,11 @@ async def test_config_flow_thread_not_hassio(hass: HomeAssistant) -> None:
 
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "not_hassio_thread"
+        assert result["description_placeholders"] == {
+            "model": TEST_HARDWARE_NAME,
+            "firmware_type": "spinel",
+            "firmware_name": "Thread",
+        }
 
 
 @pytest.mark.parametrize(
@@ -110,6 +115,12 @@ async def test_config_flow_thread_addon_info_fails(
         # Cannot get addon info
         assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "addon_info_failed"
+        assert result["description_placeholders"] == {
+            "model": TEST_HARDWARE_NAME,
+            "firmware_type": "spinel",
+            "firmware_name": "Thread",
+            "addon_name": "OpenThread Border Router",
+        }
 
 
 @pytest.mark.usefixtures("addon_not_installed")
@@ -155,6 +166,12 @@ async def test_config_flow_thread_addon_install_fails(
         # Cannot install addon
         assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "addon_install_failed"
+        assert result["description_placeholders"] == {
+            "model": TEST_HARDWARE_NAME,
+            "firmware_type": "ezsp",
+            "firmware_name": "Thread",
+            "addon_name": "OpenThread Border Router",
+        }
 
 
 @pytest.mark.usefixtures("addon_installed")
@@ -196,6 +213,12 @@ async def test_config_flow_thread_addon_set_config_fails(
 
         assert pick_thread_progress_result["type"] == FlowResultType.ABORT
         assert pick_thread_progress_result["reason"] == "addon_set_config_failed"
+        assert pick_thread_progress_result["description_placeholders"] == {
+            "model": TEST_HARDWARE_NAME,
+            "firmware_type": "ezsp",
+            "firmware_name": "Thread",
+            "addon_name": "OpenThread Border Router",
+        }
 
 
 @pytest.mark.usefixtures("addon_installed")
@@ -236,6 +259,12 @@ async def test_config_flow_thread_flasher_run_fails(
 
         assert pick_thread_progress_result["type"] == FlowResultType.ABORT
         assert pick_thread_progress_result["reason"] == "addon_start_failed"
+        assert pick_thread_progress_result["description_placeholders"] == {
+            "model": TEST_HARDWARE_NAME,
+            "firmware_type": "ezsp",
+            "firmware_name": "Thread",
+            "addon_name": "OpenThread Border Router",
+        }
 
 
 @pytest.mark.usefixtures("addon_running")
@@ -273,6 +302,11 @@ async def test_config_flow_thread_confirmation_fails(hass: HomeAssistant) -> Non
 
         assert pick_thread_progress_result["type"] is FlowResultType.ABORT
         assert pick_thread_progress_result["reason"] == "fw_install_failed"
+        assert pick_thread_progress_result["description_placeholders"] == {
+            "firmware_name": "Thread",
+            "model": TEST_HARDWARE_NAME,
+            "firmware_type": "ezsp",
+        }
 
 
 @pytest.mark.parametrize(
@@ -310,6 +344,11 @@ async def test_config_flow_firmware_index_download_fails_and_required(
 
         assert pick_result["type"] is FlowResultType.ABORT
         assert pick_result["reason"] == "fw_download_failed"
+        assert pick_result["description_placeholders"] == {
+            "firmware_name": "Zigbee",
+            "model": TEST_HARDWARE_NAME,
+            "firmware_type": "spinel",
+        }
 
 
 @pytest.mark.parametrize(
@@ -347,6 +386,11 @@ async def test_config_flow_firmware_download_fails_and_required(
 
         assert pick_result["type"] is FlowResultType.ABORT
         assert pick_result["reason"] == "fw_download_failed"
+        assert pick_result["description_placeholders"] == {
+            "firmware_name": "Zigbee",
+            "model": TEST_HARDWARE_NAME,
+            "firmware_type": "spinel",
+        }
 
 
 @pytest.mark.parametrize(
@@ -395,6 +439,11 @@ async def test_options_flow_zigbee_to_thread_zha_configured(
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "zha_still_using_stick"
+    assert result["description_placeholders"] == {
+        "model": TEST_HARDWARE_NAME,
+        "firmware_type": "ezsp",
+        "firmware_name": "unknown",
+    }
 
 
 @pytest.mark.parametrize(
@@ -442,3 +491,8 @@ async def test_options_flow_thread_to_zigbee_otbr_configured(
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "otbr_still_using_stick"
+    assert result["description_placeholders"] == {
+        "model": TEST_HARDWARE_NAME,
+        "firmware_type": "spinel",
+        "firmware_name": "unknown",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a proper fix for the issue uncovered by #153906 and migrates ZHA and the hardware integration firmware installation flows to use the more verbose API.

This fixes an issue where the ZHA abort dialog did not show in some cases when network settings could not be written to the new coordinator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
