### PR TITLE
Add wrapper class for boolean values in Tuya models

### DIFF
--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -143,6 +143,40 @@ def find_dpcode(
 
 
 @dataclass
+class DPCodeReader:
+    """Base DPCode reader.
+
+    Used to read raw values from a device for a specific DPCode.
+
+    `read_device_value` can be overridden to implement custom parsing logic.
+    """
+
+    dpcode: str
+
+    def _read_device_value_raw(self, device: CustomerDevice) -> Any | None:
+        """Read the device value for the dpcode."""
+        return device.status.get(self.dpcode)
+
+    def read_device_value(self, device: CustomerDevice) -> Any | None:
+        """Read the device value for the dpcode."""
+        return self._read_device_value_raw(device)
+
+
+@dataclass
+class BooleanDPCodeReader(DPCodeReader):
+    """Simple parser for boolean values.
+
+    Supports True/False only.
+    """
+
+    def read_device_value(self, device: CustomerDevice) -> bool | None:
+        """Read the device value for the dpcode."""
+        if (raw_value := self._read_device_value_raw(device)) in (True, False):
+            return raw_value
+        return None
+
+
+@dataclass
 class IntegerTypeData:
     """Integer Type Data."""
 

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -38,7 +38,7 @@ class DPCodeWrapper:
 
 @dataclass
 class DPCodeBooleanWrapper(DPCodeWrapper):
-    """Simple parser for boolean values.
+    """Simple wrapper for boolean values.
 
     Supports True/False only.
     """

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -36,6 +36,20 @@ class DPCodeWrapper:
         raise NotImplementedError("read_device_value must be implemented")
 
 
+@dataclass
+class DPCodeBooleanWrapper(DPCodeWrapper):
+    """Simple parser for boolean values.
+
+    Supports True/False only.
+    """
+
+    def read_device_status(self, device: CustomerDevice) -> bool | None:
+        """Read the device value for the dpcode."""
+        if (raw_value := self._read_device_status_raw(device)) in (True, False):
+            return raw_value
+        return None
+
+
 @dataclass(kw_only=True)
 class DPCodeEnumWrapper(DPCodeWrapper):
     """Simple wrapper for EnumTypeData values."""
@@ -140,40 +154,6 @@ def find_dpcode(
                 return integer_type
 
     return None
-
-
-@dataclass
-class DPCodeReader:
-    """Base DPCode reader.
-
-    Used to read and convert raw values from a device for a specific DPCode.
-
-    `read_device_value` must be overridden to implement custom parsing logic.
-    """
-
-    dpcode: str
-
-    def _read_device_value_raw(self, device: CustomerDevice) -> Any | None:
-        """Read the device value for the dpcode."""
-        return device.status.get(self.dpcode)
-
-    def read_device_value(self, device: CustomerDevice) -> Any | None:
-        """Read the device value for the dpcode."""
-        raise NotImplementedError("read_device_value must be implemented")
-
-
-@dataclass
-class BooleanDPCodeReader(DPCodeReader):
-    """Simple parser for boolean values.
-
-    Supports True/False only.
-    """
-
-    def read_device_value(self, device: CustomerDevice) -> bool | None:
-        """Read the device value for the dpcode."""
-        if (raw_value := self._read_device_value_raw(device)) in (True, False):
-            return raw_value
-        return None
 
 
 @dataclass

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -146,9 +146,9 @@ def find_dpcode(
 class DPCodeReader:
     """Base DPCode reader.
 
-    Used to read raw values from a device for a specific DPCode.
+    Used to read and convert raw values from a device for a specific DPCode.
 
-    `read_device_value` can be overridden to implement custom parsing logic.
+    `read_device_value` must be overridden to implement custom parsing logic.
     """
 
     dpcode: str
@@ -159,7 +159,7 @@ class DPCodeReader:
 
     def read_device_value(self, device: CustomerDevice) -> Any | None:
         """Read the device value for the dpcode."""
-        return self._read_device_value_raw(device)
+        raise NotImplementedError("read_device_value must be implemented")
 
 
 @dataclass

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.issue_registry import (
 from . import TuyaConfigEntry
 from .const import DOMAIN, TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
-from .models import BooleanDPCodeReader
+from .models import BooleanDPCodeWrapper
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -943,7 +943,7 @@ async def async_setup_entry(
                         device,
                         manager,
                         description,
-                        BooleanDPCodeReader(description.key),
+                        BooleanDPCodeWrapper(description.key),
                     )
                     for description in descriptions
                     if description.key in device.status
@@ -1021,23 +1021,23 @@ class TuyaSwitchEntity(TuyaEntity, SwitchEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: SwitchEntityDescription,
-        dpcode_reader: BooleanDPCodeReader,
+        dpcode_wrapper: BooleanDPCodeWrapper,
     ) -> None:
         """Init TuyaHaSwitch."""
         super().__init__(device, device_manager)
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
-        self._dpcode_reader = dpcode_reader
+        self._dpcode_wrapper = dpcode_wrapper
 
     @property
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
-        return self._dpcode_reader.read_device_value(self.device)
+        return self._dpcode_wrapper.read_device_status(self.device)
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        self._send_command([{"code": self._dpcode_reader.dpcode, "value": True}])
+        self._send_command([{"code": self._dpcode_wrapper.dpcode, "value": True}])
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        self._send_command([{"code": self._dpcode_reader.dpcode, "value": False}])
+        self._send_command([{"code": self._dpcode_wrapper.dpcode, "value": False}])

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.issue_registry import (
 from . import TuyaConfigEntry
 from .const import DOMAIN, TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
+from .models import BooleanDPCodeReader
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -938,7 +939,12 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := SWITCHES.get(device.category):
                 entities.extend(
-                    TuyaSwitchEntity(device, manager, description)
+                    TuyaSwitchEntity(
+                        device,
+                        manager,
+                        description,
+                        BooleanDPCodeReader(description.key),
+                    )
                     for description in descriptions
                     if description.key in device.status
                     and _check_deprecation(
@@ -1015,21 +1021,23 @@ class TuyaSwitchEntity(TuyaEntity, SwitchEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: SwitchEntityDescription,
+        dpcode_reader: BooleanDPCodeReader,
     ) -> None:
         """Init TuyaHaSwitch."""
         super().__init__(device, device_manager)
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._dpcode_reader = dpcode_reader
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return true if switch is on."""
-        return self.device.status.get(self.entity_description.key, False)
+        return self._dpcode_reader.read_device_value(self.device)
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        self._send_command([{"code": self.entity_description.key, "value": True}])
+        self._send_command([{"code": self._dpcode_reader.dpcode, "value": True}])
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        self._send_command([{"code": self.entity_description.key, "value": False}])
+        self._send_command([{"code": self._dpcode_reader.dpcode, "value": False}])

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.issue_registry import (
 from . import TuyaConfigEntry
 from .const import DOMAIN, TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
-from .models import BooleanDPCodeWrapper
+from .models import DPCodeBooleanWrapper
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -943,7 +943,7 @@ async def async_setup_entry(
                         device,
                         manager,
                         description,
-                        BooleanDPCodeWrapper(description.key),
+                        DPCodeBooleanWrapper(description.key),
                     )
                     for description in descriptions
                     if description.key in device.status
@@ -1021,7 +1021,7 @@ class TuyaSwitchEntity(TuyaEntity, SwitchEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: SwitchEntityDescription,
-        dpcode_wrapper: BooleanDPCodeWrapper,
+        dpcode_wrapper: DPCodeBooleanWrapper,
     ) -> None:
         """Init TuyaHaSwitch."""
         super().__init__(device, device_manager)

--- a/homeassistant/components/tuya/valve.py
+++ b/homeassistant/components/tuya/valve.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
-from .models import BooleanDPCodeWrapper
+from .models import DPCodeBooleanWrapper
 
 VALVES: dict[DeviceCategory, tuple[ValveEntityDescription, ...]] = {
     DeviceCategory.SFKZQ: (
@@ -98,7 +98,7 @@ async def async_setup_entry(
                         device,
                         manager,
                         description,
-                        BooleanDPCodeWrapper(description.key),
+                        DPCodeBooleanWrapper(description.key),
                     )
                     for description in descriptions
                     if description.key in device.status
@@ -123,7 +123,7 @@ class TuyaValveEntity(TuyaEntity, ValveEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: ValveEntityDescription,
-        dpcode_wrapper: BooleanDPCodeWrapper,
+        dpcode_wrapper: DPCodeBooleanWrapper,
     ) -> None:
         """Init TuyaValveEntity."""
         super().__init__(device, device_manager)

--- a/homeassistant/components/tuya/valve.py
+++ b/homeassistant/components/tuya/valve.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
+from .models import BooleanDPCodeReader
 
 VALVES: dict[DeviceCategory, tuple[ValveEntityDescription, ...]] = {
     DeviceCategory.SFKZQ: (
@@ -93,7 +94,12 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := VALVES.get(device.category):
                 entities.extend(
-                    TuyaValveEntity(device, manager, description)
+                    TuyaValveEntity(
+                        device,
+                        manager,
+                        description,
+                        BooleanDPCodeReader(description.key),
+                    )
                     for description in descriptions
                     if description.key in device.status
                 )
@@ -117,25 +123,29 @@ class TuyaValveEntity(TuyaEntity, ValveEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: ValveEntityDescription,
+        dpcode_reader: BooleanDPCodeReader,
     ) -> None:
         """Init TuyaValveEntity."""
         super().__init__(device, device_manager)
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._dpcode_reader = dpcode_reader
 
     @property
-    def is_closed(self) -> bool:
+    def is_closed(self) -> bool | None:
         """Return if the valve is closed."""
-        return not self.device.status.get(self.entity_description.key, False)
+        if (is_open := self._dpcode_reader.read_device_value(self.device)) is None:
+            return None
+        return not is_open
 
     async def async_open_valve(self) -> None:
         """Open the valve."""
         await self.hass.async_add_executor_job(
-            self._send_command, [{"code": self.entity_description.key, "value": True}]
+            self._send_command, [{"code": self._dpcode_reader.dpcode, "value": True}]
         )
 
     async def async_close_valve(self) -> None:
         """Close the valve."""
         await self.hass.async_add_executor_job(
-            self._send_command, [{"code": self.entity_description.key, "value": False}]
+            self._send_command, [{"code": self._dpcode_reader.dpcode, "value": False}]
         )

--- a/tests/components/tuya/test_valve.py
+++ b/tests/components/tuya/test_valve.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -13,7 +14,7 @@ from homeassistant.components.valve import (
     SERVICE_CLOSE_VALVE,
     SERVICE_OPEN_VALVE,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -95,3 +96,35 @@ async def test_close_valve(
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id, [{"code": "switch_1", "value": False}]
     )
+
+
+@patch("homeassistant.components.tuya.PLATFORMS", [Platform.VALVE])
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["sfkzq_ed7frwissyqrejic"],
+)
+@pytest.mark.parametrize(
+    ("initial_status", "expected_state"),
+    [
+        (True, "open"),
+        (False, "closed"),
+        (None, STATE_UNKNOWN),
+        ("some string", STATE_UNKNOWN),
+    ],
+)
+async def test_state(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+    initial_status: Any,
+    expected_state: str,
+) -> None:
+    """Test valve state."""
+    entity_id = "valve.jie_hashui_fa_valve_1"
+    mock_device.status["switch_1"] = initial_status
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    assert state.state == expected_state


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a common base class for "reading and converting raw values for a data point from a Tuya device".
Linked to #156232

Migrate `switch` and `valve` to use this base class, and adjust calls accordingly.
See #156039 for equivalent PR on `number` platforms.
See #155847 for equivalent PR on `select` platform.

### Background info

The problem at present is that we have lots of different ways to refer to a Tuya DPCode (=Tuya data-point)
Sometimes we refer to it directly:
```python
    self._send_command([{"code": DPCode.SUCTION, "value": fan_speed}])`
    return self.device.status.get(DPCode.STATUS)
```
Sometimes we refer to it via the description key
```python
    self._send_command([{"code": self.entity_description.key, "value": False}])
    return self.device.status.get(self.entity_description.key, False)
```
Sometimes we refer to it via the type information
```python
    self._send_command([{"code": self._presets.dpcode, "value": preset_mode}])
    return self.device.status.get(self._presets.dpcode)
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
