### PR TITLE
Enhance compressor phase with state translations in ViCare integration

### DIFF
--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -58,6 +58,7 @@ from .utils import (
     get_compressors,
     get_device_serial,
     is_supported,
+    normalize_state,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -1086,7 +1087,7 @@ COMPRESSOR_SENSORS: tuple[ViCareSensorEntityDescription, ...] = (
     ViCareSensorEntityDescription(
         key="compressor_phase",
         translation_key="compressor_phase",
-        value_getter=lambda api: api.getPhase(),
+        value_getter=lambda api: normalize_state(api.getPhase()),
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -221,9 +221,9 @@
           "preparing-defrost": "Preparing defrost",
           "defrost": "[%key:component::climate::entity_component::_::hvac_action::state::defrosting%]",
           "passive-defrost": "Passive defrosting",
-          "ready": "[%key:component::climate::entity_component::_::hvac_action::state::idle%]",
-          "pause": "[%key:component::climate::entity_component::_::hvac_action::state::idle%]",
-          "off": "[%key:component::climate::entity_component::_::hvac_action::state::off%]"
+          "ready": "[%key:common::state::idle%]",
+          "pause": "[%key:common::state::idle%]",
+          "off": "[%key:common::state::off%]"
         }
       },
       "compressor_starts": {

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -215,15 +215,15 @@
       "compressor_phase": {
         "name": "Compressor phase",
         "state": {
-          "preparing": "Preparing",
-          "heating": "[%key:component::climate::entity_component::_::hvac_action::state::heating%]",
-          "cooling": "[%key:component::climate::entity_component::_::hvac_action::state::cooling%]",
-          "preparing-defrost": "Preparing defrost",
-          "defrost": "[%key:component::climate::entity_component::_::hvac_action::state::defrosting%]",
+          "cooling": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::cooling%]",
+          "defrost": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::defrosting%]",
+          "heating": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::heating%]",
+          "off": "[%key:common::state::off%]",
           "passive-defrost": "Passive defrosting",
-          "ready": "[%key:common::state::idle%]",
           "pause": "[%key:common::state::idle%]",
-          "off": "[%key:common::state::off%]"
+          "preparing": "Preparing",
+          "preparing-defrost": "Preparing defrost",
+          "ready": "[%key:common::state::idle%]"
         }
       },
       "compressor_starts": {

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -213,7 +213,18 @@
         "name": "Compressor hours load class 5"
       },
       "compressor_phase": {
-        "name": "Compressor phase"
+        "name": "Compressor phase",
+        "state": {
+          "preparing": "Preparing",
+          "heating": "[%key:component::climate::entity_component::_::hvac_action::state::heating%]",
+          "cooling": "[%key:component::climate::entity_component::_::hvac_action::state::cooling%]",
+          "preparing-defrost": "Preparing defrost",
+          "defrost": "[%key:component::climate::entity_component::_::hvac_action::state::defrosting%]",
+          "passive-defrost": "Passive defrosting",
+          "ready": "[%key:component::climate::entity_component::_::hvac_action::state::idle%]",
+          "pause": "[%key:component::climate::entity_component::_::hvac_action::state::idle%]",
+          "off": "[%key:component::climate::entity_component::_::hvac_action::state::off%]"
+        }
       },
       "compressor_starts": {
         "name": "Compressor starts"

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -219,10 +219,10 @@
           "defrost": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::defrosting%]",
           "heating": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::heating%]",
           "off": "[%key:common::state::off%]",
-          "passive-defrost": "Passive defrosting",
+          "passive_defrost": "Passive defrosting",
           "pause": "[%key:common::state::idle%]",
           "preparing": "Preparing",
-          "preparing-defrost": "Preparing defrost",
+          "preparing_defrost": "Preparing defrost",
           "ready": "[%key:common::state::idle%]"
         }
       },

--- a/homeassistant/components/vicare/utils.py
+++ b/homeassistant/components/vicare/utils.py
@@ -133,3 +133,8 @@ def get_compressors(device: PyViCareDevice) -> list[PyViCareHeatingDeviceCompone
 def filter_state(state: str) -> str | None:
     """Return the state if not 'nothing' or 'unknown'."""
     return None if state in ("nothing", "unknown") else state
+
+
+def normalize_state(state: str) -> str:
+    """Return the state with underscores instead of hyphens."""
+    return state.replace("-", "_")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add state translations for compressor phase.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
