### PR TITLE
Remove yaml in tests for Telegram polling bot

### DIFF
--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -15,7 +15,7 @@ from telegram import (
     User,
     WebhookInfo,
 )
-from telegram.constants import AccentColor, ChatType
+from telegram.constants import ChatType
 
 from homeassistant.components.telegram_bot import (
     ATTR_PARSER,
@@ -27,6 +27,7 @@ from homeassistant.components.telegram_bot import (
 from homeassistant.components.telegram_bot.const import (
     CONF_CHAT_ID,
     PLATFORM_BROADCAST,
+    PLATFORM_POLLING,
     PLATFORM_WEBHOOKS,
 )
 from homeassistant.config_entries import ConfigSubentryData
@@ -59,22 +60,31 @@ def config_webhooks() -> dict[str, Any]:
 
 
 @pytest.fixture
-def config_polling() -> dict[str, Any]:
-    """Fixture for a polling platform configuration."""
-    return {
-        DOMAIN: [
-            {
-                CONF_PLATFORM: "polling",
-                CONF_API_KEY: "1234567890:ABC",
-                CONF_ALLOWED_CHAT_IDS: [
-                    # "me"
-                    12345678,
-                    # Some chat
-                    -123456789,
-                ],
-            }
-        ]
-    }
+def mock_polling_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        unique_id="mock api key",
+        domain=DOMAIN,
+        data={
+            CONF_PLATFORM: PLATFORM_POLLING,
+            CONF_API_KEY: "mock api key",
+        },
+        options={ATTR_PARSER: PARSER_MD},
+        subentries_data=[
+            ConfigSubentryData(
+                unique_id="1234567890",
+                data={CONF_CHAT_ID: 12345678},
+                subentry_type=CONF_ALLOWED_CHAT_IDS,
+                title="mock chat 1",
+            ),
+            ConfigSubentryData(
+                unique_id="1234567890",
+                data={CONF_CHAT_ID: -123456789},
+                subentry_type=CONF_ALLOWED_CHAT_IDS,
+                title="mock chat 2",
+            ),
+        ],
+    )
 
 
 @pytest.fixture
@@ -113,7 +123,7 @@ def mock_external_calls() -> Generator[None]:
         first_name="mock first_name",
         type="PRIVATE",
         max_reaction_count=100,
-        accent_color_id=AccentColor.COLOR_000,
+        accent_color_id=0,
         accepted_gift_types=AcceptedGiftTypes(True, True, True, True),
     )
     test_user = User(123456, "Testbot", True, "mock last name", "mock username")
@@ -274,14 +284,12 @@ def mock_broadcast_config_entry() -> MockConfigEntry:
             ConfigSubentryData(
                 unique_id="123456",
                 data={CONF_CHAT_ID: 123456},
-                subentry_id="mock_id1",
                 subentry_type=CONF_ALLOWED_CHAT_IDS,
                 title="mock chat 1",
             ),
             ConfigSubentryData(
                 unique_id="654321",
                 data={CONF_CHAT_ID: 654321},
-                subentry_id="mock_id2",
                 subentry_type=CONF_ALLOWED_CHAT_IDS,
                 title="mock chat 2",
             ),
@@ -306,7 +314,6 @@ def mock_webhooks_config_entry() -> MockConfigEntry:
             ConfigSubentryData(
                 unique_id="1234567890",
                 data={CONF_CHAT_ID: 1234567890},
-                subentry_id="mock_id",
                 subentry_type=CONF_ALLOWED_CHAT_IDS,
                 title="mock chat",
             )
@@ -334,9 +341,7 @@ async def webhook_platform(
 
 
 @pytest.fixture
-async def polling_platform(
-    hass: HomeAssistant, config_polling: dict[str, Any], mock_external_calls: None
-) -> None:
+def mock_polling_calls() -> Generator[None]:
     """Fixture for setting up the polling platform using appropriate config and mocks."""
     with patch(
         "homeassistant.components.telegram_bot.polling.ApplicationBuilder"
@@ -351,10 +356,4 @@ async def polling_platform(
         application.stop = AsyncMock()
         application.shutdown = AsyncMock()
 
-        await async_setup_component(
-            hass,
-            DOMAIN,
-            config_polling,
-        )
-
-        await hass.async_block_till_done()
+        yield

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -90,7 +90,6 @@ from homeassistant.exceptions import (
     HomeAssistantError,
     ServiceValidationError,
 )
-from homeassistant.setup import async_setup_component
 from homeassistant.util import json as json_util
 from homeassistant.util.file import write_utf8_file
 
@@ -103,8 +102,14 @@ async def test_webhook_platform_init(hass: HomeAssistant, webhook_platform) -> N
     assert hass.services.has_service(DOMAIN, SERVICE_SEND_MESSAGE) is True
 
 
-async def test_polling_platform_init(hass: HomeAssistant, polling_platform) -> None:
+async def test_polling_platform_init(
+    hass: HomeAssistant, mock_polling_config_entry: MockConfigEntry
+) -> None:
     """Test initialization of the polling platform."""
+    mock_polling_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_polling_config_entry.entry_id)
+    await hass.async_block_till_done()
+
     assert hass.services.has_service(DOMAIN, SERVICE_SEND_MESSAGE) is True
 
 
@@ -161,7 +166,7 @@ async def test_polling_platform_init(hass: HomeAssistant, polling_platform) -> N
     ],
 )
 async def test_send_message(
-    hass: HomeAssistant, webhook_platform, service: str, input: dict[str]
+    hass: HomeAssistant, webhook_platform, service: str, input: dict[str, Any]
 ) -> None:
     """Test the send_message service. Tests any service that does not require files to be sent."""
     context = Context()
@@ -614,7 +619,7 @@ async def test_webhook_endpoint_generates_telegram_attachment_event(
 
 async def test_polling_platform_message_text_update(
     hass: HomeAssistant,
-    config_polling,
+    mock_polling_config_entry: MockConfigEntry,
     update_message_text,
     mock_external_calls: None,
 ) -> None:
@@ -635,11 +640,8 @@ async def test_polling_platform_message_text_update(
         application.stop = AsyncMock()
         application.shutdown = AsyncMock()
 
-        await async_setup_component(
-            hass,
-            DOMAIN,
-            config_polling,
-        )
+        mock_polling_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_polling_config_entry.entry_id)
         await hass.async_block_till_done()
 
         # Then call the callback and assert events fired.
@@ -658,11 +660,9 @@ async def test_polling_platform_message_text_update(
 
     assert len(events) == 1
     assert events[0].data["text"] == update_message_text["message"]["text"]
-
-    config_entry = hass.config_entries.async_entry_for_domain_unique_id(
-        DOMAIN, "1234567890:ABC"
+    assert (
+        events[0].data["bot"]["config_entry_id"] == mock_polling_config_entry.entry_id
     )
-    assert events[0].data["bot"]["config_entry_id"] == config_entry.entry_id
     assert events[0].data["bot"]["id"] == 123456
     assert events[0].data["bot"]["first_name"] == "Testbot"
     assert events[0].data["bot"]["last_name"] == "mock last name"
@@ -685,7 +685,7 @@ async def test_polling_platform_message_text_update(
 )
 async def test_polling_platform_add_error_handler(
     hass: HomeAssistant,
-    config_polling: dict[str, Any],
+    mock_polling_config_entry: MockConfigEntry,
     update_message_text: dict[str, Any],
     mock_external_calls: None,
     caplog: pytest.LogCaptureFixture,
@@ -707,11 +707,8 @@ async def test_polling_platform_add_error_handler(
         application.shutdown = AsyncMock()
         application.bot.defaults.tzinfo = None
 
-        await async_setup_component(
-            hass,
-            DOMAIN,
-            config_polling,
-        )
+        mock_polling_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_polling_config_entry.entry_id)
         await hass.async_block_till_done()
 
         update = Update.de_json(update_message_text, application.bot)
@@ -735,7 +732,7 @@ async def test_polling_platform_add_error_handler(
 )
 async def test_polling_platform_start_polling_error_callback(
     hass: HomeAssistant,
-    config_polling: dict[str, Any],
+    mock_polling_config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
     mock_external_calls: None,
     error: Exception,
@@ -755,13 +752,10 @@ async def test_polling_platform_start_polling_error_callback(
         application.stop = AsyncMock()
         application.shutdown = AsyncMock()
 
-        await async_setup_component(
-            hass,
-            DOMAIN,
-            config_polling,
-        )
-
+        mock_polling_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_polling_config_entry.entry_id)
         await hass.async_block_till_done()
+
         error_callback = application.updater.start_polling.call_args.kwargs[
             "error_callback"
         ]
@@ -834,13 +828,19 @@ async def test_webhook_endpoint_invalid_secret_token_is_denied(
 
 async def test_multiple_config_entries_error(
     hass: HomeAssistant,
+    mock_polling_config_entry: MockConfigEntry,
     mock_broadcast_config_entry: MockConfigEntry,
-    polling_platform,
     mock_external_calls: None,
+    mock_polling_calls: None,
 ) -> None:
     """Test multiple config entries error."""
 
-    # setup the second entry (polling_platform is first entry)
+    # setup the first entry
+    mock_polling_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_polling_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # setup the second entry
     mock_broadcast_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -887,6 +887,7 @@ async def test_send_message_with_config_entry(
     await hass.async_block_till_done()
 
     assert err.value.translation_key == "failed_chat_ids"
+    assert err.value.translation_placeholders is not None
     assert err.value.translation_placeholders["chat_ids"] == "1"
     assert err.value.translation_placeholders["bot_name"] == "Mock Title"
 
@@ -941,6 +942,7 @@ async def test_send_message_no_chat_id_error(
         )
 
     assert err.value.translation_key == "missing_allowed_chat_ids"
+    assert err.value.translation_placeholders is not None
     assert err.value.translation_placeholders["bot_name"] == "Testbot mock last name"
 
 
@@ -995,6 +997,7 @@ async def test_delete_message(
     await hass.async_block_till_done()
 
     assert err.value.translation_key == "invalid_chat_ids"
+    assert err.value.translation_placeholders is not None
     assert err.value.translation_placeholders["chat_ids"] == "1"
     assert err.value.translation_placeholders["bot_name"] == "Mock Title"
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `MockConfigEntry` instead of yaml in tests for Telegram polling bot.
yaml is being deprecated so tests are being refactored starting with the polling platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
