### PR TITLE
Prevent overriding default values when restoring descriptions in passive bluetooth update processor

### DIFF
--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -102,7 +102,7 @@ def deserialize_entity_description(
         # Only set fields that are in the data
         # otherwise we would override default values with None
         # causing side effects
-        if field_name in data:
+        if field_name not in data:
             continue
 
         # It would be nice if field.type returned the actual

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -99,16 +99,20 @@ def deserialize_entity_description(
         descriptions_class = descriptions_class._dataclass  # noqa: SLF001
     for field in cached_fields(descriptions_class):
         field_name = field.name
-        # It would be nice if field.type returned the actual
-        # type instead of a str so we could avoid writing this
-        # out, but it doesn't. If we end up using this in more
-        # places we can add a `as_dict` and a `from_dict`
-        # method to these classes
-        if field_name == CONF_ENTITY_CATEGORY:
-            value = try_parse_enum(EntityCategory, data.get(field_name))
-        else:
-            value = data.get(field_name)
-        result[field_name] = value
+        # Only set fields that are in the data
+        # otherwise we would override default values with None
+        # causing side effects
+        if field_name in data:
+            # It would be nice if field.type returned the actual
+            # type instead of a str so we could avoid writing this
+            # out, but it doesn't. If we end up using this in more
+            # places we can add a `as_dict` and a `from_dict`
+            # method to these classes
+            if field_name == CONF_ENTITY_CATEGORY:
+                value = try_parse_enum(EntityCategory, data.get(field_name))
+            else:
+                value = data.get(field_name)
+            result[field_name] = value
     return descriptions_class(**result)
 
 

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -103,16 +103,18 @@ def deserialize_entity_description(
         # otherwise we would override default values with None
         # causing side effects
         if field_name in data:
-            # It would be nice if field.type returned the actual
-            # type instead of a str so we could avoid writing this
-            # out, but it doesn't. If we end up using this in more
-            # places we can add a `as_dict` and a `from_dict`
-            # method to these classes
-            if field_name == CONF_ENTITY_CATEGORY:
-                value = try_parse_enum(EntityCategory, data.get(field_name))
-            else:
-                value = data.get(field_name)
-            result[field_name] = value
+            continue
+
+        # It would be nice if field.type returned the actual
+        # type instead of a str so we could avoid writing this
+        # out, but it doesn't. If we end up using this in more
+        # places we can add a `as_dict` and a `from_dict`
+        # method to these classes
+        if field_name == CONF_ENTITY_CATEGORY:
+            value = try_parse_enum(EntityCategory, data.get(field_name))
+        else:
+            value = data.get(field_name)
+        result[field_name] = value
     return descriptions_class(**result)
 
 

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -1967,10 +1967,10 @@ async def test_naming(hass: HomeAssistant) -> None:
         ),
     ],
 )
-async def test_deserialize_entity_description(
+def test_deserialize_entity_description(
     description_type: type[EntityDescription],
     description_dict: dict[str, Any],
-    expected_description: SensorEntityDescription,
+    expected_description: EntityDescription,
 ) -> None:
     """Test deserializing an entity description."""
     description = deserialize_entity_description(description_type, description_dict)

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -31,11 +31,13 @@ from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothEntityKey,
     PassiveBluetoothProcessorCoordinator,
     PassiveBluetoothProcessorEntity,
+    deserialize_entity_description,
 )
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.config_entries import current_entry
 from homeassistant.const import UnitOfTemperature
@@ -1920,3 +1922,23 @@ async def test_naming(hass: HomeAssistant) -> None:
     assert sensor_entity.translation_key is None
 
     cancel_coordinator()
+
+
+async def test_deserialize_entity_description() -> None:
+    """Test deserializing an entity description."""
+    description_dict = {
+        "key": "temperature",
+        "native_unit_of_measurement": "°C",
+        "device_class": "temperature",
+        "state_class": "measurement",
+    }
+    description = deserialize_entity_description(
+        SensorEntityDescription, description_dict
+    )
+
+    assert description == SensorEntityDescription(
+        key="temperature",
+        native_unit_of_measurement="°C",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+    )


### PR DESCRIPTION
## Proposed change
While doing the entity translations for BTHome, I noticed that the names of the BTHome entities changed in the device names every time Home Assistant was restarted. 

I looked into this and found that when restoring entity descriptions in the passive Bluetooth update processor from storage, we create the data class. However, we always overwrite the default values of the data class with `None` without checking whether the field exists in the restored data.

What causes the entities to use the device name, since the `name = None` rule now applies.

This PR addresses this now and checks if the field name is present in the restored data before setting it.
This now prevents changing names after a restart.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
…criptions in passive bluetooth update processor