### PR TITLE
Support entity-based notify services in alert component

### DIFF
--- a/homeassistant/components/alert/entity.py
+++ b/homeassistant/components/alert/entity.py
@@ -251,9 +251,12 @@ class AlertEntity(Entity):
                     "Failed to call notify.%s, retrying at next notification interval",
                     target,
                 )
-            except Exception as e:
+            except ServiceValidationError as e:
                 LOGGER.error(
-                    "Unexpected error calling notify.%s: %s", target, e, exc_info=True
+                    "Service validation error calling notify.%s: %s",
+                    target,
+                    e,
+                    exc_info=True,
                 )
 
     async def async_turn_on(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Non-Breaking change

_No breaking changes. This PR maintains full backward compatibility with legacy notify service names while adding support for the new entity-based notify system._

## Proposed change

The alert component currently only supports legacy notify service names (e.g., `telegram`, `mobile_app`). With the migration of the Telegram Bot integration to entity-based notify services (see https://www.home-assistant.io/integrations/telegram_bot#notifiers), alerts configured with the new entity IDs (e.g., `home_assistant_alerts_fons_64366733`) fail with "Failed to call notify.notify.{entity_id}".

This PR adds support for entity-based notify services in the alert component by:

1. Detecting when a notifier is an entity ID (vs. a legacy service name)
2. Using the `notify.send_message` service with the `entity_id` parameter for entity-based notifiers
3. Maintaining backward compatibility with legacy service names
4. Adding proper error handling and entity existence checks

This allows alerts to work with the new Telegram Bot integration's entity-based notify entities while maintaining compatibility with existing legacy notify services.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
