### PR TITLE
Cleanup binary sensor platform for Satel Integra

### DIFF
--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from satel_integra.satel_integra import AsyncSatel
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -40,9 +42,9 @@ async def async_setup_entry(
     )
 
     for subentry in zone_subentries:
-        zone_num = subentry.data[CONF_ZONE_NUMBER]
-        zone_type = subentry.data[CONF_ZONE_TYPE]
-        zone_name = subentry.data[CONF_NAME]
+        zone_num: int = subentry.data[CONF_ZONE_NUMBER]
+        zone_type: BinarySensorDeviceClass = subentry.data[CONF_ZONE_TYPE]
+        zone_name: str = subentry.data[CONF_NAME]
 
         async_add_entities(
             [
@@ -65,9 +67,9 @@ async def async_setup_entry(
     )
 
     for subentry in output_subentries:
-        output_num = subentry.data[CONF_OUTPUT_NUMBER]
-        ouput_type = subentry.data[CONF_ZONE_TYPE]
-        output_name = subentry.data[CONF_NAME]
+        output_num: int = subentry.data[CONF_OUTPUT_NUMBER]
+        ouput_type: BinarySensorDeviceClass = subentry.data[CONF_ZONE_TYPE]
+        output_name: str = subentry.data[CONF_NAME]
 
         async_add_entities(
             [
@@ -92,14 +94,14 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
 
     def __init__(
         self,
-        controller,
-        device_number,
-        device_name,
-        zone_type,
-        sensor_type,
-        react_to_signal,
-        config_entry_id,
-    ):
+        controller: AsyncSatel,
+        device_number: int,
+        device_name: str,
+        zone_type: BinarySensorDeviceClass,
+        sensor_type: str,
+        react_to_signal: str,
+        config_entry_id: str,
+    ) -> None:
         """Initialize the binary_sensor."""
         self._device_number = device_number
         self._attr_unique_id = f"{config_entry_id}_{sensor_type}_{device_number}"
@@ -127,7 +129,7 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
         )
 
     @property
-    def name(self):
+    def name(self) -> str | None:
         """Return the name of the entity."""
         return self._name
 
@@ -139,12 +141,12 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
         return None
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool | None:
         """Return true if sensor is on."""
         return self._state == 1
 
     @property
-    def device_class(self):
+    def device_class(self) -> BinarySensorDeviceClass | None:
         """Return the class of this sensor, from DEVICE_CLASSES."""
         return self._zone_type
 

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -97,7 +97,7 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
         controller: AsyncSatel,
         device_number: int,
         device_name: str,
-        zone_type: BinarySensorDeviceClass,
+        device_class: BinarySensorDeviceClass,
         sensor_type: str,
         react_to_signal: str,
         config_entry_id: str,
@@ -106,10 +106,11 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
         self._device_number = device_number
         self._attr_unique_id = f"{config_entry_id}_{sensor_type}_{device_number}"
         self._name = device_name
-        self._zone_type = zone_type
         self._state = 0
         self._react_to_signal = react_to_signal
         self._satel = controller
+
+        self._attr_device_class = device_class
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -134,21 +135,9 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
         return self._name
 
     @property
-    def icon(self) -> str | None:
-        """Icon for device by its type."""
-        if self._zone_type is BinarySensorDeviceClass.SMOKE:
-            return "mdi:fire"
-        return None
-
-    @property
     def is_on(self) -> bool | None:
         """Return true if sensor is on."""
         return self._state == 1
-
-    @property
-    def device_class(self) -> BinarySensorDeviceClass | None:
-        """Return the class of this sensor, from DEVICE_CLASSES."""
-        return self._zone_type
 
     @callback
     def _devices_updated(self, zones):

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -106,7 +106,7 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
         """Initialize the binary_sensor."""
         self._device_number = device_number
         self._attr_unique_id = f"{config_entry_id}_{sensor_type}_{device_number}"
-        self._state = 0
+        self._state: int = 0
         self._react_to_signal = react_to_signal
         self._satel = controller
 
@@ -134,7 +134,7 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
         return self._state == 1
 
     @callback
-    def _devices_updated(self, zones: list[int]):
+    def _devices_updated(self, zones: dict[int, int]):
         """Update the zone's state, if needed."""
         if self._device_number in zones and self._state != zones[self._device_number]:
             self._state = zones[self._device_number]

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -19,6 +20,7 @@ from .const import (
     CONF_ZONE_NUMBER,
     CONF_ZONE_TYPE,
     CONF_ZONES,
+    DOMAIN,
     SIGNAL_OUTPUTS_UPDATED,
     SIGNAL_ZONES_UPDATED,
     SUBENTRY_TYPE_OUTPUT,
@@ -92,6 +94,7 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
 
     _attr_should_poll = False
     _attr_has_entity_name = True
+    _attr_name = None
 
     def __init__(
         self,
@@ -110,8 +113,10 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
         self._react_to_signal = react_to_signal
         self._satel = controller
 
-        self._attr_name = device_name
         self._attr_device_class = device_class
+        self._attr_device_info = DeviceInfo(
+            name=device_name, identifiers={(DOMAIN, self._attr_unique_id)}
+        )
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -91,6 +91,7 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
     """Representation of an Satel Integra binary sensor."""
 
     _attr_should_poll = False
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -105,11 +106,11 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
         """Initialize the binary_sensor."""
         self._device_number = device_number
         self._attr_unique_id = f"{config_entry_id}_{sensor_type}_{device_number}"
-        self._name = device_name
         self._state = 0
         self._react_to_signal = react_to_signal
         self._satel = controller
 
+        self._attr_name = device_name
         self._attr_device_class = device_class
 
     async def async_added_to_hass(self) -> None:
@@ -128,11 +129,6 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
                 self.hass, self._react_to_signal, self._devices_updated
             )
         )
-
-    @property
-    def name(self) -> str | None:
-        """Return the name of the entity."""
-        return self._name
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -116,14 +116,12 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         if self._react_to_signal == SIGNAL_OUTPUTS_UPDATED:
-            if self._device_number in self._satel.violated_outputs:
-                self._state = 1
-            else:
-                self._state = 0
-        elif self._device_number in self._satel.violated_zones:
-            self._state = 1
+            self._state = (
+                1 if self._device_number in self._satel.violated_outputs else 0
+            )
         else:
-            self._state = 0
+            self._state = 1 if self._device_number in self._satel.violated_zones else 0
+
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, self._react_to_signal, self._devices_updated
@@ -136,7 +134,7 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
         return self._state == 1
 
     @callback
-    def _devices_updated(self, zones):
+    def _devices_updated(self, zones: list[int]):
         """Update the zone's state, if needed."""
         if self._device_number in zones and self._state != zones[self._device_number]:
             self._state = zones[self._device_number]

--- a/tests/components/satel_integra/snapshots/test_binary_sensor.ambr
+++ b/tests/components/satel_integra/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,99 @@
+# serializer version: 1
+# name: test_binary_sensors[binary_sensor.output-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.output',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.SAFETY: 'safety'>,
+    'original_icon': None,
+    'original_name': 'Output',
+    'platform': 'satel_integra',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1234567890_outputs_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.output-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'safety',
+      'friendly_name': 'Output',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.output',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.zone-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.zone',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+    'original_icon': None,
+    'original_name': 'Zone',
+    'platform': 'satel_integra',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1234567890_zones_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.zone-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'motion',
+      'friendly_name': 'Zone',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.zone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/satel_integra/snapshots/test_binary_sensor.ambr
+++ b/tests/components/satel_integra/snapshots/test_binary_sensor.ambr
@@ -24,7 +24,7 @@
     }),
     'original_device_class': <BinarySensorDeviceClass.SAFETY: 'safety'>,
     'original_icon': None,
-    'original_name': 'Output',
+    'original_name': None,
     'platform': 'satel_integra',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -73,7 +73,7 @@
     }),
     'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
     'original_icon': None,
-    'original_name': 'Zone',
+    'original_name': None,
     'platform': 'satel_integra',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -95,5 +95,67 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[device-output]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'satel_integra',
+        '1234567890_outputs_1',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': None,
+    'model': None,
+    'model_id': None,
+    'name': 'Output',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_binary_sensors[device-zone]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'satel_integra',
+        '1234567890_zones_1',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': None,
+    'model': None,
+    'model_id': None,
+    'name': 'Zone',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
   })
 # ---

--- a/tests/components/satel_integra/test_binary_sensor.py
+++ b/tests/components/satel_integra/test_binary_sensor.py
@@ -1,4 +1,4 @@
-"""Test Roborock Binary Sensor."""
+"""Test Satel Integra Binary Sensor."""
 
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch

--- a/tests/components/satel_integra/test_binary_sensor.py
+++ b/tests/components/satel_integra/test_binary_sensor.py
@@ -92,7 +92,7 @@ async def test_binary_sensor_callback(
     mock_satel: AsyncMock,
     mock_config_entry_with_subentries: MockConfigEntry,
 ) -> None:
-    """Test binary sensors have a correct initial state ON after initialization."""
+    """Test binary sensors correctly change state after a callback from the panel."""
     mock_config_entry_with_subentries.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_config_entry_with_subentries.entry_id)

--- a/tests/components/satel_integra/test_binary_sensor.py
+++ b/tests/components/satel_integra/test_binary_sensor.py
@@ -1,0 +1,117 @@
+"""Test Roborock Binary Sensor."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.binary_sensor import STATE_OFF, STATE_ON
+from homeassistant.components.satel_integra.const import (
+    SIGNAL_OUTPUTS_UPDATED,
+    SIGNAL_ZONES_UPDATED,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import EntityRegistry
+
+from tests.common import MockConfigEntry, async_dispatcher_send, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+async def binary_sensor_only() -> AsyncGenerator[None]:
+    """Enable only the binary sensor platform."""
+    with patch(
+        "homeassistant.components.satel_integra.PLATFORMS",
+        [Platform.BINARY_SENSOR],
+    ):
+        yield
+
+
+async def test_binary_sensors(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry_with_subentries: MockConfigEntry,
+    entity_registry: EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test binary sensors correctly being set up."""
+
+    mock_config_entry_with_subentries.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry_with_subentries.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry_with_subentries.state is ConfigEntryState.LOADED
+
+    await snapshot_platform(
+        hass, entity_registry, snapshot, mock_config_entry_with_subentries.entry_id
+    )
+
+
+async def test_binary_sensor_initial_state_off(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry_with_subentries: MockConfigEntry,
+) -> None:
+    """Test binary sensors have a correct initial state OFF after initialization."""
+    mock_config_entry_with_subentries.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry_with_subentries.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry_with_subentries.state is ConfigEntryState.LOADED
+
+    assert hass.states.get("binary_sensor.zone").state == STATE_OFF
+    assert hass.states.get("binary_sensor.output").state == STATE_OFF
+
+
+async def test_binary_sensor_initial_state_on(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry_with_subentries: MockConfigEntry,
+) -> None:
+    """Test binary sensors have a correct initial state ON after initialization."""
+    mock_satel.return_value.violated_zones = [1]
+    mock_satel.return_value.violated_outputs = [1]
+
+    mock_config_entry_with_subentries.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry_with_subentries.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry_with_subentries.state is ConfigEntryState.LOADED
+
+    assert hass.states.get("binary_sensor.zone").state == STATE_ON
+    assert hass.states.get("binary_sensor.output").state == STATE_ON
+
+
+async def test_binary_sensor_callback(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry_with_subentries: MockConfigEntry,
+) -> None:
+    """Test binary sensors have a correct initial state ON after initialization."""
+    mock_config_entry_with_subentries.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry_with_subentries.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry_with_subentries.state is ConfigEntryState.LOADED
+
+    assert hass.states.get("binary_sensor.zone").state == STATE_OFF
+    assert hass.states.get("binary_sensor.output").state == STATE_OFF
+
+    # Should do nothing, only react to it's own number
+    async_dispatcher_send(hass, SIGNAL_ZONES_UPDATED, {2: 1})
+    async_dispatcher_send(hass, SIGNAL_OUTPUTS_UPDATED, {2: 1})
+
+    assert hass.states.get("binary_sensor.zone").state == STATE_OFF
+    assert hass.states.get("binary_sensor.output").state == STATE_OFF
+
+    async_dispatcher_send(hass, SIGNAL_ZONES_UPDATED, {1: 1})
+    async_dispatcher_send(hass, SIGNAL_OUTPUTS_UPDATED, {1: 1})
+
+    assert hass.states.get("binary_sensor.zone").state == STATE_ON
+    assert hass.states.get("binary_sensor.output").state == STATE_ON


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR modernizes the code in the binary sensor platform for Satel Integra, it adds the following:
- Type hints
- Testing
- Removed some properties (moved to _attr implementation)
- Create devices

At first I thought changing the icon property would be a breaking change, but because the value is checked using `is`, the result is always False (at least in my testing, please correct me if I'm wrong).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
