### PR TITLE
Add system-level frontend data storage

### DIFF
--- a/homeassistant/components/frontend/const.py
+++ b/homeassistant/components/frontend/const.py
@@ -1,4 +1,0 @@
-"""Constants for the frontend component."""
-
-# System storage keys
-SYSTEM_DATA_DEFAULT_PANEL = "default_panel"

--- a/homeassistant/components/frontend/const.py
+++ b/homeassistant/components/frontend/const.py
@@ -1,0 +1,4 @@
+"""Constants for the frontend component."""
+
+# System storage keys
+SYSTEM_DATA_DEFAULT_PANEL = "default_panel"

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -254,6 +254,7 @@ async def websocket_subscribe_user_data(
     connection.send_result(msg["id"])
 
 
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "frontend/set_system_data",

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -269,6 +269,7 @@ async def websocket_subscribe_user_data(
         vol.Required(SYSTEM_DATA_DEFAULT_PANEL): vol.Any(str, None),
     }
 )
+@websocket_api.require_admin
 @websocket_api.async_response
 @with_system_store
 async def websocket_set_system_data(
@@ -278,10 +279,6 @@ async def websocket_set_system_data(
     store: SystemStore,
 ) -> None:
     """Handle set system data command."""
-    if not connection.user.is_admin:
-        connection.send_error(msg["id"], "unauthorized", "Admin access required")
-        return
-
     await store.async_set_item("default_panel", msg[SYSTEM_DATA_DEFAULT_PANEL])
     connection.send_result(msg["id"])
 

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -254,7 +254,6 @@ async def websocket_subscribe_user_data(
     connection.send_result(msg["id"])
 
 
-@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "frontend/set_system_data",
@@ -262,6 +261,7 @@ async def websocket_subscribe_user_data(
         vol.Required("value"): vol.Any(bool, str, int, float, dict, list, None),
     }
 )
+@websocket_api.require_admin
 @websocket_api.async_response
 @with_system_store
 async def websocket_set_system_data(
@@ -271,10 +271,6 @@ async def websocket_set_system_data(
     store: SystemStore,
 ) -> None:
     """Handle set system data command."""
-    if not connection.user.is_admin:
-        connection.send_error(msg["id"], "unauthorized", "Admin access required")
-        return
-
     await store.async_set_item(msg["key"], msg["value"])
     connection.send_result(msg["id"])
 

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 from functools import wraps
-from typing import Any
+from typing import Any, TypedDict, cast
 
 import voluptuous as vol
 
@@ -13,6 +13,15 @@ from homeassistant.components.websocket_api import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.storage import Store
 from homeassistant.util.hass_dict import HassKey
+
+from .const import SYSTEM_DATA_DEFAULT_PANEL
+
+
+class SystemStorageData(TypedDict, total=False):
+    """System storage data structure."""
+
+    default_panel: str | None
+
 
 DATA_STORAGE: HassKey[dict[str, UserStore]] = HassKey("frontend_storage")
 DATA_SYSTEM_STORAGE: HassKey[SystemStore] = HassKey("frontend_system_storage")
@@ -102,7 +111,7 @@ class SystemStore:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the system store."""
         self._store = _SystemStore(hass)
-        self.data: dict[str, Any] = {}
+        self.data: SystemStorageData = {}
         self.subscriptions: dict[str | None, list[Callable[[], None]]] = {}
 
     async def async_load(self) -> None:
@@ -111,7 +120,7 @@ class SystemStore:
 
     async def async_set_item(self, key: str, value: Any) -> None:
         """Set an item and save the store."""
-        self.data[key] = value
+        cast(dict[str, Any], self.data)[key] = value
         await self._store.async_save(self.data)
         for cb in self.subscriptions.get(None, []):
             cb()
@@ -132,7 +141,7 @@ class SystemStore:
         return unsubscribe
 
 
-class _SystemStore(Store[dict[str, Any]]):
+class _SystemStore(Store[SystemStorageData]):
     """System store for frontend data."""
 
     def __init__(self, hass: HomeAssistant) -> None:
@@ -257,8 +266,7 @@ async def websocket_subscribe_user_data(
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "frontend/set_system_data",
-        vol.Required("key"): str,
-        vol.Required("value"): vol.Any(bool, str, int, float, dict, list, None),
+        vol.Required(SYSTEM_DATA_DEFAULT_PANEL): vol.Any(str, None),
     }
 )
 @websocket_api.async_response
@@ -274,7 +282,7 @@ async def websocket_set_system_data(
         connection.send_error(msg["id"], "unauthorized", "Admin access required")
         return
 
-    await store.async_set_item(msg["key"], msg["value"])
+    await store.async_set_item("default_panel", msg[SYSTEM_DATA_DEFAULT_PANEL])
     connection.send_result(msg["id"])
 
 

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -269,7 +269,6 @@ async def websocket_subscribe_user_data(
         vol.Required(SYSTEM_DATA_DEFAULT_PANEL): vol.Any(str, None),
     }
 )
-@websocket_api.require_admin
 @websocket_api.async_response
 @with_system_store
 async def websocket_set_system_data(
@@ -279,6 +278,10 @@ async def websocket_set_system_data(
     store: SystemStore,
 ) -> None:
     """Handle set system data command."""
+    if not connection.user.is_admin:
+        connection.send_error(msg["id"], "unauthorized", "Admin access required")
+        return
+
     await store.async_set_item("default_panel", msg[SYSTEM_DATA_DEFAULT_PANEL])
     connection.send_result(msg["id"])
 

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import singleton
 from homeassistant.helpers.storage import Store
 from homeassistant.util.hass_dict import HassKey
 
@@ -88,12 +89,12 @@ class _UserStore(Store[dict[str, Any]]):
         )
 
 
+@singleton.singleton(DATA_SYSTEM_STORAGE, async_=True)
 async def async_system_store(hass: HomeAssistant) -> SystemStore:
     """Access the system store."""
-    if DATA_SYSTEM_STORAGE not in hass.data:
-        store = hass.data[DATA_SYSTEM_STORAGE] = SystemStore(hass)
-        await store.async_load()
-    return hass.data[DATA_SYSTEM_STORAGE]
+    store = SystemStore(hass)
+    await store.async_load()
+    return store
 
 
 class SystemStore:

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -15,7 +15,9 @@ from homeassistant.helpers.storage import Store
 from homeassistant.util.hass_dict import HassKey
 
 DATA_STORAGE: HassKey[dict[str, UserStore]] = HassKey("frontend_storage")
+DATA_SYSTEM_STORAGE: HassKey[SystemStore] = HassKey("frontend_system_storage")
 STORAGE_VERSION_USER_DATA = 1
+STORAGE_VERSION_SYSTEM_DATA = 1
 
 
 async def async_setup_frontend_storage(hass: HomeAssistant) -> None:
@@ -23,6 +25,9 @@ async def async_setup_frontend_storage(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_set_user_data)
     websocket_api.async_register_command(hass, websocket_get_user_data)
     websocket_api.async_register_command(hass, websocket_subscribe_user_data)
+    websocket_api.async_register_command(hass, websocket_set_system_data)
+    websocket_api.async_register_command(hass, websocket_get_system_data)
+    websocket_api.async_register_command(hass, websocket_subscribe_system_data)
 
 
 async def async_user_store(hass: HomeAssistant, user_id: str) -> UserStore:
@@ -83,6 +88,62 @@ class _UserStore(Store[dict[str, Any]]):
         )
 
 
+async def async_system_store(hass: HomeAssistant) -> SystemStore:
+    """Access the system store."""
+    if DATA_SYSTEM_STORAGE not in hass.data:
+        store = hass.data[DATA_SYSTEM_STORAGE] = SystemStore(hass)
+        await store.async_load()
+    return hass.data[DATA_SYSTEM_STORAGE]
+
+
+class SystemStore:
+    """System store for frontend data."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the system store."""
+        self._store = _SystemStore(hass)
+        self.data: dict[str, Any] = {}
+        self.subscriptions: dict[str | None, list[Callable[[], None]]] = {}
+
+    async def async_load(self) -> None:
+        """Load the data from the store."""
+        self.data = await self._store.async_load() or {}
+
+    async def async_set_item(self, key: str, value: Any) -> None:
+        """Set an item and save the store."""
+        self.data[key] = value
+        await self._store.async_save(self.data)
+        for cb in self.subscriptions.get(None, []):
+            cb()
+        for cb in self.subscriptions.get(key, []):
+            cb()
+
+    @callback
+    def async_subscribe(
+        self, key: str | None, on_update_callback: Callable[[], None]
+    ) -> Callable[[], None]:
+        """Subscribe to store updates."""
+        self.subscriptions.setdefault(key, []).append(on_update_callback)
+
+        def unsubscribe() -> None:
+            """Unsubscribe from the store."""
+            self.subscriptions[key].remove(on_update_callback)
+
+        return unsubscribe
+
+
+class _SystemStore(Store[dict[str, Any]]):
+    """System store for frontend data."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the system store."""
+        super().__init__(
+            hass,
+            STORAGE_VERSION_SYSTEM_DATA,
+            "frontend.system_data",
+        )
+
+
 def with_user_store(
     orig_func: Callable[
         [HomeAssistant, ActiveConnection, dict[str, Any], UserStore],
@@ -105,6 +166,28 @@ def with_user_store(
         await orig_func(hass, connection, msg, store)
 
     return with_user_store_func
+
+
+def with_system_store(
+    orig_func: Callable[
+        [HomeAssistant, ActiveConnection, dict[str, Any], SystemStore],
+        Coroutine[Any, Any, None],
+    ],
+) -> Callable[
+    [HomeAssistant, ActiveConnection, dict[str, Any]], Coroutine[Any, Any, None]
+]:
+    """Decorate function to provide system store."""
+
+    @wraps(orig_func)
+    async def with_system_store_func(
+        hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
+    ) -> None:
+        """Provide system store to function."""
+        store = await async_system_store(hass)
+
+        await orig_func(hass, connection, msg, store)
+
+    return with_system_store_func
 
 
 @websocket_api.websocket_command(
@@ -161,6 +244,77 @@ async def websocket_subscribe_user_data(
 
     def on_data_update() -> None:
         """Handle user data update."""
+        data = store.data
+        connection.send_event(
+            msg["id"], {"value": data.get(key) if key is not None else data}
+        )
+
+    connection.subscriptions[msg["id"]] = store.async_subscribe(key, on_data_update)
+    on_data_update()
+    connection.send_result(msg["id"])
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "frontend/set_system_data",
+        vol.Required("key"): str,
+        vol.Required("value"): vol.Any(bool, str, int, float, dict, list, None),
+    }
+)
+@websocket_api.async_response
+@with_system_store
+async def websocket_set_system_data(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    store: SystemStore,
+) -> None:
+    """Handle set system data command."""
+    if not connection.user.is_admin:
+        connection.send_error(msg["id"], "unauthorized", "Admin access required")
+        return
+
+    await store.async_set_item(msg["key"], msg["value"])
+    connection.send_result(msg["id"])
+
+
+@websocket_api.websocket_command(
+    {vol.Required("type"): "frontend/get_system_data", vol.Optional("key"): str}
+)
+@websocket_api.async_response
+@with_system_store
+async def websocket_get_system_data(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    store: SystemStore,
+) -> None:
+    """Handle get system data command."""
+    data = store.data
+    connection.send_result(
+        msg["id"], {"value": data.get(msg["key"]) if "key" in msg else data}
+    )
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "frontend/subscribe_system_data",
+        vol.Optional("key"): str,
+    }
+)
+@websocket_api.async_response
+@with_system_store
+async def websocket_subscribe_system_data(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    store: SystemStore,
+) -> None:
+    """Handle subscribe to system data command."""
+    key: str | None = msg.get("key")
+
+    def on_data_update() -> None:
+        """Handle system data update."""
         data = store.data
         connection.send_event(
             msg["id"], {"value": data.get(key) if key is not None else data}

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -117,7 +117,7 @@ class SystemStore:
     async def async_set_item(self, key: str, value: Any) -> None:
         """Set an item and save the store."""
         self.data[key] = value
-        await self._store.async_save(self.data)
+        self._store.async_delay_save(lambda: self.data, 1.0)
         for cb in self.subscriptions.get(key, []):
             cb()
 

--- a/tests/components/frontend/test_storage.py
+++ b/tests/components/frontend/test_storage.py
@@ -328,20 +328,30 @@ async def test_get_system_data(
     hass_storage[storage_key] = {
         "key": storage_key,
         "version": 1,
-        "data": {"default_panel": "lovelace"},
+        "data": {"test-key": "test-value", "test-complex": [{"foo": "bar"}]},
     }
 
     client = await hass_ws_client(hass)
 
-    # Get default_panel key
+    # Get a simple string key
 
     await client.send_json(
-        {"id": 6, "type": "frontend/get_system_data", "key": "default_panel"}
+        {"id": 6, "type": "frontend/get_system_data", "key": "test-key"}
     )
 
     res = await client.receive_json()
     assert res["success"], res
-    assert res["result"]["value"] == "lovelace"
+    assert res["result"]["value"] == "test-value"
+
+    # Get a more complex key
+
+    await client.send_json(
+        {"id": 7, "type": "frontend/get_system_data", "key": "test-complex"}
+    )
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"][0]["foo"] == "bar"
 
     # Get all data (no key)
 
@@ -349,15 +359,16 @@ async def test_get_system_data(
 
     res = await client.receive_json()
     assert res["success"], res
-    assert res["result"]["value"]["default_panel"] == "lovelace"
+    assert res["result"]["value"]["test-key"] == "test-value"
+    assert res["result"]["value"]["test-complex"][0]["foo"] == "bar"
 
 
 @pytest.mark.parametrize(
     ("subscriptions", "events"),
     [
         ([], []),
-        ([(1, {}, {})], [(1, {"default_panel": "lovelace"})]),
-        ([(1, {"key": "default_panel"}, None)], [(1, "lovelace")]),
+        ([(1, {}, {})], [(1, {"test-key": "test-value"})]),
+        ([(1, {"key": "test-key"}, None)], [(1, "test-value")]),
         ([(1, {"key": "other-key"}, None)], []),
     ],
 )
@@ -395,7 +406,7 @@ async def test_set_system_data_empty(
     # test creating
 
     await client.send_json(
-        {"id": 6, "type": "frontend/get_system_data", "key": "default_panel"}
+        {"id": 6, "type": "frontend/get_system_data", "key": "test-key"}
     )
 
     res = await client.receive_json()
@@ -406,7 +417,8 @@ async def test_set_system_data_empty(
         {
             "id": 7,
             "type": "frontend/set_system_data",
-            "default_panel": "lovelace",
+            "key": "test-key",
+            "value": "test-value",
         }
     )
 
@@ -418,21 +430,62 @@ async def test_set_system_data_empty(
     assert res["success"], res
 
     await client.send_json(
-        {"id": 8, "type": "frontend/get_system_data", "key": "default_panel"}
+        {"id": 8, "type": "frontend/get_system_data", "key": "test-key"}
     )
 
     res = await client.receive_json()
     assert res["success"], res
-    assert res["result"]["value"] == "lovelace"
+    assert res["result"]["value"] == "test-value"
 
 
 @pytest.mark.parametrize(
     ("subscriptions", "events"),
     [
-        ([], []),
-        ([(1, {}, {"default_panel": "energy"})], [(1, {"default_panel": "lovelace"})]),
-        ([(1, {"key": "default_panel"}, "energy")], [(1, "lovelace")]),
-        ([(1, {"key": "other-key"}, None)], []),
+        (
+            [],
+            [[], []],
+        ),
+        (
+            [(1, {}, {"test-key": "test-value", "test-complex": "string"})],
+            [
+                [
+                    (
+                        1,
+                        {
+                            "test-complex": "string",
+                            "test-key": "test-value",
+                            "test-non-existent-key": "test-value-new",
+                        },
+                    )
+                ],
+                [
+                    (
+                        1,
+                        {
+                            "test-complex": [{"foo": "bar"}],
+                            "test-key": "test-value",
+                            "test-non-existent-key": "test-value-new",
+                        },
+                    )
+                ],
+            ],
+        ),
+        (
+            [(1, {"key": "test-key"}, "test-value")],
+            [[], []],
+        ),
+        (
+            [(1, {"key": "test-non-existent-key"}, None)],
+            [[(1, "test-value-new")], []],
+        ),
+        (
+            [(1, {"key": "test-complex"}, "string")],
+            [[], [(1, [{"foo": "bar"}])]],
+        ),
+        (
+            [(1, {"key": "other-key"}, None)],
+            [[], []],
+        ),
     ],
 )
 async def test_set_system_data(
@@ -440,13 +493,13 @@ async def test_set_system_data(
     hass_ws_client: WebSocketGenerator,
     hass_storage: dict[str, Any],
     subscriptions: list[tuple[int, dict[str, str], Any]],
-    events: list[tuple[int, Any]],
+    events: list[list[tuple[int, Any]]],
 ) -> None:
     """Test set_system_data command with initial data."""
     storage_key = f"{DOMAIN}.system_data"
     hass_storage[storage_key] = {
         "version": 1,
-        "data": {"default_panel": "energy"},
+        "data": {"test-key": "test-value", "test-complex": "string"},
     }
 
     client = await hass_ws_client(hass)
@@ -470,17 +523,18 @@ async def test_set_system_data(
         res = await client.receive_json()
         assert res["success"], res
 
-    # test updating default_panel
+    # test creating
 
     await client.send_json(
         {
             "id": 5,
             "type": "frontend/set_system_data",
-            "default_panel": "lovelace",
+            "key": "test-non-existent-key",
+            "value": "test-value-new",
         }
     )
 
-    for msg_id, event_data in events:
+    for msg_id, event_data in events[0]:
         event = await client.receive_json()
         assert event == {"id": msg_id, "type": "event", "event": {"value": event_data}}
 
@@ -488,12 +542,48 @@ async def test_set_system_data(
     assert res["success"], res
 
     await client.send_json(
-        {"id": 6, "type": "frontend/get_system_data", "key": "default_panel"}
+        {"id": 6, "type": "frontend/get_system_data", "key": "test-non-existent-key"}
     )
 
     res = await client.receive_json()
     assert res["success"], res
-    assert res["result"]["value"] == "lovelace"
+    assert res["result"]["value"] == "test-value-new"
+
+    # test updating with complex data
+
+    await client.send_json(
+        {
+            "id": 7,
+            "type": "frontend/set_system_data",
+            "key": "test-complex",
+            "value": [{"foo": "bar"}],
+        }
+    )
+
+    for msg_id, event_data in events[1]:
+        event = await client.receive_json()
+        assert event == {"id": msg_id, "type": "event", "event": {"value": event_data}}
+
+    res = await client.receive_json()
+    assert res["success"], res
+
+    await client.send_json(
+        {"id": 8, "type": "frontend/get_system_data", "key": "test-complex"}
+    )
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"][0]["foo"] == "bar"
+
+    # ensure other existing key was not modified
+
+    await client.send_json(
+        {"id": 9, "type": "frontend/get_system_data", "key": "test-key"}
+    )
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"] == "test-value"
 
 
 async def test_set_system_data_requires_admin(
@@ -508,7 +598,8 @@ async def test_set_system_data_requires_admin(
         {
             "id": 5,
             "type": "frontend/set_system_data",
-            "default_panel": "lovelace",
+            "key": "test-key",
+            "value": "test-value",
         }
     )
 
@@ -516,111 +607,3 @@ async def test_set_system_data_requires_admin(
     assert not res["success"], res
     assert res["error"]["code"] == "unauthorized"
     assert res["error"]["message"] == "Admin access required"
-
-
-async def test_set_system_data_default_panel_string(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
-) -> None:
-    """Test setting default_panel with valid string value."""
-    client = await hass_ws_client(hass)
-
-    # Test setting default_panel with a string value
-    await client.send_json(
-        {
-            "id": 1,
-            "type": "frontend/set_system_data",
-            "default_panel": "lovelace",
-        }
-    )
-
-    res = await client.receive_json()
-    assert res["success"], res
-
-    # Verify the value was set
-    await client.send_json(
-        {"id": 2, "type": "frontend/get_system_data", "key": "default_panel"}
-    )
-
-    res = await client.receive_json()
-    assert res["success"], res
-    assert res["result"]["value"] == "lovelace"
-
-
-async def test_set_system_data_default_panel_none(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
-) -> None:
-    """Test setting default_panel with None value."""
-    client = await hass_ws_client(hass)
-
-    # Test setting default_panel with None
-    await client.send_json(
-        {
-            "id": 1,
-            "type": "frontend/set_system_data",
-            "default_panel": None,
-        }
-    )
-
-    res = await client.receive_json()
-    assert res["success"], res
-
-    # Verify the value was set
-    await client.send_json(
-        {"id": 2, "type": "frontend/get_system_data", "key": "default_panel"}
-    )
-
-    res = await client.receive_json()
-    assert res["success"], res
-    assert res["result"]["value"] is None
-
-
-@pytest.mark.parametrize(
-    ("invalid_value", "value_type"),
-    [
-        (True, "bool"),
-        (123, "int"),
-        (45.6, "float"),
-        ({"panel": "lovelace"}, "dict"),
-        (["lovelace", "energy"], "list"),
-    ],
-)
-async def test_set_system_data_default_panel_invalid_types(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    invalid_value: Any,
-    value_type: str,
-) -> None:
-    """Test setting default_panel with invalid types fails validation."""
-    client = await hass_ws_client(hass)
-
-    await client.send_json(
-        {
-            "id": 1,
-            "type": "frontend/set_system_data",
-            "default_panel": invalid_value,
-        }
-    )
-
-    res = await client.receive_json()
-    assert not res["success"], res
-    assert res["error"]["code"] == "invalid_format"
-
-
-async def test_set_system_data_invalid_key(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
-) -> None:
-    """Test that keys other than default_panel are rejected by schema."""
-    client = await hass_ws_client(hass)
-
-    # Test that other keys are rejected by voluptuous schema
-    await client.send_json(
-        {
-            "id": 1,
-            "type": "frontend/set_system_data",
-            "other_key": "test-value",
-        }
-    )
-
-    res = await client.receive_json()
-    assert not res["success"], "Invalid key should have been rejected by schema"
-    assert res["error"]["code"] == "invalid_format"

--- a/tests/components/frontend/test_storage.py
+++ b/tests/components/frontend/test_storage.py
@@ -301,3 +301,309 @@ async def test_set_user_data(
     res = await client.receive_json()
     assert res["success"], res
     assert res["result"]["value"] == "test-value"
+
+
+async def test_get_system_data_empty(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test get_system_data command."""
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {"id": 5, "type": "frontend/get_system_data", "key": "non-existing-key"}
+    )
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"] is None
+
+
+async def test_get_system_data(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test get_system_data command."""
+    storage_key = f"{DOMAIN}.system_data"
+    hass_storage[storage_key] = {
+        "key": storage_key,
+        "version": 1,
+        "data": {"test-key": "test-value", "test-complex": [{"foo": "bar"}]},
+    }
+
+    client = await hass_ws_client(hass)
+
+    # Get a simple string key
+
+    await client.send_json(
+        {"id": 6, "type": "frontend/get_system_data", "key": "test-key"}
+    )
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"] == "test-value"
+
+    # Get a more complex key
+
+    await client.send_json(
+        {"id": 7, "type": "frontend/get_system_data", "key": "test-complex"}
+    )
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"][0]["foo"] == "bar"
+
+    # Get all data (no key)
+
+    await client.send_json({"id": 8, "type": "frontend/get_system_data"})
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"]["test-key"] == "test-value"
+    assert res["result"]["value"]["test-complex"][0]["foo"] == "bar"
+
+
+@pytest.mark.parametrize(
+    ("subscriptions", "events"),
+    [
+        ([], []),
+        ([(1, {}, {})], [(1, {"test-key": "test-value"})]),
+        ([(1, {"key": "test-key"}, None)], [(1, "test-value")]),
+        ([(1, {"key": "other-key"}, None)], []),
+    ],
+)
+async def test_set_system_data_empty(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    subscriptions: list[tuple[int, dict[str, str], Any]],
+    events: list[tuple[int, Any]],
+) -> None:
+    """Test set_system_data command.
+
+    Also test subscribing.
+    """
+    client = await hass_ws_client(hass)
+
+    for msg_id, key, event_data in subscriptions:
+        await client.send_json(
+            {
+                "id": msg_id,
+                "type": "frontend/subscribe_system_data",
+            }
+            | key
+        )
+
+        event = await client.receive_json()
+        assert event == {
+            "id": msg_id,
+            "type": "event",
+            "event": {"value": event_data},
+        }
+
+        res = await client.receive_json()
+        assert res["success"], res
+
+    # test creating
+
+    await client.send_json(
+        {"id": 6, "type": "frontend/get_system_data", "key": "test-key"}
+    )
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"] is None
+
+    await client.send_json(
+        {
+            "id": 7,
+            "type": "frontend/set_system_data",
+            "key": "test-key",
+            "value": "test-value",
+        }
+    )
+
+    for msg_id, event_data in events:
+        event = await client.receive_json()
+        assert event == {"id": msg_id, "type": "event", "event": {"value": event_data}}
+
+    res = await client.receive_json()
+    assert res["success"], res
+
+    await client.send_json(
+        {"id": 8, "type": "frontend/get_system_data", "key": "test-key"}
+    )
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"] == "test-value"
+
+
+@pytest.mark.parametrize(
+    ("subscriptions", "events"),
+    [
+        (
+            [],
+            [[], []],
+        ),
+        (
+            [(1, {}, {"test-key": "test-value", "test-complex": "string"})],
+            [
+                [
+                    (
+                        1,
+                        {
+                            "test-complex": "string",
+                            "test-key": "test-value",
+                            "test-non-existent-key": "test-value-new",
+                        },
+                    )
+                ],
+                [
+                    (
+                        1,
+                        {
+                            "test-complex": [{"foo": "bar"}],
+                            "test-key": "test-value",
+                            "test-non-existent-key": "test-value-new",
+                        },
+                    )
+                ],
+            ],
+        ),
+        (
+            [(1, {"key": "test-key"}, "test-value")],
+            [[], []],
+        ),
+        (
+            [(1, {"key": "test-non-existent-key"}, None)],
+            [[(1, "test-value-new")], []],
+        ),
+        (
+            [(1, {"key": "test-complex"}, "string")],
+            [[], [(1, [{"foo": "bar"}])]],
+        ),
+        (
+            [(1, {"key": "other-key"}, None)],
+            [[], []],
+        ),
+    ],
+)
+async def test_set_system_data(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+    subscriptions: list[tuple[int, dict[str, str], Any]],
+    events: list[list[tuple[int, Any]]],
+) -> None:
+    """Test set_system_data command with initial data."""
+    storage_key = f"{DOMAIN}.system_data"
+    hass_storage[storage_key] = {
+        "version": 1,
+        "data": {"test-key": "test-value", "test-complex": "string"},
+    }
+
+    client = await hass_ws_client(hass)
+
+    for msg_id, key, event_data in subscriptions:
+        await client.send_json(
+            {
+                "id": msg_id,
+                "type": "frontend/subscribe_system_data",
+            }
+            | key
+        )
+
+        event = await client.receive_json()
+        assert event == {
+            "id": msg_id,
+            "type": "event",
+            "event": {"value": event_data},
+        }
+
+        res = await client.receive_json()
+        assert res["success"], res
+
+    # test creating
+
+    await client.send_json(
+        {
+            "id": 5,
+            "type": "frontend/set_system_data",
+            "key": "test-non-existent-key",
+            "value": "test-value-new",
+        }
+    )
+
+    for msg_id, event_data in events[0]:
+        event = await client.receive_json()
+        assert event == {"id": msg_id, "type": "event", "event": {"value": event_data}}
+
+    res = await client.receive_json()
+    assert res["success"], res
+
+    await client.send_json(
+        {"id": 6, "type": "frontend/get_system_data", "key": "test-non-existent-key"}
+    )
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"] == "test-value-new"
+
+    # test updating with complex data
+
+    await client.send_json(
+        {
+            "id": 7,
+            "type": "frontend/set_system_data",
+            "key": "test-complex",
+            "value": [{"foo": "bar"}],
+        }
+    )
+
+    for msg_id, event_data in events[1]:
+        event = await client.receive_json()
+        assert event == {"id": msg_id, "type": "event", "event": {"value": event_data}}
+
+    res = await client.receive_json()
+    assert res["success"], res
+
+    await client.send_json(
+        {"id": 8, "type": "frontend/get_system_data", "key": "test-complex"}
+    )
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"][0]["foo"] == "bar"
+
+    # ensure other existing key was not modified
+
+    await client.send_json(
+        {"id": 9, "type": "frontend/get_system_data", "key": "test-key"}
+    )
+
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["value"] == "test-value"
+
+
+async def test_set_system_data_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test set_system_data requires admin permissions."""
+    client = await hass_ws_client(hass, hass_read_only_access_token)
+
+    await client.send_json(
+        {
+            "id": 5,
+            "type": "frontend/set_system_data",
+            "key": "test-key",
+            "value": "test-value",
+        }
+    )
+
+    res = await client.receive_json()
+    assert not res["success"], res
+    assert res["error"]["code"] == "unauthorized"
+    assert res["error"]["message"] == "Admin access required"

--- a/tests/components/frontend/test_storage.py
+++ b/tests/components/frontend/test_storage.py
@@ -606,4 +606,4 @@ async def test_set_system_data_requires_admin(
     res = await client.receive_json()
     assert not res["success"], res
     assert res["error"]["code"] == "unauthorized"
-    assert res["error"]["message"] == "Admin access required"
+    assert res["error"]["message"] == "Unauthorized"

--- a/tests/components/frontend/test_storage.py
+++ b/tests/components/frontend/test_storage.py
@@ -353,21 +353,11 @@ async def test_get_system_data(
     assert res["success"], res
     assert res["result"]["value"][0]["foo"] == "bar"
 
-    # Get all data (no key)
-
-    await client.send_json({"id": 8, "type": "frontend/get_system_data"})
-
-    res = await client.receive_json()
-    assert res["success"], res
-    assert res["result"]["value"]["test-key"] == "test-value"
-    assert res["result"]["value"]["test-complex"][0]["foo"] == "bar"
-
 
 @pytest.mark.parametrize(
     ("subscriptions", "events"),
     [
         ([], []),
-        ([(1, {}, {})], [(1, {"test-key": "test-value"})]),
         ([(1, {"key": "test-key"}, None)], [(1, "test-value")]),
         ([(1, {"key": "other-key"}, None)], []),
     ],
@@ -444,31 +434,6 @@ async def test_set_system_data_empty(
         (
             [],
             [[], []],
-        ),
-        (
-            [(1, {}, {"test-key": "test-value", "test-complex": "string"})],
-            [
-                [
-                    (
-                        1,
-                        {
-                            "test-complex": "string",
-                            "test-key": "test-value",
-                            "test-non-existent-key": "test-value-new",
-                        },
-                    )
-                ],
-                [
-                    (
-                        1,
-                        {
-                            "test-complex": [{"foo": "bar"}],
-                            "test-key": "test-value",
-                            "test-non-existent-key": "test-value-new",
-                        },
-                    )
-                ],
-            ],
         ),
         (
             [(1, {"key": "test-key"}, "test-value")],


### PR DESCRIPTION
## Proposed change

Adds system-level storage to the frontend component for admin-configurable, system-wide settings that apply to all users. Users can override these settings with their personal preferences in user storage.

### Changes

Storage:
- Added `SystemStorageData` TypedDict with `default_panel: str | None` field`
- Added `SystemStore` class with subscription support
- Storage file: `.storage/frontend.system_data`

Websocket commands:
- `frontend/get_system_data` - Get system data (all users)
- `frontend/set_system_data` - Set system data (admin only)
- `frontend/subscribe_system_data` - Real-time updates (all users)

Validation:
- Uses voluptuous schema validation (backup component pattern)
- Only allows default_panel key with str | None value
- Schema rejects invalid keys/types automatically

I will be used in https://github.com/home-assistant/frontend/pull/27899

### Usage

First use case: Admin sets default panel for all users. 

Set (admin only):
```ts
await hass.connection.sendMessagePromise({
  type: "frontend/set_system_data",
  key: "core",
  value: {
    defaultPanel: "home"
  },
});
```

Get (any user):
```ts
const { value } = await hass.connection.sendMessagePromise({
  type: "frontend/get_system_data", 
  key: "core"
});
```

Priority : User storage > System storage > Default ("lovelace")

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
