### PR TITLE
Enable trophy sensors also for friends in PlayStation Network integration

### DIFF
--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -256,6 +256,7 @@ class PlaystationNetworkFriendDataCoordinator(
                 account_id=self.user.account_id,
                 presence=self.user.get_presence(),
                 profile=self.profile,
+                trophy_summary=self.user.trophy_summary(),
             )
         except PSNAWPForbiddenError as error:
             raise UpdateFailed(

--- a/homeassistant/components/playstation_network/sensor.py
+++ b/homeassistant/components/playstation_network/sensor.py
@@ -54,7 +54,7 @@ class PlaystationNetworkSensor(StrEnum):
     NOW_PLAYING = "now_playing"
 
 
-SENSOR_DESCRIPTIONS_TROPHY: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
+SENSOR_DESCRIPTIONS: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
     PlaystationNetworkSensorEntityDescription(
         key=PlaystationNetworkSensor.TROPHY_LEVEL,
         translation_key=PlaystationNetworkSensor.TROPHY_LEVEL,
@@ -106,8 +106,6 @@ SENSOR_DESCRIPTIONS_TROPHY: tuple[PlaystationNetworkSensorEntityDescription, ...
             else None
         ),
     ),
-)
-SENSOR_DESCRIPTIONS_USER: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
     PlaystationNetworkSensorEntityDescription(
         key=PlaystationNetworkSensor.ONLINE_ID,
         translation_key=PlaystationNetworkSensor.ONLINE_ID,
@@ -152,7 +150,7 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data.user_data
     async_add_entities(
         PlaystationNetworkSensorEntity(coordinator, description)
-        for description in SENSOR_DESCRIPTIONS_TROPHY + SENSOR_DESCRIPTIONS_USER
+        for description in SENSOR_DESCRIPTIONS
     )
 
     for (
@@ -166,7 +164,7 @@ async def async_setup_entry(
                     description,
                     config_entry.subentries[subentry_id],
                 )
-                for description in SENSOR_DESCRIPTIONS_USER
+                for description in SENSOR_DESCRIPTIONS
             ],
             config_subentry_id=subentry_id,
         )

--- a/tests/components/playstation_network/conftest.py
+++ b/tests/components/playstation_network/conftest.py
@@ -185,7 +185,9 @@ def mock_psnawpapi(mock_user: MagicMock) -> Generator[MagicMock]:
             spec=User, account_id="fren-psn-id", online_id="PublicUniversalFriend"
         )
         fren.get_presence.return_value = mock_user.get_presence.return_value
-
+        fren.trophy_summary.return_value = TrophySummary(
+            "fren-psn-id", 420, 20, 5, TrophySet(4782, 1245, 437, 96)
+        )
         client.user.return_value.friends_list.return_value = [fren]
 
         yield client

--- a/tests/components/playstation_network/snapshots/test_sensor.ambr
+++ b/tests/components/playstation_network/snapshots/test_sensor.ambr
@@ -1,4 +1,102 @@
 # serializer version: 1
+# name: test_sensors[sensor.publicuniversalfriend_bronze_trophies-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.publicuniversalfriend_bronze_trophies',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bronze trophies',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.EARNED_TROPHIES_BRONZE: 'earned_trophies_bronze'>,
+    'unique_id': 'fren-psn-id_earned_trophies_bronze',
+    'unit_of_measurement': 'trophies',
+  })
+# ---
+# name: test_sensors[sensor.publicuniversalfriend_bronze_trophies-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'PublicUniversalFriend Bronze trophies',
+      'unit_of_measurement': 'trophies',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.publicuniversalfriend_bronze_trophies',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '4782',
+  })
+# ---
+# name: test_sensors[sensor.publicuniversalfriend_gold_trophies-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.publicuniversalfriend_gold_trophies',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Gold trophies',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.EARNED_TROPHIES_GOLD: 'earned_trophies_gold'>,
+    'unique_id': 'fren-psn-id_earned_trophies_gold',
+    'unit_of_measurement': 'trophies',
+  })
+# ---
+# name: test_sensors[sensor.publicuniversalfriend_gold_trophies-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'PublicUniversalFriend Gold trophies',
+      'unit_of_measurement': 'trophies',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.publicuniversalfriend_gold_trophies',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '437',
+  })
+# ---
 # name: test_sensors[sensor.publicuniversalfriend_last_online-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -46,6 +144,55 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2025-06-30T01:42:15+00:00',
+  })
+# ---
+# name: test_sensors[sensor.publicuniversalfriend_next_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.publicuniversalfriend_next_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Next level',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.TROPHY_LEVEL_PROGRESS: 'trophy_level_progress'>,
+    'unique_id': 'fren-psn-id_trophy_level_progress',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.publicuniversalfriend_next_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'PublicUniversalFriend Next level',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.publicuniversalfriend_next_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '20',
   })
 # ---
 # name: test_sensors[sensor.publicuniversalfriend_now_playing-entry]
@@ -204,6 +351,152 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'availabletoplay',
+  })
+# ---
+# name: test_sensors[sensor.publicuniversalfriend_platinum_trophies-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.publicuniversalfriend_platinum_trophies',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Platinum trophies',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.EARNED_TROPHIES_PLATINUM: 'earned_trophies_platinum'>,
+    'unique_id': 'fren-psn-id_earned_trophies_platinum',
+    'unit_of_measurement': 'trophies',
+  })
+# ---
+# name: test_sensors[sensor.publicuniversalfriend_platinum_trophies-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'PublicUniversalFriend Platinum trophies',
+      'unit_of_measurement': 'trophies',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.publicuniversalfriend_platinum_trophies',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '96',
+  })
+# ---
+# name: test_sensors[sensor.publicuniversalfriend_silver_trophies-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.publicuniversalfriend_silver_trophies',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Silver trophies',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.EARNED_TROPHIES_SILVER: 'earned_trophies_silver'>,
+    'unique_id': 'fren-psn-id_earned_trophies_silver',
+    'unit_of_measurement': 'trophies',
+  })
+# ---
+# name: test_sensors[sensor.publicuniversalfriend_silver_trophies-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'PublicUniversalFriend Silver trophies',
+      'unit_of_measurement': 'trophies',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.publicuniversalfriend_silver_trophies',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1245',
+  })
+# ---
+# name: test_sensors[sensor.publicuniversalfriend_trophy_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.publicuniversalfriend_trophy_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Trophy level',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.TROPHY_LEVEL: 'trophy_level'>,
+    'unique_id': 'fren-psn-id_trophy_level',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.publicuniversalfriend_trophy_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'PublicUniversalFriend Trophy level',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.publicuniversalfriend_trophy_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '420',
   })
 # ---
 # name: test_sensors[sensor.testuser_bronze_trophies-entry]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Enables sensors for bronze, silver, gold, platinum trophies and trophy level for friend entries. Currently these sensors are limited to the own account.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41709
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
