### PR TITLE
Add options to 1-Wire to configure timeouts

### DIFF
--- a/homeassistant/components/onewire/binary_sensor.py
+++ b/homeassistant/components/onewire/binary_sensor.py
@@ -141,6 +141,7 @@ def get_entities(
                     device_file=device_file,
                     device_info=device_info,
                     owproxy=onewire_hub.owproxy,
+                    command_timeout=onewire_hub.command_timeout,
                 )
             )
 

--- a/homeassistant/components/onewire/config_flow.py
+++ b/homeassistant/components/onewire/config_flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
-from aio_ownet.connection import DEFAULT_CONNECTION_TIMEOUT
+from aio_ownet.connection import DEFAULT_COMMAND_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT
 from aio_ownet.exceptions import OWServerConnectionError
 from aio_ownet.proxy import OWServerStatelessProxy
 import voluptuous as vol
@@ -23,6 +23,7 @@ from homeassistant.helpers.service_info.hassio import HassioServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
+    CONF_COMMAND_TIMEOUT,
     CONF_CONNECTION_TIMEOUT,
     DEFAULT_HOST,
     DEFAULT_PORT,
@@ -41,6 +42,7 @@ DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
         vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
         vol.Optional(CONF_CONNECTION_TIMEOUT, default=DEFAULT_CONNECTION_TIMEOUT): int,
+        vol.Optional(CONF_COMMAND_TIMEOUT, default=DEFAULT_COMMAND_TIMEOUT): int,
     }
 )
 
@@ -140,6 +142,9 @@ class OneWireFlowHandler(ConfigFlow, domain=DOMAIN):
             "title": discovery_info.name,
             CONF_HOST: discovery_info.hostname,
             CONF_PORT: discovery_info.port,
+            CONF_COMMAND_TIMEOUT: getattr(
+                discovery_info, CONF_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT
+            ),
             CONF_CONNECTION_TIMEOUT: getattr(
                 discovery_info, CONF_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT
             ),
@@ -155,6 +160,9 @@ class OneWireFlowHandler(ConfigFlow, domain=DOMAIN):
             data = {
                 CONF_HOST: self._discovery_data[CONF_HOST],
                 CONF_PORT: self._discovery_data[CONF_PORT],
+                CONF_COMMAND_TIMEOUT: self._discovery_data.get(
+                    CONF_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT
+                ),
                 CONF_CONNECTION_TIMEOUT: self._discovery_data.get(
                     CONF_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT
                 ),

--- a/homeassistant/components/onewire/const.py
+++ b/homeassistant/components/onewire/const.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Final
 
+CONF_COMMAND_TIMEOUT: Final = "command_timeout"
 CONF_CONNECTION_TIMEOUT: Final = "connection_timeout"
 
 DEFAULT_HOST = "localhost"

--- a/homeassistant/components/onewire/const.py
+++ b/homeassistant/components/onewire/const.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Final
+
+CONF_CONNECTION_TIMEOUT: Final = "connection_timeout"
+
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 4304
 

--- a/homeassistant/components/onewire/entity.py
+++ b/homeassistant/components/onewire/entity.py
@@ -26,6 +26,7 @@ class OneWireEntity(Entity):
         device_info: DeviceInfo,
         device_file: str,
         owproxy: OWServerStatelessProxy,
+        command_timeout: int,
     ) -> None:
         """Initialize the entity."""
         self.entity_description = description
@@ -35,6 +36,7 @@ class OneWireEntity(Entity):
         self._device_file = device_file
         self._state: str | None = None
         self._owproxy = owproxy
+        self._command_timeout = command_timeout
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
@@ -45,12 +47,16 @@ class OneWireEntity(Entity):
 
     async def _write_value(self, value: bytes) -> None:
         """Write a value to the server."""
-        await self._owproxy.write(self._device_file, value)
+        await self._owproxy.write(
+            self._device_file, value, command_timeout=self._command_timeout
+        )
 
     async def async_update(self) -> None:
         """Get the latest data from the device."""
         try:
-            state = await self._owproxy.read(self._device_file)
+            state = await self._owproxy.read(
+                self._device_file, command_timeout=self._command_timeout
+            )
         except OWServerError as exc:
             if self._last_update_success:
                 _LOGGER.error("Error fetching %s data: %s", self.name, exc)

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.signal_type import SignalType
 
 from .const import (
+    CONF_CONNECTION_TIMEOUT,
     DEVICE_SUPPORT,
     DOMAIN,
     MANUFACTURER_EDS,
@@ -72,9 +73,17 @@ class OneWireHub:
         """Connect to the server, and discover connected devices."""
         host = self._config_entry.data[CONF_HOST]
         port = self._config_entry.data[CONF_PORT]
-        _LOGGER.debug("Initializing connection to %s:%s", host, port)
+        connection_timeout = self._config_entry.data[CONF_CONNECTION_TIMEOUT]
+        _LOGGER.debug(
+            "Initializing connection to %s:%s with timeout %s",
+            host,
+            port,
+            connection_timeout,
+        )
         self.owproxy = OWServerStatelessProxy(
-            self._config_entry.data[CONF_HOST], self._config_entry.data[CONF_PORT]
+            self._config_entry.data[CONF_HOST],
+            self._config_entry.data[CONF_PORT],
+            connection_timeout=self._config_entry.data[CONF_CONNECTION_TIMEOUT],
         )
         await self.owproxy.validate()
         with contextlib.suppress(OWServerReturnError):

--- a/homeassistant/components/onewire/select.py
+++ b/homeassistant/components/onewire/select.py
@@ -82,6 +82,7 @@ def get_entities(
                     device_file=device_file,
                     device_info=device_info,
                     owproxy=onewire_hub.owproxy,
+                    command_timeout=onewire_hub.command_timeout,
                 )
             )
 

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -443,6 +443,7 @@ async def get_entities(
                     device_file=device_file,
                     device_info=device_info,
                     owproxy=onewire_hub.owproxy,
+                    command_timeout=onewire_hub.command_timeout,
                 )
             )
     return entities

--- a/homeassistant/components/onewire/strings.json
+++ b/homeassistant/components/onewire/strings.json
@@ -13,10 +13,12 @@
       },
       "reconfigure": {
         "data": {
+          "connection_timeout": "[%key:component::onewire::config::step::user::data::connection_timeout%]",
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]"
         },
         "data_description": {
+          "connection_timeout": "[%key:component::onewire::config::step::user::data_description::connection_timeout%]",
           "host": "[%key:component::onewire::config::step::user::data_description::host%]",
           "port": "[%key:component::onewire::config::step::user::data_description::port%]"
         },
@@ -24,10 +26,12 @@
       },
       "user": {
         "data": {
+          "connection_timeout": "Connection timeout",
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]"
         },
         "data_description": {
+          "connection_timeout": "The connection timeout in seconds.",
           "host": "The hostname or IP address of your OWServer instance.",
           "port": "The port of your OWServer instance (default is 4304)."
         },

--- a/homeassistant/components/onewire/strings.json
+++ b/homeassistant/components/onewire/strings.json
@@ -13,11 +13,13 @@
       },
       "reconfigure": {
         "data": {
+          "command_timeout": "[%key:component::onewire::config::step::user::data::command_timeout%]",
           "connection_timeout": "[%key:component::onewire::config::step::user::data::connection_timeout%]",
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]"
         },
         "data_description": {
+          "command_timeout": "[%key:component::onewire::config::step::user::data_description::command_timeout%]",
           "connection_timeout": "[%key:component::onewire::config::step::user::data_description::connection_timeout%]",
           "host": "[%key:component::onewire::config::step::user::data_description::host%]",
           "port": "[%key:component::onewire::config::step::user::data_description::port%]"
@@ -26,11 +28,13 @@
       },
       "user": {
         "data": {
+          "command_timeout": "Command timeout",
           "connection_timeout": "Connection timeout",
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]"
         },
         "data_description": {
+          "command_timeout": "The command timeout in seconds.",
           "connection_timeout": "The connection timeout in seconds.",
           "host": "The hostname or IP address of your OWServer instance.",
           "port": "The port of your OWServer instance (default is 4304)."

--- a/homeassistant/components/onewire/switch.py
+++ b/homeassistant/components/onewire/switch.py
@@ -194,6 +194,7 @@ def get_entities(
                     device_file=device_file,
                     device_info=device_info,
                     owproxy=onewire_hub.owproxy,
+                    command_timeout=onewire_hub.command_timeout,
                 )
             )
 

--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -23,7 +23,7 @@ def setup_owproxy_mock_devices(owproxy: MagicMock, device_ids: list[str]) -> Non
     for device_id in device_ids:
         _setup_owproxy_mock_device(dir_side_effect, read_side_effect, device_id)
 
-    async def _dir(path: str) -> Any:
+    async def _dir(path: str, **kwargs) -> Any:
         if (side_effect := dir_side_effect.get(path)) is None:
             raise NotImplementedError(f"Unexpected _dir call: {path}")
         result = side_effect.pop(0)
@@ -33,7 +33,7 @@ def setup_owproxy_mock_devices(owproxy: MagicMock, device_ids: list[str]) -> Non
             raise result
         return result
 
-    async def _read(path: str) -> Any:
+    async def _read(path: str, **kwargs) -> Any:
         if (side_effect := read_side_effect.get(path)) is None:
             raise NotImplementedError(f"Unexpected _read call: {path}")
         if len(side_effect) == 0:

--- a/tests/components/onewire/conftest.py
+++ b/tests/components/onewire/conftest.py
@@ -3,10 +3,11 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from aio_ownet.connection import DEFAULT_CONNECTION_TIMEOUT
 from aio_ownet.exceptions import OWServerConnectionError
 import pytest
 
-from homeassistant.components.onewire.const import DOMAIN
+from homeassistant.components.onewire.const import CONF_CONNECTION_TIMEOUT, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -40,6 +41,7 @@ def get_config_entry(hass: HomeAssistant) -> MockConfigEntry:
         data={
             CONF_HOST: "1.2.3.4",
             CONF_PORT: 1234,
+            CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
         },
         options={
             "device_options": {

--- a/tests/components/onewire/conftest.py
+++ b/tests/components/onewire/conftest.py
@@ -3,11 +3,15 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from aio_ownet.connection import DEFAULT_CONNECTION_TIMEOUT
+from aio_ownet.connection import DEFAULT_COMMAND_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT
 from aio_ownet.exceptions import OWServerConnectionError
 import pytest
 
-from homeassistant.components.onewire.const import CONF_CONNECTION_TIMEOUT, DOMAIN
+from homeassistant.components.onewire.const import (
+    CONF_COMMAND_TIMEOUT,
+    CONF_CONNECTION_TIMEOUT,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -42,6 +46,7 @@ def get_config_entry(hass: HomeAssistant) -> MockConfigEntry:
             CONF_HOST: "1.2.3.4",
             CONF_PORT: 1234,
             CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+            CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
         },
         options={
             "device_options": {

--- a/tests/components/onewire/snapshots/test_diagnostics.ambr
+++ b/tests/components/onewire/snapshots/test_diagnostics.ambr
@@ -23,6 +23,7 @@
     }),
     'entry': dict({
       'data': dict({
+        'command_timeout': 10,
         'connection_timeout': 10,
         'host': '**REDACTED**',
         'port': 1234,
@@ -67,6 +68,7 @@
     ]),
     'entry': dict({
       'data': dict({
+        'command_timeout': 10,
         'connection_timeout': 10,
         'host': '**REDACTED**',
         'port': 1234,

--- a/tests/components/onewire/snapshots/test_diagnostics.ambr
+++ b/tests/components/onewire/snapshots/test_diagnostics.ambr
@@ -23,6 +23,7 @@
     }),
     'entry': dict({
       'data': dict({
+        'connection_timeout': 10,
         'host': '**REDACTED**',
         'port': 1234,
       }),
@@ -66,6 +67,7 @@
     ]),
     'entry': dict({
       'data': dict({
+        'connection_timeout': 10,
         'host': '**REDACTED**',
         'port': 1234,
       }),

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -3,10 +3,12 @@
 from ipaddress import ip_address
 from unittest.mock import AsyncMock, patch
 
+from aio_ownet.connection import DEFAULT_CONNECTION_TIMEOUT
 from aio_ownet.exceptions import OWServerConnectionError
 import pytest
 
 from homeassistant.components.onewire.const import (
+    CONF_CONNECTION_TIMEOUT,
     DOMAIN,
     INPUT_ENTRY_CLEAR_OPTIONS,
     INPUT_ENTRY_DEVICE_SELECTION,
@@ -69,13 +71,21 @@ async def test_user_flow(hass: HomeAssistant) -> None:
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 1234},
+            user_input={
+                CONF_HOST: "1.2.3.4",
+                CONF_PORT: 1234,
+                CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+            },
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     new_entry = result["result"]
     assert new_entry.title == "1.2.3.4"
-    assert new_entry.data == {CONF_HOST: "1.2.3.4", CONF_PORT: 1234}
+    assert new_entry.data == {
+        CONF_HOST: "1.2.3.4",
+        CONF_PORT: 1234,
+        CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+    }
 
 
 async def test_user_flow_recovery(hass: HomeAssistant) -> None:
@@ -91,7 +101,11 @@ async def test_user_flow_recovery(hass: HomeAssistant) -> None:
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 1234},
+            user_input={
+                CONF_HOST: "1.2.3.4",
+                CONF_PORT: 1234,
+                CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+            },
         )
 
     assert result["type"] is FlowResultType.FORM
@@ -104,13 +118,21 @@ async def test_user_flow_recovery(hass: HomeAssistant) -> None:
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 1234},
+            user_input={
+                CONF_HOST: "1.2.3.4",
+                CONF_PORT: 1234,
+                CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+            },
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     new_entry = result["result"]
     assert new_entry.title == "1.2.3.4"
-    assert new_entry.data == {CONF_HOST: "1.2.3.4", CONF_PORT: 1234}
+    assert new_entry.data == {
+        CONF_HOST: "1.2.3.4",
+        CONF_PORT: 1234,
+        CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+    }
 
 
 async def test_user_duplicate(
@@ -131,7 +153,11 @@ async def test_user_duplicate(
     # Duplicate server
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 1234},
+        user_input={
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 1234,
+            CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+        },
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -153,7 +179,11 @@ async def test_reconfigure_flow(
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={CONF_HOST: "2.3.4.5", CONF_PORT: 2345},
+            user_input={
+                CONF_HOST: "2.3.4.5",
+                CONF_PORT: 2345,
+                CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+            },
         )
 
     assert result["type"] is FlowResultType.FORM
@@ -166,12 +196,20 @@ async def test_reconfigure_flow(
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={CONF_HOST: "2.3.4.5", CONF_PORT: 2345},
+            user_input={
+                CONF_HOST: "2.3.4.5",
+                CONF_PORT: 2345,
+                CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+            },
         )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert config_entry.data == {CONF_HOST: "2.3.4.5", CONF_PORT: 2345}
+    assert config_entry.data == {
+        CONF_HOST: "2.3.4.5",
+        CONF_PORT: 2345,
+        CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+    }
 
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -186,6 +224,7 @@ async def test_reconfigure_duplicate(
         data={
             CONF_HOST: "2.3.4.5",
             CONF_PORT: 2345,
+            CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
         },
         entry_id="other",
     )
@@ -199,14 +238,26 @@ async def test_reconfigure_duplicate(
     # Duplicate server
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_HOST: "2.3.4.5", CONF_PORT: 2345},
+        user_input={
+            CONF_HOST: "2.3.4.5",
+            CONF_PORT: 2345,
+            CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+        },
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     assert len(mock_setup_entry.mock_calls) == 0
-    assert config_entry.data == {CONF_HOST: "1.2.3.4", CONF_PORT: 1234}
-    assert other_config_entry.data == {CONF_HOST: "2.3.4.5", CONF_PORT: 2345}
+    assert config_entry.data == {
+        CONF_HOST: "1.2.3.4",
+        CONF_PORT: 1234,
+        CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+    }
+    assert other_config_entry.data == {
+        CONF_HOST: "2.3.4.5",
+        CONF_PORT: 2345,
+        CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+    }
 
 
 async def test_hassio_flow(hass: HomeAssistant) -> None:
@@ -246,7 +297,11 @@ async def test_hassio_flow(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.CREATE_ENTRY
     new_entry = result["result"]
     assert new_entry.title == "owserver (1-wire)"
-    assert new_entry.data == {CONF_HOST: "1302b8e0-owserver", CONF_PORT: 4304}
+    assert new_entry.data == {
+        CONF_HOST: "1302b8e0-owserver",
+        CONF_PORT: 4304,
+        CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+    }
 
 
 @pytest.mark.usefixtures("config_entry")
@@ -298,7 +353,11 @@ async def test_zeroconf_flow(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.CREATE_ENTRY
     new_entry = result["result"]
     assert new_entry.title == "OWFS (1-wire) Server"
-    assert new_entry.data == {CONF_HOST: "ubuntu.local.", CONF_PORT: 4304}
+    assert new_entry.data == {
+        CONF_HOST: "ubuntu.local.",
+        CONF_PORT: 4304,
+        CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+    }
 
 
 @pytest.mark.usefixtures("config_entry")

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -3,11 +3,12 @@
 from ipaddress import ip_address
 from unittest.mock import AsyncMock, patch
 
-from aio_ownet.connection import DEFAULT_CONNECTION_TIMEOUT
+from aio_ownet.connection import DEFAULT_COMMAND_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT
 from aio_ownet.exceptions import OWServerConnectionError
 import pytest
 
 from homeassistant.components.onewire.const import (
+    CONF_COMMAND_TIMEOUT,
     CONF_CONNECTION_TIMEOUT,
     DOMAIN,
     INPUT_ENTRY_CLEAR_OPTIONS,
@@ -75,6 +76,7 @@ async def test_user_flow(hass: HomeAssistant) -> None:
                 CONF_HOST: "1.2.3.4",
                 CONF_PORT: 1234,
                 CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+                CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
             },
         )
 
@@ -85,6 +87,7 @@ async def test_user_flow(hass: HomeAssistant) -> None:
         CONF_HOST: "1.2.3.4",
         CONF_PORT: 1234,
         CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+        CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
     }
 
 
@@ -105,6 +108,7 @@ async def test_user_flow_recovery(hass: HomeAssistant) -> None:
                 CONF_HOST: "1.2.3.4",
                 CONF_PORT: 1234,
                 CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+                CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
             },
         )
 
@@ -122,6 +126,7 @@ async def test_user_flow_recovery(hass: HomeAssistant) -> None:
                 CONF_HOST: "1.2.3.4",
                 CONF_PORT: 1234,
                 CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+                CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
             },
         )
 
@@ -132,6 +137,7 @@ async def test_user_flow_recovery(hass: HomeAssistant) -> None:
         CONF_HOST: "1.2.3.4",
         CONF_PORT: 1234,
         CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+        CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
     }
 
 
@@ -157,6 +163,7 @@ async def test_user_duplicate(
             CONF_HOST: "1.2.3.4",
             CONF_PORT: 1234,
             CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+            CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
         },
     )
     assert result["type"] is FlowResultType.ABORT
@@ -183,6 +190,7 @@ async def test_reconfigure_flow(
                 CONF_HOST: "2.3.4.5",
                 CONF_PORT: 2345,
                 CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+                CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
             },
         )
 
@@ -200,6 +208,7 @@ async def test_reconfigure_flow(
                 CONF_HOST: "2.3.4.5",
                 CONF_PORT: 2345,
                 CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+                CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
             },
         )
 
@@ -209,6 +218,7 @@ async def test_reconfigure_flow(
         CONF_HOST: "2.3.4.5",
         CONF_PORT: 2345,
         CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+        CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
@@ -225,6 +235,7 @@ async def test_reconfigure_duplicate(
             CONF_HOST: "2.3.4.5",
             CONF_PORT: 2345,
             CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+            CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
         },
         entry_id="other",
     )
@@ -242,6 +253,7 @@ async def test_reconfigure_duplicate(
             CONF_HOST: "2.3.4.5",
             CONF_PORT: 2345,
             CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+            CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
         },
     )
     assert result["type"] is FlowResultType.ABORT
@@ -252,11 +264,13 @@ async def test_reconfigure_duplicate(
         CONF_HOST: "1.2.3.4",
         CONF_PORT: 1234,
         CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+        CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
     }
     assert other_config_entry.data == {
         CONF_HOST: "2.3.4.5",
         CONF_PORT: 2345,
         CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+        CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
     }
 
 
@@ -301,6 +315,7 @@ async def test_hassio_flow(hass: HomeAssistant) -> None:
         CONF_HOST: "1302b8e0-owserver",
         CONF_PORT: 4304,
         CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+        CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
     }
 
 
@@ -357,6 +372,7 @@ async def test_zeroconf_flow(hass: HomeAssistant) -> None:
         CONF_HOST: "ubuntu.local.",
         CONF_PORT: 4304,
         CONF_CONNECTION_TIMEOUT: DEFAULT_CONNECTION_TIMEOUT,
+        CONF_COMMAND_TIMEOUT: DEFAULT_COMMAND_TIMEOUT,
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add options to 1-Wire to configure timeouts

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I have a lot of 1-Wire entities on my bus (>200). In https://github.com/home-assistant/core/pull/154439 the library was changed, and since then I have been experiencing timeouts. This adds the possibility to change both `connection_timeout` and `command_timeout`.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
