### PR TITLE
Remove arbitrary forecast limit for meteo_lt

### DIFF
--- a/homeassistant/components/meteo_lt/weather.py
+++ b/homeassistant/components/meteo_lt/weather.py
@@ -139,7 +139,7 @@ class MeteoLtWeatherEntity(CoordinatorEntity[MeteoLtUpdateCoordinator], WeatherE
             forecasts_by_date[date].append(timestamp)
 
         daily_forecasts = []
-        for date in sorted(forecasts_by_date.keys())[:5]:
+        for date in sorted(forecasts_by_date.keys()):
             day_forecasts = forecasts_by_date[date]
             if not day_forecasts:
                 continue
@@ -186,5 +186,5 @@ class MeteoLtWeatherEntity(CoordinatorEntity[MeteoLtUpdateCoordinator], WeatherE
             return None
         return [
             self._convert_forecast_data(forecast_data)
-            for forecast_data in self.coordinator.data.forecast_timestamps[:24]
+            for forecast_data in self.coordinator.data.forecast_timestamps
         ]

--- a/tests/components/meteo_lt/fixtures/forecast.json
+++ b/tests/components/meteo_lt/fixtures/forecast.json
@@ -48,6 +48,84 @@
       "relativeHumidity": 65,
       "totalPrecipitation": 0.1,
       "conditionCode": "cloudy"
+    },
+    {
+      "forecastTimeUtc": "2025-09-26 10:00:00",
+      "airTemperature": 15.0,
+      "feelsLikeTemperature": 15.0,
+      "windSpeed": 3,
+      "windGust": 9,
+      "windDirection": 35,
+      "cloudCover": 30,
+      "seaLevelPressure": 1030,
+      "relativeHumidity": 60,
+      "totalPrecipitation": 0.2,
+      "conditionCode": "cloudy"
+    },
+    {
+      "forecastTimeUtc": "2025-09-27 10:00:00",
+      "airTemperature": 16.0,
+      "feelsLikeTemperature": 16.0,
+      "windSpeed": 4,
+      "windGust": 10,
+      "windDirection": 40,
+      "cloudCover": 35,
+      "seaLevelPressure": 1029,
+      "relativeHumidity": 55,
+      "totalPrecipitation": 0.3,
+      "conditionCode": "rainy"
+    },
+    {
+      "forecastTimeUtc": "2025-09-28 10:00:00",
+      "airTemperature": 17.0,
+      "feelsLikeTemperature": 17.0,
+      "windSpeed": 5,
+      "windGust": 11,
+      "windDirection": 45,
+      "cloudCover": 40,
+      "seaLevelPressure": 1028,
+      "relativeHumidity": 50,
+      "totalPrecipitation": 0.4,
+      "conditionCode": "rainy"
+    },
+    {
+      "forecastTimeUtc": "2025-09-29 10:00:00",
+      "airTemperature": 18.0,
+      "feelsLikeTemperature": 18.0,
+      "windSpeed": 6,
+      "windGust": 12,
+      "windDirection": 50,
+      "cloudCover": 45,
+      "seaLevelPressure": 1027,
+      "relativeHumidity": 45,
+      "totalPrecipitation": 0.5,
+      "conditionCode": "rainy"
+    },
+    {
+      "forecastTimeUtc": "2025-09-30 10:00:00",
+      "airTemperature": 19.0,
+      "feelsLikeTemperature": 19.0,
+      "windSpeed": 7,
+      "windGust": 13,
+      "windDirection": 55,
+      "cloudCover": 50,
+      "seaLevelPressure": 1026,
+      "relativeHumidity": 40,
+      "totalPrecipitation": 0.6,
+      "conditionCode": "rainy"
+    },
+    {
+      "forecastTimeUtc": "2025-10-01 10:00:00",
+      "airTemperature": 20.0,
+      "feelsLikeTemperature": 20.0,
+      "windSpeed": 8,
+      "windGust": 14,
+      "windDirection": 60,
+      "cloudCover": 55,
+      "seaLevelPressure": 1025,
+      "relativeHumidity": 35,
+      "totalPrecipitation": 0.7,
+      "conditionCode": "rainy"
     }
   ]
 }

--- a/tests/components/meteo_lt/test_weather.py
+++ b/tests/components/meteo_lt/test_weather.py
@@ -34,3 +34,34 @@ async def test_weather_entity(
     await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.freeze_time("2025-09-25 9:00:00")
+async def test_forecast_no_limits(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that forecast returns all available data from API without limits."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.services.async_call(
+        "weather",
+        "get_forecasts",
+        {"entity_id": "weather.vilnius", "type": "hourly"},
+        blocking=True,
+        return_response=True,
+    )
+    hourly_forecasts = result["weather.vilnius"]["forecast"]
+    assert len(hourly_forecasts) == 9
+
+    result = await hass.services.async_call(
+        "weather",
+        "get_forecasts",
+        {"entity_id": "weather.vilnius", "type": "daily"},
+        blocking=True,
+        return_response=True,
+    )
+    daily_forecasts = result["weather.vilnius"]["forecast"]
+    assert len(daily_forecasts) == 7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes #155875. Not all data that was fetched from the API was converted to`Forecast` objects, it was truncated to 24h and 5d for hourly and daily, respectively. 
~~It also fixes a related issue -- timestamps not being converted to UTC for the `Forecast` object. It fixes the desync between the meteo.lt site and the integration due to incorrect timezone handling on the integration.~~

I've reduced the scope for now as I'm still not 100% sure about the timestamp issue. I'll raise a new PR for it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #155875
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Please tag for **2025.11.1**

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
