### PR TITLE
Handle OAuth2 implementation unavailability in Miele integration

### DIFF
--- a/homeassistant/components/miele/__init__.py
+++ b/homeassistant/components/miele/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
+    ImplementationUnavailableError,
     OAuth2Session,
     async_get_config_entry_implementation,
 )
@@ -44,7 +45,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: MieleConfigEntry) -> bool:
     """Set up Miele from a config entry."""
-    implementation = await async_get_config_entry_implementation(hass, entry)
+    try:
+        implementation = await async_get_config_entry_implementation(hass, entry)
+    except ImplementationUnavailableError as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="config_entry_not_ready",
+        ) from err
 
     session = OAuth2Session(hass, entry, implementation)
     auth = AsyncConfigEntryAuth(async_get_clientsession(hass), session)


### PR DESCRIPTION
## Overview
This pull request addresses issue #156093 by properly handling the `ImplementationUnavailableError` that can occur when setting up the Miele integration. Previously, this error was not caught, which could lead to configuration entry failures. Now, when this error occurs during OAuth2 implementation retrieval, it's caught and converted to a `ConfigEntryNotReady` exception with a proper translation domain and key, allowing for better error handling and user feedback.

## Checklist
- [ ] Code changes are complete
- [ ] Tests pass
- [ ] Documentation updated (if applicable)

## Proof that changes are correct
The change adds a try-except block around the `async_get_config_entry_implementation` call to catch `ImplementationUnavailableError` and re-raise it as `ConfigEntryNotReady`. This follows Home Assistant's pattern for handling unavailable integrations and provides a more graceful failure state with proper localization support. The modification is minimal and focused on the specific error condition without affecting other functionality.