### PR TITLE
Migrate friends to subentries in Xbox integration

### DIFF
--- a/homeassistant/components/xbox/__init__.py
+++ b/homeassistant/components/xbox/__init__.py
@@ -4,11 +4,22 @@ from __future__ import annotations
 
 import logging
 
+from httpx import HTTPStatusError, RequestError, TimeoutException
+from pythonxbox.api.client import XboxLiveClient
+
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    ImplementationUnavailableError,
+    OAuth2Session,
+    async_get_config_entry_implementation,
+)
+from homeassistant.helpers.httpx_client import get_async_client
 
+from .api import AsyncConfigEntryAuth
 from .const import DOMAIN
 from .coordinator import (
     XboxConfigEntry,
@@ -42,8 +53,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: XboxConfigEntry) -> bool
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    await async_migrate_config_entry(hass, entry)
-
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     return True
@@ -60,48 +69,89 @@ async def async_unload_entry(hass: HomeAssistant, entry: XboxConfigEntry) -> boo
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def async_migrate_config_entry(
-    hass: HomeAssistant, entry: XboxConfigEntry
-) -> bool:
-    """Migrate config entry.
+async def async_migrate_entry(hass: HomeAssistant, entry: XboxConfigEntry) -> bool:
+    """Migrate config entry."""
 
-    Migration requires runtime data
-    """
-    coordinator = entry.runtime_data.status
-
-    if entry.version == 1 and entry.minor_version < 2:
-        # Migrate unique_id from `xbox` to account xuid and
-        # change generic entry name to user's gamertag
-        xuid = coordinator.client.xuid
-        gamertag = coordinator.data.presence[xuid].gamertag
-
-        hass.config_entries.async_update_entry(
-            entry,
-            unique_id=xuid,
-            title=(gamertag if entry.title == "Home Assistant Cloud" else entry.title),
-            minor_version=2,
-        )
     if entry.version == 1 and entry.minor_version < 3:
-        # Migrate favorite friends to friend subentries
-        dev_reg = dr.async_get(hass)
-        for friend in coordinator.data.presence.values():
-            if not friend.is_favorite:
-                continue
-            subentry = ConfigSubentry(
-                subentry_type="friend",
-                title=friend.gamertag,
-                unique_id=friend.xuid,
-                data={},  # type: ignore[arg-type]
-            )
-            hass.config_entries.async_add_subentry(entry, subentry)
+        try:
+            implementation = await async_get_config_entry_implementation(hass, entry)
+        except ImplementationUnavailableError as e:
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="oauth2_implementation_unavailable",
+            ) from e
+        session = OAuth2Session(hass, entry, implementation)
+        async_session = get_async_client(hass)
+        auth = AsyncConfigEntryAuth(async_session, session)
+        await auth.refresh_tokens()
+        client = XboxLiveClient(auth)
 
-            if device := dev_reg.async_get_device({(DOMAIN, friend.xuid)}):
-                dev_reg.async_update_device(
-                    device.id,
-                    remove_config_entry_id=entry.entry_id,
-                    add_config_subentry_id=subentry.subentry_id,
-                    add_config_entry_id=entry.entry_id,
+        if entry.minor_version < 2:
+            # Migrate unique_id from `xbox` to account xuid and
+            # change generic entry name to user's gamertag
+            try:
+                own = await client.people.get_friends_by_xuid(client.xuid)
+            except TimeoutException as e:
+                raise ConfigEntryNotReady(
+                    translation_domain=DOMAIN,
+                    translation_key="timeout_exception",
+                ) from e
+            except (RequestError, HTTPStatusError) as e:
+                _LOGGER.debug("Xbox exception:", exc_info=True)
+                raise ConfigEntryNotReady(
+                    translation_domain=DOMAIN,
+                    translation_key="request_exception",
+                ) from e
+
+            hass.config_entries.async_update_entry(
+                entry,
+                unique_id=client.xuid,
+                title=(
+                    own.people[0].gamertag
+                    if entry.title == "Home Assistant Cloud"
+                    else entry.title
+                ),
+                minor_version=2,
+            )
+        if entry.minor_version < 3:
+            # Migrate favorite friends to friend subentries
+            try:
+                friends = await client.people.get_friends_own()
+            except TimeoutException as e:
+                raise ConfigEntryNotReady(
+                    translation_domain=DOMAIN,
+                    translation_key="timeout_exception",
+                ) from e
+            except (RequestError, HTTPStatusError) as e:
+                _LOGGER.debug("Xbox exception:", exc_info=True)
+                raise ConfigEntryNotReady(
+                    translation_domain=DOMAIN,
+                    translation_key="request_exception",
+                ) from e
+
+            dev_reg = dr.async_get(hass)
+            for friend in friends.people:
+                if not friend.is_favorite:
+                    continue
+                subentry = ConfigSubentry(
+                    subentry_type="friend",
+                    title=friend.gamertag,
+                    unique_id=friend.xuid,
+                    data={},  # type: ignore[arg-type]
                 )
-        hass.config_entries.async_update_entry(entry, minor_version=3)
-        hass.config_entries.async_schedule_reload(entry.entry_id)
+                hass.config_entries.async_add_subentry(entry, subentry)
+
+                if device := dev_reg.async_get_device({(DOMAIN, friend.xuid)}):
+                    dev_reg.async_update_device(
+                        device.id,
+                        remove_config_entry_id=entry.entry_id,
+                        add_config_subentry_id=subentry.subentry_id,
+                        add_config_entry_id=entry.entry_id,
+                    )
+            if device := dev_reg.async_get_device({(DOMAIN, "xbox_live")}):
+                dev_reg.async_update_device(
+                    device.id, new_identifiers={(DOMAIN, client.xuid)}
+                )
+            hass.config_entries.async_update_entry(entry, minor_version=3)
+            hass.config_entries.async_schedule_reload(entry.entry_id)
     return True

--- a/homeassistant/components/xbox/__init__.py
+++ b/homeassistant/components/xbox/__init__.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 
 from .const import DOMAIN
 from .coordinator import (
@@ -41,8 +42,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: XboxConfigEntry) -> bool
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    await async_migrate_unique_id(hass, entry)
+    await async_migrate_config_entry(hass, entry)
+
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: XboxConfigEntry) -> None:
+    """Handle update."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: XboxConfigEntry) -> bool:
@@ -51,24 +60,48 @@ async def async_unload_entry(hass: HomeAssistant, entry: XboxConfigEntry) -> boo
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def async_migrate_unique_id(hass: HomeAssistant, entry: XboxConfigEntry) -> bool:
+async def async_migrate_config_entry(
+    hass: HomeAssistant, entry: XboxConfigEntry
+) -> bool:
     """Migrate config entry.
 
     Migration requires runtime data
     """
+    coordinator = entry.runtime_data.status
 
     if entry.version == 1 and entry.minor_version < 2:
         # Migrate unique_id from `xbox` to account xuid and
         # change generic entry name to user's gamertag
-        coordinator = entry.runtime_data.status
         xuid = coordinator.client.xuid
         gamertag = coordinator.data.presence[xuid].gamertag
 
-        return hass.config_entries.async_update_entry(
+        hass.config_entries.async_update_entry(
             entry,
             unique_id=xuid,
             title=(gamertag if entry.title == "Home Assistant Cloud" else entry.title),
             minor_version=2,
         )
+    if entry.version == 1 and entry.minor_version < 3:
+        # Migrate favorite friends to friend subentries
+        dev_reg = dr.async_get(hass)
+        for friend in coordinator.data.presence.values():
+            if not friend.is_favorite:
+                continue
+            subentry = ConfigSubentry(
+                subentry_type="friend",
+                title=friend.gamertag,
+                unique_id=friend.xuid,
+                data={},  # type: ignore[arg-type]
+            )
+            hass.config_entries.async_add_subentry(entry, subentry)
 
+            if device := dev_reg.async_get_device({(DOMAIN, friend.xuid)}):
+                dev_reg.async_update_device(
+                    device.id,
+                    remove_config_entry_id=entry.entry_id,
+                    add_config_subentry_id=subentry.subentry_id,
+                    add_config_entry_id=entry.entry_id,
+                )
+        hass.config_entries.async_update_entry(entry, minor_version=3)
+        hass.config_entries.async_schedule_reload(entry.entry_id)
     return True

--- a/homeassistant/components/xbox/binary_sensor.py
+++ b/homeassistant/components/xbox/binary_sensor.py
@@ -136,6 +136,7 @@ async def async_setup_entry(
                     hass, subentry.unique_id, description, BINARY_SENSOR_DOMAIN
                 )
                 and subentry.unique_id in coordinator.data.presence
+                and subentry.subentry_type == "friend"
             ],
             config_subentry_id=subentry_id,
         )

--- a/homeassistant/components/xbox/binary_sensor.py
+++ b/homeassistant/components/xbox/binary_sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pythonxbox.api.provider.people.models import Person
 from pythonxbox.api.provider.titlehub.models import Title
@@ -15,7 +15,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import XboxConfigEntry
@@ -112,30 +112,33 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Xbox Live friends."""
-    xuids_added: set[str] = set()
     coordinator = entry.runtime_data.status
 
-    @callback
-    def add_entities() -> None:
-        nonlocal xuids_added
-
-        current_xuids = set(coordinator.data.presence)
-        if new_xuids := current_xuids - xuids_added:
-            async_add_entities(
-                [
-                    XboxBinarySensorEntity(coordinator, xuid, description)
-                    for xuid in new_xuids
-                    for description in SENSOR_DESCRIPTIONS
-                    if check_deprecated_entity(
-                        hass, xuid, description, BINARY_SENSOR_DOMAIN
-                    )
-                ]
+    if TYPE_CHECKING:
+        assert entry.unique_id
+    async_add_entities(
+        [
+            XboxBinarySensorEntity(coordinator, entry.unique_id, description)
+            for description in SENSOR_DESCRIPTIONS
+            if check_deprecated_entity(
+                hass, entry.unique_id, description, BINARY_SENSOR_DOMAIN
             )
-            xuids_added |= new_xuids
-        xuids_added &= current_xuids
+        ]
+    )
 
-    coordinator.async_add_listener(add_entities)
-    add_entities()
+    for subentry_id, subentry in entry.subentries.items():
+        async_add_entities(
+            [
+                XboxBinarySensorEntity(coordinator, subentry.unique_id, description)
+                for description in SENSOR_DESCRIPTIONS
+                if subentry.unique_id
+                and check_deprecated_entity(
+                    hass, subentry.unique_id, description, BINARY_SENSOR_DOMAIN
+                )
+                and subentry.unique_id in coordinator.data.presence
+            ],
+            config_subentry_id=subentry_id,
+        )
 
 
 class XboxBinarySensorEntity(XboxBaseEntity, BinarySensorEntity):

--- a/homeassistant/components/xbox/config_flow.py
+++ b/homeassistant/components/xbox/config_flow.py
@@ -8,11 +8,26 @@ from httpx import AsyncClient
 from pythonxbox.api.client import XboxLiveClient
 from pythonxbox.authentication.manager import AuthenticationManager
 from pythonxbox.authentication.models import OAuth2TokenResponse
+import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    ConfigEntry,
+    ConfigEntryState,
+    ConfigFlowResult,
+    ConfigSubentryFlow,
+    SubentryFlowResult,
+)
+from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+)
 
-from .const import DOMAIN
+from .const import CONF_XUID, DOMAIN
+from .coordinator import XboxConfigEntry
 
 
 class OAuth2FlowHandler(
@@ -22,7 +37,7 @@ class OAuth2FlowHandler(
 
     DOMAIN = DOMAIN
 
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     @property
     def logger(self) -> logging.Logger:
@@ -34,6 +49,14 @@ class OAuth2FlowHandler(
         """Extra data that needs to be appended to the authorize url."""
         scopes = ["Xboxlive.signin", "Xboxlive.offline_access"]
         return {"scope": " ".join(scopes)}
+
+    @classmethod
+    @callback
+    def async_get_supported_subentry_types(
+        cls, config_entry: ConfigEntry
+    ) -> dict[str, type[ConfigSubentryFlow]]:
+        """Return subentries supported by this integration."""
+        return {"friend": FriendSubentryFlowHandler}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -65,6 +88,14 @@ class OAuth2FlowHandler(
             )
 
         self._abort_if_unique_id_configured()
+
+        config_entries = self.hass.config_entries.async_entries(DOMAIN)
+        for entry in config_entries:
+            if client.xuid in {
+                subentry.unique_id for subentry in entry.subentries.values()
+            }:
+                return self.async_abort(reason="already_configured_as_subentry")
+
         return self.async_create_entry(title=me.people[0].gamertag, data=data)
 
     async def async_step_reauth(self, _: Mapping[str, Any]) -> ConfigFlowResult:
@@ -78,3 +109,63 @@ class OAuth2FlowHandler(
         if user_input is None:
             return self.async_show_form(step_id="reauth_confirm")
         return await self.async_step_user()
+
+
+class FriendSubentryFlowHandler(ConfigSubentryFlow):
+    """Handle subentry flow for adding a friend."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Subentry user flow."""
+        config_entry: XboxConfigEntry = self._get_entry()
+        if config_entry.state is not ConfigEntryState.LOADED:
+            return self.async_abort(reason="config_entry_not_loaded")
+
+        client = config_entry.runtime_data.status.client
+        friends_list = await client.people.get_friends_own()
+
+        if user_input is not None:
+            config_entries = self.hass.config_entries.async_entries(DOMAIN)
+            if user_input[CONF_XUID] in {entry.unique_id for entry in config_entries}:
+                return self.async_abort(reason="already_configured_as_entry")
+            for entry in config_entries:
+                if user_input[CONF_XUID] in {
+                    subentry.unique_id for subentry in entry.subentries.values()
+                }:
+                    return self.async_abort(reason="already_configured")
+
+            return self.async_create_entry(
+                title=next(
+                    f.gamertag
+                    for f in friends_list.people
+                    if f.xuid == user_input[CONF_XUID]
+                ),
+                data={},
+                unique_id=user_input[CONF_XUID],
+            )
+
+        if not friends_list.people:
+            return self.async_abort(reason="no_friends")
+
+        options = [
+            SelectOptionDict(
+                value=friend.xuid,
+                label=friend.gamertag,
+            )
+            for friend in friends_list.people
+        ]
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema(
+                    {
+                        vol.Required(CONF_XUID): SelectSelector(
+                            SelectSelectorConfig(options=options)
+                        )
+                    }
+                ),
+                user_input,
+            ),
+        )

--- a/homeassistant/components/xbox/const.py
+++ b/homeassistant/components/xbox/const.py
@@ -4,3 +4,5 @@ DOMAIN = "xbox"
 
 OAUTH2_AUTHORIZE = "https://login.live.com/oauth20_authorize.srf"
 OAUTH2_TOKEN = "https://login.live.com/oauth20_token.srf"
+
+CONF_XUID = "xuid"

--- a/homeassistant/components/xbox/coordinator.py
+++ b/homeassistant/components/xbox/coordinator.py
@@ -21,7 +21,6 @@ from pythonxbox.api.provider.titlehub.models import Title
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
     OAuth2Session,
@@ -208,14 +207,8 @@ class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
             ) from e
         else:
             presence_data = {self.client.xuid: batch.people[0]}
-            configured_xuids = self.configured_as_entry()
-            presence_data.update(
-                {
-                    friend.xuid: friend
-                    for friend in friends.people
-                    if friend.is_favorite and friend.xuid not in configured_xuids
-                }
-            )
+            # configured_xuids = self.configured_as_entry()
+            presence_data.update({friend.xuid: friend for friend in friends.people})
 
         # retrieve title details
         for person in presence_data.values():
@@ -260,12 +253,12 @@ class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
             else:
                 self.title_data.pop(person.xuid, None)
             person.last_seen_date_time_utc = self.last_seen_timestamp(person)
-        if (
-            self.current_friends - (new_friends := set(presence_data))
-            or not self.current_friends
-        ):
-            self.remove_stale_devices(new_friends)
-        self.current_friends = new_friends
+        # if (
+        #     self.current_friends - (new_friends := set(presence_data))
+        #     or not self.current_friends
+        # ):
+        #     self.remove_stale_devices(new_friends)
+        # self.current_friends = new_friends
 
         return XboxData(new_console_data, presence_data, self.title_data)
 
@@ -285,24 +278,24 @@ class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
 
         return cur_dt
 
-    def remove_stale_devices(self, xuids: set[str]) -> None:
-        """Remove stale devices from registry."""
+    # def remove_stale_devices(self, xuids: set[str]) -> None:
+    #     """Remove stale devices from registry."""
 
-        device_reg = dr.async_get(self.hass)
-        identifiers = (
-            {(DOMAIN, xuid) for xuid in xuids}
-            | {(DOMAIN, console.id) for console in self.consoles.result}
-            | self.configured_as_entry()
-        )
+    #     device_reg = dr.async_get(self.hass)
+    #     identifiers = (
+    #         {(DOMAIN, xuid) for xuid in xuids}
+    #         | {(DOMAIN, console.id) for console in self.consoles.result}
+    #         | self.configured_as_entry()
+    #     )
 
-        for device in dr.async_entries_for_config_entry(
-            device_reg, self.config_entry.entry_id
-        ):
-            if not set(device.identifiers) & identifiers:
-                _LOGGER.debug("Removing stale device %s", device.name)
-                device_reg.async_update_device(
-                    device.id, remove_config_entry_id=self.config_entry.entry_id
-                )
+    #     for device in dr.async_entries_for_config_entry(
+    #         device_reg, self.config_entry.entry_id
+    #     ):
+    #         if not set(device.identifiers) & identifiers:
+    #             _LOGGER.debug("Removing stale device %s", device.name)
+    #             device_reg.async_update_device(
+    #                 device.id, remove_config_entry_id=self.config_entry.entry_id
+    #             )
 
     def configured_as_entry(self) -> set[str]:
         """Get xuids of configured entries."""

--- a/homeassistant/components/xbox/coordinator.py
+++ b/homeassistant/components/xbox/coordinator.py
@@ -207,7 +207,6 @@ class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
             ) from e
         else:
             presence_data = {self.client.xuid: batch.people[0]}
-            # configured_xuids = self.configured_as_entry()
             presence_data.update({friend.xuid: friend for friend in friends.people})
 
         # retrieve title details
@@ -253,13 +252,6 @@ class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
             else:
                 self.title_data.pop(person.xuid, None)
             person.last_seen_date_time_utc = self.last_seen_timestamp(person)
-        # if (
-        #     self.current_friends - (new_friends := set(presence_data))
-        #     or not self.current_friends
-        # ):
-        #     self.remove_stale_devices(new_friends)
-        # self.current_friends = new_friends
-
         return XboxData(new_console_data, presence_data, self.title_data)
 
     def last_seen_timestamp(self, person: Person) -> datetime | None:
@@ -277,25 +269,6 @@ class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
             return max(prev_dt, cur_dt)
 
         return cur_dt
-
-    # def remove_stale_devices(self, xuids: set[str]) -> None:
-    #     """Remove stale devices from registry."""
-
-    #     device_reg = dr.async_get(self.hass)
-    #     identifiers = (
-    #         {(DOMAIN, xuid) for xuid in xuids}
-    #         | {(DOMAIN, console.id) for console in self.consoles.result}
-    #         | self.configured_as_entry()
-    #     )
-
-    #     for device in dr.async_entries_for_config_entry(
-    #         device_reg, self.config_entry.entry_id
-    #     ):
-    #         if not set(device.identifiers) & identifiers:
-    #             _LOGGER.debug("Removing stale device %s", device.name)
-    #             device_reg.async_update_device(
-    #                 device.id, remove_config_entry_id=self.config_entry.entry_id
-    #             )
 
     def configured_as_entry(self) -> set[str]:
         """Get xuids of configured entries."""

--- a/homeassistant/components/xbox/entity.py
+++ b/homeassistant/components/xbox/entity.py
@@ -84,7 +84,8 @@ class XboxBaseEntity(CoordinatorEntity[XboxUpdateCoordinator]):
 
         return (
             entity_picture
-            if (fn := self.entity_description.entity_picture_fn) is not None
+            if self.available
+            and (fn := self.entity_description.entity_picture_fn) is not None
             and (entity_picture := fn(self.data, self.title_info)) is not None
             else super().entity_picture
         )
@@ -97,6 +98,12 @@ class XboxBaseEntity(CoordinatorEntity[XboxUpdateCoordinator]):
             if (fn := self.entity_description.attributes_fn)
             else super().extra_state_attributes
         )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+
+        return super().available and self.xuid in self.coordinator.data.presence
 
 
 class XboxConsoleBaseEntity(CoordinatorEntity[XboxUpdateCoordinator]):

--- a/homeassistant/components/xbox/image.py
+++ b/homeassistant/components/xbox/image.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import TYPE_CHECKING
 
 from pythonxbox.api.provider.people.models import Person
 from pythonxbox.api.provider.titlehub.models import Title
 
 from homeassistant.components.image import ImageEntity, ImageEntityDescription
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
@@ -63,30 +64,26 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Xbox images."""
-
     coordinator = config_entry.runtime_data.status
+    if TYPE_CHECKING:
+        assert config_entry.unique_id
+    async_add_entities(
+        [
+            XboxImageEntity(hass, coordinator, config_entry.unique_id, description)
+            for description in IMAGE_DESCRIPTIONS
+        ]
+    )
 
-    xuids_added: set[str] = set()
-
-    @callback
-    def add_entities() -> None:
-        """Add image entities."""
-        nonlocal xuids_added
-
-        current_xuids = set(coordinator.data.presence)
-        if new_xuids := current_xuids - xuids_added:
-            async_add_entities(
-                [
-                    XboxImageEntity(hass, coordinator, xuid, description)
-                    for xuid in new_xuids
-                    for description in IMAGE_DESCRIPTIONS
-                ]
-            )
-            xuids_added |= new_xuids
-        xuids_added &= current_xuids
-
-    coordinator.async_add_listener(add_entities)
-    add_entities()
+    for subentry_id, subentry in config_entry.subentries.items():
+        async_add_entities(
+            [
+                XboxImageEntity(hass, coordinator, subentry.unique_id, description)
+                for description in IMAGE_DESCRIPTIONS
+                if subentry.unique_id
+                and subentry.unique_id in coordinator.data.presence
+            ],
+            config_subentry_id=subentry_id,
+        )
 
 
 class XboxImageEntity(XboxBaseEntity, ImageEntity):
@@ -113,11 +110,12 @@ class XboxImageEntity(XboxBaseEntity, ImageEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
 
-        url = self.entity_description.image_url_fn(self.data, self.title_info)
+        if self.available:
+            url = self.entity_description.image_url_fn(self.data, self.title_info)
 
-        if url != self._attr_image_url:
-            self._attr_image_url = url
-            self._cached_image = None
-            self._attr_image_last_updated = dt_util.utcnow()
+            if url != self._attr_image_url:
+                self._attr_image_url = url
+                self._cached_image = None
+                self._attr_image_last_updated = dt_util.utcnow()
 
         super()._handle_coordinator_update()

--- a/homeassistant/components/xbox/image.py
+++ b/homeassistant/components/xbox/image.py
@@ -81,6 +81,7 @@ async def async_setup_entry(
                 for description in IMAGE_DESCRIPTIONS
                 if subentry.unique_id
                 and subentry.unique_id in coordinator.data.presence
+                and subentry.subentry_type == "friend"
             ],
             config_subentry_id=subentry_id,
         )

--- a/homeassistant/components/xbox/sensor.py
+++ b/homeassistant/components/xbox/sensor.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pythonxbox.api.provider.people.models import Person
 from pythonxbox.api.provider.smartglass.models import SmartglassConsole, StorageDevice
@@ -21,7 +21,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import CONF_NAME, UnitOfInformation
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -253,28 +253,31 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Xbox Live friends."""
-    xuids_added: set[str] = set()
     coordinator = config_entry.runtime_data.status
-
-    @callback
-    def add_entities() -> None:
-        nonlocal xuids_added
-
-        current_xuids = set(coordinator.data.presence)
-        if new_xuids := current_xuids - xuids_added:
-            async_add_entities(
-                [
-                    XboxSensorEntity(coordinator, xuid, description)
-                    for xuid in new_xuids
-                    for description in SENSOR_DESCRIPTIONS
-                    if check_deprecated_entity(hass, xuid, description, SENSOR_DOMAIN)
-                ]
+    if TYPE_CHECKING:
+        assert config_entry.unique_id
+    async_add_entities(
+        [
+            XboxSensorEntity(coordinator, config_entry.unique_id, description)
+            for description in SENSOR_DESCRIPTIONS
+            if check_deprecated_entity(
+                hass, config_entry.unique_id, description, SENSOR_DOMAIN
             )
-            xuids_added |= new_xuids
-        xuids_added &= current_xuids
-
-    coordinator.async_add_listener(add_entities)
-    add_entities()
+        ]
+    )
+    for subentry_id, subentry in config_entry.subentries.items():
+        async_add_entities(
+            [
+                XboxSensorEntity(coordinator, subentry.unique_id, description)
+                for description in SENSOR_DESCRIPTIONS
+                if subentry.unique_id
+                and check_deprecated_entity(
+                    hass, subentry.unique_id, description, SENSOR_DOMAIN
+                )
+                and subentry.unique_id in coordinator.data.presence
+            ],
+            config_subentry_id=subentry_id,
+        )
 
     consoles_coordinator = config_entry.runtime_data.consoles
 

--- a/homeassistant/components/xbox/sensor.py
+++ b/homeassistant/components/xbox/sensor.py
@@ -275,6 +275,7 @@ async def async_setup_entry(
                     hass, subentry.unique_id, description, SENSOR_DOMAIN
                 )
                 and subentry.unique_id in coordinator.data.presence
+                and subentry.subentry_type == "friend"
             ],
             config_subentry_id=subentry_id,
         )

--- a/homeassistant/components/xbox/strings.json
+++ b/homeassistant/components/xbox/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_configured_as_subentry": "This account is already configured as a sub-entry. Please remove the existing sub-entry before adding it.",
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
       "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
@@ -31,6 +32,36 @@
       "reauth_confirm": {
         "description": "The Xbox integration needs to re-authenticate your account",
         "title": "[%key:common::config_flow::title::reauth%]"
+      }
+    }
+  },
+  "config_subentries": {
+    "friend": {
+      "abort": {
+        "already_configured": "Already configured as a friend in this or another account.",
+        "already_configured_as_entry": "Already configured as a service. This account cannot be added as a friend.",
+        "config_entry_not_loaded": "Cannot add friend accounts when the main account is disabled or not loaded.",
+        "no_friends": "Looks like your friend list is empty right now. Add friends on Xbox Network first."
+      },
+      "entry_type": "Friend",
+      "error": {
+        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "unknown": "[%key:common::config_flow::error::unknown%]"
+      },
+      "initiate_flow": {
+        "user": "Add friend"
+      },
+      "step": {
+        "user": {
+          "data": {
+            "xuid": "Gamertag"
+          },
+          "data_description": {
+            "xuid": "Select a friend from your friend list to track their online status."
+          },
+          "description": "Track the online status of an Xbox Network friend.",
+          "title": "Friend online status"
+        }
       }
     }
   },

--- a/tests/components/xbox/conftest.py
+++ b/tests/components/xbox/conftest.py
@@ -21,6 +21,7 @@ from homeassistant.components.application_credentials import (
     async_import_client_credential,
 )
 from homeassistant.components.xbox.const import DOMAIN
+from homeassistant.config_entries import ConfigSubentryData
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -44,7 +45,7 @@ def mock_config_entry() -> MockConfigEntry:
     """Mock Xbox configuration entry."""
     return MockConfigEntry(
         domain=DOMAIN,
-        title="Home Assistant Cloud",
+        title="GSR Ae",
         data={
             "auth_implementation": "cloud",
             "token": {
@@ -59,6 +60,27 @@ def mock_config_entry() -> MockConfigEntry:
             },
         },
         unique_id="271958441785640",
+        subentries_data=[
+            ConfigSubentryData(
+                data={},
+                subentry_type="friend",
+                title="erics273",
+                unique_id="2533274913657542",
+            ),
+            ConfigSubentryData(
+                data={},
+                subentry_type="friend",
+                title="Ikken Hissatsuu",
+                unique_id="2533274838782903",
+            ),
+            ConfigSubentryData(
+                data={},
+                subentry_type="friend",
+                title="test",
+                unique_id="2533274838782904",
+            ),
+        ],
+        minor_version=3,
     )
 
 

--- a/tests/components/xbox/conftest.py
+++ b/tests/components/xbox/conftest.py
@@ -93,6 +93,10 @@ def mock_authentication_manager() -> Generator[AsyncMock]:
             "homeassistant.components.xbox.config_flow.AuthenticationManager",
             autospec=True,
         ) as mock_client,
+        patch(
+            "homeassistant.components.xbox.AsyncConfigEntryAuth",
+            autospec=True,
+        ),
     ):
         client = mock_client.return_value
 
@@ -110,6 +114,7 @@ def mock_xbox_live_client() -> Generator[AsyncMock]:
         patch(
             "homeassistant.components.xbox.config_flow.XboxLiveClient", new=mock_client
         ),
+        patch("homeassistant.components.xbox.XboxLiveClient", new=mock_client),
     ):
         client = mock_client.return_value
 

--- a/tests/components/xbox/fixtures/people_friends_own_no_friends.json
+++ b/tests/components/xbox/fixtures/people_friends_own_no_friends.json
@@ -1,0 +1,6 @@
+{
+  "people": [],
+  "recommendationSummary": null,
+  "friendFinderState": null,
+  "accountLinkDetails": null
+}

--- a/tests/components/xbox/test_config_flow.py
+++ b/tests/components/xbox/test_config_flow.py
@@ -4,16 +4,28 @@ from http import HTTPStatus
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pythonxbox.api.provider.people.models import PeopleResponse
 
 from homeassistant import config_entries
-from homeassistant.components.xbox.const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from homeassistant.components.xbox.const import (
+    CONF_XUID,
+    DOMAIN,
+    OAUTH2_AUTHORIZE,
+    OAUTH2_TOKEN,
+)
+from homeassistant.config_entries import (
+    SOURCE_USER,
+    ConfigEntryState,
+    ConfigSubentry,
+    ConfigSubentryData,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .conftest import CLIENT_ID
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
 
@@ -131,6 +143,342 @@ async def test_form_already_configured(
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.usefixtures(
+    "current_request_with_host",
+    "xbox_live_client",
+    "authentication_manager",
+)
+async def test_form_already_configured_as_subentry(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test we abort flow when entry is already configured."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Ikken Hissatsuu",
+        data={
+            "auth_implementation": "cloud",
+            "token": {
+                "access_token": "1234567890",
+                "expires_at": 1760697327.7298331,
+                "expires_in": 3600,
+                "refresh_token": "0987654321",
+                "scope": "XboxLive.signin XboxLive.offline_access",
+                "service": "xbox",
+                "token_type": "bearer",
+                "user_id": "AAAAAAAAAAAAAAAAAAAAA",
+            },
+        },
+        subentries_data=[
+            ConfigSubentryData(
+                data={},
+                subentry_type="friend",
+                title="GSR Ae",
+                unique_id="271958441785640",
+            ),
+        ],
+        unique_id="2533274838782903",
+        minor_version=3,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == HTTPStatus.OK
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+            "scope": "XboxLive.signin XboxLive.offline_access",
+            "service": "xbox",
+            "token_type": "bearer",
+            "user_id": "AAAAAAAAAAAAAAAAAAAAA",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured_as_subentry"
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host",
+    "xbox_live_client",
+    "authentication_manager",
+)
+async def test_add_friend_flow(hass: HomeAssistant) -> None:
+    """Test add friend subentry flow."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="GSR Ae",
+        data={
+            "auth_implementation": "cloud",
+            "token": {
+                "access_token": "1234567890",
+                "expires_at": 1760697327.7298331,
+                "expires_in": 3600,
+                "refresh_token": "0987654321",
+                "scope": "XboxLive.signin XboxLive.offline_access",
+                "service": "xbox",
+                "token_type": "bearer",
+                "user_id": "AAAAAAAAAAAAAAAAAAAAA",
+            },
+        },
+        unique_id="271958441785640",
+        minor_version=3,
+    )
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    result = await hass.config_entries.subentries.async_init(
+        (config_entry.entry_id, "friend"),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        user_input={CONF_XUID: "2533274913657542"},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    subentry_id = list(config_entry.subentries)[0]
+    assert config_entry.subentries == {
+        subentry_id: ConfigSubentry(
+            data={},
+            subentry_id=subentry_id,
+            subentry_type="friend",
+            title="erics273",
+            unique_id="2533274913657542",
+        )
+    }
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host",
+    "xbox_live_client",
+    "authentication_manager",
+)
+async def test_add_friend_flow_already_configured(hass: HomeAssistant) -> None:
+    """Test add friend subentry flow."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="GSR Ae",
+        data={
+            "auth_implementation": "cloud",
+            "token": {
+                "access_token": "1234567890",
+                "expires_at": 1760697327.7298331,
+                "expires_in": 3600,
+                "refresh_token": "0987654321",
+                "scope": "XboxLive.signin XboxLive.offline_access",
+                "service": "xbox",
+                "token_type": "bearer",
+                "user_id": "AAAAAAAAAAAAAAAAAAAAA",
+            },
+        },
+        subentries_data=[
+            ConfigSubentryData(
+                data={},
+                subentry_type="friend",
+                title="erics273",
+                unique_id="2533274913657542",
+            )
+        ],
+        unique_id="271958441785640",
+        minor_version=3,
+    )
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    result = await hass.config_entries.subentries.async_init(
+        (config_entry.entry_id, "friend"),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        user_input={CONF_XUID: "2533274913657542"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host",
+    "xbox_live_client",
+    "authentication_manager",
+)
+async def test_add_friend_flow_already_configured_as_entry(hass: HomeAssistant) -> None:
+    """Test add friend subentry flow."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="GSR Ae",
+        data={
+            "auth_implementation": "cloud",
+            "token": {
+                "access_token": "1234567890",
+                "expires_at": 1760697327.7298331,
+                "expires_in": 3600,
+                "refresh_token": "0987654321",
+                "scope": "XboxLive.signin XboxLive.offline_access",
+                "service": "xbox",
+                "token_type": "bearer",
+                "user_id": "AAAAAAAAAAAAAAAAAAAAA",
+            },
+        },
+        unique_id="271958441785640",
+        minor_version=3,
+    )
+    MockConfigEntry(
+        domain=DOMAIN,
+        title="erics273",
+        data={
+            "auth_implementation": "cloud",
+            "token": {
+                "access_token": "1234567890",
+                "expires_at": 1760697327.7298331,
+                "expires_in": 3600,
+                "refresh_token": "0987654321",
+                "scope": "XboxLive.signin XboxLive.offline_access",
+                "service": "xbox",
+                "token_type": "bearer",
+                "user_id": "AAAAAAAAAAAAAAAAAAAAA",
+            },
+        },
+        unique_id="2533274913657542",
+        minor_version=3,
+    ).add_to_hass(hass)
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    result = await hass.config_entries.subentries.async_init(
+        (config_entry.entry_id, "friend"),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        user_input={CONF_XUID: "2533274913657542"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured_as_entry"
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host",
+    "authentication_manager",
+)
+async def test_add_friend_flow_no_friends(
+    hass: HomeAssistant, xbox_live_client: AsyncMock
+) -> None:
+    """Test add friend subentry flow."""
+    xbox_live_client.people.get_friends_own.return_value = PeopleResponse(
+        **await async_load_json_object_fixture(
+            hass, "people_friends_own_no_friends.json", DOMAIN
+        )  # type: ignore[reportArgumentType]
+    )
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="GSR Ae",
+        data={
+            "auth_implementation": "cloud",
+            "token": {
+                "access_token": "1234567890",
+                "expires_at": 1760697327.7298331,
+                "expires_in": 3600,
+                "refresh_token": "0987654321",
+                "scope": "XboxLive.signin XboxLive.offline_access",
+                "service": "xbox",
+                "token_type": "bearer",
+                "user_id": "AAAAAAAAAAAAAAAAAAAAA",
+            },
+        },
+        unique_id="271958441785640",
+        minor_version=3,
+    )
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    result = await hass.config_entries.subentries.async_init(
+        (config_entry.entry_id, "friend"),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_friends"
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host",
+    "xbox_live_client",
+    "authentication_manager",
+)
+async def test_add_friend_flow_config_entry_not_loaded(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test add friend subentry flow."""
+    config_entry.add_to_hass(hass)
+
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+    result = await hass.config_entries.subentries.async_init(
+        (config_entry.entry_id, "friend"),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "config_entry_not_loaded"
+
+
 @pytest.mark.usefixtures("xbox_live_client")
 async def test_unique_id_migration(
     hass: HomeAssistant,
@@ -164,9 +512,18 @@ async def test_unique_id_migration(
 
     assert config_entry.state is config_entries.ConfigEntryState.LOADED
     assert config_entry.version == 1
-    assert config_entry.minor_version == 2
+    assert config_entry.minor_version == 3
     assert config_entry.unique_id == "271958441785640"
     assert config_entry.title == "GSR Ae"
+    assert len(config_entry.subentries) == 2
+
+    subentries = list(config_entry.subentries.values())
+    assert subentries[0].unique_id == "2533274838782903"
+    assert subentries[0].title == "Ikken Hissatsuu"
+    assert subentries[0].subentry_type == "friend"
+    assert subentries[1].unique_id == "2533274913657542"
+    assert subentries[1].title == "erics273"
+    assert subentries[1].subentry_type == "friend"
 
 
 @pytest.mark.usefixtures(

--- a/tests/components/xbox/test_config_flow.py
+++ b/tests/components/xbox/test_config_flow.py
@@ -480,10 +480,10 @@ async def test_add_friend_flow_config_entry_not_loaded(
 
 
 @pytest.mark.usefixtures("xbox_live_client")
-async def test_unique_id_migration(
+async def test_unique_id_and_friends_migration(
     hass: HomeAssistant,
 ) -> None:
-    """Test config entry unique_id migration."""
+    """Test config entry unique_id migration and favorite to subentry migration."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="Home Assistant Cloud",
@@ -515,8 +515,9 @@ async def test_unique_id_migration(
     assert config_entry.minor_version == 3
     assert config_entry.unique_id == "271958441785640"
     assert config_entry.title == "GSR Ae"
-    assert len(config_entry.subentries) == 2
 
+    # Assert favorite friends migrated to subentries
+    assert len(config_entry.subentries) == 2
     subentries = list(config_entry.subentries.values())
     assert subentries[0].unique_id == "2533274838782903"
     assert subentries[0].title == "Ikken Hissatsuu"

--- a/tests/components/xbox/test_config_flow.py
+++ b/tests/components/xbox/test_config_flow.py
@@ -479,10 +479,8 @@ async def test_add_friend_flow_config_entry_not_loaded(
     assert result["reason"] == "config_entry_not_loaded"
 
 
-@pytest.mark.usefixtures("xbox_live_client")
-async def test_unique_id_and_friends_migration(
-    hass: HomeAssistant,
-) -> None:
+@pytest.mark.usefixtures("xbox_live_client", "authentication_manager")
+async def test_unique_id_and_friends_migration(hass: HomeAssistant) -> None:
     """Test config entry unique_id migration and favorite to subentry migration."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/xbox/test_media_source.py
+++ b/tests/components/xbox/test_media_source.py
@@ -87,12 +87,29 @@ async def test_browse_media(
 
 async def test_browse_media_accounts(
     hass: HomeAssistant,
-    config_entry: MockConfigEntry,
     xbox_live_client: AsyncMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test browsing media we get account view if more than 1 account is configured."""
-
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="GSR Ae",
+        data={
+            "auth_implementation": "cloud",
+            "token": {
+                "access_token": "1234567890",
+                "expires_at": 1760697327.7298331,
+                "expires_in": 3600,
+                "refresh_token": "0987654321",
+                "scope": "XboxLive.signin XboxLive.offline_access",
+                "service": "xbox",
+                "token_type": "bearer",
+                "user_id": "AAAAAAAAAAAAAAAAAAAAA",
+            },
+        },
+        unique_id="271958441785640",
+        minor_version=3,
+    )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -120,7 +137,7 @@ async def test_browse_media_accounts(
             },
         },
         unique_id="277923030577271",
-        minor_version=2,
+        minor_version=3,
     )
     config_entry2.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry2.entry_id)
@@ -213,7 +230,7 @@ async def test_browse_media_not_configured_exception(
         },
         unique_id="2533274838782903",
         disabled_by=ConfigEntryDisabler.USER,
-        minor_version=2,
+        minor_version=3,
     )
 
     config_entry.add_to_hass(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, adding friends to the Xbox integration is handled by marking them as favorites in the Xbox Network. However, since the integration was recently expanded to support multiple Xbox accounts, this approach can lead to unique ID conflicts when a person is a friend of more than one account. In such cases, each integration instance may attempt to create entities for the same friend, and which one succeeds depends on the order in which the integrations are loaded.

By migrating from favorites to sub-entries, we gain finer control over which integration entry is responsible for creating entities for a given friend.

To avoid breaking existing setups, a config entry migration will run once and automatically create sub-entries for each friend currently marked as a favorite.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42166
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
