### PR TITLE
Fix octoprint tests opening sockets

### DIFF
--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -2,24 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-from unittest.mock import patch
-
-from pyoctoprintapi import (
-    DiscoverySettings,
-    OctoprintJobInfo,
-    OctoprintPrinterInfo,
-    TrackingSetting,
-)
-
-from homeassistant.components.octoprint import DOMAIN
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import UNDEFINED, UndefinedType
-
-from tests.common import MockConfigEntry
-
 DEFAULT_JOB = {
     "job": {
         "averagePrintTime": None,
@@ -46,60 +28,3 @@ DEFAULT_PRINTER = {
     },
     "temperature": [],
 }
-
-
-async def init_integration(
-    hass: HomeAssistant,
-    platform: Platform,
-    printer: dict[str, Any] | UndefinedType | None = UNDEFINED,
-    job: dict[str, Any] | None = None,
-) -> MockConfigEntry:
-    """Set up the octoprint integration in Home Assistant."""
-    printer_info: OctoprintPrinterInfo | None = None
-    if printer is UNDEFINED:
-        printer = DEFAULT_PRINTER
-    if printer is not None:
-        printer_info = OctoprintPrinterInfo(printer)
-    if job is None:
-        job = DEFAULT_JOB
-    with (
-        patch("homeassistant.components.octoprint.PLATFORMS", [platform]),
-        patch("pyoctoprintapi.OctoprintClient.get_server_info", return_value={}),
-        patch(
-            "pyoctoprintapi.OctoprintClient.get_printer_info",
-            return_value=printer_info,
-        ),
-        patch(
-            "pyoctoprintapi.OctoprintClient.get_job_info",
-            return_value=OctoprintJobInfo(job),
-        ),
-        patch(
-            "pyoctoprintapi.OctoprintClient.get_tracking_info",
-            return_value=TrackingSetting({"unique_id": "uuid"}),
-        ),
-        patch(
-            "pyoctoprintapi.OctoprintClient.get_discovery_info",
-            return_value=DiscoverySettings({"upnpUuid": "uuid"}),
-        ),
-    ):
-        config_entry = MockConfigEntry(
-            domain=DOMAIN,
-            entry_id="uuid",
-            unique_id="uuid",
-            data={
-                "host": "1.1.1.1",
-                "api_key": "test-key",
-                "name": "OctoPrint",
-                "port": 81,
-                "ssl": True,
-                "path": "/",
-            },
-            title="OctoPrint",
-        )
-        config_entry.add_to_hass(hass)
-
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.LOADED
-    return config_entry

--- a/tests/components/octoprint/conftest.py
+++ b/tests/components/octoprint/conftest.py
@@ -1,0 +1,105 @@
+"""Tests for the OctoPrint integration."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import patch
+
+from pyoctoprintapi import (
+    DiscoverySettings,
+    OctoprintJobInfo,
+    OctoprintPrinterInfo,
+    TrackingSetting,
+    WebcamSettings,
+)
+import pytest
+
+from homeassistant.components.octoprint import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from . import DEFAULT_JOB, DEFAULT_PRINTER
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def job() -> dict[str, Any]:
+    """Job fixture."""
+    return DEFAULT_JOB
+
+
+@pytest.fixture
+def printer() -> dict[str, Any]:
+    """Printer fixture."""
+    return DEFAULT_PRINTER
+
+
+@pytest.fixture
+def webcam() -> dict[str, Any] | None:
+    """Webcam fixture."""
+    return None
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    platform: Platform,
+    printer: dict[str, Any] | None,
+    job: dict[str, Any],
+    webcam: dict[str, Any] | None,
+) -> AsyncGenerator[MockConfigEntry]:
+    """Set up the octoprint integration in Home Assistant."""
+    printer_info: OctoprintPrinterInfo | None = None
+    if printer is not None:
+        printer_info = OctoprintPrinterInfo(printer)
+    webcam_info: WebcamSettings | None = None
+    if webcam is not None:
+        webcam_info = WebcamSettings(**webcam)
+    with (
+        patch("homeassistant.components.octoprint.PLATFORMS", [platform]),
+        patch("pyoctoprintapi.OctoprintClient.get_server_info", return_value={}),
+        patch(
+            "pyoctoprintapi.OctoprintClient.get_printer_info",
+            return_value=printer_info,
+        ),
+        patch(
+            "pyoctoprintapi.OctoprintClient.get_job_info",
+            return_value=OctoprintJobInfo(job),
+        ),
+        patch(
+            "pyoctoprintapi.OctoprintClient.get_tracking_info",
+            return_value=TrackingSetting({"unique_id": "uuid"}),
+        ),
+        patch(
+            "pyoctoprintapi.OctoprintClient.get_discovery_info",
+            return_value=DiscoverySettings({"upnpUuid": "uuid"}),
+        ),
+        patch(
+            "pyoctoprintapi.OctoprintClient.get_webcam_info",
+            return_value=webcam_info,
+        ),
+    ):
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            entry_id="uuid",
+            unique_id="uuid",
+            data={
+                "host": "1.1.1.1",
+                "api_key": "test-key",
+                "name": "OctoPrint",
+                "port": 81,
+                "ssl": True,
+                "path": "/",
+            },
+            title="OctoPrint",
+        )
+        config_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert config_entry.state is ConfigEntryState.LOADED
+        yield config_entry

--- a/tests/components/octoprint/snapshots/test_number.ambr
+++ b/tests/components/octoprint/snapshots/test_number.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_numbers[number.octoprint_bed_temperature-entry]
+# name: test_numbers[printer0][number.octoprint_bed_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -39,7 +39,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_numbers[number.octoprint_bed_temperature-state]
+# name: test_numbers[printer0][number.octoprint_bed_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
@@ -58,7 +58,7 @@
     'state': '60.0',
   })
 # ---
-# name: test_numbers[number.octoprint_extruder_1_temperature-entry]
+# name: test_numbers[printer0][number.octoprint_extruder_1_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -98,7 +98,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_numbers[number.octoprint_extruder_1_temperature-state]
+# name: test_numbers[printer0][number.octoprint_extruder_1_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
@@ -117,7 +117,7 @@
     'state': '31.0',
   })
 # ---
-# name: test_numbers[number.octoprint_extruder_temperature-entry]
+# name: test_numbers[printer0][number.octoprint_extruder_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -157,7 +157,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_numbers[number.octoprint_extruder_temperature-state]
+# name: test_numbers[printer0][number.octoprint_extruder_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',

--- a/tests/components/octoprint/test_binary_sensor.py
+++ b/tests/components/octoprint/test_binary_sensor.py
@@ -2,15 +2,15 @@
 
 import pytest
 
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 
 @pytest.fixture
-def platform() -> str:
+def platform() -> Platform:
     """Fixture to specify platform."""
-    return "binary_sensor"
+    return Platform.BINARY_SENSOR
 
 
 @pytest.mark.parametrize(

--- a/tests/components/octoprint/test_binary_sensor.py
+++ b/tests/components/octoprint/test_binary_sensor.py
@@ -1,23 +1,33 @@
 """The tests for Octoptint binary sensor module."""
 
+import pytest
+
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import init_integration
+
+@pytest.fixture
+def platform() -> str:
+    """Fixture to specify platform."""
+    return "binary_sensor"
 
 
+@pytest.mark.parametrize(
+    "printer",
+    [
+        {
+            "state": {
+                "flags": {"printing": True, "error": False},
+                "text": "Operational",
+            },
+            "temperature": [],
+        },
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
 async def test_sensors(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test the underlying sensors."""
-    printer = {
-        "state": {
-            "flags": {"printing": True, "error": False},
-            "text": "Operational",
-        },
-        "temperature": [],
-    }
-    await init_integration(hass, "binary_sensor", printer=printer)
-
     state = hass.states.get("binary_sensor.octoprint_printing")
     assert state is not None
     assert state.state == STATE_ON
@@ -33,12 +43,12 @@ async def test_sensors(hass: HomeAssistant, entity_registry: er.EntityRegistry) 
     assert entry.unique_id == "Printing Error-uuid"
 
 
+@pytest.mark.parametrize("printer", [None])
+@pytest.mark.usefixtures("init_integration")
 async def test_sensors_printer_offline(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test the underlying sensors when the printer is offline."""
-    await init_integration(hass, "binary_sensor", printer=None)
-
     state = hass.states.get("binary_sensor.octoprint_printing")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE

--- a/tests/components/octoprint/test_button.py
+++ b/tests/components/octoprint/test_button.py
@@ -9,14 +9,14 @@ from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRE
 from homeassistant.components.octoprint import OctoprintDataUpdateCoordinator
 from homeassistant.components.octoprint.button import InvalidPrinterState
 from homeassistant.components.octoprint.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture
-def platform() -> str:
+def platform() -> Platform:
     """Fixture to specify platform."""
-    return BUTTON_DOMAIN
+    return Platform.BUTTON
 
 
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/octoprint/test_button.py
+++ b/tests/components/octoprint/test_button.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import patch
 
-from freezegun import freeze_time
 from pyoctoprintapi import OctoprintPrinterInfo
 import pytest
 
@@ -13,13 +12,16 @@ from homeassistant.components.octoprint.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
-from . import init_integration
+
+@pytest.fixture
+def platform() -> str:
+    """Fixture to specify platform."""
+    return BUTTON_DOMAIN
 
 
+@pytest.mark.usefixtures("init_integration")
 async def test_pause_job(hass: HomeAssistant) -> None:
     """Test the pause job button."""
-    await init_integration(hass, BUTTON_DOMAIN)
-
     coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN]["uuid"][
         "coordinator"
     ]
@@ -75,10 +77,9 @@ async def test_pause_job(hass: HomeAssistant) -> None:
             )
 
 
+@pytest.mark.usefixtures("init_integration")
 async def test_resume_job(hass: HomeAssistant) -> None:
     """Test the resume job button."""
-    await init_integration(hass, BUTTON_DOMAIN)
-
     coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN]["uuid"][
         "coordinator"
     ]
@@ -134,10 +135,9 @@ async def test_resume_job(hass: HomeAssistant) -> None:
             )
 
 
+@pytest.mark.usefixtures("init_integration")
 async def test_stop_job(hass: HomeAssistant) -> None:
     """Test the stop job button."""
-    await init_integration(hass, BUTTON_DOMAIN)
-
     coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN]["uuid"][
         "coordinator"
     ]
@@ -194,11 +194,10 @@ async def test_stop_job(hass: HomeAssistant) -> None:
         assert len(stop_command.mock_calls) == 0
 
 
-@freeze_time("2023-01-01 00:00")
+@pytest.mark.freeze_time("2023-01-01 00:00")
+@pytest.mark.usefixtures("init_integration")
 async def test_shutdown_system(hass: HomeAssistant) -> None:
     """Test the shutdown system button."""
-    await init_integration(hass, BUTTON_DOMAIN)
-
     entity_id = "button.octoprint_shutdown_system"
 
     # Test shutting down the system
@@ -219,11 +218,10 @@ async def test_shutdown_system(hass: HomeAssistant) -> None:
         assert state.state == "2023-01-01T00:00:00+00:00"
 
 
-@freeze_time("2023-01-01 00:00")
+@pytest.mark.freeze_time("2023-01-01 00:00")
+@pytest.mark.usefixtures("init_integration")
 async def test_reboot_system(hass: HomeAssistant) -> None:
     """Test the reboot system button."""
-    await init_integration(hass, BUTTON_DOMAIN)
-
     entity_id = "button.octoprint_reboot_system"
 
     # Test rebooting the system
@@ -246,11 +244,10 @@ async def test_reboot_system(hass: HomeAssistant) -> None:
         assert state.state == "2023-01-01T00:00:00+00:00"
 
 
-@freeze_time("2023-01-01 00:00")
+@pytest.mark.freeze_time("2023-01-01 00:00")
+@pytest.mark.usefixtures("init_integration")
 async def test_restart_octoprint(hass: HomeAssistant) -> None:
     """Test the restart octoprint button."""
-    await init_integration(hass, BUTTON_DOMAIN)
-
     entity_id = "button.octoprint_restart_octoprint"
 
     # Test restarting octoprint

--- a/tests/components/octoprint/test_camera.py
+++ b/tests/components/octoprint/test_camera.py
@@ -1,66 +1,65 @@
 """The tests for Octoptint camera module."""
 
-from unittest.mock import patch
-
-from pyoctoprintapi import WebcamSettings
+import pytest
 
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import init_integration
+
+@pytest.fixture
+def platform() -> str:
+    """Fixture to specify platform."""
+    return CAMERA_DOMAIN
 
 
-async def test_camera(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
-    """Test the underlying camera."""
-    with patch(
-        "pyoctoprintapi.OctoprintClient.get_webcam_info",
-        return_value=WebcamSettings(
-            base_url="http://fake-octoprint/",
-            raw={
+@pytest.mark.parametrize(
+    "webcam",
+    [
+        {
+            "base_url": "http://fake-octoprint/",
+            "raw": {
                 "streamUrl": "/webcam/?action=stream",
                 "snapshotUrl": "http://127.0.0.1:8080/?action=snapshot",
                 "webcamEnabled": True,
             },
-        ),
-    ):
-        await init_integration(hass, CAMERA_DOMAIN)
-
+        }
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_camera(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
+    """Test the underlying camera."""
     entry = entity_registry.async_get("camera.octoprint_camera")
     assert entry is not None
     assert entry.unique_id == "uuid"
 
 
-async def test_camera_disabled(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
-) -> None:
-    """Test that the camera does not load if there is not one configured."""
-    with patch(
-        "pyoctoprintapi.OctoprintClient.get_webcam_info",
-        return_value=WebcamSettings(
-            base_url="http://fake-octoprint/",
-            raw={
+@pytest.mark.parametrize(
+    "webcam",
+    [
+        {
+            "base_url": "http://fake-octoprint/",
+            "raw": {
                 "streamUrl": "/webcam/?action=stream",
                 "snapshotUrl": "http://127.0.0.1:8080/?action=snapshot",
                 "webcamEnabled": False,
             },
-        ),
-    ):
-        await init_integration(hass, CAMERA_DOMAIN)
-
+        }
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_camera_disabled(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test that the camera does not load if there is not one configured."""
     entry = entity_registry.async_get("camera.octoprint_camera")
     assert entry is None
 
 
+@pytest.mark.usefixtures("init_integration")
 async def test_no_supported_camera(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test that the camera does not load if there is not one configured."""
-    with patch(
-        "pyoctoprintapi.OctoprintClient.get_webcam_info",
-        return_value=None,
-    ):
-        await init_integration(hass, CAMERA_DOMAIN)
-
     entry = entity_registry.async_get("camera.octoprint_camera")
     assert entry is None

--- a/tests/components/octoprint/test_camera.py
+++ b/tests/components/octoprint/test_camera.py
@@ -2,15 +2,15 @@
 
 import pytest
 
-from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 
 @pytest.fixture
-def platform() -> str:
+def platform() -> Platform:
     """Fixture to specify platform."""
-    return CAMERA_DOMAIN
+    return Platform.CAMERA
 
 
 @pytest.mark.parametrize(

--- a/tests/components/octoprint/test_number.py
+++ b/tests/components/octoprint/test_number.py
@@ -12,7 +12,7 @@ from homeassistant.components.number import (
     DOMAIN as NUMBER_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -20,9 +20,9 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.fixture
-def platform() -> str:
+def platform() -> Platform:
     """Fixture to specify platform."""
-    return NUMBER_DOMAIN
+    return Platform.NUMBER
 
 
 @pytest.fixture

--- a/tests/components/octoprint/test_number.py
+++ b/tests/components/octoprint/test_number.py
@@ -1,9 +1,11 @@
 """The tests for OctoPrint number module."""
 
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.number import (
@@ -15,55 +17,70 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import init_integration
-
-from tests.common import snapshot_platform
+from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.fixture
+def platform() -> str:
+    """Fixture to specify platform."""
+    return NUMBER_DOMAIN
+
+
+@pytest.fixture
+def job() -> dict[str, Any]:
+    """Job fixture."""
+    return __standard_job()
+
+
+@pytest.mark.parametrize(
+    "printer",
+    [
+        {
+            "state": {
+                "flags": {"printing": True},
+                "text": "Operational",
+            },
+            "temperature": {
+                "tool0": {"actual": 18.83136, "target": 37.83136},
+                "tool1": {"actual": 21.0, "target": 31.0},
+                "bed": {"actual": 25.5, "target": 60.0},
+            },
+        },
+    ],
+)
+@pytest.mark.freeze_time(datetime(2020, 2, 20, 9, 10, 13, 543, tzinfo=UTC))
 async def test_numbers(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
+    init_integration: MockConfigEntry,
 ) -> None:
     """Test the underlying number entities."""
-    printer = {
-        "state": {
-            "flags": {"printing": True},
-            "text": "Operational",
+    await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
+
+
+@pytest.mark.parametrize(
+    "printer",
+    [
+        {
+            "state": {
+                "flags": {"printing": True, "paused": False},
+                "text": "Operational",
+            },
+            "temperature": {
+                "tool0": {"actual": 18.83136, "target": None},
+                "bed": {"actual": 25.5, "target": None},
+            },
         },
-        "temperature": {
-            "tool0": {"actual": 18.83136, "target": 37.83136},
-            "tool1": {"actual": 21.0, "target": 31.0},
-            "bed": {"actual": 25.5, "target": 60.0},
-        },
-    }
-    job = __standard_job()
-    freezer.move_to(datetime(2020, 2, 20, 9, 10, 13, 543, tzinfo=UTC))
-    config_entry = await init_integration(hass, "number", printer=printer, job=job)
-
-    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
-
-
+    ],
+)
+@pytest.mark.freeze_time(datetime(2020, 2, 20, 9, 10, 0))
+@pytest.mark.usefixtures("init_integration")
 async def test_numbers_no_target_temp(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the number entities when target temperature is None."""
-    printer = {
-        "state": {
-            "flags": {"printing": True, "paused": False},
-            "text": "Operational",
-        },
-        "temperature": {
-            "tool0": {"actual": 18.83136, "target": None},
-            "bed": {"actual": 25.5, "target": None},
-        },
-    }
-    freezer.move_to(datetime(2020, 2, 20, 9, 10, 0))
-    await init_integration(hass, "number", printer=printer)
-
     state = hass.states.get("number.octoprint_extruder_temperature")
     assert state is not None
     assert state.state == STATE_UNKNOWN
@@ -79,22 +96,24 @@ async def test_numbers_no_target_temp(
     assert entry.unique_id == "uuid_bed_temperature"
 
 
+@pytest.mark.parametrize(
+    "printer",
+    [
+        {
+            "state": {
+                "flags": {"printing": False},
+                "text": "Operational",
+            },
+            "temperature": {"tool0": {"actual": 18.83136, "target": 25.0}},
+        },
+    ],
+)
+@pytest.mark.freeze_time(datetime(2020, 2, 20, 9, 10, 0))
+@pytest.mark.usefixtures("init_integration")
 async def test_set_tool_temp(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test setting tool temperature via number entity."""
-    printer = {
-        "state": {
-            "flags": {"printing": False},
-            "text": "Operational",
-        },
-        "temperature": {"tool0": {"actual": 18.83136, "target": 25.0}},
-    }
-    job = __standard_job()
-    freezer.move_to(datetime(2020, 2, 20, 9, 10, 0))
-    await init_integration(hass, "number", printer=printer, job=job)
-
     with patch(
         "pyoctoprintapi.OctoprintClient.set_tool_temperature"
     ) as mock_set_tool_temp:
@@ -114,22 +133,24 @@ async def test_set_tool_temp(
         mock_set_tool_temp.assert_called_with("tool0", 200)
 
 
+@pytest.mark.parametrize(
+    "printer",
+    [
+        {
+            "state": {
+                "flags": {"printing": False},
+                "text": "Operational",
+            },
+            "temperature": {"bed": {"actual": 20.0, "target": 50.0}},
+        },
+    ],
+)
+@pytest.mark.freeze_time(datetime(2020, 2, 20, 9, 10, 0))
+@pytest.mark.usefixtures("init_integration")
 async def test_set_bed_temp(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test setting bed temperature via number entity."""
-    printer = {
-        "state": {
-            "flags": {"printing": False},
-            "text": "Operational",
-        },
-        "temperature": {"bed": {"actual": 20.0, "target": 50.0}},
-    }
-    job = __standard_job()
-    freezer.move_to(datetime(2020, 2, 20, 9, 10, 0))
-    await init_integration(hass, "number", printer=printer, job=job)
-
     with patch(
         "pyoctoprintapi.OctoprintClient.set_bed_temperature"
     ) as mock_set_bed_temp:
@@ -149,25 +170,27 @@ async def test_set_bed_temp(
         mock_set_bed_temp.assert_called_with(80)
 
 
+@pytest.mark.parametrize(
+    "printer",
+    [
+        {
+            "state": {
+                "flags": {"printing": False},
+                "text": "Operational",
+            },
+            "temperature": {
+                "tool0": {"actual": 20.0, "target": 30.0},
+                "tool1": {"actual": 21.0, "target": 31.0},
+            },
+        },
+    ],
+)
+@pytest.mark.freeze_time(datetime(2020, 2, 20, 9, 10, 0))
+@pytest.mark.usefixtures("init_integration")
 async def test_set_tool_n_temp(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test setting tool temperature via number entity when multiple tools are present."""
-    printer = {
-        "state": {
-            "flags": {"printing": False},
-            "text": "Operational",
-        },
-        "temperature": {
-            "tool0": {"actual": 20.0, "target": 30.0},
-            "tool1": {"actual": 21.0, "target": 31.0},
-        },
-    }
-    job = __standard_job()
-    freezer.move_to(datetime(2020, 2, 20, 9, 10, 0))
-    await init_integration(hass, "number", printer=printer, job=job)
-
     with patch(
         "pyoctoprintapi.OctoprintClient.set_tool_temperature"
     ) as mock_set_tool_temp:
@@ -187,16 +210,14 @@ async def test_set_tool_n_temp(
         mock_set_tool_temp.assert_called_with("tool1", 41)
 
 
+@pytest.mark.parametrize("printer", [None])
+@pytest.mark.freeze_time(datetime(2020, 2, 20, 9, 10, 0))
+@pytest.mark.usefixtures("init_integration")
 async def test_numbers_printer_disconnected(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
-    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test number entities when printer is disconnected."""
-    job = __standard_job()
-    freezer.move_to(datetime(2020, 2, 20, 9, 10, 0))
-    await init_integration(hass, "number", printer=None, job=job)
-
     # When printer is disconnected, no number entities should be created
     state = hass.states.get("number.octoprint_tool0_temperature")
     assert state is None

--- a/tests/components/octoprint/test_number.py
+++ b/tests/components/octoprint/test_number.py
@@ -4,7 +4,6 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import patch
 
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -215,7 +214,6 @@ async def test_set_tool_n_temp(
 @pytest.mark.usefixtures("init_integration")
 async def test_numbers_printer_disconnected(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test number entities when printer is disconnected."""
     # When printer is disconnected, no number entities should be created

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -5,7 +5,12 @@ from typing import Any
 
 import pytest
 
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfInformation
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+    UnitOfInformation,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -13,9 +18,9 @@ from . import DEFAULT_JOB
 
 
 @pytest.fixture
-def platform() -> str:
+def platform() -> Platform:
     """Fixture to specify platform."""
-    return "sensor"
+    return Platform.SENSOR
 
 
 @pytest.fixture

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -3,7 +3,6 @@
 from datetime import UTC, datetime
 from typing import Any
 
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfInformation
@@ -126,7 +125,6 @@ async def test_sensors(
 @pytest.mark.usefixtures("init_integration")
 async def test_sensors_no_target_temp(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the underlying sensors."""
@@ -175,7 +173,6 @@ async def test_sensors_no_target_temp(
 @pytest.mark.usefixtures("init_integration")
 async def test_sensors_paused(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the underlying sensors."""
@@ -199,7 +196,6 @@ async def test_sensors_paused(
 @pytest.mark.usefixtures("init_integration")
 async def test_sensors_printer_disconnected(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the underlying sensors."""

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -1,33 +1,49 @@
 """The tests for Octoptint binary sensor module."""
 
 from datetime import UTC, datetime
+from typing import Any
 
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfInformation
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import init_integration
+from . import DEFAULT_JOB
 
 
+@pytest.fixture
+def platform() -> str:
+    """Fixture to specify platform."""
+    return "sensor"
+
+
+@pytest.fixture
+def job() -> dict[str, Any]:
+    """Job fixture."""
+    return __standard_job()
+
+
+@pytest.mark.parametrize(
+    "printer",
+    [
+        {
+            "state": {
+                "flags": {"printing": True},
+                "text": "Operational",
+            },
+            "temperature": {"tool1": {"actual": 18.83136, "target": 37.83136}},
+        },
+    ],
+)
+@pytest.mark.freeze_time(datetime(2020, 2, 20, 9, 10, 13, 543, tzinfo=UTC))
+@pytest.mark.usefixtures("init_integration")
 async def test_sensors(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the underlying sensors."""
-    printer = {
-        "state": {
-            "flags": {"printing": True},
-            "text": "Operational",
-        },
-        "temperature": {"tool1": {"actual": 18.83136, "target": 37.83136}},
-    }
-    job = __standard_job()
-    freezer.move_to(datetime(2020, 2, 20, 9, 10, 13, 543, tzinfo=UTC))
-    await init_integration(hass, "sensor", printer=printer, job=job)
-
     state = hass.states.get("sensor.octoprint_job_percentage")
     assert state is not None
     assert state.state == "50"
@@ -93,22 +109,27 @@ async def test_sensors(
     assert entry.unique_id == "Current File Size-uuid"
 
 
+@pytest.mark.parametrize("job", [DEFAULT_JOB])
+@pytest.mark.parametrize(
+    "printer",
+    [
+        {
+            "state": {
+                "flags": {"printing": True, "paused": False},
+                "text": "Operational",
+            },
+            "temperature": {"tool1": {"actual": 18.83136, "target": None}},
+        },
+    ],
+)
+@pytest.mark.freeze_time(datetime(2020, 2, 20, 9, 10, 0))
+@pytest.mark.usefixtures("init_integration")
 async def test_sensors_no_target_temp(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the underlying sensors."""
-    printer = {
-        "state": {
-            "flags": {"printing": True, "paused": False},
-            "text": "Operational",
-        },
-        "temperature": {"tool1": {"actual": 18.83136, "target": None}},
-    }
-    freezer.move_to(datetime(2020, 2, 20, 9, 10, 0))
-    await init_integration(hass, "sensor", printer=printer)
-
     state = hass.states.get("sensor.octoprint_actual_tool1_temp")
     assert state is not None
     assert state.state == "18.83"
@@ -138,23 +159,26 @@ async def test_sensors_no_target_temp(
     assert entry.unique_id == "Current File Size-uuid"
 
 
+@pytest.mark.parametrize(
+    "printer",
+    [
+        {
+            "state": {
+                "flags": {"printing": False},
+                "text": "Operational",
+            },
+            "temperature": {"tool1": {"actual": 18.83136, "target": None}},
+        },
+    ],
+)
+@pytest.mark.freeze_time(datetime(2020, 2, 20, 9, 10, 0))
+@pytest.mark.usefixtures("init_integration")
 async def test_sensors_paused(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the underlying sensors."""
-    printer = {
-        "state": {
-            "flags": {"printing": False},
-            "text": "Operational",
-        },
-        "temperature": {"tool1": {"actual": 18.83136, "target": None}},
-    }
-    job = __standard_job()
-    freezer.move_to(datetime(2020, 2, 20, 9, 10, 0))
-    await init_integration(hass, "sensor", printer=printer, job=job)
-
     state = hass.states.get("sensor.octoprint_start_time")
     assert state is not None
     assert state.state == STATE_UNKNOWN
@@ -170,16 +194,15 @@ async def test_sensors_paused(
     assert entry.unique_id == "Estimated Finish Time-uuid"
 
 
+@pytest.mark.parametrize("printer", [None])
+@pytest.mark.freeze_time(datetime(2020, 2, 20, 9, 10, 0))
+@pytest.mark.usefixtures("init_integration")
 async def test_sensors_printer_disconnected(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the underlying sensors."""
-    job = __standard_job()
-    freezer.move_to(datetime(2020, 2, 20, 9, 10, 0))
-    await init_integration(hass, "sensor", printer=None, job=job)
-
     state = hass.states.get("sensor.octoprint_job_percentage")
     assert state is not None
     assert state.state == "50"

--- a/tests/components/octoprint/test_services.py
+++ b/tests/components/octoprint/test_services.py
@@ -9,15 +9,15 @@ from homeassistant.components.octoprint.const import (
     DOMAIN,
     SERVICE_CONNECT,
 )
-from homeassistant.const import ATTR_DEVICE_ID, CONF_PORT, CONF_PROFILE_NAME
+from homeassistant.const import ATTR_DEVICE_ID, CONF_PORT, CONF_PROFILE_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 
 @pytest.fixture
-def platform() -> str:
+def platform() -> Platform:
     """Fixture to specify platform."""
-    return "sensor"
+    return Platform.SENSOR
 
 
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/octoprint/test_services.py
+++ b/tests/components/octoprint/test_services.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components.octoprint.const import (
     CONF_BAUDRATE,
     DOMAIN,
@@ -11,15 +13,18 @@ from homeassistant.const import ATTR_DEVICE_ID, CONF_PORT, CONF_PROFILE_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from . import init_integration
+
+@pytest.fixture
+def platform() -> str:
+    """Fixture to specify platform."""
+    return "sensor"
 
 
+@pytest.mark.usefixtures("init_integration")
 async def test_connect_default(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test the connect to printer service."""
-    await init_integration(hass, "sensor")
-
     device = dr.async_entries_for_config_entry(device_registry, "uuid")[0]
 
     # Test pausing the printer when it is printing
@@ -39,12 +44,11 @@ async def test_connect_default(
         )
 
 
+@pytest.mark.usefixtures("init_integration")
 async def test_connect_all_arguments(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test the connect to printer service."""
-    await init_integration(hass, "sensor")
-
     device = dr.async_entries_for_config_entry(device_registry, "uuid")[0]
 
     # Test pausing the printer when it is printing


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rewrite `octoprint` tests to use fixtures which keeps patches in place throughout the test instead of just when setting up the `octoprint` integration. Without the fixtures, tests were opening sockets because the library wasn't patched out throughout the test.

Seen in https://github.com/home-assistant/core/pull/155398

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
