### PR TITLE
Fix `issues()` template method returns non active issues

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -1304,7 +1304,11 @@ def issues(hass: HomeAssistant) -> dict[tuple[str, str], dict[str, Any]]:
     """Return all open issues."""
     current_issues = ir.async_get(hass).issues
     # Use JSON for safe representation
-    return {k: v.to_json() for (k, v) in current_issues.items()}
+    return {
+        key: issue_entry.to_json()
+        for (key, issue_entry) in current_issues.items()
+        if issue_entry.active
+    }
 
 
 def issue(hass: HomeAssistant, domain: str, issue_id: str) -> dict[str, Any] | None:

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -2878,6 +2878,55 @@ async def test_issues(hass: HomeAssistant, issue_registry: ir.IssueRegistry) -> 
     assert_result_info(info, {})
     assert info.rate_limit is None
 
+    issue = ir.IssueEntry(
+        active=False,
+        breaks_in_ha_version="2025.12",
+        created=dt_util.utcnow(),
+        data=None,
+        dismissed_version=None,
+        domain="test",
+        is_fixable=False,
+        is_persistent=False,
+        issue_domain="test",
+        issue_id="issue 2",
+        learn_more_url=None,
+        severity="warning",
+        translation_key="abc_1234",
+        translation_placeholders={"abc": "123"},
+    )
+    # Add non active issue
+    issue_registry.issues[("test", "issue 2")] = issue
+    # Test non active issue is omitted
+    issue_entry = issue_registry.async_get_issue("test", "issue 2")
+    assert issue_entry
+    issue_2_created = issue_entry.created
+    assert issue_entry and not issue_entry.active
+    info = render_to_info(hass, "{{ issues() }}")
+    assert_result_info(info, {})
+    assert info.rate_limit is None
+
+    # Load and activate the issue
+    ir.async_create_issue(
+        hass=hass,
+        breaks_in_ha_version="2025.12",
+        data=None,
+        domain="test",
+        is_fixable=False,
+        is_persistent=False,
+        issue_domain="test",
+        issue_id="issue 2",
+        learn_more_url=None,
+        severity="warning",
+        translation_key="abc_1234",
+        translation_placeholders={"abc": "123"},
+    )
+    activated_issue_entry = issue_registry.async_get_issue("test", "issue 2")
+    assert activated_issue_entry and activated_issue_entry.active
+    assert issue_2_created == activated_issue_entry.created
+    info = render_to_info(hass, "{{ issues()['test', 'issue 2'] }}")
+    assert_result_info(info, activated_issue_entry.to_json())
+    assert info.rate_limit is None
+
 
 async def test_issue(hass: HomeAssistant, issue_registry: ir.IssueRegistry) -> None:
     """Test issue function."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The  [issues](https://www.home-assistant.io/docs/configuration/templating/#issues) templating method used to return all issues, inluding fixed issues, from now only active issues are returned.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When working with issues in a template we should only show active issues, and not issues that do no longer exists, because they were no longer activated.

This PR will only return active issue for template `{{ issues() }}`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #156236
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
