### PR TITLE
Make BTHome sensor entities translatable

### DIFF
--- a/homeassistant/components/bthome/sensor.py
+++ b/homeassistant/components/bthome/sensor.py
@@ -59,6 +59,7 @@ SENSOR_DESCRIPTIONS = {
         key=f"{BTHomeSensorDeviceClass.ACCELERATION}_{Units.ACCELERATION_METERS_PER_SQUARE_SECOND}",
         native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="acceleration",
     ),
     # Battery (percent)
     (BTHomeSensorDeviceClass.BATTERY, Units.PERCENTAGE): SensorEntityDescription(
@@ -72,6 +73,7 @@ SENSOR_DESCRIPTIONS = {
     (BTHomeExtendedSensorDeviceClass.CHANNEL, None): SensorEntityDescription(
         key=str(BTHomeExtendedSensorDeviceClass.CHANNEL),
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="channel",
     ),
     # Conductivity (μS/cm)
     (
@@ -87,6 +89,7 @@ SENSOR_DESCRIPTIONS = {
     (BTHomeSensorDeviceClass.COUNT, None): SensorEntityDescription(
         key=str(BTHomeSensorDeviceClass.COUNT),
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="count",
     ),
     # CO2 (parts per million)
     (
@@ -114,12 +117,14 @@ SENSOR_DESCRIPTIONS = {
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="dew_point",
     ),
     # Directions (°)
     (BTHomeExtendedSensorDeviceClass.DIRECTION, Units.DEGREE): SensorEntityDescription(
         key=f"{BTHomeExtendedSensorDeviceClass.DIRECTION}_{Units.DEGREE}",
         native_unit_of_measurement=DEGREE,
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="direction",
     ),
     # Distance (mm)
     (
@@ -173,6 +178,7 @@ SENSOR_DESCRIPTIONS = {
         key=f"{BTHomeSensorDeviceClass.GYROSCOPE}_{Units.GYROSCOPE_DEGREES_PER_SECOND}",
         native_unit_of_measurement=Units.GYROSCOPE_DEGREES_PER_SECOND,
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="gyroscope",
     ),
     # Humidity in (percent)
     (BTHomeSensorDeviceClass.HUMIDITY, Units.PERCENTAGE): SensorEntityDescription(
@@ -215,6 +221,7 @@ SENSOR_DESCRIPTIONS = {
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        translation_key="packet_id",
     ),
     # PM10 (μg/m3)
     (
@@ -263,12 +270,14 @@ SENSOR_DESCRIPTIONS = {
     # Raw (-)
     (BTHomeExtendedSensorDeviceClass.RAW, None): SensorEntityDescription(
         key=str(BTHomeExtendedSensorDeviceClass.RAW),
+        translation_key="raw",
     ),
     # Rotation (°)
     (BTHomeSensorDeviceClass.ROTATION, Units.DEGREE): SensorEntityDescription(
         key=f"{BTHomeSensorDeviceClass.ROTATION}_{Units.DEGREE}",
         native_unit_of_measurement=DEGREE,
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="rotation",
     ),
     # Rotational speed (rpm)
     (
@@ -278,6 +287,7 @@ SENSOR_DESCRIPTIONS = {
         key=f"{BTHomeExtendedSensorDeviceClass.ROTATIONAL_SPEED}_{Units.REVOLUTIONS_PER_MINUTE}",
         native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="rotational_speed",
     ),
     # Signal Strength (RSSI) (dB)
     (
@@ -311,6 +321,7 @@ SENSOR_DESCRIPTIONS = {
     # Text (-)
     (BTHomeExtendedSensorDeviceClass.TEXT, None): SensorEntityDescription(
         key=str(BTHomeExtendedSensorDeviceClass.TEXT),
+        translation_key="text",
     ),
     # Timestamp (datetime object)
     (
@@ -327,6 +338,7 @@ SENSOR_DESCRIPTIONS = {
     ): SensorEntityDescription(
         key=str(BTHomeSensorDeviceClass.UV_INDEX),
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="uv_index",
     ),
     # Volatile organic Compounds (VOC) (μg/m3)
     (
@@ -423,10 +435,7 @@ def sensor_update_to_bluetooth_data_update(
             )
             for device_key, sensor_values in sensor_update.entity_values.items()
         },
-        entity_names={
-            device_key_to_bluetooth_entity_key(device_key): sensor_values.name
-            for device_key, sensor_values in sensor_update.entity_values.items()
-        },
+        entity_names={},
     )
 
 

--- a/homeassistant/components/bthome/strings.json
+++ b/homeassistant/components/bthome/strings.json
@@ -78,6 +78,44 @@
           }
         }
       }
+    },
+    "sensor": {
+      "acceleration": {
+        "name": "Acceleration"
+      },
+      "channel": {
+        "name": "Channel"
+      },
+      "count": {
+        "name": "Count"
+      },
+      "dew_point": {
+        "name": "Dew Point"
+      },
+      "direction": {
+        "name": "Direction"
+      },
+      "gyroscope": {
+        "name": "Gyroscope"
+      },
+      "packet_id": {
+        "name": "Packet ID"
+      },
+      "raw": {
+        "name": "Raw"
+      },
+      "rotation": {
+        "name": "Rotation"
+      },
+      "rotational_speed": {
+        "name": "Rotational Speed"
+      },
+      "text": {
+        "name": "Text"
+      },
+      "uv_index": {
+        "name": "UV Index"
+      }
     }
   }
 }

--- a/homeassistant/components/bthome/strings.json
+++ b/homeassistant/components/bthome/strings.json
@@ -90,7 +90,7 @@
         "name": "Count"
       },
       "dew_point": {
-        "name": "Dew Point"
+        "name": "Dew point"
       },
       "direction": {
         "name": "Direction"
@@ -108,7 +108,7 @@
         "name": "Rotation"
       },
       "rotational_speed": {
-        "name": "Rotational Speed"
+        "name": "Rotational speed"
       },
       "text": {
         "name": "Text"

--- a/tests/components/bthome/test_sensor.py
+++ b/tests/components/bthome/test_sensor.py
@@ -168,7 +168,7 @@ _LOGGER = logging.getLogger(__name__)
             [
                 {
                     "sensor_entity": "sensor.test_device_18b2_dew_point",
-                    "friendly_name": "Test Device 18B2 Dew Point",
+                    "friendly_name": "Test Device 18B2 Dew point",
                     "unit_of_measurement": "°C",
                     "state_class": "measurement",
                     "expected_state": "17.38",
@@ -522,7 +522,7 @@ async def test_v1_sensors(
             [
                 {
                     "sensor_entity": "sensor.test_device_18b2_dew_point",
-                    "friendly_name": "Test Device 18B2 Dew Point",
+                    "friendly_name": "Test Device 18B2 Dew point",
                     "unit_of_measurement": "°C",
                     "state_class": "measurement",
                     "expected_state": "17.38",

--- a/tests/components/bthome/test_sensor.py
+++ b/tests/components/bthome/test_sensor.py
@@ -133,8 +133,8 @@ _LOGGER = logging.getLogger(__name__)
             None,
             [
                 {
-                    "sensor_entity": "sensor.test_device_18b2_mass",
-                    "friendly_name": "Test Device 18B2 Mass",
+                    "sensor_entity": "sensor.test_device_18b2_weight",
+                    "friendly_name": "Test Device 18B2 Weight",
                     "unit_of_measurement": "kg",
                     "state_class": "measurement",
                     "expected_state": "80.3",
@@ -150,8 +150,8 @@ _LOGGER = logging.getLogger(__name__)
             None,
             [
                 {
-                    "sensor_entity": "sensor.test_device_18b2_mass",
-                    "friendly_name": "Test Device 18B2 Mass",
+                    "sensor_entity": "sensor.test_device_18b2_weight",
+                    "friendly_name": "Test Device 18B2 Weight",
                     "unit_of_measurement": "lb",
                     "state_class": "measurement",
                     "expected_state": "74.86",
@@ -252,14 +252,14 @@ _LOGGER = logging.getLogger(__name__)
             [
                 {
                     "sensor_entity": "sensor.test_device_18b2_pm10",
-                    "friendly_name": "Test Device 18B2 Pm10",
+                    "friendly_name": "Test Device 18B2 PM10",
                     "unit_of_measurement": "μg/m³",
                     "state_class": "measurement",
                     "expected_state": "7170",
                 },
                 {
-                    "sensor_entity": "sensor.test_device_18b2_pm25",
-                    "friendly_name": "Test Device 18B2 Pm25",
+                    "sensor_entity": "sensor.test_device_18b2_pm2_5",
+                    "friendly_name": "Test Device 18B2 PM2.5",
                     "unit_of_measurement": "μg/m³",
                     "state_class": "measurement",
                     "expected_state": "3090",
@@ -276,7 +276,7 @@ _LOGGER = logging.getLogger(__name__)
             [
                 {
                     "sensor_entity": "sensor.test_device_18b2_carbon_dioxide",
-                    "friendly_name": "Test Device 18B2 Carbon Dioxide",
+                    "friendly_name": "Test Device 18B2 Carbon dioxide",
                     "unit_of_measurement": "ppm",
                     "state_class": "measurement",
                     "expected_state": "1250",
@@ -295,7 +295,7 @@ _LOGGER = logging.getLogger(__name__)
                     "sensor_entity": (
                         "sensor.test_device_18b2_volatile_organic_compounds"
                     ),
-                    "friendly_name": "Test Device 18B2 Volatile Organic Compounds",
+                    "friendly_name": "Test Device 18B2 Volatile organic compounds",
                     "unit_of_measurement": "μg/m³",
                     "state_class": "measurement",
                     "expected_state": "307",
@@ -487,8 +487,8 @@ async def test_v1_sensors(
             None,
             [
                 {
-                    "sensor_entity": "sensor.test_device_18b2_mass",
-                    "friendly_name": "Test Device 18B2 Mass",
+                    "sensor_entity": "sensor.test_device_18b2_weight",
+                    "friendly_name": "Test Device 18B2 Weight",
                     "unit_of_measurement": "kg",
                     "state_class": "measurement",
                     "expected_state": "80.3",
@@ -504,8 +504,8 @@ async def test_v1_sensors(
             None,
             [
                 {
-                    "sensor_entity": "sensor.test_device_18b2_mass",
-                    "friendly_name": "Test Device 18B2 Mass",
+                    "sensor_entity": "sensor.test_device_18b2_weight",
+                    "friendly_name": "Test Device 18B2 Weight",
                     "unit_of_measurement": "lb",
                     "state_class": "measurement",
                     "expected_state": "74.86",
@@ -606,14 +606,14 @@ async def test_v1_sensors(
             [
                 {
                     "sensor_entity": "sensor.test_device_18b2_pm10",
-                    "friendly_name": "Test Device 18B2 Pm10",
+                    "friendly_name": "Test Device 18B2 PM10",
                     "unit_of_measurement": "μg/m³",
                     "state_class": "measurement",
                     "expected_state": "7170",
                 },
                 {
-                    "sensor_entity": "sensor.test_device_18b2_pm25",
-                    "friendly_name": "Test Device 18B2 Pm25",
+                    "sensor_entity": "sensor.test_device_18b2_pm2_5",
+                    "friendly_name": "Test Device 18B2 PM2.5",
                     "unit_of_measurement": "μg/m³",
                     "state_class": "measurement",
                     "expected_state": "3090",
@@ -630,7 +630,7 @@ async def test_v1_sensors(
             [
                 {
                     "sensor_entity": "sensor.test_device_18b2_carbon_dioxide",
-                    "friendly_name": "Test Device 18B2 Carbon Dioxide",
+                    "friendly_name": "Test Device 18B2 Carbon dioxide",
                     "unit_of_measurement": "ppm",
                     "state_class": "measurement",
                     "expected_state": "1250",
@@ -649,7 +649,7 @@ async def test_v1_sensors(
                     "sensor_entity": (
                         "sensor.test_device_18b2_volatile_organic_compounds"
                     ),
-                    "friendly_name": "Test Device 18B2 Volatile Organic Compounds",
+                    "friendly_name": "Test Device 18B2 Volatile organic compounds",
                     "unit_of_measurement": "μg/m³",
                     "state_class": "measurement",
                     "expected_state": "307",
@@ -802,7 +802,7 @@ async def test_v1_sensors(
             [
                 {
                     "sensor_entity": "sensor.test_device_18b2_uv_index",
-                    "friendly_name": "Test Device 18B2 Uv Index",
+                    "friendly_name": "Test Device 18B2 UV Index",
                     "state_class": "measurement",
                     "expected_state": "5.0",
                 },
@@ -852,7 +852,7 @@ async def test_v1_sensors(
             [
                 {
                     "sensor_entity": "sensor.test_device_18b2_volume_flow_rate",
-                    "friendly_name": "Test Device 18B2 Volume Flow Rate",
+                    "friendly_name": "Test Device 18B2 Volume flow rate",
                     "unit_of_measurement": "m³/h",
                     "state_class": "measurement",
                     "expected_state": "34.78",
@@ -982,8 +982,8 @@ async def test_v1_sensors(
             None,
             [
                 {
-                    "sensor_entity": "sensor.test_device_18b2_volume_storage",
-                    "friendly_name": "Test Device 18B2 Volume Storage",
+                    "sensor_entity": "sensor.test_device_18b2_stored_volume",
+                    "friendly_name": "Test Device 18B2 Stored volume",
                     "unit_of_measurement": "L",
                     "state_class": "measurement",
                     "expected_state": "19551.879",
@@ -999,15 +999,15 @@ async def test_v1_sensors(
             None,
             [
                 {
-                    "sensor_entity": "sensor.test_device_18b2_temperature_1",
-                    "friendly_name": "Test Device 18B2 Temperature 1",
+                    "sensor_entity": "sensor.test_device_18b2_temperature",
+                    "friendly_name": "Test Device 18B2 Temperature",
                     "unit_of_measurement": "°C",
                     "state_class": "measurement",
                     "expected_state": "25.06",
                 },
                 {
                     "sensor_entity": "sensor.test_device_18b2_temperature_2",
-                    "friendly_name": "Test Device 18B2 Temperature 2",
+                    "friendly_name": "Test Device 18B2 Temperature",
                     "unit_of_measurement": "°C",
                     "state_class": "measurement",
                     "expected_state": "25.11",
@@ -1023,36 +1023,36 @@ async def test_v1_sensors(
             None,
             [
                 {
-                    "sensor_entity": "sensor.test_device_18b2_temperature_1",
-                    "friendly_name": "Test Device 18B2 Temperature 1",
+                    "sensor_entity": "sensor.test_device_18b2_temperature",
+                    "friendly_name": "Test Device 18B2 Temperature",
                     "unit_of_measurement": "°C",
                     "state_class": "measurement",
                     "expected_state": "25.06",
                 },
                 {
                     "sensor_entity": "sensor.test_device_18b2_temperature_2",
-                    "friendly_name": "Test Device 18B2 Temperature 2",
+                    "friendly_name": "Test Device 18B2 Temperature",
                     "unit_of_measurement": "°C",
                     "state_class": "measurement",
                     "expected_state": "25.11",
                 },
                 {
                     "sensor_entity": "sensor.test_device_18b2_temperature_3",
-                    "friendly_name": "Test Device 18B2 Temperature 3",
+                    "friendly_name": "Test Device 18B2 Temperature",
                     "unit_of_measurement": "°C",
                     "state_class": "measurement",
                     "expected_state": "22.55",
                 },
                 {
-                    "sensor_entity": "sensor.test_device_18b2_humidity_1",
-                    "friendly_name": "Test Device 18B2 Humidity 1",
+                    "sensor_entity": "sensor.test_device_18b2_humidity",
+                    "friendly_name": "Test Device 18B2 Humidity",
                     "unit_of_measurement": "%",
                     "state_class": "measurement",
                     "expected_state": "63.27",
                 },
                 {
                     "sensor_entity": "sensor.test_device_18b2_humidity_2",
-                    "friendly_name": "Test Device 18B2 Humidity 2",
+                    "friendly_name": "Test Device 18B2 Humidity",
                     "unit_of_measurement": "%",
                     "state_class": "measurement",
                     "expected_state": "60.71",


### PR DESCRIPTION
## Proposed change
Make the BTHome sensor entities translatable. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
