### PR TITLE
Add `In party` sensor to Xbox integration

### DIFF
--- a/homeassistant/components/xbox/icons.json
+++ b/homeassistant/components/xbox/icons.json
@@ -35,6 +35,13 @@
           "0": "mdi:headset-off"
         }
       },
+      "join_restrictions": {
+        "default": "mdi:account-voice-off",
+        "state": {
+          "invite_only": "mdi:email-newsletter",
+          "joinable": "mdi:account-multiple-plus-outline"
+        }
+      },
       "last_online": {
         "default": "mdi:account-clock"
       },

--- a/homeassistant/components/xbox/icons.json
+++ b/homeassistant/components/xbox/icons.json
@@ -29,6 +29,12 @@
       "gamer_score": {
         "default": "mdi:alpha-g-circle"
       },
+      "in_party": {
+        "default": "mdi:headset",
+        "state": {
+          "0": "mdi:headset-off"
+        }
+      },
       "last_online": {
         "default": "mdi:account-clock"
       },

--- a/homeassistant/components/xbox/sensor.py
+++ b/homeassistant/components/xbox/sensor.py
@@ -37,6 +37,7 @@ class XboxSensor(StrEnum):
     FOLLOWER = "follower"
     NOW_PLAYING = "now_playing"
     FRIENDS = "friends"
+    IN_PARTY = "in_party"
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -93,6 +94,21 @@ def now_playing_attributes(_: Person, title: Title | None) -> dict[str, Any]:
         )
 
     return attributes
+
+
+def in_party_attributes(person: Person, _: Title | None = None) -> dict[str, Any]:
+    """In party attributes."""
+    MAP = {
+        "local": "invite_only",
+        "followed": "joinable",
+    }
+    return {
+        "join_restrictions": MAP.get(
+            person.multiplayer_summary.party_details[0].join_restriction
+        )
+        if person.multiplayer_summary and person.multiplayer_summary.party_details
+        else None
+    }
 
 
 def title_logo(_: Person, title: Title | None) -> str | None:
@@ -158,6 +174,16 @@ SENSOR_DESCRIPTIONS: tuple[XboxSensorEntityDescription, ...] = (
         key=XboxSensor.FRIENDS,
         translation_key=XboxSensor.FRIENDS,
         value_fn=lambda x, _: x.detail.friend_count if x.detail else None,
+    ),
+    XboxSensorEntityDescription(
+        key=XboxSensor.IN_PARTY,
+        translation_key=XboxSensor.IN_PARTY,
+        value_fn=(
+            lambda x, _: x.multiplayer_summary.in_party
+            if x.multiplayer_summary
+            else None
+        ),
+        attributes_fn=in_party_attributes,
     ),
 )
 

--- a/homeassistant/components/xbox/strings.json
+++ b/homeassistant/components/xbox/strings.json
@@ -73,6 +73,19 @@
         "name": "Gamerscore",
         "unit_of_measurement": "points"
       },
+      "in_party": {
+        "name": "In party",
+        "state_attributes": {
+          "join_restrictions": {
+            "name": "Join restrictions",
+            "state": {
+              "invite_only": "Invite-only",
+              "joinable": "Joinable"
+            }
+          }
+        },
+        "unit_of_measurement": "[%key:component::xbox::entity::sensor::following::unit_of_measurement%]"
+      },
       "last_online": {
         "name": "Last online"
       },

--- a/homeassistant/components/xbox/strings.json
+++ b/homeassistant/components/xbox/strings.json
@@ -75,16 +75,14 @@
       },
       "in_party": {
         "name": "In party",
-        "state_attributes": {
-          "join_restrictions": {
-            "name": "Join restrictions",
-            "state": {
-              "invite_only": "Invite-only",
-              "joinable": "Joinable"
-            }
-          }
-        },
         "unit_of_measurement": "[%key:component::xbox::entity::sensor::following::unit_of_measurement%]"
+      },
+      "join_restrictions": {
+        "name": "Party join restrictions",
+        "state": {
+          "invite_only": "Invite-only",
+          "joinable": "Joinable"
+        }
       },
       "last_online": {
         "name": "Last online"

--- a/tests/components/xbox/fixtures/people_batch.json
+++ b/tests/components/xbox/fixtures/people_batch.json
@@ -33,8 +33,21 @@
       "search": null,
       "titleHistory": null,
       "multiplayerSummary": {
-        "inMultiplayerSession": 0,
-        "inParty": 0
+        "joinableActivities": [],
+        "partyDetails": [
+          {
+            "sessionRef": {
+              "scid": "7ffcfe63-a320-4086-85bb-a1734bef7a30",
+              "templateName": "chat",
+              "name": "d3804c40-ac93-4c7d-9414-6cb419931105"
+            },
+            "status": "active",
+            "visibility": "open",
+            "joinRestriction": "followed",
+            "accepted": 2
+          }
+        ],
+        "inParty": 2
       },
       "recentPlayer": null,
       "follower": null,

--- a/tests/components/xbox/snapshots/test_sensor.ambr
+++ b/tests/components/xbox/snapshots/test_sensor.ambr
@@ -234,7 +234,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'erics273 In party',
-      'join_restrictions': None,
       'unit_of_measurement': 'people',
     }),
     'context': <ANY>,
@@ -345,6 +344,64 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.erics273_now_playing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.erics273_party_join_restrictions-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'invite_only',
+        'joinable',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.erics273_party_join_restrictions',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Party join restrictions',
+    'platform': 'xbox',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <XboxSensor.JOIN_RESTRICTIONS: 'join_restrictions'>,
+    'unique_id': '2533274913657542_join_restrictions',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.erics273_party_join_restrictions-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'erics273 Party join restrictions',
+      'options': list([
+        'invite_only',
+        'joinable',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.erics273_party_join_restrictions',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -634,7 +691,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'GSR Ae In party',
-      'join_restrictions': 'joinable',
       'unit_of_measurement': 'people',
     }),
     'context': <ANY>,
@@ -750,6 +806,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'Blue Dragon',
+  })
+# ---
+# name: test_sensors[sensor.gsr_ae_party_join_restrictions-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'invite_only',
+        'joinable',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.gsr_ae_party_join_restrictions',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Party join restrictions',
+    'platform': 'xbox',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <XboxSensor.JOIN_RESTRICTIONS: 'join_restrictions'>,
+    'unique_id': '271958441785640_join_restrictions',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.gsr_ae_party_join_restrictions-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'GSR Ae Party join restrictions',
+      'options': list([
+        'invite_only',
+        'joinable',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.gsr_ae_party_join_restrictions',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'joinable',
   })
 # ---
 # name: test_sensors[sensor.gsr_ae_status-entry]
@@ -1035,7 +1149,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ikken Hissatsuu In party',
-      'join_restrictions': 'joinable',
       'unit_of_measurement': 'people',
     }),
     'context': <ANY>,
@@ -1150,6 +1263,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.ikken_hissatsuu_party_join_restrictions-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'invite_only',
+        'joinable',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ikken_hissatsuu_party_join_restrictions',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Party join restrictions',
+    'platform': 'xbox',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <XboxSensor.JOIN_RESTRICTIONS: 'join_restrictions'>,
+    'unique_id': '2533274838782903_join_restrictions',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.ikken_hissatsuu_party_join_restrictions-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Ikken Hissatsuu Party join restrictions',
+      'options': list([
+        'invite_only',
+        'joinable',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ikken_hissatsuu_party_join_restrictions',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'joinable',
   })
 # ---
 # name: test_sensors[sensor.ikken_hissatsuu_status-entry]

--- a/tests/components/xbox/snapshots/test_sensor.ambr
+++ b/tests/components/xbox/snapshots/test_sensor.ambr
@@ -195,6 +195,56 @@
     'state': '3802',
   })
 # ---
+# name: test_sensors[sensor.erics273_in_party-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.erics273_in_party',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'In party',
+    'platform': 'xbox',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <XboxSensor.IN_PARTY: 'in_party'>,
+    'unique_id': '2533274913657542_in_party',
+    'unit_of_measurement': 'people',
+  })
+# ---
+# name: test_sensors[sensor.erics273_in_party-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'erics273 In party',
+      'join_restrictions': None,
+      'unit_of_measurement': 'people',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.erics273_in_party',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
 # name: test_sensors[sensor.erics273_last_online-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -543,6 +593,56 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '27750',
+  })
+# ---
+# name: test_sensors[sensor.gsr_ae_in_party-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.gsr_ae_in_party',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'In party',
+    'platform': 'xbox',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <XboxSensor.IN_PARTY: 'in_party'>,
+    'unique_id': '271958441785640_in_party',
+    'unit_of_measurement': 'people',
+  })
+# ---
+# name: test_sensors[sensor.gsr_ae_in_party-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'GSR Ae In party',
+      'join_restrictions': 'joinable',
+      'unit_of_measurement': 'people',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.gsr_ae_in_party',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
   })
 # ---
 # name: test_sensors[sensor.gsr_ae_last_online-entry]
@@ -894,6 +994,56 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '27210',
+  })
+# ---
+# name: test_sensors[sensor.ikken_hissatsuu_in_party-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ikken_hissatsuu_in_party',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'In party',
+    'platform': 'xbox',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <XboxSensor.IN_PARTY: 'in_party'>,
+    'unique_id': '2533274838782903_in_party',
+    'unit_of_measurement': 'people',
+  })
+# ---
+# name: test_sensors[sensor.ikken_hissatsuu_in_party-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Ikken Hissatsuu In party',
+      'join_restrictions': 'joinable',
+      'unit_of_measurement': 'people',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ikken_hissatsuu_in_party',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
   })
 # ---
 # name: test_sensors[sensor.ikken_hissatsuu_last_online-entry]


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds `In party` sensor to Xbox integration. This sensor was previously implemented as a binary sensor, which was removed in 2025.11 due to long-term non-functionality. With the recent library update, this functionality is now restored. The sensor has been reintroduced as a regular sensor, as it now provides an integer value representing the number of people in the user’s party chat. Additional attributes indicate whether the party is joinable or invite-only.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41649
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
