### PR TITLE
Remove deprecated square meters constant

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -685,13 +685,6 @@ class UnitOfArea(StrEnum):
     HECTARES = "ha"
 
 
-_DEPRECATED_AREA_SQUARE_METERS: Final = DeprecatedConstantEnum(
-    UnitOfArea.SQUARE_METERS,
-    "2025.12",
-)
-"""Deprecated: please use UnitOfArea.SQUARE_METERS"""
-
-
 # Mass units
 class UnitOfMass(StrEnum):
     """Mass units."""

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,43 +1,10 @@
 """Test const module."""
 
-from enum import Enum
-
-import pytest
-
 from homeassistant import const
 
-from .common import help_test_all, import_and_test_deprecated_constant
-
-
-def _create_tuples(
-    value: type[Enum] | list[Enum], constant_prefix: str
-) -> list[tuple[Enum, str]]:
-    return [(enum, constant_prefix) for enum in value]
+from .common import help_test_all
 
 
 def test_all() -> None:
     """Test module.__all__ is correctly set."""
     help_test_all(const)
-
-
-@pytest.mark.parametrize(
-    ("replacement", "constant_name", "breaks_in_version"),
-    [
-        (const.UnitOfArea.SQUARE_METERS, "AREA_SQUARE_METERS", "2025.12"),
-    ],
-)
-def test_deprecated_constant_name_changes(
-    caplog: pytest.LogCaptureFixture,
-    replacement: Enum,
-    constant_name: str,
-    breaks_in_version: str,
-) -> None:
-    """Test deprecated constants, where the name is not the same as the enum value."""
-    import_and_test_deprecated_constant(
-        caplog,
-        const,
-        constant_name,
-        f"{replacement.__class__.__name__}.{replacement.name}",
-        replacement,
-        breaks_in_version,
-    )


### PR DESCRIPTION
## Breaking change
Removes the previously deprecated constant for square meters

## Proposed change


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 