### PR TITLE
Add wrapper class for integer values in Tuya models

### DIFF
--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -190,6 +190,22 @@ class DPCodeEnumWrapper(DPCodeWrapper):
         return None
 
 
+class DPCodeIntegerWrapper(DPCodeWrapper):
+    """Simple wrapper for IntegerTypeData values."""
+
+    type_information: IntegerTypeData
+
+    def read_device_status(self, device: CustomerDevice) -> float | None:
+        """Read the device value for the dpcode.
+
+        Value will be scaled based on the Integer type information
+        return None.
+        """
+        if (raw_value := self._read_device_status_raw(device)) is None:
+            return None
+        return self.type_information.scale_value(raw_value)
+
+
 @overload
 def find_dpcode(
     device: CustomerDevice,

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -139,7 +139,7 @@ class DPCodeWrapper:
 
     def read_device_status(self, device: CustomerDevice) -> Any | None:
         """Read the device value for the dpcode."""
-        raise NotImplementedError("read_device_value must be implemented")
+        raise NotImplementedError("read_device_status must be implemented")
 
 
 @dataclass

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -204,6 +204,21 @@ class DPCodeIntegerWrapper(DPCodeWrapper):
             return None
         return self.type_information.scale_value(raw_value)
 
+    @classmethod
+    def find_dpcode(
+        cls,
+        device: CustomerDevice,
+        dpcodes: str | DPCode | tuple[DPCode, ...],
+        *,
+        prefer_function: bool = False,
+    ) -> Self | None:
+        """Find and return a DPCodeIntegerWrapper for the given DP codes."""
+        if int_type := find_dpcode(
+            device, dpcodes, dptype=DPType.INTEGER, prefer_function=prefer_function
+        ):
+            return cls(dpcode=int_type.dpcode, integer_type_information=int_type)
+        return None
+
 
 @overload
 def find_dpcode(

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -120,6 +120,7 @@ _TYPE_INFORMATION_MAPPINGS: dict[DPType, type[TypeInformation]] = {
 }
 
 
+@dataclass
 class DPCodeWrapper:
     """Base DPCode wrapper.
 

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -198,8 +198,7 @@ class DPCodeIntegerWrapper(DPCodeWrapper):
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode.
 
-        Value will be scaled based on the Integer type information
-        return None.
+        Value will be scaled based on the Integer type information.
         """
         if (raw_value := self._read_device_status_raw(device)) is None:
             return None

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -171,7 +171,7 @@ class DPCodeTypeInformationWrapper[T: TypeInformation](DPCodeWrapper):
         *,
         prefer_function: bool = False,
     ) -> Self | None:
-        """Find and return a DPCodeIntegerWrapper for the given DP codes."""
+        """Find and return a DPCodeTypeInformationWrapper for the given DP codes."""
         if type_information := find_dpcode(  # type: ignore[call-overload]
             device, dpcodes, dptype=cls.dptype, prefer_function=prefer_function
         ):

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -120,7 +120,6 @@ _TYPE_INFORMATION_MAPPINGS: dict[DPType, type[TypeInformation]] = {
 }
 
 
-@dataclass
 class DPCodeWrapper:
     """Base DPCode wrapper.
 
@@ -160,7 +159,7 @@ class DPCodeBooleanWrapper(DPCodeWrapper):
 class DPCodeEnumWrapper(DPCodeWrapper):
     """Simple wrapper for EnumTypeData values."""
 
-    type_information: EnumTypeData
+    enum_type_information: EnumTypeData
 
     def read_device_status(self, device: CustomerDevice) -> str | None:
         """Read the device value for the dpcode.
@@ -170,7 +169,7 @@ class DPCodeEnumWrapper(DPCodeWrapper):
         """
         if (
             raw_value := self._read_device_status_raw(device)
-        ) in self.type_information.range:
+        ) in self.enum_type_information.range:
             return raw_value
         return None
 
@@ -186,14 +185,15 @@ class DPCodeEnumWrapper(DPCodeWrapper):
         if enum_type := find_dpcode(
             device, dpcodes, dptype=DPType.ENUM, prefer_function=prefer_function
         ):
-            return cls(dpcode=enum_type.dpcode, type_information=enum_type)
+            return cls(dpcode=enum_type.dpcode, enum_type_information=enum_type)
         return None
 
 
+@dataclass(kw_only=True)
 class DPCodeIntegerWrapper(DPCodeWrapper):
     """Simple wrapper for IntegerTypeData values."""
 
-    type_information: IntegerTypeData
+    integer_type_information: IntegerTypeData
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode.
@@ -202,7 +202,7 @@ class DPCodeIntegerWrapper(DPCodeWrapper):
         """
         if (raw_value := self._read_device_status_raw(device)) is None:
             return None
-        return raw_value / (10**self.type_information.scale)
+        return raw_value / (10**self.integer_type_information.scale)
 
     @classmethod
     def find_dpcode(
@@ -216,7 +216,7 @@ class DPCodeIntegerWrapper(DPCodeWrapper):
         if int_type := find_dpcode(
             device, dpcodes, dptype=DPType.INTEGER, prefer_function=prefer_function
         ):
-            return cls(dpcode=int_type.dpcode, type_information=int_type)
+            return cls(dpcode=int_type.dpcode, integer_type_information=int_type)
         return None
 
 

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -202,7 +202,7 @@ class DPCodeIntegerWrapper(DPCodeWrapper):
         """
         if (raw_value := self._read_device_status_raw(device)) is None:
             return None
-        return self.type_information.scale_value(raw_value)
+        return raw_value / (10**self.type_information.scale)
 
     @classmethod
     def find_dpcode(
@@ -216,7 +216,7 @@ class DPCodeIntegerWrapper(DPCodeWrapper):
         if int_type := find_dpcode(
             device, dpcodes, dptype=DPType.INTEGER, prefer_function=prefer_function
         ):
-            return cls(dpcode=int_type.dpcode, integer_type_information=int_type)
+            return cls(dpcode=int_type.dpcode, type_information=int_type)
         return None
 
 

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -6,7 +6,7 @@ import base64
 from dataclasses import dataclass
 import json
 import struct
-from typing import Any, Literal, Self, overload
+from typing import Any, ClassVar, Literal, Self, overload
 
 from tuya_sharing import CustomerDevice
 
@@ -160,7 +160,7 @@ class DPCodeBooleanWrapper(DPCodeWrapper):
 class DPCodeTypeInformationWrapper[T: TypeInformation](DPCodeWrapper):
     """Base DPCode wrapper with Type Information."""
 
-    dptype: DPType = None  # type: ignore[assignment]
+    dptype: ClassVar[DPType]
     type_information: T
 
     @classmethod

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -26,8 +26,7 @@ from .const import (
     DPType,
 )
 from .entity import TuyaEntity
-from .models import IntegerTypeData, find_dpcode
-from .util import ActionDPCodeNotFoundError
+from .models import DPCodeIntegerWrapper, IntegerTypeData, find_dpcode
 
 NUMBERS: dict[DeviceCategory, tuple[NumberEntityDescription, ...]] = {
     DeviceCategory.BH: (
@@ -456,9 +455,23 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := NUMBERS.get(device.category):
                 entities.extend(
-                    TuyaNumberEntity(device, manager, description)
+                    TuyaNumberEntity(
+                        device,
+                        manager,
+                        description,
+                        DPCodeIntegerWrapper(
+                            dpcode=int_type.dpcode, integer_type_information=int_type
+                        ),
+                    )
                     for description in descriptions
-                    if description.key in device.status
+                    if (
+                        int_type := find_dpcode(
+                            device,
+                            description.key,
+                            dptype=DPType.INTEGER,
+                            prefer_function=True,
+                        )
+                    )
                 )
 
         async_add_entities(entities)
@@ -480,21 +493,21 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: NumberEntityDescription,
+        dpcode_wrapper: DPCodeIntegerWrapper,
     ) -> None:
         """Init Tuya sensor."""
         super().__init__(device, device_manager)
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._dpcode_wrapper = dpcode_wrapper
 
-        if int_type := find_dpcode(
-            self.device, description.key, dptype=DPType.INTEGER, prefer_function=True
-        ):
-            self._number = int_type
-            self._attr_native_max_value = self._number.max_scaled
-            self._attr_native_min_value = self._number.min_scaled
-            self._attr_native_step = self._number.step_scaled
-            if description.native_unit_of_measurement is None:
-                self._attr_native_unit_of_measurement = int_type.unit
+        self._attr_native_max_value = dpcode_wrapper.integer_type_information.max_scaled
+        self._attr_native_min_value = dpcode_wrapper.integer_type_information.min_scaled
+        self._attr_native_step = dpcode_wrapper.integer_type_information.step_scaled
+        if description.native_unit_of_measurement is None:
+            self._attr_native_unit_of_measurement = (
+                dpcode_wrapper.integer_type_information.unit
+            )
 
         # Logic to ensure the set device class and API received Unit Of Measurement
         # match Home Assistants requirements.
@@ -538,26 +551,19 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
     @property
     def native_value(self) -> float | None:
         """Return the entity value to represent the entity state."""
-        # Unknown or unsupported data type
-        if self._number is None:
-            return None
-
-        # Raw value
-        if (value := self.device.status.get(self.entity_description.key)) is None:
-            return None
-
-        return self._number.scale_value(value)
+        return self._dpcode_wrapper.read_device_status(self.device)
 
     def set_native_value(self, value: float) -> None:
         """Set new value."""
-        if self._number is None:
-            raise ActionDPCodeNotFoundError(self.device, self.entity_description.key)
-
         self._send_command(
             [
                 {
-                    "code": self.entity_description.key,
-                    "value": self._number.scale_value_back(value),
+                    "code": self._dpcode_wrapper.dpcode,
+                    "value": (
+                        self._dpcode_wrapper.integer_type_information.scale_value_back(
+                            value
+                        )
+                    ),
                 }
             ]
         )

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -490,13 +490,11 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._dpcode_wrapper = dpcode_wrapper
 
-        self._attr_native_max_value = dpcode_wrapper.integer_type_information.max_scaled
-        self._attr_native_min_value = dpcode_wrapper.integer_type_information.min_scaled
-        self._attr_native_step = dpcode_wrapper.integer_type_information.step_scaled
+        self._attr_native_max_value = dpcode_wrapper.type_information.max_scaled
+        self._attr_native_min_value = dpcode_wrapper.type_information.min_scaled
+        self._attr_native_step = dpcode_wrapper.type_information.step_scaled
         if description.native_unit_of_measurement is None:
-            self._attr_native_unit_of_measurement = (
-                dpcode_wrapper.integer_type_information.unit
-            )
+            self._attr_native_unit_of_measurement = dpcode_wrapper.type_information.unit
 
         # Logic to ensure the set device class and API received Unit Of Measurement
         # match Home Assistants requirements.
@@ -549,9 +547,7 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
                 {
                     "code": self._dpcode_wrapper.dpcode,
                     "value": (
-                        self._dpcode_wrapper.integer_type_information.scale_value_back(
-                            value
-                        )
+                        self._dpcode_wrapper.type_information.scale_value_back(value)
                     ),
                 }
             ]

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -23,10 +23,9 @@ from .const import (
     TUYA_DISCOVERY_NEW,
     DeviceCategory,
     DPCode,
-    DPType,
 )
 from .entity import TuyaEntity
-from .models import DPCodeIntegerWrapper, IntegerTypeData, find_dpcode
+from .models import DPCodeIntegerWrapper, IntegerTypeData
 
 NUMBERS: dict[DeviceCategory, tuple[NumberEntityDescription, ...]] = {
     DeviceCategory.BH: (
@@ -455,21 +454,11 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := NUMBERS.get(device.category):
                 entities.extend(
-                    TuyaNumberEntity(
-                        device,
-                        manager,
-                        description,
-                        DPCodeIntegerWrapper(
-                            dpcode=int_type.dpcode, integer_type_information=int_type
-                        ),
-                    )
+                    TuyaNumberEntity(device, manager, description, dpcode_wrapper)
                     for description in descriptions
                     if (
-                        int_type := find_dpcode(
-                            device,
-                            description.key,
-                            dptype=DPType.INTEGER,
-                            prefer_function=True,
+                        dpcode_wrapper := DPCodeIntegerWrapper.find_dpcode(
+                            device, description.key, prefer_function=True
                         )
                     )
                 )

--- a/tests/components/tuya/test_number.py
+++ b/tests/components/tuya/test_number.py
@@ -15,7 +15,6 @@ from homeassistant.components.number import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from . import initialize_entry
@@ -66,46 +65,3 @@ async def test_set_value(
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id, [{"code": "delay_set", "value": 18}]
     )
-
-
-@pytest.mark.parametrize(
-    "mock_device_code",
-    ["mal_gyitctrjj1kefxp2"],
-)
-async def test_set_value_no_function(
-    hass: HomeAssistant,
-    mock_manager: Manager,
-    mock_config_entry: MockConfigEntry,
-    mock_device: CustomerDevice,
-) -> None:
-    """Test set value when no function available."""
-
-    # Mock a device with delay_set in status but not in function or status_range
-    mock_device.function.pop("delay_set")
-    mock_device.status_range.pop("delay_set")
-
-    entity_id = "number.multifunction_alarm_arm_delay"
-    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
-
-    state = hass.states.get(entity_id)
-    assert state is not None, f"{entity_id} does not exist"
-    with pytest.raises(ServiceValidationError) as err:
-        await hass.services.async_call(
-            NUMBER_DOMAIN,
-            SERVICE_SET_VALUE,
-            {
-                ATTR_ENTITY_ID: entity_id,
-                ATTR_VALUE: 18,
-            },
-            blocking=True,
-        )
-    assert err.value.translation_key == "action_dpcode_not_found"
-    assert err.value.translation_placeholders == {
-        "expected": "['delay_set']",
-        "available": (
-            "['alarm_delay_time', 'alarm_time', 'master_mode', 'master_state', "
-            "'muffling', 'sub_admin', 'sub_class', 'switch_alarm_light', "
-            "'switch_alarm_propel', 'switch_alarm_sound', 'switch_kb_light', "
-            "'switch_kb_sound', 'switch_mode_sound']"
-        ),
-    }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a common base class for "reading and converting raw values from Tuya Device".
Linked to #156232

Migrate `number` platform to use this base class, and adjust calls accordingly.
See #155847 for equivalent PR on `select` platforms.
See #155905 for equivalent PR on `switch` and `valve` platforms.

### Background info

The problem at present is that we have lots of different ways to refer to a Tuya DPCode (=Tuya data-point)
Sometimes we refer to it directly:
```python
    self._send_command([{"code": DPCode.SUCTION, "value": fan_speed}])`
    return self.device.status.get(DPCode.STATUS)
```
Sometimes we refer to it via the description key
```python
    self._send_command([{"code": self.entity_description.key, "value": False}])
    return self.device.status.get(self.entity_description.key, False)
```
Sometimes we refer to it via the type information
```python
    self._send_command([{"code": self._presets.dpcode, "value": preset_mode}])
    return self.device.status.get(self._presets.dpcode)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
