### PR TITLE
Migrate traccar_server to use entry.runtime_data

### DIFF
--- a/homeassistant/components/traccar_server/__init__.py
+++ b/homeassistant/components/traccar_server/__init__.py
@@ -24,9 +24,7 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import CONF_EVENTS, DOMAIN
-from .coordinator import TraccarServerCoordinator
-
-type TraccarServerConfigEntry = ConfigEntry[TraccarServerCoordinator]
+from .coordinator import TraccarServerConfigEntry, TraccarServerCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,

--- a/homeassistant/components/traccar_server/binary_sensor.py
+++ b/homeassistant/components/traccar_server/binary_sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from pytraccar import DeviceModel
 
@@ -17,11 +17,8 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import TraccarServerCoordinator
+from .coordinator import TraccarServerConfigEntry, TraccarServerCoordinator
 from .entity import TraccarServerEntity
-
-if TYPE_CHECKING:
-    from . import TraccarServerConfigEntry
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/traccar_server/binary_sensor.py
+++ b/homeassistant/components/traccar_server/binary_sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pytraccar import DeviceModel
 
@@ -13,14 +13,15 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import TraccarServerCoordinator
 from .entity import TraccarServerEntity
+
+if TYPE_CHECKING:
+    from . import TraccarServerConfigEntry
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -54,18 +55,18 @@ TRACCAR_SERVER_BINARY_SENSOR_ENTITY_DESCRIPTIONS: tuple[
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: TraccarServerConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up binary sensor entities."""
-    coordinator: TraccarServerCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     async_add_entities(
         TraccarServerBinarySensor(
             coordinator=coordinator,
-            device=entry["device"],
+            device=device_entry["device"],
             description=description,
         )
-        for entry in coordinator.data.values()
+        for device_entry in coordinator.data.values()
         for description in TRACCAR_SERVER_BINARY_SENSOR_ENTITY_DESCRIPTIONS
     )
 

--- a/homeassistant/components/traccar_server/coordinator.py
+++ b/homeassistant/components/traccar_server/coordinator.py
@@ -35,6 +35,8 @@ from .const import (
 )
 from .helpers import get_device, get_first_geofence, get_geofence_ids
 
+type TraccarServerConfigEntry = ConfigEntry[TraccarServerCoordinator]
+
 
 class TraccarServerCoordinatorDataDevice(TypedDict):
     """Traccar Server coordinator data."""
@@ -51,12 +53,12 @@ type TraccarServerCoordinatorData = dict[int, TraccarServerCoordinatorDataDevice
 class TraccarServerCoordinator(DataUpdateCoordinator[TraccarServerCoordinatorData]):
     """Class to manage fetching Traccar Server data."""
 
-    config_entry: ConfigEntry
+    config_entry: TraccarServerConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: TraccarServerConfigEntry,
         client: ApiClient,
     ) -> None:
         """Initialize global Traccar Server data updater."""

--- a/homeassistant/components/traccar_server/device_tracker.py
+++ b/homeassistant/components/traccar_server/device_tracker.py
@@ -2,28 +2,29 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.device_tracker import TrackerEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import ATTR_CATEGORY, ATTR_TRACCAR_ID, ATTR_TRACKER, DOMAIN
-from .coordinator import TraccarServerCoordinator
 from .entity import TraccarServerEntity
+
+if TYPE_CHECKING:
+    from . import TraccarServerConfigEntry
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: TraccarServerConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up device tracker entities."""
-    coordinator: TraccarServerCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     async_add_entities(
-        TraccarServerDeviceTracker(coordinator, entry["device"])
-        for entry in coordinator.data.values()
+        TraccarServerDeviceTracker(coordinator, device_entry["device"])
+        for device_entry in coordinator.data.values()
     )
 
 

--- a/homeassistant/components/traccar_server/device_tracker.py
+++ b/homeassistant/components/traccar_server/device_tracker.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import ATTR_CATEGORY, ATTR_TRACCAR_ID, ATTR_TRACKER, DOMAIN
+from .coordinator import TraccarServerConfigEntry
 from .entity import TraccarServerEntity
-
-if TYPE_CHECKING:
-    from . import TraccarServerConfigEntry
 
 
 async def async_setup_entry(

--- a/homeassistant/components/traccar_server/diagnostics.py
+++ b/homeassistant/components/traccar_server/diagnostics.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from homeassistant.components.diagnostics import REDACTED, async_redact_data
 from homeassistant.const import CONF_ADDRESS, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .coordinator import TraccarServerCoordinator
-
-if TYPE_CHECKING:
-    from . import TraccarServerConfigEntry
+from .coordinator import TraccarServerConfigEntry, TraccarServerCoordinator
 
 KEYS_TO_REDACT = {
     "area",  # This is the polygon area of a geofence
@@ -84,6 +81,8 @@ async def async_get_device_diagnostics(
         device_id=device.id,
         include_disabled_entities=True,
     )
+
+    await hass.config_entries.async_reload(entry.entry_id)
 
     return async_redact_data(
         {

--- a/homeassistant/components/traccar_server/diagnostics.py
+++ b/homeassistant/components/traccar_server/diagnostics.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.diagnostics import REDACTED, async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .const import DOMAIN
 from .coordinator import TraccarServerCoordinator
+
+if TYPE_CHECKING:
+    from . import TraccarServerConfigEntry
 
 KEYS_TO_REDACT = {
     "area",  # This is the polygon area of a geofence
@@ -39,10 +40,10 @@ def _entity_state(
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: TraccarServerConfigEntry,
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: TraccarServerCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
     entity_registry = er.async_get(hass)
 
     entities = er.async_entries_for_config_entry(
@@ -71,11 +72,11 @@ async def async_get_config_entry_diagnostics(
 
 async def async_get_device_diagnostics(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: TraccarServerConfigEntry,
     device: dr.DeviceEntry,
 ) -> dict[str, Any]:
     """Return device diagnostics."""
-    coordinator: TraccarServerCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     entity_registry = er.async_get(hass)
 
     entities = er.async_entries_for_device(
@@ -84,7 +85,6 @@ async def async_get_device_diagnostics(
         include_disabled_entities=True,
     )
 
-    await hass.config_entries.async_reload(entry.entry_id)
     return async_redact_data(
         {
             "subscription_status": coordinator.client.subscription_status,

--- a/homeassistant/components/traccar_server/sensor.py
+++ b/homeassistant/components/traccar_server/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pytraccar import DeviceModel, GeofenceModel, PositionModel
 
@@ -14,15 +14,16 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfLength, UnitOfSpeed
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .const import DOMAIN
 from .coordinator import TraccarServerCoordinator
 from .entity import TraccarServerEntity
+
+if TYPE_CHECKING:
+    from . import TraccarServerConfigEntry
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -82,18 +83,18 @@ TRACCAR_SERVER_SENSOR_ENTITY_DESCRIPTIONS: tuple[
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: TraccarServerConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up sensor entities."""
-    coordinator: TraccarServerCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     async_add_entities(
         TraccarServerSensor(
             coordinator=coordinator,
-            device=entry["device"],
+            device=device_entry["device"],
             description=description,
         )
-        for entry in coordinator.data.values()
+        for device_entry in coordinator.data.values()
         for description in TRACCAR_SERVER_SENSOR_ENTITY_DESCRIPTIONS
     )
 

--- a/homeassistant/components/traccar_server/sensor.py
+++ b/homeassistant/components/traccar_server/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from pytraccar import DeviceModel, GeofenceModel, PositionModel
 
@@ -19,11 +19,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .coordinator import TraccarServerCoordinator
+from .coordinator import TraccarServerConfigEntry, TraccarServerCoordinator
 from .entity import TraccarServerEntity
-
-if TYPE_CHECKING:
-    from . import TraccarServerConfigEntry
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/components/traccar_server/snapshots/test_diagnostics.ambr
+++ b/tests/components/traccar_server/snapshots/test_diagnostics.ambr
@@ -74,13 +74,24 @@
       dict({
         'disabled': False,
         'entity_id': 'binary_sensor.x_wing_motion',
-        'state': None,
+        'state': dict({
+          'attributes': dict({
+            'device_class': 'motion',
+            'friendly_name': 'X-Wing Motion',
+          }),
+          'state': 'off',
+        }),
         'unit_of_measurement': None,
       }),
       dict({
         'disabled': False,
         'entity_id': 'binary_sensor.x_wing_status',
-        'state': None,
+        'state': dict({
+          'attributes': dict({
+            'friendly_name': 'X-Wing Status',
+          }),
+          'state': 'on',
+        }),
         'unit_of_measurement': None,
       }),
       dict({
@@ -105,31 +116,64 @@
       dict({
         'disabled': False,
         'entity_id': 'sensor.x_wing_address',
-        'state': None,
+        'state': dict({
+          'attributes': dict({
+            'friendly_name': 'X-Wing Address',
+          }),
+          'state': '**REDACTED**',
+        }),
         'unit_of_measurement': None,
       }),
       dict({
         'disabled': False,
         'entity_id': 'sensor.x_wing_altitude',
-        'state': None,
+        'state': dict({
+          'attributes': dict({
+            'friendly_name': 'X-Wing Altitude',
+            'state_class': 'measurement',
+            'unit_of_measurement': 'm',
+          }),
+          'state': '546841384638',
+        }),
         'unit_of_measurement': 'm',
       }),
       dict({
         'disabled': False,
         'entity_id': 'sensor.x_wing_battery',
-        'state': None,
+        'state': dict({
+          'attributes': dict({
+            'device_class': 'battery',
+            'friendly_name': 'X-Wing Battery',
+            'state_class': 'measurement',
+            'unit_of_measurement': '%',
+          }),
+          'state': '15.00000867601',
+        }),
         'unit_of_measurement': '%',
       }),
       dict({
         'disabled': False,
         'entity_id': 'sensor.x_wing_geofence',
-        'state': None,
+        'state': dict({
+          'attributes': dict({
+            'friendly_name': 'X-Wing Geofence',
+          }),
+          'state': 'Tatooine',
+        }),
         'unit_of_measurement': None,
       }),
       dict({
         'disabled': False,
         'entity_id': 'sensor.x_wing_speed',
-        'state': None,
+        'state': dict({
+          'attributes': dict({
+            'device_class': 'speed',
+            'friendly_name': 'X-Wing Speed',
+            'state_class': 'measurement',
+            'unit_of_measurement': 'kn',
+          }),
+          'state': '4568795',
+        }),
         'unit_of_measurement': 'kn',
       }),
     ]),

--- a/tests/components/traccar_server/snapshots/test_diagnostics.ambr
+++ b/tests/components/traccar_server/snapshots/test_diagnostics.ambr
@@ -74,24 +74,13 @@
       dict({
         'disabled': False,
         'entity_id': 'binary_sensor.x_wing_motion',
-        'state': dict({
-          'attributes': dict({
-            'device_class': 'motion',
-            'friendly_name': 'X-Wing Motion',
-          }),
-          'state': 'off',
-        }),
+        'state': None,
         'unit_of_measurement': None,
       }),
       dict({
         'disabled': False,
         'entity_id': 'binary_sensor.x_wing_status',
-        'state': dict({
-          'attributes': dict({
-            'friendly_name': 'X-Wing Status',
-          }),
-          'state': 'on',
-        }),
+        'state': None,
         'unit_of_measurement': None,
       }),
       dict({
@@ -116,64 +105,31 @@
       dict({
         'disabled': False,
         'entity_id': 'sensor.x_wing_address',
-        'state': dict({
-          'attributes': dict({
-            'friendly_name': 'X-Wing Address',
-          }),
-          'state': '**REDACTED**',
-        }),
+        'state': None,
         'unit_of_measurement': None,
       }),
       dict({
         'disabled': False,
         'entity_id': 'sensor.x_wing_altitude',
-        'state': dict({
-          'attributes': dict({
-            'friendly_name': 'X-Wing Altitude',
-            'state_class': 'measurement',
-            'unit_of_measurement': 'm',
-          }),
-          'state': '546841384638',
-        }),
+        'state': None,
         'unit_of_measurement': 'm',
       }),
       dict({
         'disabled': False,
         'entity_id': 'sensor.x_wing_battery',
-        'state': dict({
-          'attributes': dict({
-            'device_class': 'battery',
-            'friendly_name': 'X-Wing Battery',
-            'state_class': 'measurement',
-            'unit_of_measurement': '%',
-          }),
-          'state': '15.00000867601',
-        }),
+        'state': None,
         'unit_of_measurement': '%',
       }),
       dict({
         'disabled': False,
         'entity_id': 'sensor.x_wing_geofence',
-        'state': dict({
-          'attributes': dict({
-            'friendly_name': 'X-Wing Geofence',
-          }),
-          'state': 'Tatooine',
-        }),
+        'state': None,
         'unit_of_measurement': None,
       }),
       dict({
         'disabled': False,
         'entity_id': 'sensor.x_wing_speed',
-        'state': dict({
-          'attributes': dict({
-            'device_class': 'speed',
-            'friendly_name': 'X-Wing Speed',
-            'state_class': 'measurement',
-            'unit_of_measurement': 'kn',
-          }),
-          'state': '4568795',
-        }),
+        'state': None,
         'unit_of_measurement': 'kn',
       }),
     ]),


### PR DESCRIPTION
Modernizes the traccar_server integration by migrating from the hass.data pattern to entry.runtime_data with a typed ConfigEntry. Also fixes a bug in device diagnostics.

Changes:
- Add TraccarServerConfigEntry type alias
- Replace hass.data storage with entry.runtime_data
- Update all platform setup functions to use typed config entry
- Add TYPE_CHECKING guards for circular import prevention
- Fix diagnostics bug: remove inappropriate async_reload() call
- Simplify async_unload_entry by removing manual cleanup

The diagnostics fix removes an async_reload() call that was causing unintended side effects by reloading the entire integration during diagnostics collection. Snapshots now correctly show state: None for disabled-by-default entities that aren't started.


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR modernizes the `traccar_server` integration by migrating from the deprecated `hass.data` pattern to the current best practice of using `entry.runtime_data` with a typed `ConfigEntry`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
