### PR TITLE
Remove deprecated start of flow no link to config entry

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1419,7 +1419,7 @@ class ConfigEntriesFlowManager(
             SOURCE_RECONFIGURE,
         } and "entry_id" not in context:
             raise HomeAssistantError(
-                f"Initialises a {source} flow without a link to the config entry"
+                f"Cannot initialize a {source} flow without a link to the config entry"
             )
 
         flow_id = ulid_util.ulid_now()

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1418,10 +1418,8 @@ class ConfigEntriesFlowManager(
             SOURCE_REAUTH,
             SOURCE_RECONFIGURE,
         } and "entry_id" not in context:
-            # Deprecated in 2024.12, should fail in 2025.12
-            report_usage(
-                f"initialises a {source} flow without a link to the config entry",
-                breaks_in_ha_version="2025.12",
+            raise HomeAssistantError(
+                f"Initialises a {source} flow without a link to the config entry"
             )
 
         flow_id = ulid_util.ulid_now()

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5983,9 +5983,8 @@ async def test_reauth_reconfigure_missing_entry(
     await hass.async_block_till_done()
 
     with pytest.raises(
-        RuntimeError,
-        match=f"Detected code that initialises a {source} flow without a link "
-        "to the config entry. Please report this issue",
+        HomeAssistantError,
+        match=f"Initialises a {source} flow without a link to the config entry",
     ):
         await manager.flow.async_init("test", context={"source": source})
     await hass.async_block_till_done()
@@ -6002,7 +6001,6 @@ async def test_reauth_reconfigure_missing_entry_component(
     hass: HomeAssistant,
     manager: config_entries.ConfigEntries,
     source: str,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the async_reauth_helper."""
     entry = MockConfigEntry(title="test_title", domain="test")
@@ -6015,19 +6013,18 @@ async def test_reauth_reconfigure_missing_entry_component(
     await manager.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
+    with (
+        patch.object(frame, "_REPORTED_INTEGRATIONS", set()),
+        pytest.raises(
+            HomeAssistantError,
+            match=f"Initialises a {source} flow without a link to the config entry",
+        ),
+    ):
         await manager.flow.async_init("test", context={"source": source})
-        await hass.async_block_till_done()
 
-    # Flow still created, but deprecation logged
+    # Flow is not created
     flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
-    assert flows[0]["context"]["source"] == source
-
-    assert (
-        f"Detected that integration 'hue' initialises a {source} flow"
-        " without a link to the config entry at homeassistant/components" in caplog.text
-    )
+    assert len(flows) == 0
 
 
 async def test_reconfigure(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6017,7 +6017,7 @@ async def test_reauth_reconfigure_missing_entry_component(
         patch.object(frame, "_REPORTED_INTEGRATIONS", set()),
         pytest.raises(
             HomeAssistantError,
-            match=f"Initialises a {source} flow without a link to the config entry",
+            match=f"Cannot initialize a {source} flow without a link to the config entry",
         ),
     ):
         await manager.flow.async_init("test", context={"source": source})

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5984,7 +5984,7 @@ async def test_reauth_reconfigure_missing_entry(
 
     with pytest.raises(
         HomeAssistantError,
-        match=f"Initialises a {source} flow without a link to the config entry",
+        match=f"Cannot initialize a {source} flow without a link to the config entry",
     ):
         await manager.flow.async_init("test", context={"source": source})
     await hass.async_block_till_done()


### PR DESCRIPTION
## Breaking change
Remove deprecated start of `reconfigure`/`reauth` flows with no linked config entry.

## Proposed change


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 