### PR TITLE
Log `HomeAssistantError`s in ZHA config flow

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -8,6 +8,7 @@ import collections
 from contextlib import suppress
 from enum import StrEnum
 import json
+import logging
 import os
 from typing import Any
 
@@ -56,6 +57,8 @@ from .radio_manager import (
     ProbeResult,
     ZhaRadioManager,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 CONF_MANUAL_PATH = "Enter Manually"
 DECONZ_DOMAIN = "deconz"
@@ -527,6 +530,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
         try:
             await self._reset_old_radio_task
         except HomeAssistantError:
+            _LOGGER.exception("Failed to reset old radio during migration")
             # Old adapter not found or cannot connect, show prompt to plug back in
             return self.async_show_progress_done(next_step_id="plug_in_old_radio")
         finally:
@@ -785,6 +789,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
                 next_step_id="pre_confirm_ezsp_ieee_overwrite"
             )
         except HomeAssistantError:
+            _LOGGER.exception("Failed to restore network backup to new radio")
             # User unplugged the new adapter, allow retry
             return self.async_show_progress_done(next_step_id="pre_plug_in_new_radio")
         except CannotWriteNetworkSettings as exc:


### PR DESCRIPTION
## Proposed change

This logs the full traceback of the `HomeAssistantError` when we cannot connect to the old or new adapter in the config flow. This is an `OSError` converted to a `HomeAssistantError` and generally means that the user just unplugged their device, but there may be some cases where a user decided to flash different firmware (during the migration), for example.

This is similar to what the HA hardware integrations log: https://github.com/home-assistant/core/blob/67156d159f856612c7675054359b8baec7514914/homeassistant/components/homeassistant_hardware/firmware_config_flow.py#L205-L206

We can check if the exception test is correctly printed in an existing test, but I don't think we generally check log messages like this in tests. So, I've left that out for now.

This would be nice to get into some patch release, but it's not critical at all.

Note: This is NOT related to the previous progress PRs at all. This would just be nice to have in general, so we can check the exact errors if this is thrown when the user did not unplug their device and we failed to connect for some other reason (i.e. network issues for Serial over TCP coordinators). This is also only logged during a migration that fails, so very rarely.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
