### PR TITLE
Add manual IP configuration for cross-subnet Switcher devices

### DIFF
--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -122,7 +122,7 @@ async def async_setup_manual_entry(
             device_key,
             device_type,
         )
-    except (TimeoutError, ValueError) as err:
+    except (TimeoutError, ValueError, ConnectionError) as err:
         raise ConfigEntryNotReady(
             f"Unable to connect to Switcher device at {ip_address}"
         ) from err

--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 
-from aioswitcher.api import SwitcherApi
 from aioswitcher.bridge import SwitcherBridge
 from aioswitcher.device import DeviceType, SwitcherBase
 
@@ -24,6 +23,7 @@ from .coordinator import (
     SwitcherDataUpdateCoordinator,
     SwitcherPollingDataUpdateCoordinator,
 )
+from .utils import async_test_device_connection
 
 PLATFORMS = [
     Platform.BUTTON,
@@ -114,21 +114,15 @@ async def async_setup_manual_entry(
     # Convert device type name to DeviceType enum (e.g., "MINI" -> DeviceType.MINI)
     device_type = DeviceType[device_type_name]
 
-    # Test connection to device
+    # Test connection to device using utility function
     try:
-        async with SwitcherApi(
-            device_type,
+        await async_test_device_connection(
             ip_address,
             device_id,
             device_key,
-            token,
-        ) as api:
-            response = await api.get_state()
-
-        if not response or not response.successful:
-            raise ConfigEntryNotReady(f"Failed to connect to device at {ip_address}")
-
-    except (TimeoutError, OSError, RuntimeError) as err:
+            device_type,
+        )
+    except (TimeoutError, ValueError) as err:
         raise ConfigEntryNotReady(
             f"Unable to connect to Switcher device at {ip_address}"
         ) from err

--- a/homeassistant/components/switcher_kis/config_flow.py
+++ b/homeassistant/components/switcher_kis/config_flow.py
@@ -191,9 +191,6 @@ class SwitcherFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="manual",
             data_schema=MANUAL_SCHEMA,
             errors=errors,
-            description_placeholders={
-                "device_info": "Device ID and key can be found in the Switcher app settings"
-            },
         )
 
     async def _create_entry(self) -> ConfigFlowResult:

--- a/homeassistant/components/switcher_kis/config_flow.py
+++ b/homeassistant/components/switcher_kis/config_flow.py
@@ -6,15 +6,23 @@ from collections.abc import Mapping
 import logging
 from typing import Any, Final
 
-from aioswitcher.device import SwitcherBase
+from aioswitcher.device import DeviceType, SwitcherBase
 from aioswitcher.device.tools import validate_token
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_TOKEN, CONF_USERNAME
+from homeassistant.const import CONF_HOST, CONF_TOKEN, CONF_USERNAME
+from homeassistant.data_entry_flow import AbortFlow
+from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN, PREREQUISITES_URL
-from .utils import async_discover_devices
+from .const import (
+    CONF_DEVICE_ID,
+    CONF_DEVICE_KEY,
+    CONF_DEVICE_TYPE,
+    DOMAIN,
+    PREREQUISITES_URL,
+)
+from .utils import async_discover_devices, async_test_device_connection
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,6 +31,15 @@ CONFIG_SCHEMA: Final = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_TOKEN): str,
+    }
+)
+
+MANUAL_SCHEMA: Final = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_DEVICE_ID): cv.string,
+        vol.Required(CONF_DEVICE_KEY): cv.string,
+        vol.Required(CONF_DEVICE_TYPE): vol.In([dt.name for dt in DeviceType]),
     }
 )
 
@@ -38,11 +55,21 @@ class SwitcherFlowHandler(ConfigFlow, domain=DOMAIN):
         self.discovered_devices: dict[str, SwitcherBase] = {}
         self.username: str | None = None
         self.token: str | None = None
+        self.manual_device_data: dict[str, Any] = {}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the start of the config flow."""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["discovery", "manual"],
+        )
+
+    async def async_step_discovery(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle discovery-based setup."""
         self.discovered_devices = await async_discover_devices()
 
         return self.async_show_form(step_id="confirm")
@@ -112,7 +139,74 @@ class SwitcherFlowHandler(ConfigFlow, domain=DOMAIN):
             description_placeholders={"prerequisites_url": PREREQUISITES_URL},
         )
 
+    async def async_step_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle manual device configuration."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                # Get the selected device type by name (e.g., "MINI")
+                device_type_name = user_input[CONF_DEVICE_TYPE]
+                device_type = DeviceType[device_type_name]
+
+                response = await async_test_device_connection(
+                    user_input[CONF_HOST],
+                    user_input[CONF_DEVICE_ID],
+                    user_input[CONF_DEVICE_KEY],
+                    device_type,
+                )
+
+                self.manual_device_data = {
+                    CONF_HOST: user_input[CONF_HOST],
+                    CONF_DEVICE_ID: user_input[CONF_DEVICE_ID],
+                    CONF_DEVICE_KEY: user_input[CONF_DEVICE_KEY],
+                    CONF_DEVICE_TYPE: device_type_name,
+                }
+
+                await self.async_set_unique_id(user_input[CONF_DEVICE_ID])
+                self._abort_if_unique_id_configured()
+
+                if getattr(response, "token_needed", False):
+                    return await self.async_step_credentials()
+
+                return await self._create_entry()
+
+            except AbortFlow:
+                raise
+            except TimeoutError:
+                _LOGGER.error("Network timeout connecting to device")
+                errors["base"] = "cannot_connect"
+            except ValueError:
+                _LOGGER.error(
+                    "Authentication failed - invalid credentials or device type"
+                )
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception during manual configuration")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="manual",
+            data_schema=MANUAL_SCHEMA,
+            errors=errors,
+            description_placeholders={
+                "device_info": "Device ID and key can be found in the Switcher app settings"
+            },
+        )
+
     async def _create_entry(self) -> ConfigFlowResult:
+        if self.manual_device_data:
+            return self.async_create_entry(
+                title="Switcher",
+                data={
+                    CONF_USERNAME: self.username,
+                    CONF_TOKEN: self.token,
+                    **self.manual_device_data,
+                },
+            )
+
         return self.async_create_entry(
             title="Switcher",
             data={

--- a/homeassistant/components/switcher_kis/const.py
+++ b/homeassistant/components/switcher_kis/const.py
@@ -8,6 +8,11 @@ DISCOVERY_TIME_SEC = 12
 
 SIGNAL_DEVICE_ADD = "switcher_device_add"
 
+# Configuration
+CONF_DEVICE_ID = "device_id"
+CONF_DEVICE_KEY = "device_key"
+CONF_DEVICE_TYPE = "device_type"
+
 # Services
 CONF_AUTO_OFF = "auto_off"
 CONF_TIMER_MINUTES = "timer_minutes"
@@ -16,6 +21,9 @@ SERVICE_TURN_ON_WITH_TIMER_NAME = "turn_on_with_timer"
 
 # Defines the maximum interval device must send an update before it marked unavailable
 MAX_UPDATE_INTERVAL_SEC = 30
+
+# Defines polling interval for manually configured devices (no UDP broadcasts)
+MANUAL_DEVICE_POLLING_INTERVAL_SEC = 60
 
 PREREQUISITES_URL = (
     "https://www.home-assistant.io/integrations/switcher_kis/#prerequisites"

--- a/homeassistant/components/switcher_kis/coordinator.py
+++ b/homeassistant/components/switcher_kis/coordinator.py
@@ -125,7 +125,6 @@ class SwitcherPollingDataUpdateCoordinator(
         self._device_key = device_key
         self._device_type = device_type
         self.token = token
-        self.data: SwitcherBase | None = None
 
     async def _async_update_data(self) -> SwitcherBase:
         """Fetch data from device via polling."""

--- a/homeassistant/components/switcher_kis/coordinator.py
+++ b/homeassistant/components/switcher_kis/coordinator.py
@@ -5,7 +5,18 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from aioswitcher.device import SwitcherBase
+from aioswitcher.api import SwitcherApi
+from aioswitcher.device import (
+    DeviceCategory,
+    DeviceState,
+    DeviceType,
+    SwitcherBase,
+    SwitcherLight,
+    SwitcherPowerPlug,
+    SwitcherShutter,
+    SwitcherThermostat,
+    SwitcherWaterHeater,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_TOKEN
@@ -13,7 +24,12 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, update_coordinator
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DOMAIN, MAX_UPDATE_INTERVAL_SEC, SIGNAL_DEVICE_ADD
+from .const import (
+    DOMAIN,
+    MANUAL_DEVICE_POLLING_INTERVAL_SEC,
+    MAX_UPDATE_INTERVAL_SEC,
+    SIGNAL_DEVICE_ADD,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,6 +79,189 @@ class SwitcherDataUpdateCoordinator(
     def mac_address(self) -> str:
         """Switcher device mac address."""
         return self.data.mac_address
+
+    @callback
+    def async_setup(self) -> None:
+        """Set up the coordinator."""
+        dev_reg = dr.async_get(self.hass)
+        dev_reg.async_get_or_create(
+            config_entry_id=self.config_entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, self.mac_address)},
+            identifiers={(DOMAIN, self.device_id)},
+            manufacturer="Switcher",
+            name=self.name,
+            model=self.model,
+        )
+        async_dispatcher_send(self.hass, SIGNAL_DEVICE_ADD, self)
+
+
+class SwitcherPollingDataUpdateCoordinator(
+    update_coordinator.DataUpdateCoordinator[SwitcherBase]
+):
+    """Switcher device polling data update coordinator for manually configured devices."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        ip_address: str,
+        device_id: str,
+        device_key: str,
+        device_type: DeviceType,
+        token: str | None = None,
+    ) -> None:
+        """Initialize the Switcher polling device coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=f"Switcher {device_id}",
+            update_interval=timedelta(seconds=MANUAL_DEVICE_POLLING_INTERVAL_SEC),
+        )
+        self._ip_address = ip_address
+        self._device_id = device_id
+        self._device_key = device_key
+        self._device_type = device_type
+        self.token = token
+        self.data: SwitcherBase | None = None
+
+    async def _async_update_data(self) -> SwitcherBase:
+        """Fetch data from device via polling."""
+        try:
+            async with SwitcherApi(
+                self._device_type,
+                self._ip_address,
+                self._device_id,
+                self._device_key,
+                self.token,
+            ) as api:
+                # Call the appropriate API method and create proper device object
+                if self._device_type.category == DeviceCategory.THERMOSTAT:
+                    response = await api.get_breeze_state()
+                    if not response or not response.successful:
+                        raise update_coordinator.UpdateFailed(
+                            f"Failed to get state from device at {self._ip_address}"
+                        )
+                    return SwitcherThermostat(
+                        device_type=self._device_type,
+                        device_state=response.state,
+                        device_id=self._device_id,
+                        device_key=self._device_key,
+                        ip_address=self._ip_address,
+                        mac_address="00:00:00:00:00:00",
+                        name=self.name,
+                        token_needed=self._device_type.token_needed,
+                        mode=response.mode,
+                        temperature=response.temperature,
+                        target_temperature=response.target_temperature,
+                        fan_level=response.fan_level,
+                        swing=response.swing,
+                        remote_id=response.remote_id,
+                    )
+
+                if self._device_type.category in (
+                    DeviceCategory.SHUTTER,
+                    DeviceCategory.SINGLE_SHUTTER_DUAL_LIGHT,
+                    DeviceCategory.DUAL_SHUTTER_SINGLE_LIGHT,
+                ):
+                    response = await api.get_shutter_state(index=0)
+                    if not response or not response.successful:
+                        raise update_coordinator.UpdateFailed(
+                            f"Failed to get state from device at {self._ip_address}"
+                        )
+                    return SwitcherShutter(
+                        device_type=self._device_type,
+                        device_state=DeviceState.OFF,
+                        device_id=self._device_id,
+                        device_key=self._device_key,
+                        ip_address=self._ip_address,
+                        mac_address="00:00:00:00:00:00",
+                        name=self.name,
+                        token_needed=self._device_type.token_needed,
+                        position=[response.position],
+                        direction=[response.direction],
+                        child_lock=[response.child_lock],
+                    )
+
+                if self._device_type.category == DeviceCategory.LIGHT:
+                    response = await api.get_light_state(index=0)
+                    if not response or not response.successful:
+                        raise update_coordinator.UpdateFailed(
+                            f"Failed to get state from device at {self._ip_address}"
+                        )
+                    return SwitcherLight(
+                        device_type=self._device_type,
+                        device_state=response.state,
+                        device_id=self._device_id,
+                        device_key=self._device_key,
+                        ip_address=self._ip_address,
+                        mac_address="00:00:00:00:00:00",
+                        name=self.name,
+                        token_needed=self._device_type.token_needed,
+                        light=[response.state],
+                    )
+
+                if self._device_type.category == DeviceCategory.POWER_PLUG:
+                    response = await api.get_state()
+                    if not response or not response.successful:
+                        raise update_coordinator.UpdateFailed(
+                            f"Failed to get state from device at {self._ip_address}"
+                        )
+                    return SwitcherPowerPlug(
+                        device_type=self._device_type,
+                        device_state=response.state,
+                        device_id=self._device_id,
+                        device_key=self._device_key,
+                        ip_address=self._ip_address,
+                        mac_address="00:00:00:00:00:00",
+                        name=self.name,
+                        token_needed=self._device_type.token_needed,
+                        power_consumption=response.power_consumption,
+                        electric_current=response.electric_current,
+                    )
+
+                # Water heater devices
+                response = await api.get_state()
+                if not response or not response.successful:
+                    raise update_coordinator.UpdateFailed(
+                        f"Failed to get state from device at {self._ip_address}"
+                    )
+                return SwitcherWaterHeater(
+                    device_type=self._device_type,
+                    device_state=response.state,
+                    device_id=self._device_id,
+                    device_key=self._device_key,
+                    ip_address=self._ip_address,
+                    mac_address="00:00:00:00:00:00",
+                    name=self.name,
+                    token_needed=self._device_type.token_needed,
+                    remaining_time=response.time_left,
+                    auto_shutdown=response.auto_shutdown,
+                    power_consumption=response.power_consumption,
+                    electric_current=response.electric_current,
+                )
+
+        except (TimeoutError, OSError, RuntimeError) as err:
+            raise update_coordinator.UpdateFailed(
+                f"Error communicating with device at {self._ip_address}: {err}"
+            ) from err
+
+    @property
+    def model(self) -> str:
+        """Switcher device model."""
+        return self._device_type.value
+
+    @property
+    def device_id(self) -> str:
+        """Switcher device id."""
+        return self._device_id
+
+    @property
+    def mac_address(self) -> str:
+        """Switcher device mac address."""
+        return self.data.mac_address if self.data else "00:00:00:00:00:00"
 
     @callback
     def async_setup(self) -> None:

--- a/homeassistant/components/switcher_kis/diagnostics.py
+++ b/homeassistant/components/switcher_kis/diagnostics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+import logging
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -12,6 +13,8 @@ from . import SwitcherConfigEntry
 
 TO_REDACT = {"device_id", "device_key", "ip_address", "mac_address"}
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: SwitcherConfigEntry
@@ -19,11 +22,15 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinators = entry.runtime_data
 
-    devices = [
-        asdict(data)
-        for coordinator in coordinators.values()
-        if (data := coordinator.data) is not None
-    ]
+    devices = []
+    for device_id, coordinator in coordinators.items():
+        if coordinator.data is not None:
+            devices.append(asdict(coordinator.data))
+        else:
+            _LOGGER.debug(
+                "Coordinator for device %s has no data yet (possibly still initializing)",
+                device_id,
+            )
 
     return async_redact_data(
         {

--- a/homeassistant/components/switcher_kis/diagnostics.py
+++ b/homeassistant/components/switcher_kis/diagnostics.py
@@ -19,10 +19,16 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinators = entry.runtime_data
 
+    devices = [
+        asdict(data)
+        for coordinator in coordinators.values()
+        if (data := coordinator.data) is not None
+    ]
+
     return async_redact_data(
         {
             "entry": entry.as_dict(),
-            "devices": [asdict(coordinators[d].data) for d in coordinators],
+            "devices": devices,
         },
         TO_REDACT,
     )

--- a/homeassistant/components/switcher_kis/manifest.json
+++ b/homeassistant/components/switcher_kis/manifest.json
@@ -7,6 +7,5 @@
   "iot_class": "local_push",
   "loggers": ["aioswitcher"],
   "quality_scale": "silver",
-  "requirements": ["aioswitcher==6.0.0"],
-  "single_config_entry": true
+  "requirements": ["aioswitcher==6.0.0"]
 }

--- a/homeassistant/components/switcher_kis/strings.json
+++ b/homeassistant/components/switcher_kis/strings.json
@@ -3,8 +3,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/homeassistant/components/switcher_kis/strings.json
+++ b/homeassistant/components/switcher_kis/strings.json
@@ -33,10 +33,10 @@
         "data_description": {
           "host": "The IP address of your Switcher device",
           "device_id": "6-character hex ID",
-          "device_key": "2-character hex key (example: '1b', '00', '01')",
+          "device_key": "2-character hex key (example: '1b')",
           "device_type": "Select your Switcher device model"
         },
-        "description": "Manual configuration for cross-subnet devices. To get device ID and key: 1) Temporarily connect to the same network as your Switcher, 2) Use automatic discovery to add it, 3) Go to device info to note the device ID and key values, 4) Remove that entry, 5) Use manual configuration with those values from your normal network."
+        "description": "Configure a Switcher device using its IP address. Device ID and key can be obtained via automatic discovery. See documentation for details."
       },
       "credentials": {
         "data": {

--- a/homeassistant/components/switcher_kis/strings.json
+++ b/homeassistant/components/switcher_kis/strings.json
@@ -1,16 +1,43 @@
 {
   "config": {
     "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     },
     "error": {
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "user": {
+        "menu_options": {
+          "discovery": "Automatic discovery",
+          "manual": "Manual configuration"
+        }
+      },
+      "discovery": {
+        "description": "Searching for Switcher devices on your network"
+      },
       "confirm": {
         "description": "[%key:common::config_flow::description::confirm_setup%]"
+      },
+      "manual": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "device_id": "Device ID",
+          "device_key": "Device key",
+          "device_type": "Device model"
+        },
+        "data_description": {
+          "host": "The IP address of your Switcher device",
+          "device_id": "6-character hex ID",
+          "device_key": "2-character hex key (example: '1b', '00', '01')",
+          "device_type": "Select your Switcher device model"
+        },
+        "description": "Manual configuration for cross-subnet devices. To get device ID and key: 1) Temporarily connect to the same network as your Switcher, 2) Use automatic discovery to add it, 3) Go to device info to note the device ID and key values, 4) Remove that entry, 5) Use manual configuration with those values from your normal network."
       },
       "credentials": {
         "data": {
@@ -33,6 +60,28 @@
           "username": "[%key:component::switcher_kis::config::step::credentials::data_description::username%]"
         },
         "description": "[%key:component::switcher_kis::config::step::credentials::description%]"
+      }
+    },
+    "selector": {
+      "device_type": {
+        "options": {
+          "MINI": "Switcher Mini",
+          "POWER_PLUG": "Switcher Power Plug",
+          "TOUCH": "Switcher Touch",
+          "V2_ESP": "Switcher V2 (esp)",
+          "V2_QCA": "Switcher V2 (qualcomm)",
+          "V4": "Switcher V4",
+          "BREEZE": "Switcher Breeze",
+          "RUNNER": "Switcher Runner",
+          "RUNNER_MINI": "Switcher Runner Mini",
+          "RUNNER_S11": "Switcher Runner S11",
+          "RUNNER_S12": "Switcher Runner S12",
+          "LIGHT_SL01": "Switcher Light SL01",
+          "LIGHT_SL01_MINI": "Switcher Light SL01 Mini",
+          "LIGHT_SL02": "Switcher Light SL02",
+          "LIGHT_SL02_MINI": "Switcher Light SL02 Mini",
+          "LIGHT_SL03": "Switcher Light SL03"
+        }
       }
     }
   },

--- a/homeassistant/components/switcher_kis/utils.py
+++ b/homeassistant/components/switcher_kis/utils.py
@@ -88,13 +88,14 @@ async def async_test_device_connection(
             err,
         )
         raise ValueError("Invalid device credentials or device type") from err
-    else:
-        if not response or not response.successful:
-            _LOGGER.error("Device at %s returned unsuccessful response", ip_address)
-            raise ConnectionError(f"Failed to get state from device at {ip_address}")
 
-        _LOGGER.info("Successfully connected to device at %s", ip_address)
-        return response
+    # Process response outside try block
+    if not response or not response.successful:
+        _LOGGER.error("Device at %s returned unsuccessful response", ip_address)
+        raise ConnectionError(f"Failed to get state from device at {ip_address}")
+
+    _LOGGER.info("Successfully connected to device at %s", ip_address)
+    return response
 
 
 @singleton.singleton("switcher_breeze_remote_manager")

--- a/tests/components/switcher_kis/test_config_flow.py
+++ b/tests/components/switcher_kis/test_config_flow.py
@@ -5,8 +5,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.switcher_kis.const import DOMAIN
-from homeassistant.const import CONF_TOKEN, CONF_USERNAME
+from homeassistant.components.switcher_kis.const import (
+    CONF_DEVICE_ID,
+    CONF_DEVICE_KEY,
+    CONF_DEVICE_TYPE,
+    DOMAIN,
+)
+from homeassistant.const import CONF_HOST, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -38,20 +43,27 @@ async def test_user_setup(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_bridge: MagicMock
 ) -> None:
     """Test we can finish a config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+
     with patch("homeassistant.components.switcher_kis.utils.DISCOVERY_TIME_SEC", 0):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "discovery"}
         )
 
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "confirm"
+        assert result2["type"] is FlowResultType.FORM
+        assert result2["step_id"] == "confirm"
 
-        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        result3 = await hass.config_entries.flow.async_configure(result2["flow_id"], {})
 
         assert mock_bridge.is_running is False
-        assert result2["type"] is FlowResultType.CREATE_ENTRY
-        assert result2["title"] == "Switcher"
-        assert result2["result"].data == {CONF_USERNAME: None, CONF_TOKEN: None}
+        assert result3["type"] is FlowResultType.CREATE_ENTRY
+        assert result3["title"] == "Switcher"
+        assert result3["result"].data == {CONF_USERNAME: None, CONF_TOKEN: None}
 
         await hass.async_block_till_done()
 
@@ -72,32 +84,38 @@ async def test_user_setup_found_token_device_valid_token(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_bridge: MagicMock
 ) -> None:
     """Test we can finish a config flow with token device found."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.MENU
+
     with patch("homeassistant.components.switcher_kis.utils.DISCOVERY_TIME_SEC", 0):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "discovery"}
         )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "confirm"
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "confirm"
 
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    result3 = await hass.config_entries.flow.async_configure(result2["flow_id"], {})
 
     assert mock_bridge.is_running is False
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "credentials"
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["step_id"] == "credentials"
 
     with patch(
         "homeassistant.components.switcher_kis.config_flow.validate_token",
         return_value=True,
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
             {CONF_USERNAME: DUMMY_USERNAME, CONF_TOKEN: DUMMY_TOKEN},
         )
 
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Switcher"
-    assert result3["result"].data == {
+    assert result4["type"] is FlowResultType.CREATE_ENTRY
+    assert result4["title"] == "Switcher"
+    assert result4["result"].data == {
         CONF_USERNAME: DUMMY_USERNAME,
         CONF_TOKEN: DUMMY_TOKEN,
     }
@@ -120,43 +138,49 @@ async def test_user_setup_found_token_device_invalid_token(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test we can finish a config flow with token device found."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.MENU
+
     with patch("homeassistant.components.switcher_kis.utils.DISCOVERY_TIME_SEC", 0):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "discovery"}
         )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "confirm"
-
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
     assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "credentials"
+    assert result2["step_id"] == "confirm"
+
+    result3 = await hass.config_entries.flow.async_configure(result2["flow_id"], {})
+
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["step_id"] == "credentials"
 
     with patch(
         "homeassistant.components.switcher_kis.config_flow.validate_token",
         return_value=False,
-    ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
-            {CONF_USERNAME: DUMMY_USERNAME, CONF_TOKEN: DUMMY_TOKEN},
-        )
-
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["errors"] == {"base": "invalid_auth"}
-
-    with patch(
-        "homeassistant.components.switcher_kis.config_flow.validate_token",
-        return_value=True,
     ):
         result4 = await hass.config_entries.flow.async_configure(
             result3["flow_id"],
             {CONF_USERNAME: DUMMY_USERNAME, CONF_TOKEN: DUMMY_TOKEN},
         )
 
-        assert result4["type"] is FlowResultType.CREATE_ENTRY
-        assert result4["title"] == "Switcher"
-        assert result4["result"].data == {
+    assert result4["type"] is FlowResultType.FORM
+    assert result4["errors"] == {"base": "invalid_auth"}
+
+    with patch(
+        "homeassistant.components.switcher_kis.config_flow.validate_token",
+        return_value=True,
+    ):
+        result5 = await hass.config_entries.flow.async_configure(
+            result4["flow_id"],
+            {CONF_USERNAME: DUMMY_USERNAME, CONF_TOKEN: DUMMY_TOKEN},
+        )
+
+        assert result5["type"] is FlowResultType.CREATE_ENTRY
+        assert result5["title"] == "Switcher"
+        assert result5["result"].data == {
             CONF_USERNAME: DUMMY_USERNAME,
             CONF_TOKEN: DUMMY_TOKEN,
         }
@@ -168,36 +192,175 @@ async def test_user_setup_abort_no_devices_found(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_bridge: MagicMock
 ) -> None:
     """Test we abort a config flow if no devices found."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.MENU
+
     with patch("homeassistant.components.switcher_kis.utils.DISCOVERY_TIME_SEC", 0):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "discovery"}
         )
 
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "confirm"
+        assert result2["type"] is FlowResultType.FORM
+        assert result2["step_id"] == "confirm"
 
-        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        result3 = await hass.config_entries.flow.async_configure(result2["flow_id"], {})
 
         assert mock_bridge.is_running is False
-        assert result2["type"] is FlowResultType.ABORT
-        assert result2["reason"] == "no_devices_found"
+        assert result3["type"] is FlowResultType.ABORT
+        assert result3["reason"] == "no_devices_found"
 
         await hass.async_block_till_done()
 
         assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_single_instance(hass: HomeAssistant) -> None:
-    """Test we only allow a single config flow."""
-    MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
-    await hass.async_block_till_done()
+async def test_manual_configuration_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test manual configuration with valid credentials."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.MENU
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "manual"}
+    )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "manual"
+
+    with patch(
+        "homeassistant.components.switcher_kis.config_flow.async_test_device_connection"
+    ) as mock_test:
+        mock_response = MagicMock()
+        mock_response.successful = True
+        mock_response.token_needed = False
+        mock_test.return_value = mock_response
+
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_DEVICE_ID: "abc123",
+                CONF_DEVICE_KEY: "1b",
+                CONF_DEVICE_TYPE: "MINI",
+            },
+        )
+
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "Switcher"
+    assert result3["result"].data == {
+        CONF_USERNAME: None,
+        CONF_TOKEN: None,
+        CONF_HOST: "192.168.1.100",
+        CONF_DEVICE_ID: "abc123",
+        CONF_DEVICE_KEY: "1b",
+        CONF_DEVICE_TYPE: "MINI",
+    }
+
+
+async def test_manual_configuration_cannot_connect(hass: HomeAssistant) -> None:
+    """Test manual configuration with connection error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "manual"}
+    )
+
+    with patch(
+        "homeassistant.components.switcher_kis.config_flow.async_test_device_connection",
+        side_effect=TimeoutError("timeout"),
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_DEVICE_ID: "abc123",
+                CONF_DEVICE_KEY: "1b",
+                CONF_DEVICE_TYPE: "MINI",
+            },
+        )
+
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["errors"] == {"base": "cannot_connect"}
+
+
+async def test_manual_configuration_invalid_auth(hass: HomeAssistant) -> None:
+    """Test manual configuration with invalid credentials."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "manual"}
+    )
+
+    with patch(
+        "homeassistant.components.switcher_kis.config_flow.async_test_device_connection",
+        side_effect=ValueError("invalid"),
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_DEVICE_ID: "abc123",
+                CONF_DEVICE_KEY: "1b",
+                CONF_DEVICE_TYPE: "MINI",
+            },
+        )
+
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["errors"] == {"base": "invalid_auth"}
+
+
+async def test_manual_configuration_already_configured(hass: HomeAssistant) -> None:
+    """Test manual configuration with already configured device."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="abc123",
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_DEVICE_ID: "abc123",
+            CONF_DEVICE_KEY: "1b",
+            CONF_DEVICE_TYPE: "MINI",
+        },
+    ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "single_instance_allowed"
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "manual"}
+    )
+
+    with patch(
+        "homeassistant.components.switcher_kis.config_flow.async_test_device_connection"
+    ) as mock_test:
+        mock_response = MagicMock()
+        mock_response.successful = True
+        mock_response.token_needed = False
+        mock_test.return_value = mock_response
+
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_DEVICE_ID: "abc123",
+                CONF_DEVICE_KEY: "1b",
+                CONF_DEVICE_TYPE: "MINI",
+            },
+        )
+
+    assert result3["type"] is FlowResultType.ABORT
+    assert result3["reason"] == "already_configured"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds manual IP configuration support to the Switcher integration, enabling setup of devices on different subnets that cannot be reached via UDP broadcast discovery.

Users can now choose between:
- **Automatic discovery** (existing behavior) - for devices on the same subnet
- **Manual configuration** (new) - for cross-subnet deployments

Manual configuration requires:
- IP address of the Switcher device
- Device ID (6-character hex)
- Device Key (2-character hex, obtained from UDP broadcast)
- Device model selection from dropdown

Manual devices use a polling-based coordinator (`SwitcherPollingDataUpdateCoordinator`) that connects directly via TCP every 60 seconds. The coordinator uses device-specific aioswitcher API methods to retrieve complete device data, ensuring parity with autodiscovered devices.

This solves the limitation where UDP broadcasts don't cross subnet boundaries, enabling users to control Switcher devices on different network segments while maintaining Home Assistant on a separate subnet.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- Link to documentation pull request: (will create after approval)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
- [x] New or updated dependencies have been added to `requirements_all.txt` (no new dependencies).

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr