### PR TITLE
Fix Matter `ValveFault` attribute handling

### DIFF
--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -428,7 +428,7 @@ DISCOVERY_SCHEMAS = [
             entity_category=EntityCategory.DIAGNOSTIC,
             device_to_ha=lambda x: bool(
                 x
-                == clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kGeneralFault
+                & clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kGeneralFault
             ),
         ),
         entity_class=MatterBinarySensor,
@@ -447,7 +447,7 @@ DISCOVERY_SCHEMAS = [
             # Test Blocked bit from ValveFault attribute
             device_to_ha=lambda x: bool(
                 x
-                == clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kBlocked
+                & clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kBlocked
             ),
         ),
         entity_class=MatterBinarySensor,
@@ -466,7 +466,7 @@ DISCOVERY_SCHEMAS = [
             # Test Leaking bit from ValveFault attribute
             device_to_ha=lambda x: bool(
                 x
-                == clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kLeaking
+                & clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kLeaking
             ),
         ),
         entity_class=MatterBinarySensor,

--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -425,7 +425,7 @@ DISCOVERY_SCHEMAS = [
             translation_key="valve_fault_general_fault",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            # Test GeneralFault bit from ValveFault attribute
+            # GeneralFault bit from ValveFault attribute
             device_to_ha=lambda x: bool(
                 x
                 & clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kGeneralFault
@@ -444,7 +444,7 @@ DISCOVERY_SCHEMAS = [
             translation_key="valve_fault_blocked",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            # Test Blocked bit from ValveFault attribute
+            # Blocked bit from ValveFault attribute
             device_to_ha=lambda x: bool(
                 x
                 & clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kBlocked
@@ -463,7 +463,7 @@ DISCOVERY_SCHEMAS = [
             translation_key="valve_fault_leaking",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            # Test Leaking bit from ValveFault attribute
+            # Leaking bit from ValveFault attribute
             device_to_ha=lambda x: bool(
                 x
                 & clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kLeaking

--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -424,8 +424,9 @@ DISCOVERY_SCHEMAS = [
             key="ValveConfigurationAndControlValveFault_GeneralFault",
             translation_key="valve_fault_general_fault",
             device_class=BinarySensorDeviceClass.PROBLEM,
+            # Test GeneralFault bit from ValveFault attribute
             entity_category=EntityCategory.DIAGNOSTIC,
-            device_to_ha=lambda x: (
+            device_to_ha=lambda x: bool(
                 x
                 == clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kGeneralFault
             ),
@@ -443,7 +444,8 @@ DISCOVERY_SCHEMAS = [
             translation_key="valve_fault_blocked",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            device_to_ha=lambda x: (
+            # Test Blocked bit from ValveFault attribute
+            device_to_ha=lambda x: bool(
                 x
                 == clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kBlocked
             ),
@@ -461,7 +463,8 @@ DISCOVERY_SCHEMAS = [
             translation_key="valve_fault_leaking",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            device_to_ha=lambda x: (
+            # Test Leaking bit from ValveFault attribute
+            device_to_ha=lambda x: bool(
                 x
                 == clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kLeaking
             ),

--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -424,8 +424,8 @@ DISCOVERY_SCHEMAS = [
             key="ValveConfigurationAndControlValveFault_GeneralFault",
             translation_key="valve_fault_general_fault",
             device_class=BinarySensorDeviceClass.PROBLEM,
-            # Test GeneralFault bit from ValveFault attribute
             entity_category=EntityCategory.DIAGNOSTIC,
+            # Test GeneralFault bit from ValveFault attribute
             device_to_ha=lambda x: bool(
                 x
                 & clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kGeneralFault

--- a/tests/components/matter/test_binary_sensor.py
+++ b/tests/components/matter/test_binary_sensor.py
@@ -298,7 +298,7 @@ async def test_water_valve(
     assert state
     assert state.state == "off"
 
-    # ValveFault general_fault test
+    # ValveFault general_fault test (bit 0)
     set_node_attribute(matter_node, 1, 129, 9, 1)
     await trigger_subscription_callback(hass, matter_client)
 
@@ -314,7 +314,7 @@ async def test_water_valve(
     assert state
     assert state.state == "off"
 
-    # ValveFault valve_blocked test
+    # ValveFault valve_blocked test (bit 1)
     set_node_attribute(matter_node, 1, 129, 9, 2)
     await trigger_subscription_callback(hass, matter_client)
 
@@ -330,13 +330,29 @@ async def test_water_valve(
     assert state
     assert state.state == "off"
 
-    # ValveFault valve_leaking test
+    # ValveFault valve_leaking test (bit 2)
     set_node_attribute(matter_node, 1, 129, 9, 4)
     await trigger_subscription_callback(hass, matter_client)
 
     state = hass.states.get("binary_sensor.valve_general_fault")
     assert state
     assert state.state == "off"
+
+    state = hass.states.get("binary_sensor.valve_valve_blocked")
+    assert state
+    assert state.state == "off"
+
+    state = hass.states.get("binary_sensor.valve_valve_leaking")
+    assert state
+    assert state.state == "on"
+
+    # ValveFault multiple faults test (bits 0 and 2)
+    set_node_attribute(matter_node, 1, 129, 9, 5)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get("binary_sensor.valve_general_fault")
+    assert state
+    assert state.state == "on"
 
     state = hass.states.get("binary_sensor.valve_valve_blocked")
     assert state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Update ValveFault handling in Matter binary sensors to use bitwise operations
- Enhance ValveFault tests in water valve by specifying bitwise checks for general_fault, valve_blocked, and valve_leaking states, and add a test for multiple faults.

The original code used `x == kGeneralFault` which only returns True when the value exactly equals that specific bit value, not when that bit is set among other bits.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
