### PR TITLE
feat(shelly): add switch entity strings and fix translation keys (closes #156146)

### DIFF
--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -400,6 +400,32 @@
         "name": "Water temperature"
       }
     },
+    "switch": {
+      "motion_switch": {
+        "name": "Motion detection"
+      },
+      "start_charging": {
+        "name": "Charging"
+      },
+      "cury_slot": {
+        "name": "Slot"
+      },
+      "cury_boost": {
+        "name": "Boost"
+      },
+      "cury_left_slot": {
+        "name": "Left slot"
+      },
+      "cury_left_boost": {
+        "name": "Left slot boost"
+      },
+      "cury_right_slot": {
+        "name": "Right slot"
+      },
+      "cury_right_boost": {
+        "name": "Right slot boost"
+      }
+    },
     "update": {
       "beta_firmware": {
         "name": "Beta firmware"

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -143,7 +143,7 @@ RPC_SWITCHES = {
     "boolean_start_charging": RpcSwitchDescription(
         key="boolean",
         sub_key="value",
-        name="Charging",
+        translation_key="start_charging",
         is_on=lambda status: bool(status["value"]),
         method_on="boolean_set",
         method_off="boolean_set",
@@ -241,8 +241,7 @@ RPC_SWITCHES = {
     "cury_left": RpcSwitchDescription(
         key="cury",
         sub_key="slots",
-        name="Left slot",
-        translation_key="cury_slot",
+        translation_key="cury_left_slot",
         is_on=lambda status: bool(status["slots"]["left"]["on"]),
         method_on="cury_set",
         method_off="cury_set",
@@ -254,8 +253,7 @@ RPC_SWITCHES = {
     "cury_left_boost": RpcSwitchDescription(
         key="cury",
         sub_key="slots",
-        name="Left slot boost",
-        translation_key="cury_boost",
+        translation_key="cury_left_boost",
         is_on=lambda status: status["slots"]["left"]["boost"] is not None,
         method_on="cury_boost",
         method_off="cury_stop_boost",
@@ -267,8 +265,7 @@ RPC_SWITCHES = {
     "cury_right": RpcSwitchDescription(
         key="cury",
         sub_key="slots",
-        name="Right slot",
-        translation_key="cury_slot",
+        translation_key="cury_right_slot",
         is_on=lambda status: bool(status["slots"]["right"]["on"]),
         method_on="cury_set",
         method_off="cury_set",
@@ -280,8 +277,7 @@ RPC_SWITCHES = {
     "cury_right_boost": RpcSwitchDescription(
         key="cury",
         sub_key="slots",
-        name="Right slot boost",
-        translation_key="cury_boost",
+        translation_key="cury_right_boost",
         is_on=lambda status: status["slots"]["right"]["boost"] is not None,
         method_on="cury_boost",
         method_off="cury_stop_boost",


### PR DESCRIPTION
# Overview
This PR adds new switch entity strings to the Shelly integration and fixes existing translation keys to properly reference the localized strings. The changes address issue #156146 by ensuring all switch entities have proper translations and correct mapping to their respective string keys.

# Checklist
- [ ] Code changes are complete
- [ ] Tests pass
- [ ] Documentation updated (if applicable)

# Proof that changes are correct
The changes introduce new translation keys for various switch entities including motion detection, charging, and Cury-specific slot and boost switches. The Python code has been updated to use the new translation_key values that match the keys in the strings.json file. This ensures proper localization of switch names in the UI. The changes maintain backward compatibility while improving the translation system for these entities.
Closes #156146