### PR TITLE
Fix MFA Notify setup flow schema

### DIFF
--- a/homeassistant/auth/mfa_modules/notify.py
+++ b/homeassistant/auth/mfa_modules/notify.py
@@ -6,7 +6,6 @@ Sending HOTP through notify service
 from __future__ import annotations
 
 import asyncio
-from collections import OrderedDict
 import logging
 from typing import Any, cast
 
@@ -304,13 +303,14 @@ class NotifySetupFlow(SetupFlow[NotifyAuthModule]):
         if not self._available_notify_services:
             return self.async_abort(reason="no_available_service")
 
-        schema: dict[str, Any] = OrderedDict()
-        schema["notify_service"] = vol.In(self._available_notify_services)
-        schema["target"] = vol.Optional(str)
-
-        return self.async_show_form(
-            step_id="init", data_schema=vol.Schema(schema), errors=errors
+        schema = vol.Schema(
+            {
+                vol.Required("notify_service"): vol.In(self._available_notify_services),
+                vol.Optional("target"): str,
+            }
         )
+
+        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)
 
     async def async_step_setup(
         self, user_input: dict[str, str] | None = None

--- a/tests/auth/mfa_modules/test_notify.py
+++ b/tests/auth/mfa_modules/test_notify.py
@@ -3,6 +3,8 @@
 import asyncio
 from unittest.mock import patch
 
+import voluptuous_serialize
+
 from homeassistant import data_entry_flow
 from homeassistant.auth import auth_manager_from_config, models as auth_models
 from homeassistant.auth.mfa_modules import auth_mfa_module_from_config
@@ -248,6 +250,30 @@ async def test_setup_user_notify_service(hass: HomeAssistant) -> None:
     assert step["step_id"] == "init"
     schema = step["data_schema"]
     schema({"notify_service": "test2"})
+    # ensure the schema can be serialized
+    assert voluptuous_serialize.convert(schema) == [
+        {
+            "name": "notify_service",
+            "options": [
+                (
+                    "test1",
+                    "test1",
+                ),
+                (
+                    "test2",
+                    "test2",
+                ),
+            ],
+            "required": True,
+            "type": "select",
+        },
+        {
+            "name": "target",
+            "optional": True,
+            "required": False,
+            "type": "string",
+        },
+    ]
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         step = await flow.async_step_init({"notify_service": "test1"})


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update the mfa setup schema so that voluptuous_serialize can serialize it. Previously, it was failing and making it impossible to set up MFA notify:


```
  File "/usr/src/homeassistant/homeassistant/components/auth/mfa_setup_flow.py", line 117, in async_setup_flow
    websocket_api.result_message(msg["id"], _prepare_result_json(result))
                                            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/auth/mfa_setup_flow.py", line 163, in _prepare_result_json
    data["data_schema"] = voluptuous_serialize.convert(schema)
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/voluptuous_serialize/__init__.py", line 59, in convert
    pval = convert(value, custom_serializer=custom_serializer)
  File "/usr/local/lib/python3.13/site-packages/voluptuous_serialize/__init__.py", line 164, in convert
    raise ValueError(f"Unable to convert schema: {schema}")
ValueError: Unable to convert schema: <class 'str'>
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
