### PR TITLE
Reorder TypeInformation classes in Tuya models

### DIFF
--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -134,7 +134,7 @@ class TuyaEventEntity(TuyaEntity, EventEntity):
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._dpcode_wrapper = dpcode_wrapper
-        self._attr_event_types = dpcode_wrapper.enum_type_information.range
+        self._attr_event_types = dpcode_wrapper.type_information.range
 
     async def _handle_state_update(
         self,

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -15,137 +15,6 @@ from .util import remap_value
 
 
 @dataclass
-class DPCodeWrapper:
-    """Base DPCode wrapper.
-
-    Used as a common interface for referring to a DPCode, and
-    access read conversion routines.
-    """
-
-    dpcode: str
-
-    def _read_device_status_raw(self, device: CustomerDevice) -> Any | None:
-        """Read the raw device status for the DPCode.
-
-        Private helper method for `read_device_status`.
-        """
-        return device.status.get(self.dpcode)
-
-    def read_device_status(self, device: CustomerDevice) -> Any | None:
-        """Read the device value for the dpcode."""
-        raise NotImplementedError("read_device_value must be implemented")
-
-
-@dataclass
-class DPCodeBooleanWrapper(DPCodeWrapper):
-    """Simple wrapper for boolean values.
-
-    Supports True/False only.
-    """
-
-    def read_device_status(self, device: CustomerDevice) -> bool | None:
-        """Read the device value for the dpcode."""
-        if (raw_value := self._read_device_status_raw(device)) in (True, False):
-            return raw_value
-        return None
-
-
-@dataclass(kw_only=True)
-class DPCodeEnumWrapper(DPCodeWrapper):
-    """Simple wrapper for EnumTypeData values."""
-
-    enum_type_information: EnumTypeData
-
-    def read_device_status(self, device: CustomerDevice) -> str | None:
-        """Read the device value for the dpcode.
-
-        Values outside of the list defined by the Enum type information will
-        return None.
-        """
-        if (
-            raw_value := self._read_device_status_raw(device)
-        ) in self.enum_type_information.range:
-            return raw_value
-        return None
-
-    @classmethod
-    def find_dpcode(
-        cls,
-        device: CustomerDevice,
-        dpcodes: str | DPCode | tuple[DPCode, ...],
-        *,
-        prefer_function: bool = False,
-    ) -> Self | None:
-        """Find and return a DPCodeEnumWrapper for the given DP codes."""
-        if enum_type := find_dpcode(
-            device, dpcodes, dptype=DPType.ENUM, prefer_function=prefer_function
-        ):
-            return cls(dpcode=enum_type.dpcode, enum_type_information=enum_type)
-        return None
-
-
-@overload
-def find_dpcode(
-    device: CustomerDevice,
-    dpcodes: str | DPCode | tuple[DPCode, ...] | None,
-    *,
-    prefer_function: bool = False,
-    dptype: Literal[DPType.ENUM],
-) -> EnumTypeData | None: ...
-
-
-@overload
-def find_dpcode(
-    device: CustomerDevice,
-    dpcodes: str | DPCode | tuple[DPCode, ...] | None,
-    *,
-    prefer_function: bool = False,
-    dptype: Literal[DPType.INTEGER],
-) -> IntegerTypeData | None: ...
-
-
-def find_dpcode(
-    device: CustomerDevice,
-    dpcodes: str | DPCode | tuple[DPCode, ...] | None,
-    *,
-    prefer_function: bool = False,
-    dptype: DPType,
-) -> TypeInformation | None:
-    """Find type information for a matching DP code available for this device."""
-    if not (type_information_cls := _TYPE_INFORMATION_MAPPINGS.get(dptype)):
-        raise NotImplementedError(f"find_dpcode not supported for {dptype}")
-
-    if dpcodes is None:
-        return None
-
-    if isinstance(dpcodes, str):
-        dpcodes = (DPCode(dpcodes),)
-    elif not isinstance(dpcodes, tuple):
-        dpcodes = (dpcodes,)
-
-    lookup_tuple = (
-        (device.function, device.status_range)
-        if prefer_function
-        else (device.status_range, device.function)
-    )
-
-    for dpcode in dpcodes:
-        for device_specs in lookup_tuple:
-            if (
-                (current_definition := device_specs.get(dpcode))
-                and current_definition.type == dptype
-                and (
-                    type_information := type_information_cls.from_json(
-                        dpcode, current_definition.values
-                    )
-                )
-            ):
-                return type_information
-
-    return None
-
-
-@dataclass
 class TypeInformation:
     """Type information.
 
@@ -214,7 +83,7 @@ class IntegerTypeData(TypeInformation):
         return remap_value(value, from_min, from_max, self.min, self.max, reverse)
 
     @classmethod
-    def from_json(cls, dpcode: DPCode, data: str) -> IntegerTypeData | None:
+    def from_json(cls, dpcode: DPCode, data: str) -> Self | None:
         """Load JSON string and return a IntegerTypeData object."""
         if not (parsed := json.loads(data)):
             return None
@@ -238,7 +107,7 @@ class EnumTypeData(TypeInformation):
     range: list[str]
 
     @classmethod
-    def from_json(cls, dpcode: DPCode, data: str) -> EnumTypeData | None:
+    def from_json(cls, dpcode: DPCode, data: str) -> Self | None:
         """Load JSON string and return a EnumTypeData object."""
         if not (parsed := json.loads(data)):
             return None
@@ -249,6 +118,137 @@ _TYPE_INFORMATION_MAPPINGS: dict[DPType, type[TypeInformation]] = {
     DPType.ENUM: EnumTypeData,
     DPType.INTEGER: IntegerTypeData,
 }
+
+
+@dataclass
+class DPCodeWrapper:
+    """Base DPCode wrapper.
+
+    Used as a common interface for referring to a DPCode, and
+    access read conversion routines.
+    """
+
+    dpcode: str
+
+    def _read_device_status_raw(self, device: CustomerDevice) -> Any | None:
+        """Read the raw device status for the DPCode.
+
+        Private helper method for `read_device_status`.
+        """
+        return device.status.get(self.dpcode)
+
+    def read_device_status(self, device: CustomerDevice) -> Any | None:
+        """Read the device value for the dpcode."""
+        raise NotImplementedError("read_device_value must be implemented")
+
+
+@dataclass
+class DPCodeBooleanWrapper(DPCodeWrapper):
+    """Simple wrapper for boolean values.
+
+    Supports True/False only.
+    """
+
+    def read_device_status(self, device: CustomerDevice) -> bool | None:
+        """Read the device value for the dpcode."""
+        if (raw_value := self._read_device_status_raw(device)) in (True, False):
+            return raw_value
+        return None
+
+
+@dataclass(kw_only=True)
+class DPCodeEnumWrapper(DPCodeWrapper):
+    """Simple wrapper for EnumTypeData values."""
+
+    type_information: EnumTypeData
+
+    def read_device_status(self, device: CustomerDevice) -> str | None:
+        """Read the device value for the dpcode.
+
+        Values outside of the list defined by the Enum type information will
+        return None.
+        """
+        if (
+            raw_value := self._read_device_status_raw(device)
+        ) in self.type_information.range:
+            return raw_value
+        return None
+
+    @classmethod
+    def find_dpcode(
+        cls,
+        device: CustomerDevice,
+        dpcodes: str | DPCode | tuple[DPCode, ...],
+        *,
+        prefer_function: bool = False,
+    ) -> Self | None:
+        """Find and return a DPCodeEnumWrapper for the given DP codes."""
+        if enum_type := find_dpcode(
+            device, dpcodes, dptype=DPType.ENUM, prefer_function=prefer_function
+        ):
+            return cls(dpcode=enum_type.dpcode, type_information=enum_type)
+        return None
+
+
+@overload
+def find_dpcode(
+    device: CustomerDevice,
+    dpcodes: str | DPCode | tuple[DPCode, ...] | None,
+    *,
+    prefer_function: bool = False,
+    dptype: Literal[DPType.ENUM],
+) -> EnumTypeData | None: ...
+
+
+@overload
+def find_dpcode(
+    device: CustomerDevice,
+    dpcodes: str | DPCode | tuple[DPCode, ...] | None,
+    *,
+    prefer_function: bool = False,
+    dptype: Literal[DPType.INTEGER],
+) -> IntegerTypeData | None: ...
+
+
+def find_dpcode(
+    device: CustomerDevice,
+    dpcodes: str | DPCode | tuple[DPCode, ...] | None,
+    *,
+    prefer_function: bool = False,
+    dptype: DPType,
+) -> TypeInformation | None:
+    """Find type information for a matching DP code available for this device."""
+    if not (type_information_cls := _TYPE_INFORMATION_MAPPINGS.get(dptype)):
+        raise NotImplementedError(f"find_dpcode not supported for {dptype}")
+
+    if dpcodes is None:
+        return None
+
+    if isinstance(dpcodes, str):
+        dpcodes = (DPCode(dpcodes),)
+    elif not isinstance(dpcodes, tuple):
+        dpcodes = (dpcodes,)
+
+    lookup_tuple = (
+        (device.function, device.status_range)
+        if prefer_function
+        else (device.status_range, device.function)
+    )
+
+    for dpcode in dpcodes:
+        for device_specs in lookup_tuple:
+            if (
+                (current_definition := device_specs.get(dpcode))
+                and current_definition.type == dptype
+                and (
+                    type_information := type_information_cls.from_json(
+                        dpcode, current_definition.values
+                    )
+                )
+            ):
+                return type_information
+
+    return None
 
 
 class ComplexValue:

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -395,7 +395,7 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._dpcode_wrapper = dpcode_wrapper
-        self._attr_options = dpcode_wrapper.enum_type_information.range
+        self._attr_options = dpcode_wrapper.type_information.range
 
     @property
     def current_option(self) -> str | None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Preliminary work for #156039
Linked to #156232

Whilst working on a generic class, I realised that the `TypeInformation` classes needed to be declared BEFORE the `DPCodeWrapper` classes

This simply moves the code around with two minor aments:
- `from_json` now returns `Self` rather than `xxxTypeData`
- `enum_type_information` attribute is renamed as `type_information` to avoid future conflicts

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
