### PR TITLE
Add service for setting hot water schedule

### DIFF
--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -27,12 +27,17 @@ from homeassistant.exceptions import (
     ConfigEntryError,
     ConfigEntryNotReady,
 )
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_PASSKEY, DOMAIN
 from .coordinator import BSBLanFastCoordinator, BSBLanSlowCoordinator
+from .services import async_setup_services
 
 PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.WATER_HEATER]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 type BSBLanConfigEntry = ConfigEntry[BSBLanData]
 
@@ -47,6 +52,12 @@ class BSBLanData:
     device: Device
     info: Info
     static: StaticState
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the BSB-Lan integration."""
+    async_setup_services(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bool:

--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -133,4 +133,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
 
 async def async_unload_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bool:
     """Unload BSBLAN config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    # Remove services only if this is the last loaded entry for this integration
+    if unload_ok and not hass.config_entries.async_loaded_entries(DOMAIN):
+        for service_name in hass.services.async_services()[DOMAIN]:
+            hass.services.async_remove(DOMAIN, service_name)
+
+    return unload_ok

--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -33,7 +33,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_PASSKEY, DOMAIN
 from .coordinator import BSBLanFastCoordinator, BSBLanSlowCoordinator
-from .services import SERVICE_SET_HOT_WATER_SCHEDULE, async_setup_services
+from .services import async_setup_services
 
 PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.WATER_HEATER]
 
@@ -133,10 +133,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
 
 async def async_unload_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bool:
     """Unload BSBLAN config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    # Remove services only if this is the last loaded entry for this integration
-    if unload_ok and not hass.config_entries.async_loaded_entries(DOMAIN):
-        hass.services.async_remove(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -33,7 +33,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_PASSKEY, DOMAIN
 from .coordinator import BSBLanFastCoordinator, BSBLanSlowCoordinator
-from .services import async_setup_services
+from .services import SERVICE_SET_HOT_WATER_SCHEDULE, async_setup_services
 
 PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.WATER_HEATER]
 
@@ -137,7 +137,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> b
 
     # Remove services only if this is the last loaded entry for this integration
     if unload_ok and not hass.config_entries.async_loaded_entries(DOMAIN):
-        for service_name in hass.services.async_services()[DOMAIN]:
-            hass.services.async_remove(DOMAIN, service_name)
+        hass.services.async_remove(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
 
     return unload_ok

--- a/homeassistant/components/bsblan/icons.json
+++ b/homeassistant/components/bsblan/icons.json
@@ -1,0 +1,7 @@
+{
+  "services": {
+    "set_hot_water_schedule": {
+      "service": "mdi:calendar-clock"
+    }
+  }
+}

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from bsblan import DHWTimeSwitchPrograms
+from bsblan import BSBLANError, DHWTimeSwitchPrograms
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntryState
@@ -111,7 +111,7 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
     try:
         # Call the BSB-Lan API to set the schedule
         await client.set_hot_water(dhw_time_programs=dhw_programs)
-    except Exception as err:
+    except BSBLANError as err:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="set_schedule_failed",

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
 from .const import DOMAIN
@@ -112,13 +112,11 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
         # Call the BSB-Lan API to set the schedule
         await client.set_hot_water(dhw_time_programs=dhw_programs)
     except BSBLANError as err:
-        raise ServiceValidationError(
+        raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="set_schedule_failed",
             translation_placeholders={"error": str(err)},
         ) from err
-
-    LOGGER.info("Hot water schedule updated successfully")
 
     # Refresh the slow coordinator to get the updated schedule
     await entry.runtime_data.slow_coordinator.async_request_refresh()

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -69,20 +69,20 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
         )
 
     # Find the config entry for this device
-    loaded_entries: list[BSBLanConfigEntry] = [
+    matching_entries: list[BSBLanConfigEntry] = [
         entry
-        for entry in service_call.hass.config_entries.async_loaded_entries(DOMAIN)
+        for entry in service_call.hass.config_entries.async_entries(DOMAIN)
         if entry.entry_id in device_entry.config_entries
     ]
 
-    if not loaded_entries:
+    if not matching_entries:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="no_config_entry_for_device",
             translation_placeholders={"device_id": device_entry.name or device_id},
         )
 
-    entry = loaded_entries[0]
+    entry = matching_entries[0]
 
     # Verify the config entry is loaded
     if entry.state is not ConfigEntryState.LOADED:

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -1,0 +1,141 @@
+"""Support for BSB-Lan services."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from bsblan import DHWTimeSwitchPrograms
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv, device_registry as dr
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from . import BSBLanConfigEntry
+
+LOGGER = logging.getLogger(__name__)
+
+ATTR_DEVICE = "device"
+ATTR_SCHEDULE = "schedule"
+
+# Service name
+SERVICE_SET_HOT_WATER_SCHEDULE = "set_hot_water_schedule"
+
+# Schema for the day schedule
+SERVICE_SCHEDULE_DAY_SCHEMA = vol.Schema(cv.string)
+
+# Schema for the complete schedule
+SERVICE_SCHEDULE_SCHEMA = vol.Schema(
+    {
+        vol.Optional("monday"): vol.Any(None, SERVICE_SCHEDULE_DAY_SCHEMA),
+        vol.Optional("tuesday"): vol.Any(None, SERVICE_SCHEDULE_DAY_SCHEMA),
+        vol.Optional("wednesday"): vol.Any(None, SERVICE_SCHEDULE_DAY_SCHEMA),
+        vol.Optional("thursday"): vol.Any(None, SERVICE_SCHEDULE_DAY_SCHEMA),
+        vol.Optional("friday"): vol.Any(None, SERVICE_SCHEDULE_DAY_SCHEMA),
+        vol.Optional("saturday"): vol.Any(None, SERVICE_SCHEDULE_DAY_SCHEMA),
+        vol.Optional("sunday"): vol.Any(None, SERVICE_SCHEDULE_DAY_SCHEMA),
+        vol.Optional("standard_values"): vol.Any(None, SERVICE_SCHEDULE_DAY_SCHEMA),
+    }
+)
+
+# Schema for the service call
+SERVICE_SET_HOT_WATER_SCHEDULE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE): cv.string,
+        vol.Required(ATTR_SCHEDULE): SERVICE_SCHEDULE_SCHEMA,
+    }
+)
+
+
+async def set_hot_water_schedule(service_call: ServiceCall) -> None:
+    """Set hot water heating schedule."""
+    schedule_data: dict[str, Any] = service_call.data[ATTR_SCHEDULE]
+    device_id = service_call.data[ATTR_DEVICE]
+
+    # Get the device and config entry
+    device_registry = dr.async_get(service_call.hass)
+    device_entry = device_registry.async_get(device_id)
+
+    if device_entry is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_device_id",
+            translation_placeholders={"device_id": device_id},
+        )
+
+    # Find the config entry for this device
+    loaded_entries: list[BSBLanConfigEntry] = [
+        entry
+        for entry in service_call.hass.config_entries.async_loaded_entries(DOMAIN)
+        if entry.entry_id in device_entry.config_entries
+    ]
+
+    if not loaded_entries:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="no_config_entry_for_device",
+            translation_placeholders={"device_id": device_entry.name or device_id},
+        )
+
+    entry = loaded_entries[0]
+
+    # Verify the config entry is loaded
+    if entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="config_entry_not_loaded",
+            translation_placeholders={"device_name": device_entry.name or device_id},
+        )
+
+    client = entry.runtime_data.client
+
+    # Create the DHWTimeSwitchPrograms object
+    dhw_programs = DHWTimeSwitchPrograms(
+        monday=schedule_data.get("monday"),
+        tuesday=schedule_data.get("tuesday"),
+        wednesday=schedule_data.get("wednesday"),
+        thursday=schedule_data.get("thursday"),
+        friday=schedule_data.get("friday"),
+        saturday=schedule_data.get("saturday"),
+        sunday=schedule_data.get("sunday"),
+        standard_values=schedule_data.get("standard_values"),
+    )
+
+    LOGGER.debug("Setting hot water schedule: %s", schedule_data)
+
+    try:
+        # Call the BSB-Lan API to set the schedule
+        await client.set_hot_water(dhw_time_programs=dhw_programs)
+    except Exception as err:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="set_schedule_failed",
+            translation_placeholders={"error": str(err)},
+        ) from err
+
+    LOGGER.info("Hot water schedule updated successfully")
+
+    # Refresh the slow coordinator to get the updated schedule
+    await entry.runtime_data.slow_coordinator.async_request_refresh()
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register the BSB-Lan services."""
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_HOT_WATER_SCHEDULE,
+        set_hot_water_schedule,
+        schema=SERVICE_SET_HOT_WATER_SCHEDULE_SCHEMA,
+    )
+
+
+@callback
+def async_unload_services(hass: HomeAssistant) -> None:
+    """Unload BSB-Lan services."""
+    hass.services.async_remove(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -34,15 +34,19 @@ ATTR_STANDARD_VALUES_SLOTS = "standard_values_slots"
 SERVICE_SET_HOT_WATER_SCHEDULE = "set_hot_water_schedule"
 
 
-def _convert_time_slots_to_string(slots: list[dict[str, time]] | None) -> str:
+def _convert_time_slots_to_string(slots: list[dict[str, time]] | None) -> str | None:
     """Convert list of time slot dicts to BSB-LAN format string.
 
     Example: [{"start_time": "06:00", "end_time": "08:00"}, {"start_time": "17:00", "end_time": "21:00"}]
     becomes: "06:00-08:00 17:00-21:00"
 
-    Empty list or None returns empty string.
+    None returns None (don't modify this day).
+    Empty list returns empty string (clear this day).
     """
-    if slots is None or not slots:
+    if slots is None:
+        return None
+
+    if not slots:
         return ""
 
     time_periods = []

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -45,9 +45,6 @@ def _convert_time_slots_to_string(slots: list[dict[str, time]] | None) -> str:
     if slots is None or not slots:
         return ""
 
-    if not slots:  # Empty list (shouldn't happen, but handle it)
-        return ""
-
     time_periods = []
     for slot in slots:
         start = slot.get("start_time")

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -133,9 +133,3 @@ def async_setup_services(hass: HomeAssistant) -> None:
         set_hot_water_schedule,
         schema=SERVICE_SET_HOT_WATER_SCHEDULE_SCHEMA,
     )
-
-
-@callback
-def async_unload_services(hass: HomeAssistant) -> None:
-    """Unload BSB-Lan services."""
-    hass.services.async_remove(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)

--- a/homeassistant/components/bsblan/services.yaml
+++ b/homeassistant/components/bsblan/services.yaml
@@ -1,20 +1,128 @@
 set_hot_water_schedule:
   fields:
-    device:
+    device_id:
       required: true
       example: "abc123device456"
       selector:
         device:
           integration: bsblan
-    schedule:
-      required: true
-      example:
-        monday: "06:00-08:00 17:00-21:00"
-        tuesday: "06:00-08:00 17:00-21:00"
-        wednesday: "06:00-08:00 17:00-21:00"
-        thursday: "06:00-08:00 17:00-21:00"
-        friday: "06:00-08:00 17:00-21:00"
-        saturday: "08:00-22:00"
-        sunday: "08:00-22:00"
+    monday_slots:
       selector:
         object:
+          multiple: true
+          label_field: start_time
+          description_field: end_time
+          fields:
+            start_time:
+              required: true
+              selector:
+                time:
+            end_time:
+              required: true
+              selector:
+                time:
+    tuesday_slots:
+      selector:
+        object:
+          multiple: true
+          label_field: start_time
+          description_field: end_time
+          fields:
+            start_time:
+              required: true
+              selector:
+                time:
+            end_time:
+              required: true
+              selector:
+                time:
+    wednesday_slots:
+      selector:
+        object:
+          multiple: true
+          label_field: start_time
+          description_field: end_time
+          fields:
+            start_time:
+              required: true
+              selector:
+                time:
+            end_time:
+              required: true
+              selector:
+                time:
+    thursday_slots:
+      selector:
+        object:
+          multiple: true
+          label_field: start_time
+          description_field: end_time
+          fields:
+            start_time:
+              required: true
+              selector:
+                time:
+            end_time:
+              required: true
+              selector:
+                time:
+    friday_slots:
+      selector:
+        object:
+          multiple: true
+          label_field: start_time
+          description_field: end_time
+          fields:
+            start_time:
+              required: true
+              selector:
+                time:
+            end_time:
+              required: true
+              selector:
+                time:
+    saturday_slots:
+      selector:
+        object:
+          multiple: true
+          label_field: start_time
+          description_field: end_time
+          fields:
+            start_time:
+              required: true
+              selector:
+                time:
+            end_time:
+              required: true
+              selector:
+                time:
+    sunday_slots:
+      selector:
+        object:
+          multiple: true
+          label_field: start_time
+          description_field: end_time
+          fields:
+            start_time:
+              required: true
+              selector:
+                time:
+            end_time:
+              required: true
+              selector:
+                time:
+    standard_values_slots:
+      selector:
+        object:
+          multiple: true
+          label_field: start_time
+          description_field: end_time
+          fields:
+            start_time:
+              required: true
+              selector:
+                time:
+            end_time:
+              required: true
+              selector:
+                time:

--- a/homeassistant/components/bsblan/services.yaml
+++ b/homeassistant/components/bsblan/services.yaml
@@ -111,18 +111,3 @@ set_hot_water_schedule:
               required: true
               selector:
                 time:
-    standard_values_slots:
-      selector:
-        object:
-          multiple: true
-          label_field: start_time
-          description_field: end_time
-          fields:
-            start_time:
-              required: true
-              selector:
-                time:
-            end_time:
-              required: true
-              selector:
-                time:

--- a/homeassistant/components/bsblan/services.yaml
+++ b/homeassistant/components/bsblan/services.yaml
@@ -1,0 +1,20 @@
+set_hot_water_schedule:
+  fields:
+    device:
+      required: true
+      example: "abc123device456"
+      selector:
+        device:
+          integration: bsblan
+    schedule:
+      required: true
+      example:
+        monday: "06:00-08:00 17:00-21:00"
+        tuesday: "06:00-08:00 17:00-21:00"
+        wednesday: "06:00-08:00 17:00-21:00"
+        thursday: "06:00-08:00 17:00-21:00"
+        friday: "06:00-08:00 17:00-21:00"
+        saturday: "08:00-22:00"
+        sunday: "08:00-22:00"
+      selector:
+        object:

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -106,14 +106,14 @@
   },
   "services": {
     "set_hot_water_schedule": {
-      "description": "Set the hot water heating schedule for a BSB-Lan device.",
+      "description": "Set the hot water heating schedule for a BSB-LAN device.",
       "fields": {
         "device": {
-          "description": "The BSB-Lan device to configure.",
+          "description": "The BSB-LAN device to configure.",
           "name": "Device"
         },
         "schedule": {
-          "description": "Hot water schedule configuration. Each day can have time periods specified as strings in the format \"HH:MM-HH:MM HH:MM-HH:MM\" (e.g., \"06:00-08:00 17:00-21:00\" for morning and evening periods). Set a day to null to clear its schedule.",
+          "description": "Schedule with day names (monday, tuesday, etc.) as keys. Time format: \"HH:MM-HH:MM\" (24-hour). Multiple periods per day separated by spaces: \"06:00-08:00 17:00-21:00\". Set a day to null to clear its schedule.",
           "name": "Schedule"
         }
       },

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -73,8 +73,14 @@
     "config_entry_not_loaded": {
       "message": "The device `{device_name}` is not currently loaded or available"
     },
+    "end_time_before_start_time": {
+      "message": "End time ({end_time}) must be after start time ({start_time})"
+    },
     "invalid_device_id": {
       "message": "Invalid device ID: {device_id}"
+    },
+    "invalid_time_format": {
+      "message": "Invalid time format provided"
     },
     "no_config_entry_for_device": {
       "message": "No configuration entry found for device: {device_id}"

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -108,13 +108,41 @@
     "set_hot_water_schedule": {
       "description": "Set the hot water heating schedule for a BSB-LAN device.",
       "fields": {
-        "device": {
+        "device_id": {
           "description": "The BSB-LAN device to configure.",
           "name": "Device"
         },
-        "schedule": {
-          "description": "Schedule with day names (monday, tuesday, etc.) as keys. Time format: \"HH:MM-HH:MM\" (24-hour). Multiple periods per day separated by spaces: \"06:00-08:00 17:00-21:00\". Set a day to null to clear its schedule.",
-          "name": "Schedule"
+        "friday_slots": {
+          "description": "Time periods for Friday. Add multiple slots for different heating periods throughout the day.",
+          "name": "Friday time slots"
+        },
+        "monday_slots": {
+          "description": "Time periods for Monday. Add multiple slots for different heating periods throughout the day.",
+          "name": "Monday time slots"
+        },
+        "saturday_slots": {
+          "description": "Time periods for Saturday. Add multiple slots for different heating periods throughout the day.",
+          "name": "Saturday time slots"
+        },
+        "standard_values_slots": {
+          "description": "Default time periods that apply to days without specific slots configured.",
+          "name": "Default time slots"
+        },
+        "sunday_slots": {
+          "description": "Time periods for Sunday. Add multiple slots for different heating periods throughout the day.",
+          "name": "Sunday time slots"
+        },
+        "thursday_slots": {
+          "description": "Time periods for Thursday. Add multiple slots for different heating periods throughout the day.",
+          "name": "Thursday time slots"
+        },
+        "tuesday_slots": {
+          "description": "Time periods for Tuesday. Add multiple slots for different heating periods throughout the day.",
+          "name": "Tuesday time slots"
+        },
+        "wednesday_slots": {
+          "description": "Time periods for Wednesday. Add multiple slots for different heating periods throughout the day.",
+          "name": "Wednesday time slots"
         }
       },
       "name": "Set hot water schedule"

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -70,6 +70,15 @@
     }
   },
   "exceptions": {
+    "config_entry_not_loaded": {
+      "message": "The device `{device_name}` is not currently loaded or available"
+    },
+    "invalid_device_id": {
+      "message": "Invalid device ID: {device_id}"
+    },
+    "no_config_entry_for_device": {
+      "message": "No configuration entry found for device: {device_id}"
+    },
     "set_data_error": {
       "message": "An error occurred while sending the data to the BSB-Lan device"
     },
@@ -78,6 +87,9 @@
     },
     "set_preset_mode_error": {
       "message": "Can't set preset mode to {preset_mode} when HVAC mode is not set to auto"
+    },
+    "set_schedule_failed": {
+      "message": "Failed to set hot water schedule: {error}"
     },
     "set_temperature_error": {
       "message": "An error occurred while setting the temperature"
@@ -90,6 +102,22 @@
     },
     "setup_general_error": {
       "message": "An unknown error occurred while retrieving static device data"
+    }
+  },
+  "services": {
+    "set_hot_water_schedule": {
+      "description": "Set the hot water heating schedule for a BSB-Lan device.",
+      "fields": {
+        "device": {
+          "description": "The BSB-Lan device to configure.",
+          "name": "Device"
+        },
+        "schedule": {
+          "description": "Hot water schedule configuration. Each day can have time periods specified as strings in the format \"HH:MM-HH:MM HH:MM-HH:MM\" (e.g., \"06:00-08:00 17:00-21:00\" for morning and evening periods). Set a day to null to clear its schedule.",
+          "name": "Schedule"
+        }
+      },
+      "name": "Set hot water schedule"
     }
   }
 }

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -130,10 +130,6 @@
           "description": "Time periods for Saturday. Add multiple slots for different heating periods throughout the day.",
           "name": "Saturday time slots"
         },
-        "standard_values_slots": {
-          "description": "Default time periods that apply to days without specific slots configured.",
-          "name": "Default time slots"
-        },
         "sunday_slots": {
           "description": "Time periods for Sunday. Add multiple slots for different heating periods throughout the day.",
           "name": "Sunday time slots"

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -18,7 +18,34 @@ from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
+# Test constants
+TEST_DEVICE_MAC = "00:80:41:19:69:90"
 
+
+@pytest.fixture
+async def setup_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Set up the BSB-LAN integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.fixture
+def device_entry(
+    device_registry: dr.DeviceRegistry,
+    setup_integration: None,
+) -> dr.DeviceEntry:
+    """Get the device entry for testing."""
+    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    assert device is not None
+    return device
+
+
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.parametrize(
     ("service_data", "expected_strings"),
     [
@@ -91,22 +118,11 @@ from tests.common import MockConfigEntry
 async def test_set_hot_water_schedule(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    device_registry: dr.DeviceRegistry,
+    device_entry: dr.DeviceEntry,
     service_data: dict[str, Any],
     expected_strings: dict[str, str],
 ) -> None:
     """Test setting hot water schedule with various configurations."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Get the device ID
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:80:41:19:69:90")}
-    )
-    assert device_entry is not None
-
     # Call the service with device_id and slot fields
     service_call_data = {"device_id": device_entry.id}
     service_call_data.update(service_data)
@@ -176,7 +192,7 @@ async def test_service_error_scenarios(
         device_registry = dr.async_get(hass)
         device_entry = device_registry.async_get_or_create(
             config_entry_id=mock_config_entry.entry_id,
-            identifiers={(DOMAIN, "00:80:41:19:69:90")},
+            identifiers={(DOMAIN, TEST_DEVICE_MAC)},
             name="BSB-LAN Device",
         )
         device_id = device_entry.id
@@ -190,7 +206,7 @@ async def test_service_error_scenarios(
 
         device_registry = dr.async_get(hass)
         device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, "00:80:41:19:69:90")}
+            identifiers={(DOMAIN, TEST_DEVICE_MAC)}
         )
         assert device_entry is not None
         device_id = device_entry.id
@@ -224,23 +240,31 @@ async def test_service_error_scenarios(
     assert exc_info.value.translation_key == expected_translation_key
 
 
-async def test_end_time_before_start_time(
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.parametrize(
+    ("input_type", "start_time", "end_time", "expected_error"),
+    [
+        ("time_objects", time(13, 0), time(11, 0), "end_time_before_start_time"),
+        ("strings", "13:00", "11:00", "end_time_before_start_time"),
+        ("invalid_start", "invalid", "08:00", "invalid_time_format"),
+        ("invalid_end", "06:00", "not-a-time", "invalid_time_format"),
+    ],
+    ids=[
+        "time_objects_end_before_start",
+        "strings_end_before_start",
+        "invalid_start_time_format",
+        "invalid_end_time_format",
+    ],
+)
+async def test_time_validation_errors(
     hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_bsblan: MagicMock,
-    device_registry: dr.DeviceRegistry,
+    device_entry: dr.DeviceEntry,
+    input_type: str,
+    start_time: time | str,
+    end_time: time | str,
+    expected_error: str,
 ) -> None:
-    """Test validation error when end time is before start time."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:80:41:19:69:90")}
-    )
-    assert device_entry is not None
-
-    # Try to create a time slot where end is before start
+    """Test validation errors for various time input scenarios."""
     with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
@@ -248,31 +272,63 @@ async def test_end_time_before_start_time(
             {
                 "device_id": device_entry.id,
                 "monday_slots": [
-                    {"start_time": time(13, 0), "end_time": time(11, 0)},  # Invalid!
+                    {"start_time": start_time, "end_time": end_time},
                 ],
             },
             blocking=True,
         )
 
-    assert exc_info.value.translation_key == "end_time_before_start_time"
+    assert exc_info.value.translation_key == expected_error
 
 
+@pytest.mark.usefixtures("setup_integration")
+async def test_unprovided_days_are_none(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    device_entry: dr.DeviceEntry,
+) -> None:
+    """Test that unprovided days are sent as None to BSB-LAN API."""
+    # Only provide Monday and Tuesday, leave other days unprovided
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HOT_WATER_SCHEDULE,
+        {
+            "device_id": device_entry.id,
+            "monday_slots": [
+                {"start_time": time(6, 0), "end_time": time(8, 0)},
+            ],
+            "tuesday_slots": [
+                {"start_time": time(17, 0), "end_time": time(21, 0)},
+            ],
+        },
+        blocking=True,
+    )
+
+    # Verify the API was called
+    assert mock_bsblan.set_hot_water.called
+    call_args = mock_bsblan.set_hot_water.call_args
+    dhw_programs = call_args.kwargs["dhw_time_programs"]
+
+    # Verify provided days have values
+    assert dhw_programs.monday == "06:00-08:00"
+    assert dhw_programs.tuesday == "17:00-21:00"
+
+    # Verify unprovided days are None (not empty string)
+    assert dhw_programs.wednesday is None
+    assert dhw_programs.thursday is None
+    assert dhw_programs.friday is None
+    assert dhw_programs.saturday is None
+    assert dhw_programs.sunday is None
+    assert dhw_programs.standard_values is None
+
+
+@pytest.mark.usefixtures("setup_integration")
 async def test_string_time_formats(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    device_registry: dr.DeviceRegistry,
+    device_entry: dr.DeviceEntry,
 ) -> None:
     """Test service with string time formats."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:80:41:19:69:90")}
-    )
-    assert device_entry is not None
-
     # Test with string time formats
     await hass.services.async_call(
         DOMAIN,
@@ -299,104 +355,13 @@ async def test_string_time_formats(
     assert dhw_programs.tuesday == "17:00-21:00"
 
 
-async def test_invalid_time_format(
-    hass: HomeAssistant,
-    mock_bsblan: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Test service with invalid time format in string."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:80:41:19:69:90")}
-    )
-    assert device_entry is not None
-
-    # Test with invalid start_time string format
-    with pytest.raises(ServiceValidationError) as exc_info:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
-            {
-                "device_id": device_entry.id,
-                "monday_slots": [
-                    {"start_time": "invalid", "end_time": "08:00"},
-                ],
-            },
-            blocking=True,
-        )
-
-    assert exc_info.value.translation_key == "invalid_time_format"
-
-    # Test with invalid end_time string format
-    with pytest.raises(ServiceValidationError) as exc_info:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
-            {
-                "device_id": device_entry.id,
-                "tuesday_slots": [
-                    {"start_time": "06:00", "end_time": "not-a-time"},
-                ],
-            },
-            blocking=True,
-        )
-
-    assert exc_info.value.translation_key == "invalid_time_format"
-
-
-async def test_string_time_validation(
-    hass: HomeAssistant,
-    mock_bsblan: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Test that end time validation works with string times."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:80:41:19:69:90")}
-    )
-    assert device_entry is not None
-
-    # Test with string format where end is before start
-    with pytest.raises(ServiceValidationError) as exc_info:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
-            {
-                "device_id": device_entry.id,
-                "wednesday_slots": [
-                    {"start_time": "13:00", "end_time": "11:00"},  # Invalid!
-                ],
-            },
-            blocking=True,
-        )
-
-    assert exc_info.value.translation_key == "end_time_before_start_time"
-
-
+@pytest.mark.usefixtures("setup_integration")
 async def test_non_standard_time_types(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    device_registry: dr.DeviceRegistry,
+    device_entry: dr.DeviceEntry,
 ) -> None:
     """Test service with non-standard time types (edge case for coverage)."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:80:41:19:69:90")}
-    )
-    assert device_entry is not None
-
     # Test with integer time values (shouldn't happen but need coverage)
     await hass.services.async_call(
         DOMAIN,

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -1,5 +1,6 @@
 """Tests for BSB-LAN services."""
 
+from typing import Any
 from unittest.mock import MagicMock
 
 from bsblan import BSBLANError
@@ -9,9 +10,7 @@ from homeassistant.components.bsblan.const import DOMAIN
 from homeassistant.components.bsblan.services import (
     SERVICE_SET_HOT_WATER_SCHEDULE,
     async_setup_services,
-    async_unload_services,
 )
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
@@ -19,12 +18,71 @@ from homeassistant.helpers import device_registry as dr
 from tests.common import MockConfigEntry
 
 
-async def test_service_set_hot_water_schedule_success(
+@pytest.mark.parametrize(
+    ("schedule_data", "expected_calls"),
+    [
+        (
+            {
+                "monday": "06:00-08:00 17:00-21:00",
+                "tuesday": "06:00-08:00 17:00-21:00",
+                "wednesday": "06:00-08:00 17:00-21:00",
+                "thursday": "06:00-08:00 17:00-21:00",
+                "friday": "06:00-08:00 17:00-21:00",
+                "saturday": "08:00-22:00",
+                "sunday": "08:00-22:00",
+            },
+            {
+                "monday": "06:00-08:00 17:00-21:00",
+                "tuesday": "06:00-08:00 17:00-21:00",
+                "saturday": "08:00-22:00",
+            },
+        ),
+        (
+            {
+                "monday": "06:00-08:00",
+                "friday": "17:00-21:00",
+            },
+            {
+                "monday": "06:00-08:00",
+                "friday": "17:00-21:00",
+            },
+        ),
+        (
+            {
+                "monday": None,
+                "tuesday": None,
+            },
+            {
+                "monday": None,
+                "tuesday": None,
+            },
+        ),
+        (
+            {
+                "wednesday": "06:00-08:00",
+                "standard_values": True,
+            },
+            {
+                "wednesday": "06:00-08:00",
+                "standard_values": "True",  # Converted to string by service layer
+            },
+        ),
+    ],
+    ids=[
+        "full_week_schedule",
+        "partial_days",
+        "clear_days_with_none",
+        "with_standard_values",
+    ],
+)
+async def test_service_set_hot_water_schedule(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_bsblan: MagicMock,
+    schedule_data: dict[str, Any],
+    expected_calls: dict[str, Any],
 ) -> None:
-    """Test successfully setting hot water schedule."""
+    """Test setting hot water schedule with various configurations."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -42,15 +100,7 @@ async def test_service_set_hot_water_schedule_success(
         SERVICE_SET_HOT_WATER_SCHEDULE,
         {
             "device": device_entry.id,
-            "schedule": {
-                "monday": "06:00-08:00 17:00-21:00",
-                "tuesday": "06:00-08:00 17:00-21:00",
-                "wednesday": "06:00-08:00 17:00-21:00",
-                "thursday": "06:00-08:00 17:00-21:00",
-                "friday": "06:00-08:00 17:00-21:00",
-                "saturday": "08:00-22:00",
-                "sunday": "08:00-22:00",
-            },
+            "schedule": schedule_data,
         },
         blocking=True,
     )
@@ -58,255 +108,103 @@ async def test_service_set_hot_water_schedule_success(
     # Verify the service was called correctly
     assert len(mock_bsblan.set_hot_water.mock_calls) == 1
     call_args = mock_bsblan.set_hot_water.call_args
-    assert call_args.kwargs["dhw_time_programs"].monday == "06:00-08:00 17:00-21:00"
-    assert call_args.kwargs["dhw_time_programs"].tuesday == "06:00-08:00 17:00-21:00"
-    assert call_args.kwargs["dhw_time_programs"].saturday == "08:00-22:00"
+
+    # Verify expected values - all values are in the dhw_time_programs object
+    dhw_programs = call_args.kwargs["dhw_time_programs"]
+    for key, value in expected_calls.items():
+        assert getattr(dhw_programs, key) == value
 
 
-async def test_service_set_hot_water_schedule_partial(
+@pytest.mark.parametrize(
+    ("setup_error", "device_id_override", "expected_translation_key"),
+    [
+        (None, "invalid_device_id", "invalid_device_id"),
+        ("no_config_entry", None, "no_config_entry_for_device"),
+        ("config_entry_not_loaded", None, "config_entry_not_loaded"),
+        ("api_error", None, "set_schedule_failed"),
+    ],
+    ids=[
+        "invalid_device_id",
+        "no_config_entry_for_device",
+        "config_entry_not_loaded",
+        "api_error",
+    ],
+)
+async def test_service_error_scenarios(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_bsblan: MagicMock,
+    setup_error: str | None,
+    device_id_override: str | None,
+    expected_translation_key: str,
 ) -> None:
-    """Test setting hot water schedule with partial days."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    """Test service error scenarios."""
+    if setup_error == "no_config_entry":
+        # Create a different config entry (not for bsblan)
+        other_entry = MockConfigEntry(domain="other_domain", data={})
+        other_entry.add_to_hass(hass)
 
-    device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:80:41:19:69:90")}
-    )
-    assert device_entry is not None
+        # Create a device for that other entry
+        device_registry = dr.async_get(hass)
+        device_entry = device_registry.async_get_or_create(
+            config_entry_id=other_entry.entry_id,
+            identifiers={("other_domain", "other_device")},
+            name="Other Device",
+        )
+        device_id = device_entry.id
 
-    # Call the service with only some days
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_HOT_WATER_SCHEDULE,
-        {
-            "device": device_entry.id,
-            "schedule": {
-                "monday": "06:00-08:00",
-                "friday": "17:00-21:00",
-            },
-        },
-        blocking=True,
-    )
+        # Register the bsblan service without setting up any bsblan config entry
+        async_setup_services(hass)
+    elif setup_error == "config_entry_not_loaded":
+        # Add the config entry but don't set it up (so it stays in NOT_LOADED state)
+        mock_config_entry.add_to_hass(hass)
 
-    # Verify the service was called
-    assert len(mock_bsblan.set_hot_water.mock_calls) == 1
-    call_args = mock_bsblan.set_hot_water.call_args
-    assert call_args.kwargs["dhw_time_programs"].monday == "06:00-08:00"
-    assert call_args.kwargs["dhw_time_programs"].friday == "17:00-21:00"
-    assert call_args.kwargs["dhw_time_programs"].tuesday is None
+        # Create the device manually since setup won't run
+        device_registry = dr.async_get(hass)
+        device_entry = device_registry.async_get_or_create(
+            config_entry_id=mock_config_entry.entry_id,
+            identifiers={(DOMAIN, "00:80:41:19:69:90")},
+            name="BSB-LAN Device",
+        )
+        device_id = device_entry.id
 
+        # Register the service
+        async_setup_services(hass)
+    else:
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
 
-async def test_service_set_hot_water_schedule_with_none(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_bsblan: MagicMock,
-) -> None:
-    """Test setting hot water schedule with None values to clear days."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+        device_registry = dr.async_get(hass)
+        device_entry = device_registry.async_get_device(
+            identifiers={(DOMAIN, "00:80:41:19:69:90")}
+        )
+        assert device_entry is not None
+        device_id = device_entry.id
 
-    device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:80:41:19:69:90")}
-    )
-    assert device_entry is not None
+        if setup_error == "api_error":
+            # Make the API call fail
+            mock_bsblan.set_hot_water.side_effect = BSBLANError("API Error")
 
-    # Call the service with None values
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_HOT_WATER_SCHEDULE,
-        {
-            "device": device_entry.id,
-            "schedule": {
-                "monday": None,
-                "tuesday": "06:00-08:00",
-            },
-        },
-        blocking=True,
-    )
+    # Override device ID if needed
+    if device_id_override:
+        device_id = device_id_override
 
-    # Verify the service was called
-    assert len(mock_bsblan.set_hot_water.mock_calls) == 1
-    call_args = mock_bsblan.set_hot_water.call_args
-    assert call_args.kwargs["dhw_time_programs"].monday is None
-    assert call_args.kwargs["dhw_time_programs"].tuesday == "06:00-08:00"
-
-
-async def test_service_invalid_device_id(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_bsblan: MagicMock,
-) -> None:
-    """Test service call with invalid device ID."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Call the service with invalid device ID
+    # Call the service and expect error
     with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_SET_HOT_WATER_SCHEDULE,
             {
-                "device": "invalid_device_id",
+                "device": device_id,
                 "schedule": {"monday": "06:00-08:00"},
             },
             blocking=True,
         )
 
-    assert exc_info.value.translation_key == "invalid_device_id"
-    assert "invalid_device_id" in exc_info.value.translation_placeholders["device_id"]
+    assert exc_info.value.translation_key == expected_translation_key
 
-
-async def test_service_no_config_entry_for_device(
-    hass: HomeAssistant,
-    mock_bsblan: MagicMock,
-) -> None:
-    """Test service call when device has no associated config entry."""
-    # Create a different config entry (not for bsblan)
-    other_entry = MockConfigEntry(domain="other_domain", data={})
-    other_entry.add_to_hass(hass)
-
-    # Create a device for that other entry
-    device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_or_create(
-        config_entry_id=other_entry.entry_id,
-        identifiers={("other_domain", "other_device")},
-        name="Other Device",
-    )
-
-    # Now register the bsblan service without setting up any bsblan config entry
-    async_setup_services(hass)
-
-    # Call the service with device from other domain
-    with pytest.raises(ServiceValidationError) as exc_info:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
-            {
-                "device": device_entry.id,
-                "schedule": {"monday": "06:00-08:00"},
-            },
-            blocking=True,
-        )
-
-    assert exc_info.value.translation_key == "no_config_entry_for_device"
-
-
-async def test_service_config_entry_not_loaded(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_bsblan: MagicMock,
-) -> None:
-    """Test service call when config entry is not loaded."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:80:41:19:69:90")}
-    )
-    assert device_entry is not None
-
-    # Unload the config entry
-    await hass.config_entries.async_unload(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
-
-    # Call the service with unloaded config entry
-    with pytest.raises(ServiceValidationError) as exc_info:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
-            {
-                "device": device_entry.id,
-                "schedule": {"monday": "06:00-08:00"},
-            },
-            blocking=True,
-        )
-
-    assert exc_info.value.translation_key == "config_entry_not_loaded"
-
-
-async def test_service_api_error(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_bsblan: MagicMock,
-) -> None:
-    """Test service call when API raises an error."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:80:41:19:69:90")}
-    )
-    assert device_entry is not None
-
-    # Make the API call fail
-    mock_bsblan.set_hot_water.side_effect = BSBLANError("API Error")
-
-    # Call the service
-    with pytest.raises(ServiceValidationError) as exc_info:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
-            {
-                "device": device_entry.id,
-                "schedule": {"monday": "06:00-08:00"},
-            },
-            blocking=True,
-        )
-
-    assert exc_info.value.translation_key == "set_schedule_failed"
-    assert "API Error" in exc_info.value.translation_placeholders["error"]
-
-
-async def test_service_with_standard_values(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_bsblan: MagicMock,
-) -> None:
-    """Test setting hot water schedule with standard_values field."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:80:41:19:69:90")}
-    )
-    assert device_entry is not None
-
-    # Call the service with standard_values
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_HOT_WATER_SCHEDULE,
-        {
-            "device": device_entry.id,
-            "schedule": {
-                "standard_values": "06:00-08:00 17:00-21:00",
-            },
-        },
-        blocking=True,
-    )
-
-    # Verify the service was called
-    assert len(mock_bsblan.set_hot_water.mock_calls) == 1
-    call_args = mock_bsblan.set_hot_water.call_args
-    assert (
-        call_args.kwargs["dhw_time_programs"].standard_values
-        == "06:00-08:00 17:00-21:00"
-    )
+    assert exc_info.value.translation_key == expected_translation_key
 
 
 async def test_async_setup_services(hass: HomeAssistant) -> None:
@@ -321,14 +219,23 @@ async def test_async_setup_services(hass: HomeAssistant) -> None:
     assert hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
 
 
-async def test_async_unload_services(hass: HomeAssistant) -> None:
-    """Test service unregistration."""
-    # Register services first
-    async_setup_services(hass)
+async def test_async_unload_services_when_last_entry_removed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test services are removed when the last config entry is unloaded."""
+    # Setup the config entry
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify service is registered
     assert hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
 
-    # Unload services
-    async_unload_services(hass)
+    # Unload the config entry
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-    # Verify service is removed
+    # Verify service is removed when last entry is unloaded
     assert not hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -12,7 +12,7 @@ from homeassistant.components.bsblan.services import (
     async_setup_services,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
@@ -191,7 +191,11 @@ async def test_service_error_scenarios(
         device_id = device_id_override
 
     # Call the service and expect error
-    with pytest.raises(ServiceValidationError) as exc_info:
+    # API errors raise HomeAssistantError, user input errors raise ServiceValidationError
+    expected_exception = (
+        HomeAssistantError if setup_error == "api_error" else ServiceValidationError
+    )
+    with pytest.raises(expected_exception) as exc_info:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_SET_HOT_WATER_SCHEDULE,

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -1,0 +1,334 @@
+"""Tests for BSB-LAN services."""
+
+from unittest.mock import MagicMock
+
+from bsblan import BSBLANError
+import pytest
+
+from homeassistant.components.bsblan.const import DOMAIN
+from homeassistant.components.bsblan.services import (
+    SERVICE_SET_HOT_WATER_SCHEDULE,
+    async_setup_services,
+    async_unload_services,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+
+async def test_service_set_hot_water_schedule_success(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test successfully setting hot water schedule."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Get the device ID
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "00:80:41:19:69:90")}
+    )
+    assert device_entry is not None
+
+    # Call the service
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HOT_WATER_SCHEDULE,
+        {
+            "device": device_entry.id,
+            "schedule": {
+                "monday": "06:00-08:00 17:00-21:00",
+                "tuesday": "06:00-08:00 17:00-21:00",
+                "wednesday": "06:00-08:00 17:00-21:00",
+                "thursday": "06:00-08:00 17:00-21:00",
+                "friday": "06:00-08:00 17:00-21:00",
+                "saturday": "08:00-22:00",
+                "sunday": "08:00-22:00",
+            },
+        },
+        blocking=True,
+    )
+
+    # Verify the service was called correctly
+    assert len(mock_bsblan.set_hot_water.mock_calls) == 1
+    call_args = mock_bsblan.set_hot_water.call_args
+    assert call_args.kwargs["dhw_time_programs"].monday == "06:00-08:00 17:00-21:00"
+    assert call_args.kwargs["dhw_time_programs"].tuesday == "06:00-08:00 17:00-21:00"
+    assert call_args.kwargs["dhw_time_programs"].saturday == "08:00-22:00"
+
+
+async def test_service_set_hot_water_schedule_partial(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test setting hot water schedule with partial days."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "00:80:41:19:69:90")}
+    )
+    assert device_entry is not None
+
+    # Call the service with only some days
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HOT_WATER_SCHEDULE,
+        {
+            "device": device_entry.id,
+            "schedule": {
+                "monday": "06:00-08:00",
+                "friday": "17:00-21:00",
+            },
+        },
+        blocking=True,
+    )
+
+    # Verify the service was called
+    assert len(mock_bsblan.set_hot_water.mock_calls) == 1
+    call_args = mock_bsblan.set_hot_water.call_args
+    assert call_args.kwargs["dhw_time_programs"].monday == "06:00-08:00"
+    assert call_args.kwargs["dhw_time_programs"].friday == "17:00-21:00"
+    assert call_args.kwargs["dhw_time_programs"].tuesday is None
+
+
+async def test_service_set_hot_water_schedule_with_none(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test setting hot water schedule with None values to clear days."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "00:80:41:19:69:90")}
+    )
+    assert device_entry is not None
+
+    # Call the service with None values
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HOT_WATER_SCHEDULE,
+        {
+            "device": device_entry.id,
+            "schedule": {
+                "monday": None,
+                "tuesday": "06:00-08:00",
+            },
+        },
+        blocking=True,
+    )
+
+    # Verify the service was called
+    assert len(mock_bsblan.set_hot_water.mock_calls) == 1
+    call_args = mock_bsblan.set_hot_water.call_args
+    assert call_args.kwargs["dhw_time_programs"].monday is None
+    assert call_args.kwargs["dhw_time_programs"].tuesday == "06:00-08:00"
+
+
+async def test_service_invalid_device_id(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test service call with invalid device ID."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Call the service with invalid device ID
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HOT_WATER_SCHEDULE,
+            {
+                "device": "invalid_device_id",
+                "schedule": {"monday": "06:00-08:00"},
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "invalid_device_id"
+    assert "invalid_device_id" in exc_info.value.translation_placeholders["device_id"]
+
+
+async def test_service_no_config_entry_for_device(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test service call when device has no associated config entry."""
+    # Create a different config entry (not for bsblan)
+    other_entry = MockConfigEntry(domain="other_domain", data={})
+    other_entry.add_to_hass(hass)
+
+    # Create a device for that other entry
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        identifiers={("other_domain", "other_device")},
+        name="Other Device",
+    )
+
+    # Now register the bsblan service without setting up any bsblan config entry
+    async_setup_services(hass)
+
+    # Call the service with device from other domain
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HOT_WATER_SCHEDULE,
+            {
+                "device": device_entry.id,
+                "schedule": {"monday": "06:00-08:00"},
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "no_config_entry_for_device"
+
+
+async def test_service_config_entry_not_loaded(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test service call when config entry is not loaded."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "00:80:41:19:69:90")}
+    )
+    assert device_entry is not None
+
+    # Unload the config entry
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+    # Call the service with unloaded config entry
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HOT_WATER_SCHEDULE,
+            {
+                "device": device_entry.id,
+                "schedule": {"monday": "06:00-08:00"},
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "config_entry_not_loaded"
+
+
+async def test_service_api_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test service call when API raises an error."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "00:80:41:19:69:90")}
+    )
+    assert device_entry is not None
+
+    # Make the API call fail
+    mock_bsblan.set_hot_water.side_effect = BSBLANError("API Error")
+
+    # Call the service
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HOT_WATER_SCHEDULE,
+            {
+                "device": device_entry.id,
+                "schedule": {"monday": "06:00-08:00"},
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "set_schedule_failed"
+    assert "API Error" in exc_info.value.translation_placeholders["error"]
+
+
+async def test_service_with_standard_values(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test setting hot water schedule with standard_values field."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "00:80:41:19:69:90")}
+    )
+    assert device_entry is not None
+
+    # Call the service with standard_values
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HOT_WATER_SCHEDULE,
+        {
+            "device": device_entry.id,
+            "schedule": {
+                "standard_values": "06:00-08:00 17:00-21:00",
+            },
+        },
+        blocking=True,
+    )
+
+    # Verify the service was called
+    assert len(mock_bsblan.set_hot_water.mock_calls) == 1
+    call_args = mock_bsblan.set_hot_water.call_args
+    assert (
+        call_args.kwargs["dhw_time_programs"].standard_values
+        == "06:00-08:00 17:00-21:00"
+    )
+
+
+async def test_async_setup_services(hass: HomeAssistant) -> None:
+    """Test service registration."""
+    # Verify service doesn't exist initially
+    assert not hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
+
+    # Register services
+    async_setup_services(hass)
+
+    # Verify service is now registered
+    assert hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
+
+
+async def test_async_unload_services(hass: HomeAssistant) -> None:
+    """Test service unregistration."""
+    # Register services first
+    async_setup_services(hass)
+    assert hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
+
+    # Unload services
+    async_unload_services(hass)
+
+    # Verify service is removed
+    assert not hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -205,7 +205,6 @@ async def test_service_error_scenarios(
     assert exc_info.value.translation_key == expected_translation_key
 
 
-
 async def test_async_setup_services(hass: HomeAssistant) -> None:
     """Test service registration."""
     # Verify service doesn't exist initially

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -204,7 +204,6 @@ async def test_service_error_scenarios(
 
     assert exc_info.value.translation_key == expected_translation_key
 
-    assert exc_info.value.translation_key == expected_translation_key
 
 
 async def test_async_setup_services(hass: HomeAssistant) -> None:

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -4,7 +4,7 @@ from datetime import time
 from typing import Any
 from unittest.mock import MagicMock
 
-from bsblan import BSBLANError
+from bsblan import BSBLANError, DaySchedule, TimeSlot
 import pytest
 
 from homeassistant.components.bsblan.const import DOMAIN
@@ -47,7 +47,7 @@ def device_entry(
 
 @pytest.mark.usefixtures("setup_integration")
 @pytest.mark.parametrize(
-    ("service_data", "expected_strings"),
+    ("service_data", "expected_schedules"),
     [
         (
             {
@@ -60,8 +60,15 @@ def device_entry(
                 ],
             },
             {
-                "monday": "06:00-08:00 17:00-21:00",
-                "tuesday": "06:00-08:00",
+                "monday": DaySchedule(
+                    slots=[
+                        TimeSlot(start=time(6, 0), end=time(8, 0)),
+                        TimeSlot(start=time(17, 0), end=time(21, 0)),
+                    ]
+                ),
+                "tuesday": DaySchedule(
+                    slots=[TimeSlot(start=time(6, 0), end=time(8, 0))]
+                ),
             },
         ),
         (
@@ -74,8 +81,12 @@ def device_entry(
                 ],
             },
             {
-                "friday": "17:00-21:00",
-                "saturday": "08:00-22:00",
+                "friday": DaySchedule(
+                    slots=[TimeSlot(start=time(17, 0), end=time(21, 0))]
+                ),
+                "saturday": DaySchedule(
+                    slots=[TimeSlot(start=time(8, 0), end=time(22, 0))]
+                ),
             },
         ),
         (
@@ -85,17 +96,9 @@ def device_entry(
                 ],
             },
             {
-                "wednesday": "06:00-08:00",
-            },
-        ),
-        (
-            {
-                "standard_values_slots": [
-                    {"start_time": time(7, 0), "end_time": time(20, 0)},
-                ],
-            },
-            {
-                "standard_values": "07:00-20:00",
+                "wednesday": DaySchedule(
+                    slots=[TimeSlot(start=time(6, 0), end=time(8, 0))]
+                ),
             },
         ),
         (
@@ -103,7 +106,7 @@ def device_entry(
                 "monday_slots": [],  # Empty array (shouldn't happen in UI)
             },
             {
-                "monday": "",
+                "monday": DaySchedule(slots=[]),
             },
         ),
     ],
@@ -111,7 +114,6 @@ def device_entry(
         "multiple_slots_per_day",
         "weekend_schedule",
         "single_day",
-        "standard_values",
         "clear_schedule_with_empty_array",
     ],
 )
@@ -120,7 +122,7 @@ async def test_set_hot_water_schedule(
     mock_bsblan: MagicMock,
     device_entry: dr.DeviceEntry,
     service_data: dict[str, Any],
-    expected_strings: dict[str, str],
+    expected_schedules: dict[str, DaySchedule],
 ) -> None:
     """Test setting hot water schedule with various configurations."""
     # Call the service with device_id and slot fields
@@ -135,101 +137,32 @@ async def test_set_hot_water_schedule(
     )
 
     # Verify the service was called correctly
-    assert len(mock_bsblan.set_hot_water.mock_calls) == 1
-    call_args = mock_bsblan.set_hot_water.call_args
+    assert len(mock_bsblan.set_hot_water_schedule.mock_calls) == 1
+    call_args = mock_bsblan.set_hot_water_schedule.call_args
 
-    # Verify expected values - all values are in the dhw_time_programs object
-    dhw_programs = call_args.kwargs["dhw_time_programs"]
-    for key, value in expected_strings.items():
-        assert getattr(dhw_programs, key) == value
+    # Verify expected values - all values are in the DHWSchedule object
+    dhw_schedule = call_args.args[0]
+    for key, expected_schedule in expected_schedules.items():
+        actual_schedule = getattr(dhw_schedule, key)
+        assert actual_schedule == expected_schedule
 
 
-@pytest.mark.parametrize(
-    ("setup_error", "device_id_override", "expected_translation_key"),
-    [
-        (None, "invalid_device_id", "invalid_device_id"),
-        ("no_config_entry", None, "no_config_entry_for_device"),
-        ("config_entry_not_loaded", None, "config_entry_not_loaded"),
-        ("api_error", None, "set_schedule_failed"),
-    ],
-    ids=[
-        "invalid_device_id",
-        "no_config_entry_for_device",
-        "config_entry_not_loaded",
-        "api_error",
-    ],
-)
-async def test_service_error_scenarios(
+async def test_invalid_device_id(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_bsblan: MagicMock,
-    setup_error: str | None,
-    device_id_override: str | None,
-    expected_translation_key: str,
 ) -> None:
-    """Test service error scenarios."""
-    if setup_error == "no_config_entry":
-        # Create a different config entry (not for bsblan)
-        other_entry = MockConfigEntry(domain="other_domain", data={})
-        other_entry.add_to_hass(hass)
+    """Test error when device ID is invalid."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-        # Create a device for that other entry
-        device_registry = dr.async_get(hass)
-        device_entry = device_registry.async_get_or_create(
-            config_entry_id=other_entry.entry_id,
-            identifiers={("other_domain", "other_device")},
-            name="Other Device",
-        )
-        device_id = device_entry.id
-
-        # Register the bsblan service without setting up any bsblan config entry
-        async_setup_services(hass)
-    elif setup_error == "config_entry_not_loaded":
-        # Add the config entry but don't set it up (so it stays in NOT_LOADED state)
-        mock_config_entry.add_to_hass(hass)
-
-        # Create the device manually since setup won't run
-        device_registry = dr.async_get(hass)
-        device_entry = device_registry.async_get_or_create(
-            config_entry_id=mock_config_entry.entry_id,
-            identifiers={(DOMAIN, TEST_DEVICE_MAC)},
-            name="BSB-LAN Device",
-        )
-        device_id = device_entry.id
-
-        # Register the service
-        async_setup_services(hass)
-    else:
-        mock_config_entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
-
-        device_registry = dr.async_get(hass)
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, TEST_DEVICE_MAC)}
-        )
-        assert device_entry is not None
-        device_id = device_entry.id
-
-        if setup_error == "api_error":
-            # Make the API call fail
-            mock_bsblan.set_hot_water.side_effect = BSBLANError("API Error")
-
-    # Override device ID if needed
-    if device_id_override:
-        device_id = device_id_override
-
-    # Call the service and expect error
-    # API errors raise HomeAssistantError, user input errors raise ServiceValidationError
-    expected_exception = (
-        HomeAssistantError if setup_error == "api_error" else ServiceValidationError
-    )
-    with pytest.raises(expected_exception) as exc_info:
+    with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_SET_HOT_WATER_SCHEDULE,
             {
-                "device_id": device_id,
+                "device_id": "invalid_device_id",
                 "monday_slots": [
                     {"start_time": time(6, 0), "end_time": time(8, 0)},
                 ],
@@ -237,17 +170,112 @@ async def test_service_error_scenarios(
             blocking=True,
         )
 
-    assert exc_info.value.translation_key == expected_translation_key
+    assert exc_info.value.translation_key == "invalid_device_id"
+
+
+async def test_no_config_entry_for_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test error when device has no matching BSB-LAN config entry."""
+    # Create a different config entry (not for bsblan)
+    other_entry = MockConfigEntry(domain="other_domain", data={})
+    other_entry.add_to_hass(hass)
+
+    # Create a device for that other entry
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        identifiers={("other_domain", "other_device")},
+        name="Other Device",
+    )
+
+    # Register the bsblan service without setting up any bsblan config entry
+    async_setup_services(hass)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HOT_WATER_SCHEDULE,
+            {
+                "device_id": device_entry.id,
+                "monday_slots": [
+                    {"start_time": time(6, 0), "end_time": time(8, 0)},
+                ],
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "no_config_entry_for_device"
+
+
+async def test_config_entry_not_loaded(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test error when config entry is not loaded."""
+    # Add the config entry but don't set it up (so it stays in NOT_LOADED state)
+    mock_config_entry.add_to_hass(hass)
+
+    # Create the device manually since setup won't run
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, TEST_DEVICE_MAC)},
+        name="BSB-LAN Device",
+    )
+
+    # Register the service
+    async_setup_services(hass)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HOT_WATER_SCHEDULE,
+            {
+                "device_id": device_entry.id,
+                "monday_slots": [
+                    {"start_time": time(6, 0), "end_time": time(8, 0)},
+                ],
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "config_entry_not_loaded"
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_api_error(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    device_entry: dr.DeviceEntry,
+) -> None:
+    """Test error when BSB-LAN API call fails."""
+    mock_bsblan.set_hot_water_schedule.side_effect = BSBLANError("API Error")
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HOT_WATER_SCHEDULE,
+            {
+                "device_id": device_entry.id,
+                "monday_slots": [
+                    {"start_time": time(6, 0), "end_time": time(8, 0)},
+                ],
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "set_schedule_failed"
 
 
 @pytest.mark.usefixtures("setup_integration")
 @pytest.mark.parametrize(
-    ("input_type", "start_time", "end_time", "expected_error"),
+    ("start_time", "end_time", "expected_error"),
     [
-        ("time_objects", time(13, 0), time(11, 0), "end_time_before_start_time"),
-        ("strings", "13:00", "11:00", "end_time_before_start_time"),
-        ("invalid_start", "invalid", "08:00", "invalid_time_format"),
-        ("invalid_end", "06:00", "not-a-time", "invalid_time_format"),
+        (time(13, 0), time(11, 0), "end_time_before_start_time"),
+        ("13:00", "11:00", "end_time_before_start_time"),
+        ("invalid", "08:00", "invalid_time_format"),
+        ("06:00", "not-a-time", "invalid_time_format"),
     ],
     ids=[
         "time_objects_end_before_start",
@@ -259,7 +287,6 @@ async def test_service_error_scenarios(
 async def test_time_validation_errors(
     hass: HomeAssistant,
     device_entry: dr.DeviceEntry,
-    input_type: str,
     start_time: time | str,
     end_time: time | str,
     expected_error: str,
@@ -305,21 +332,24 @@ async def test_unprovided_days_are_none(
     )
 
     # Verify the API was called
-    assert mock_bsblan.set_hot_water.called
-    call_args = mock_bsblan.set_hot_water.call_args
-    dhw_programs = call_args.kwargs["dhw_time_programs"]
+    assert mock_bsblan.set_hot_water_schedule.called
+    call_args = mock_bsblan.set_hot_water_schedule.call_args
+    dhw_schedule = call_args.args[0]
 
     # Verify provided days have values
-    assert dhw_programs.monday == "06:00-08:00"
-    assert dhw_programs.tuesday == "17:00-21:00"
+    assert dhw_schedule.monday == DaySchedule(
+        slots=[TimeSlot(start=time(6, 0), end=time(8, 0))]
+    )
+    assert dhw_schedule.tuesday == DaySchedule(
+        slots=[TimeSlot(start=time(17, 0), end=time(21, 0))]
+    )
 
-    # Verify unprovided days are None (not empty string)
-    assert dhw_programs.wednesday is None
-    assert dhw_programs.thursday is None
-    assert dhw_programs.friday is None
-    assert dhw_programs.saturday is None
-    assert dhw_programs.sunday is None
-    assert dhw_programs.standard_values is None
+    # Verify unprovided days are None (not empty DaySchedule)
+    assert dhw_schedule.wednesday is None
+    assert dhw_schedule.thursday is None
+    assert dhw_schedule.friday is None
+    assert dhw_schedule.saturday is None
+    assert dhw_schedule.sunday is None
 
 
 @pytest.mark.usefixtures("setup_integration")
@@ -346,51 +376,55 @@ async def test_string_time_formats(
     )
 
     # Verify the API was called
-    assert mock_bsblan.set_hot_water.called
-    call_args = mock_bsblan.set_hot_water.call_args
-    dhw_programs = call_args.kwargs["dhw_time_programs"]
+    assert mock_bsblan.set_hot_water_schedule.called
+    call_args = mock_bsblan.set_hot_water_schedule.call_args
+    dhw_schedule = call_args.args[0]
 
-    # Should strip seconds from both formats
-    assert dhw_programs.monday == "06:00-08:00"
-    assert dhw_programs.tuesday == "17:00-21:00"
+    # Should parse both formats correctly (seconds are stripped)
+    assert dhw_schedule.monday == DaySchedule(
+        slots=[TimeSlot(start=time(6, 0), end=time(8, 0))]
+    )
+    assert dhw_schedule.tuesday == DaySchedule(
+        slots=[TimeSlot(start=time(17, 0), end=time(21, 0))]
+    )
 
 
 @pytest.mark.usefixtures("setup_integration")
 async def test_non_standard_time_types(
     hass: HomeAssistant,
-    mock_bsblan: MagicMock,
     device_entry: dr.DeviceEntry,
 ) -> None:
-    """Test service with non-standard time types (edge case for coverage)."""
+    """Test service with non-standard time types raises error."""
     # Test with integer time values (shouldn't happen but need coverage)
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_HOT_WATER_SCHEDULE,
-        {
-            "device_id": device_entry.id,
-            "monday_slots": [
-                {"start_time": 600, "end_time": 800},  # Non-standard types
-            ],
-        },
-        blocking=True,
-    )
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HOT_WATER_SCHEDULE,
+            {
+                "device_id": device_entry.id,
+                "monday_slots": [
+                    {"start_time": 600, "end_time": 800},  # Non-standard types
+                ],
+            },
+            blocking=True,
+        )
 
-    # Verify the API was called
-    assert mock_bsblan.set_hot_water.called
-    call_args = mock_bsblan.set_hot_water.call_args
-    dhw_programs = call_args.kwargs["dhw_time_programs"]
-
-    # Should convert to strings
-    assert dhw_programs.monday == "600-800"
+    assert exc_info.value.translation_key == "invalid_time_format"
 
 
-async def test_async_setup_services(hass: HomeAssistant) -> None:
+async def test_async_setup_services(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
     """Test service registration."""
     # Verify service doesn't exist initially
     assert not hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
 
-    # Register services
-    async_setup_services(hass)
+    # Set up the integration
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     # Verify service is now registered
     assert hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -215,25 +215,3 @@ async def test_async_setup_services(hass: HomeAssistant) -> None:
 
     # Verify service is now registered
     assert hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
-
-
-async def test_async_unload_services_when_last_entry_removed(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_bsblan: MagicMock,
-) -> None:
-    """Test services are removed when the last config entry is unloaded."""
-    # Setup the config entry
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Verify service is registered
-    assert hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
-
-    # Unload the config entry
-    await hass.config_entries.async_unload(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Verify service is removed when last entry is unloaded
-    assert not hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request adds a new "Set Hot Water Schedule" service to the BSB-Lan integration, allowing users to configure daily hot water heating schedules for their devices through Home Assistant. The implementation includes backend service logic, schema and selector definitions for the service fields, icons, and user-facing strings for validation and error handling.

**New Service Implementation**

* Added the `set_hot_water_schedule` service, enabling users to specify time slots for hot water heating for each day of the week via the `services.py` module. This includes input validation, error handling, and integration with the BSB-Lan API.
* Registered the new service during integration setup in `__init__.py` via the new `async_setup_services` function. [[1]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adR30-R41) [[2]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adR57-R62)

**Service Schema and UI Integration**

* Defined the service schema and selectors in `services.yaml`, allowing users to input multiple time slots per day with start and end times for each.
* Added an icon for the new service in `icons.json` for improved UI representation.

**User-Facing Strings and Error Handling**

* Added localized exception and service descriptions to `strings.json`, including detailed error messages for invalid input and a description for the new service and its fields. [[1]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310R73-R87) [[2]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310R97-R99) [[3]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310R112-R151)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41682
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
