### PR TITLE
fix(icloud): handle devices as dict instead of object with attributes

### DIFF
--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -1,0 +1,301 @@
+"""Tests for the iCloud account."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from homeassistant.components.icloud.account import IcloudAccount
+from homeassistant.components.icloud.const import (
+    CONF_GPS_ACCURACY_THRESHOLD,
+    CONF_MAX_INTERVAL,
+    CONF_WITH_FAMILY,
+    DOMAIN,
+)
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.storage import Store
+
+from .const import MOCK_CONFIG, USERNAME
+
+from tests.common import MockConfigEntry
+
+
+class IterableDict(dict):
+    """A dict that can be iterated over custom items."""
+
+    def __init__(self, *args, iter_items=None, **kwargs) -> None:
+        """Initialize the dict with optional iterable items."""
+        super().__init__(*args, **kwargs)
+        self._iter_items = iter_items or []
+
+    def __iter__(self):
+        """Iterate over the custom items."""
+        return iter(self._iter_items)
+
+
+@pytest.fixture(name="mock_store")
+def mock_store_fixture():
+    """Mock the storage."""
+    with patch("homeassistant.components.icloud.account.Store") as store_mock:
+        store_instance = Mock(spec=Store)
+        store_instance.path = "/mock/path"
+        store_mock.return_value = store_instance
+        yield store_instance
+
+
+@pytest.fixture(name="mock_icloud_service")
+def mock_icloud_service_fixture():
+    """Mock PyiCloudService with devices as dict."""
+    with patch(
+        "homeassistant.components.icloud.account.PyiCloudService"
+    ) as service_mock:
+        service_instance = MagicMock()
+        service_instance.requires_2fa = False
+
+        # Mock device for iteration
+        mock_device = MagicMock()
+        mock_device.status.return_value = {
+            "id": "device1",
+            "name": "iPhone",
+            "deviceStatus": "200",
+            "batteryStatus": "NotCharging",
+            "batteryLevel": 0.8,
+            "rawDeviceModel": "iPhone14,2",
+            "deviceClass": "iPhone",
+            "deviceDisplayName": "iPhone",
+            "prsId": None,
+            "lowPowerMode": False,
+            "location": None,
+        }
+        # Make device indexable like a dict (for account.py line 211)
+        mock_device.__getitem__ = lambda self, key: {
+            "deviceStatus": "200",
+        }.get(key)
+
+        # Mock devices as dict with userInfo, iterable over devices
+        mock_devices = IterableDict(
+            {
+                "userInfo": {
+                    "firstName": "John",
+                    "lastName": "Doe",
+                    "membersInfo": {
+                        "person1": {
+                            "firstName": "Jane",
+                            "lastName": "Doe",
+                        }
+                    },
+                }
+            },
+            iter_items=[mock_device],
+        )
+
+        service_instance.devices = mock_devices
+        service_mock.return_value = service_instance
+        yield service_instance
+
+
+@pytest.fixture(name="mock_icloud_service_no_userinfo")
+def mock_icloud_service_no_userinfo_fixture():
+    """Mock PyiCloudService with devices as dict but no userInfo."""
+    with patch(
+        "homeassistant.components.icloud.account.PyiCloudService"
+    ) as service_mock:
+        service_instance = MagicMock()
+        service_instance.requires_2fa = False
+        service_instance.devices = {}
+        service_mock.return_value = service_instance
+        yield service_instance
+
+
+@pytest.fixture(name="mock_icloud_service_not_dict")
+def mock_icloud_service_not_dict_fixture():
+    """Mock PyiCloudService with devices as object (not dict)."""
+    with patch(
+        "homeassistant.components.icloud.account.PyiCloudService"
+    ) as service_mock:
+        service_instance = MagicMock()
+        service_instance.requires_2fa = False
+        # Return a non-dict object
+        service_instance.devices = Mock()
+        service_mock.return_value = service_instance
+        yield service_instance
+
+
+async def test_setup_success_with_dict_devices(
+    hass: HomeAssistant,
+    mock_store: Mock,
+    mock_icloud_service: MagicMock,
+) -> None:
+    """Test successful setup with devices as dict."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    account = IcloudAccount(
+        hass,
+        MOCK_CONFIG[CONF_USERNAME],
+        MOCK_CONFIG[CONF_PASSWORD],
+        mock_store,
+        MOCK_CONFIG[CONF_WITH_FAMILY],
+        MOCK_CONFIG[CONF_MAX_INTERVAL],
+        MOCK_CONFIG[CONF_GPS_ACCURACY_THRESHOLD],
+        config_entry,
+    )
+
+    with patch.object(account, "_schedule_next_fetch"):
+        account.setup()
+
+    assert account.api is not None
+    assert account.owner_fullname == "John Doe"
+    assert "person1" in account.family_members_fullname
+    assert account.family_members_fullname["person1"] == "Jane Doe"
+
+
+async def test_setup_fails_when_userinfo_missing(
+    hass: HomeAssistant,
+    mock_store: Mock,
+    mock_icloud_service_no_userinfo: MagicMock,
+) -> None:
+    """Test setup fails when userInfo is missing from devices dict."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    account = IcloudAccount(
+        hass,
+        MOCK_CONFIG[CONF_USERNAME],
+        MOCK_CONFIG[CONF_PASSWORD],
+        mock_store,
+        MOCK_CONFIG[CONF_WITH_FAMILY],
+        MOCK_CONFIG[CONF_MAX_INTERVAL],
+        MOCK_CONFIG[CONF_GPS_ACCURACY_THRESHOLD],
+        config_entry,
+    )
+
+    with pytest.raises(ConfigEntryNotReady, match="No user info found"):
+        account.setup()
+
+
+async def test_setup_fails_when_devices_not_dict(
+    hass: HomeAssistant,
+    mock_store: Mock,
+    mock_icloud_service_not_dict: MagicMock,
+) -> None:
+    """Test setup fails when devices is not a dict."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    account = IcloudAccount(
+        hass,
+        MOCK_CONFIG[CONF_USERNAME],
+        MOCK_CONFIG[CONF_PASSWORD],
+        mock_store,
+        MOCK_CONFIG[CONF_WITH_FAMILY],
+        MOCK_CONFIG[CONF_MAX_INTERVAL],
+        MOCK_CONFIG[CONF_GPS_ACCURACY_THRESHOLD],
+        config_entry,
+    )
+
+    with pytest.raises(ConfigEntryNotReady, match="not a dictionary"):
+        account.setup()
+
+
+async def test_setup_with_family_members_info(
+    hass: HomeAssistant,
+    mock_store: Mock,
+    mock_icloud_service: MagicMock,
+) -> None:
+    """Test setup correctly extracts family members info."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    account = IcloudAccount(
+        hass,
+        MOCK_CONFIG[CONF_USERNAME],
+        MOCK_CONFIG[CONF_PASSWORD],
+        mock_store,
+        MOCK_CONFIG[CONF_WITH_FAMILY],
+        MOCK_CONFIG[CONF_MAX_INTERVAL],
+        MOCK_CONFIG[CONF_GPS_ACCURACY_THRESHOLD],
+        config_entry,
+    )
+
+    with patch.object(account, "_schedule_next_fetch"):
+        account.setup()
+
+    assert account.family_members_fullname["person1"] == "Jane Doe"
+
+
+async def test_setup_without_family_members_info(
+    hass: HomeAssistant,
+    mock_store: Mock,
+) -> None:
+    """Test setup without family members info."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.icloud.account.PyiCloudService"
+    ) as service_mock:
+        service_instance = MagicMock()
+        service_instance.requires_2fa = False
+
+        # Mock device for iteration
+        mock_device = MagicMock()
+        mock_device.status.return_value = {
+            "id": "device1",
+            "name": "iPhone",
+            "deviceStatus": "200",
+            "batteryStatus": "NotCharging",
+            "batteryLevel": 0.8,
+            "rawDeviceModel": "iPhone14,2",
+            "deviceClass": "iPhone",
+            "deviceDisplayName": "iPhone",
+            "prsId": None,
+            "lowPowerMode": False,
+            "location": None,
+        }
+        # Make device indexable like a dict (for account.py line 211)
+        mock_device.__getitem__ = lambda self, key: {
+            "deviceStatus": "200",
+        }.get(key)
+
+        # Mock devices as dict with userInfo, iterable over devices
+        mock_devices = IterableDict(
+            {
+                "userInfo": {
+                    "firstName": "John",
+                    "lastName": "Doe",
+                }
+            },
+            iter_items=[mock_device],
+        )
+
+        service_instance.devices = mock_devices
+        service_mock.return_value = service_instance
+
+        account = IcloudAccount(
+            hass,
+            MOCK_CONFIG[CONF_USERNAME],
+            MOCK_CONFIG[CONF_PASSWORD],
+            mock_store,
+            MOCK_CONFIG[CONF_WITH_FAMILY],
+            MOCK_CONFIG[CONF_MAX_INTERVAL],
+            MOCK_CONFIG[CONF_GPS_ACCURACY_THRESHOLD],
+            config_entry,
+        )
+
+        with patch.object(account, "_schedule_next_fetch"):
+            account.setup()
+
+        assert account.owner_fullname == "John Doe"
+        assert account.family_members_fullname == {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!

  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

-->

## Proposed change

The pyicloud library returns `devices` as a dict, not an object with attributes. This change fixes the AttributeError that occurs when trying to access `user_info` as an attribute.

**What was changed:**
- Changed from `self.api.devices.user_info` to `devices_data.get('userInfo')` for dictionary access
- Added type checking with `isinstance()` to ensure devices is a dict before accessing
- Added comprehensive tests for dict-based device access scenarios
- Improved error handling with specific error messages

**Why:**
The pyicloud library API changed to return devices as a dictionary instead of an object with attributes. This caused AttributeError when the code tried to access `user_info` as an attribute.

**Related Issues:**
- Fixes #155652 (Error setting up entry for iCloud)
- Fixes #155933 (iCloud stopped working after updating to 2025.11.0)

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?

  NOTE: Please, check only 1! box!

  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.

  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #155652, fixes #155933
- This PR is related to issue: #155652, #155933
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.

- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.

- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
