### PR TITLE
Add Shelly update translation

### DIFF
--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -393,6 +393,11 @@
       "water_temperature": {
         "name": "Water temperature"
       }
+    },
+    "update": {
+      "beta_firmware": {
+        "name": "Beta firmware"
+      }
     }
   },
   "exceptions": {

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -23,6 +23,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_registry import RegistryEntry
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
@@ -68,7 +69,6 @@ class RestUpdateDescription(RestEntityDescription, UpdateEntityDescription):
 
 REST_UPDATES: Final = {
     "fwupdate": RestUpdateDescription(
-        name="Firmware",
         key="fwupdate",
         latest_version=lambda status: status["update"]["new_version"],
         beta=False,
@@ -77,8 +77,8 @@ REST_UPDATES: Final = {
         entity_registry_enabled_default=False,
     ),
     "fwupdate_beta": RestUpdateDescription(
-        name="Beta firmware",
         key="fwupdate",
+        translation_key="beta_firmware",
         latest_version=lambda status: status["update"].get("beta_version"),
         beta=True,
         device_class=UpdateDeviceClass.FIRMWARE,
@@ -89,7 +89,6 @@ REST_UPDATES: Final = {
 
 RPC_UPDATES: Final = {
     "fwupdate": RpcUpdateDescription(
-        name="Firmware",
         key="sys",
         sub_key="available_updates",
         latest_version=lambda status: status.get("stable", {"version": ""})["version"],
@@ -98,9 +97,9 @@ RPC_UPDATES: Final = {
         entity_category=EntityCategory.CONFIG,
     ),
     "fwupdate_beta": RpcUpdateDescription(
-        name="Beta firmware",
         key="sys",
         sub_key="available_updates",
+        translation_key="beta_firmware",
         latest_version=lambda status: status.get("beta", {"version": ""})["version"],
         beta=True,
         device_class=UpdateDeviceClass.FIRMWARE,
@@ -182,6 +181,9 @@ class RestUpdateEntity(ShellyRestAttributeEntity, UpdateEntity):
             description.beta,
         )
         self._in_progress_old_version: str | None = None
+
+        if hasattr(self, "_attr_name"):
+            delattr(self, "_attr_name")
 
     @property
     def installed_version(self) -> str | None:
@@ -275,6 +277,9 @@ class RpcUpdateEntity(ShellyRpcAttributeEntity, UpdateEntity):
         self._attr_release_url = get_release_url(
             coordinator.device.gen, coordinator.model, description.beta
         )
+
+        if hasattr(self, "_attr_name"):
+            delattr(self, "_attr_name")
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
@@ -370,6 +375,20 @@ class RpcSleepingUpdateEntity(
     """Represent a RPC sleeping update entity."""
 
     entity_description: RpcUpdateDescription
+
+    def __init__(
+        self,
+        coordinator: ShellyRpcCoordinator,
+        key: str,
+        attribute: str,
+        description: RpcUpdateDescription,
+        entry: RegistryEntry | None = None,
+    ) -> None:
+        """Initialize the sleeping sensor."""
+        super().__init__(coordinator, key, attribute, description, entry)
+
+        if hasattr(self, "_attr_name"):
+            delattr(self, "_attr_name")
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -786,7 +786,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 5>,
-    'translation_key': None,
+    'translation_key': 'beta_firmware',
     'unique_id': '123456789ABC-sys-fwupdate_beta',
     'unit_of_measurement': None,
   })
@@ -1343,7 +1343,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 5>,
-    'translation_key': None,
+    'translation_key': 'beta_firmware',
     'unique_id': '123456789ABC-sys-fwupdate_beta',
     'unit_of_measurement': None,
   })
@@ -4303,7 +4303,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 5>,
-    'translation_key': None,
+    'translation_key': 'beta_firmware',
     'unique_id': '123456789ABC-sys-fwupdate_beta',
     'unit_of_measurement': None,
   })
@@ -5037,7 +5037,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 5>,
-    'translation_key': None,
+    'translation_key': 'beta_firmware',
     'unique_id': '123456789ABC-sys-fwupdate_beta',
     'unit_of_measurement': None,
   })
@@ -5956,7 +5956,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 5>,
-    'translation_key': None,
+    'translation_key': 'beta_firmware',
     'unique_id': '123456789ABC-sys-fwupdate_beta',
     'unit_of_measurement': None,
   })
@@ -7010,7 +7010,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 5>,
-    'translation_key': None,
+    'translation_key': 'beta_firmware',
     'unique_id': '123456789ABC-sys-fwupdate_beta',
     'unit_of_measurement': None,
   })
@@ -8881,7 +8881,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 5>,
-    'translation_key': None,
+    'translation_key': 'beta_firmware',
     'unique_id': '123456789ABC-sys-fwupdate_beta',
     'unit_of_measurement': None,
   })
@@ -11000,7 +11000,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 5>,
-    'translation_key': None,
+    'translation_key': 'beta_firmware',
     'unique_id': '123456789ABC-sys-fwupdate_beta',
     'unit_of_measurement': None,
   })


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Road to completion:
https://github.com/home-assistant/core/blob/b157afac13b07f37fd2378dbc0611387e5461a77/homeassistant/components/shelly/quality_scale.yaml#L58

- Stage 2: https://github.com/home-assistant/core/pull/154116
- Stage 3: Add update translation
- Stage 4: https://github.com/home-assistant/core/pull/156146

Tested devices:
- [x] ...

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
