### PR TITLE
Use pytest.mark.freeze_time in caldav tests

### DIFF
--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, Mock
 import zoneinfo
 
 from caldav.objects import Event
-from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -437,7 +436,7 @@ async def test_setup_component_config(
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(_local_datetime(17, 45))
+@pytest.mark.freeze_time(_local_datetime(17, 45))
 async def test_ongoing_event(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -462,7 +461,7 @@ async def test_ongoing_event(
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(_local_datetime(17, 30))
+@pytest.mark.freeze_time(_local_datetime(17, 30))
 async def test_just_ended_event(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -487,7 +486,7 @@ async def test_just_ended_event(
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(_local_datetime(17, 00))
+@pytest.mark.freeze_time(_local_datetime(17, 00))
 async def test_ongoing_event_different_tz(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -512,7 +511,7 @@ async def test_ongoing_event_different_tz(
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(_local_datetime(19, 10))
+@pytest.mark.freeze_time(_local_datetime(19, 10))
 async def test_ongoing_floating_event_returned(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -537,7 +536,7 @@ async def test_ongoing_floating_event_returned(
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(_local_datetime(8, 30))
+@pytest.mark.freeze_time(_local_datetime(8, 30))
 async def test_ongoing_event_with_offset(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -578,7 +577,7 @@ async def test_ongoing_event_with_offset(
         )
     ],
 )
-@freeze_time(_local_datetime(12, 00))
+@pytest.mark.freeze_time(_local_datetime(12, 00))
 async def test_matching_filter(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -619,7 +618,7 @@ async def test_matching_filter(
         )
     ],
 )
-@freeze_time(_local_datetime(12, 00))
+@pytest.mark.freeze_time(_local_datetime(12, 00))
 async def test_matching_filter_real_regexp(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -658,7 +657,7 @@ async def test_matching_filter_real_regexp(
         }
     ],
 )
-@freeze_time(_local_datetime(20, 00))
+@pytest.mark.freeze_time(_local_datetime(20, 00))
 async def test_filter_matching_past_event(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -691,7 +690,7 @@ async def test_filter_matching_past_event(
         }
     ],
 )
-@freeze_time(_local_datetime(12, 00))
+@pytest.mark.freeze_time(_local_datetime(12, 00))
 async def test_no_result_with_filtering(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -765,7 +764,7 @@ async def test_all_day_event(
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(_local_datetime(21, 45))
+@pytest.mark.freeze_time(_local_datetime(21, 45))
 async def test_event_rrule(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -790,7 +789,7 @@ async def test_event_rrule(
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(_local_datetime(22, 15))
+@pytest.mark.freeze_time(_local_datetime(22, 15))
 async def test_event_rrule_ongoing(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -815,7 +814,7 @@ async def test_event_rrule_ongoing(
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(_local_datetime(22, 45))
+@pytest.mark.freeze_time(_local_datetime(22, 45))
 async def test_event_rrule_duration(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -840,7 +839,7 @@ async def test_event_rrule_duration(
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(_local_datetime(23, 15))
+@pytest.mark.freeze_time(_local_datetime(23, 15))
 async def test_event_rrule_duration_ongoing(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -865,7 +864,7 @@ async def test_event_rrule_duration_ongoing(
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(_local_datetime(23, 37))
+@pytest.mark.freeze_time(_local_datetime(23, 37))
 async def test_event_rrule_endless(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -947,7 +946,7 @@ async def test_event_rrule_all_day_early(
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(dt_util.as_local(datetime.datetime(2015, 11, 27, 0, 15)))
+@pytest.mark.freeze_time(dt_util.as_local(datetime.datetime(2015, 11, 27, 0, 15)))
 async def test_event_rrule_hourly_on_first(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -972,7 +971,7 @@ async def test_event_rrule_hourly_on_first(
 
 
 @pytest.mark.parametrize("tz", ["UTC"])
-@freeze_time(dt_util.as_local(datetime.datetime(2015, 11, 27, 11, 15)))
+@pytest.mark.freeze_time(dt_util.as_local(datetime.datetime(2015, 11, 27, 11, 15)))
 async def test_event_rrule_hourly_on_last(
     hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
 ) -> None:
@@ -1104,7 +1103,7 @@ async def test_calendar_components(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("tz", [UTC])
-@freeze_time(_local_datetime(17, 30))
+@pytest.mark.freeze_time(_local_datetime(17, 30))
 async def test_setup_config_entry(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `pytest.mark.freeze_time` instead of `freezegun.freeze_time` in caldav tests

This ensures time is frozen during the entire test, including when setting up and tearing down test fixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
