### PR TITLE
Add async dpcode update wrapper to Tuya

### DIFF
--- a/homeassistant/components/tuya/entity.py
+++ b/homeassistant/components/tuya/entity.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, LOGGER, TUYA_HA_SIGNAL_UPDATE_ENTITY
+from .models import DPCodeWrapper
 
 
 class TuyaEntity(Entity):
@@ -64,3 +65,12 @@ class TuyaEntity(Entity):
         """Send command to the device."""
         LOGGER.debug("Sending commands for device %s: %s", self.device.id, commands)
         self.device_manager.send_commands(self.device.id, commands)
+
+    async def _async_send_dpcode_update(
+        self, dpcode_wrapper: DPCodeWrapper, value: Any
+    ) -> None:
+        """Send command to the device."""
+        await self.hass.async_add_executor_job(
+            self._send_command,
+            [dpcode_wrapper.get_update_command(self.device, value)],
+        )

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -146,9 +146,12 @@ class DPCodeWrapper:
         raise NotImplementedError("read_device_status must be implemented")
 
     def _convert_value_back(self, device: CustomerDevice, value: Any) -> Any:
-        """Get the update command value for the dpcode.
+        """Convert a Home Assistant value back to a raw device value.
 
         Private helper method for `get_update_command`.
+
+        Checks should be added to ensure that the Home Assistant value is valid
+        for the corresponding type information (if applicable).
         """
         raise NotImplementedError("convert_value_back must be implemented")
 

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -177,9 +177,10 @@ class DPCodeBooleanWrapper(DPCodeWrapper):
 
     def _convert_value_back(self, device: CustomerDevice, value: Any) -> Any | None:
         """Get the update command value for the dpcode."""
-        # Currently only called with boolean values
-        # Safety net in case of future changes
-        assert value in (True, False), "Invalid boolean value"
+        if value not in (True, False):
+            # Currently only called with boolean values
+            # Safety net in case of future changes
+            raise ValueError(f"Invalid boolean value `{value}`")
         return value
 
 
@@ -231,9 +232,12 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
 
     def _convert_value_back(self, device: CustomerDevice, value: Any) -> Any:
         """Get the update command value for the dpcode."""
-        # Guarded by select option validation
-        # Safety net in case of future changes
-        assert value in self.type_information.range, "Enum value out of range"
+        if value not in self.type_information.range:
+            # Guarded by select option validation
+            # Safety net in case of future changes
+            raise ValueError(
+                f"Enum value `{value}` out of range: {self.type_information.range}"
+            )
         return value
 
 
@@ -254,11 +258,13 @@ class DPCodeIntegerWrapper(DPCodeTypeInformationWrapper[IntegerTypeData]):
     def _convert_value_back(self, device: CustomerDevice, value: Any) -> Any:
         """Get the update command value for the dpcode."""
         new_value = round(value * (10**self.type_information.scale))
-        # Guarded by number option validation
-        # Safety net in case of future changes
-        assert self.type_information.min <= new_value <= self.type_information.max, (
-            "Integer value out of range"
-        )
+        if self.type_information.min <= new_value <= self.type_information.max:
+            # Guarded by number validation
+            # Safety net in case of future changes
+            raise ValueError(
+                f"Value `{new_value}` (converted from `{value}`) out of range:"
+                f" ({self.type_information.min}-{self.type_information.max})"
+            )
         return new_value
 
 

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -261,21 +261,6 @@ class DPCodeIntegerWrapper(DPCodeTypeInformationWrapper[IntegerTypeData]):
         )
         return new_value
 
-    @classmethod
-    def find_dpcode(
-        cls,
-        device: CustomerDevice,
-        dpcodes: str | DPCode | tuple[DPCode, ...],
-        *,
-        prefer_function: bool = False,
-    ) -> Self | None:
-        """Find and return a DPCodeEnumWrapper for the given DP codes."""
-        if enum_type := find_dpcode(
-            device, dpcodes, dptype=DPType.ENUM, prefer_function=prefer_function
-        ):
-            return cls(dpcode=enum_type.dpcode, type_information=enum_type)
-        return None
-
 
 @overload
 def find_dpcode(

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -177,11 +177,11 @@ class DPCodeBooleanWrapper(DPCodeWrapper):
 
     def _convert_value_back(self, device: CustomerDevice, value: Any) -> Any | None:
         """Get the update command value for the dpcode."""
-        if value not in (True, False):
-            # Currently only called with boolean values
-            # Safety net in case of future changes
-            raise ValueError(f"Invalid boolean value `{value}`")
-        return value
+        if value in (True, False):
+            return value
+        # Currently only called with boolean values
+        # Safety net in case of future changes
+        raise ValueError(f"Invalid boolean value `{value}`")
 
 
 class DPCodeTypeInformationWrapper[T: TypeInformation](DPCodeWrapper):
@@ -232,13 +232,13 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
 
     def _convert_value_back(self, device: CustomerDevice, value: Any) -> Any:
         """Get the update command value for the dpcode."""
-        if value not in self.type_information.range:
-            # Guarded by select option validation
-            # Safety net in case of future changes
-            raise ValueError(
-                f"Enum value `{value}` out of range: {self.type_information.range}"
-            )
-        return value
+        if value in self.type_information.range:
+            return value
+        # Guarded by select option validation
+        # Safety net in case of future changes
+        raise ValueError(
+            f"Enum value `{value}` out of range: {self.type_information.range}"
+        )
 
 
 class DPCodeIntegerWrapper(DPCodeTypeInformationWrapper[IntegerTypeData]):
@@ -259,13 +259,13 @@ class DPCodeIntegerWrapper(DPCodeTypeInformationWrapper[IntegerTypeData]):
         """Get the update command value for the dpcode."""
         new_value = round(value * (10**self.type_information.scale))
         if self.type_information.min <= new_value <= self.type_information.max:
-            # Guarded by number validation
-            # Safety net in case of future changes
-            raise ValueError(
-                f"Value `{new_value}` (converted from `{value}`) out of range:"
-                f" ({self.type_information.min}-{self.type_information.max})"
-            )
-        return new_value
+            return new_value
+        # Guarded by number validation
+        # Safety net in case of future changes
+        raise ValueError(
+            f"Value `{new_value}` (converted from `{value}`) out of range:"
+            f" ({self.type_information.min}-{self.type_information.max})"
+        )
 
 
 @overload

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -540,15 +540,6 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
         """Return the entity value to represent the entity state."""
         return self._dpcode_wrapper.read_device_status(self.device)
 
-    def set_native_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
-        self._send_command(
-            [
-                {
-                    "code": self._dpcode_wrapper.dpcode,
-                    "value": (
-                        self._dpcode_wrapper.type_information.scale_value_back(value)
-                    ),
-                }
-            ]
-        )
+        await self._async_send_dpcode_update(self._dpcode_wrapper, value)

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -402,6 +402,6 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         """Return the selected entity option to represent the entity state."""
         return self._dpcode_wrapper.read_device_status(self.device)
 
-    def select_option(self, option: str) -> None:
+    async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        self._send_command([{"code": self._dpcode_wrapper.dpcode, "value": option}])
+        await self._async_send_dpcode_update(self._dpcode_wrapper, option)

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -1034,10 +1034,10 @@ class TuyaSwitchEntity(TuyaEntity, SwitchEntity):
         """Return true if switch is on."""
         return self._dpcode_wrapper.read_device_status(self.device)
 
-    def turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        self._send_command([{"code": self._dpcode_wrapper.dpcode, "value": True}])
+        await self._async_send_dpcode_update(self._dpcode_wrapper, True)
 
-    def turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        self._send_command([{"code": self._dpcode_wrapper.dpcode, "value": False}])
+        await self._async_send_dpcode_update(self._dpcode_wrapper, False)

--- a/homeassistant/components/tuya/valve.py
+++ b/homeassistant/components/tuya/valve.py
@@ -140,12 +140,8 @@ class TuyaValveEntity(TuyaEntity, ValveEntity):
 
     async def async_open_valve(self) -> None:
         """Open the valve."""
-        await self.hass.async_add_executor_job(
-            self._send_command, [{"code": self._dpcode_wrapper.dpcode, "value": True}]
-        )
+        await self._async_send_dpcode_update(self._dpcode_wrapper, True)
 
     async def async_close_valve(self) -> None:
         """Close the valve."""
-        await self.hass.async_add_executor_job(
-            self._send_command, [{"code": self._dpcode_wrapper.dpcode, "value": False}]
-        )
+        await self._async_send_dpcode_update(self._dpcode_wrapper, False)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add `get_update_command` / `_convert_value_back` to `DPCodeWrapper` base class
- Implement `_convert_value_back` in `DPCodeBooleanWrapper`/`DPCodeEnumWrapper` classes
- Add `_async_send_dpcode_update` to base `TuyaEntity` class
- Migrate `select`, `switch` and `valve` platforms to use `_async_send_dpcode_update`.

Linked to #156232

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
