### PR TITLE
Inject httpx.AsyncClient session in Xbox integration

### DIFF
--- a/homeassistant/components/xbox/api.py
+++ b/homeassistant/components/xbox/api.py
@@ -1,7 +1,5 @@
 """API for xbox bound to Home Assistant OAuth."""
 
-from contextlib import suppress
-
 from httpx import AsyncClient
 from pythonxbox.authentication.manager import AuthenticationManager
 from pythonxbox.authentication.models import OAuth2TokenResponse
@@ -15,14 +13,8 @@ class AsyncConfigEntryAuth(AuthenticationManager):
 
     def __init__(self, session: AsyncClient, oauth_session: OAuth2Session) -> None:
         """Initialize xbox auth."""
-
-        # The library deprecated direct use of httpx.AsyncClient in favor of SignedSession,
-        # which wraps it. Since SignedSession is only needed for XAL authentication and Home Assistant
-        # uses XUser authentication instead, we can safely inject a standard httpx.AsyncClient session
-        # and ignore the deprecation warning.
-        with suppress(DeprecationWarning):
-            # Leaving out client credentials as they are handled by Home Assistant
-            super().__init__(session, "", "", "")  # type: ignore[arg-type]
+        # Leaving out client credentials as they are handled by Home Assistant
+        super().__init__(session, "", "", "")
         self._oauth_session = oauth_session
         self.oauth = self._get_oauth_token()
 

--- a/homeassistant/components/xbox/config_flow.py
+++ b/homeassistant/components/xbox/config_flow.py
@@ -1,12 +1,13 @@
 """Config flow for xbox."""
 
+from contextlib import suppress
 import logging
 from typing import Any
 
+from httpx import AsyncClient
 from pythonxbox.api.client import XboxLiveClient
 from pythonxbox.authentication.manager import AuthenticationManager
 from pythonxbox.authentication.models import OAuth2TokenResponse
-from pythonxbox.common.signed_session import SignedSession
 
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -43,8 +44,9 @@ class OAuth2FlowHandler(
     async def async_oauth_create_entry(self, data: dict) -> ConfigFlowResult:
         """Create an entry for the flow."""
 
-        async with SignedSession() as session:
-            auth = AuthenticationManager(session, "", "", "")
+        async with AsyncClient() as session:
+            with suppress(DeprecationWarning):
+                auth = AuthenticationManager(session, "", "", "")  # type: ignore[arg-type]
             auth.oauth = OAuth2TokenResponse(**data["token"])
             await auth.refresh_tokens()
 

--- a/homeassistant/components/xbox/config_flow.py
+++ b/homeassistant/components/xbox/config_flow.py
@@ -1,6 +1,5 @@
 """Config flow for xbox."""
 
-from contextlib import suppress
 import logging
 from typing import Any
 
@@ -45,8 +44,7 @@ class OAuth2FlowHandler(
         """Create an entry for the flow."""
 
         async with AsyncClient() as session:
-            with suppress(DeprecationWarning):
-                auth = AuthenticationManager(session, "", "", "")  # type: ignore[arg-type]
+            auth = AuthenticationManager(session, "", "", "")
             auth.oauth = OAuth2TokenResponse(**data["token"])
             await auth.refresh_tokens()
 

--- a/homeassistant/components/xbox/coordinator.py
+++ b/homeassistant/components/xbox/coordinator.py
@@ -17,7 +17,6 @@ from pythonxbox.api.provider.smartglass.models import (
     SmartglassConsoleStatus,
 )
 from pythonxbox.api.provider.titlehub.models import Title
-from pythonxbox.common.signed_session import SignedSession
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -28,8 +27,8 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2Session,
     async_get_config_entry_implementation,
 )
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util.ssl import get_default_context
 
 from . import api
 from .const import DOMAIN
@@ -92,8 +91,8 @@ class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
             ) from e
 
         session = OAuth2Session(self.hass, self.config_entry, implementation)
-        signed_session = SignedSession(ssl_context=get_default_context())
-        auth = api.AsyncConfigEntryAuth(signed_session, session)
+        async_session = get_async_client(self.hass)
+        auth = api.AsyncConfigEntryAuth(async_session, session)
         self.client = XboxLiveClient(auth)
 
         try:

--- a/tests/components/xbox/conftest.py
+++ b/tests/components/xbox/conftest.py
@@ -86,25 +86,8 @@ def mock_authentication_manager() -> Generator[AsyncMock]:
         yield client
 
 
-@pytest.fixture(name="signed_session")
-def mock_signed_session() -> Generator[AsyncMock]:
-    """Mock xbox-webapi SignedSession."""
-
-    with (
-        patch(
-            "homeassistant.components.xbox.coordinator.SignedSession", autospec=True
-        ) as mock_client,
-        patch(
-            "homeassistant.components.xbox.config_flow.SignedSession", new=mock_client
-        ),
-    ):
-        client = mock_client.return_value
-
-        yield client
-
-
 @pytest.fixture(name="xbox_live_client")
-def mock_xbox_live_client(signed_session) -> Generator[AsyncMock]:
+def mock_xbox_live_client() -> Generator[AsyncMock]:
     """Mock xbox-webapi XboxLiveClient."""
 
     with (


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Inject `httpx.AsyncClient` session instead of using `SignedSession`. `SignedSession` is a wrapper around `AsyncClient` and extends it with some methods that are only ever used in the XAL authentication module, which is not used in the HA integration. So it is safe to inject a standard session. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
