### PR TITLE
Improve logging of failing miele action commands

### DIFF
--- a/homeassistant/components/miele/button.py
+++ b/homeassistant/components/miele/button.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import logging
 from typing import Final
 
-import aiohttp
+from aiohttp import ClientResponseError
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
@@ -153,11 +153,12 @@ class MieleButton(MieleEntity, ButtonEntity):
                 self._device_id,
                 {PROCESS_ACTION: self.entity_description.press_data},
             )
-        except aiohttp.ClientResponseError as ex:
+        except ClientResponseError as ex:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
+                    "err_status": str(ex.status),
                 },
             ) from ex

--- a/homeassistant/components/miele/button.py
+++ b/homeassistant/components/miele/button.py
@@ -153,12 +153,12 @@ class MieleButton(MieleEntity, ButtonEntity):
                 self._device_id,
                 {PROCESS_ACTION: self.entity_description.press_data},
             )
-        except ClientResponseError as ex:
+        except ClientResponseError as err:
+            _LOGGER.debug("Error setting button state for %s: %s", self.entity_id, err)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
-                    "err_status": str(ex.status),
                 },
-            ) from ex
+            ) from err

--- a/homeassistant/components/miele/climate.py
+++ b/homeassistant/components/miele/climate.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any, Final, cast
 
-import aiohttp
+from aiohttp import ClientResponseError
 from pymiele import MieleDevice, MieleTemperature
 
 from homeassistant.components.climate import (
@@ -250,12 +250,13 @@ class MieleClimate(MieleEntity, ClimateEntity):
                 cast(float, kwargs.get(ATTR_TEMPERATURE)),
                 self.entity_description.zone,
             )
-        except aiohttp.ClientError as err:
+        except ClientResponseError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
+                    "err_status": str(err.status),
                 },
             ) from err
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/miele/climate.py
+++ b/homeassistant/components/miele/climate.py
@@ -251,12 +251,12 @@ class MieleClimate(MieleEntity, ClimateEntity):
                 self.entity_description.zone,
             )
         except ClientResponseError as err:
+            _LOGGER.debug("Error setting climate state for %s: %s", self.entity_id, err)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
-                    "err_status": str(err.status),
                 },
             ) from err
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/miele/coordinator.py
+++ b/homeassistant/components/miele/coordinator.py
@@ -73,7 +73,7 @@ class MieleDataUpdateCoordinator(DataUpdateCoordinator[MieleCoordinatorData]):
                     _LOGGER.debug(
                         "Error fetching actions for device %s: Status: %s, Message: %s",
                         device_id,
-                        err.status,
+                        str(err.status),
                         err.message,
                     )
                     actions_json = {}

--- a/homeassistant/components/miele/fan.py
+++ b/homeassistant/components/miele/fan.py
@@ -142,15 +142,15 @@ class MieleFan(MieleEntity, FanEntity):
                 await self.api.send_action(
                     self._device_id, {VENTILATION_STEP: ventilation_step}
                 )
-            except ClientResponseError as ex:
+            except ClientResponseError as err:
+                _LOGGER.debug("Error setting fan state for %s: %s", self.entity_id, err)
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="set_state_error",
                     translation_placeholders={
                         "entity": self.entity_id,
-                        "err_status": str(ex.status),
                     },
-                ) from ex
+                ) from err
             self.device.state_ventilation_step = ventilation_step
             self.async_write_ha_state()
 

--- a/homeassistant/components/miele/fan.py
+++ b/homeassistant/components/miele/fan.py
@@ -148,6 +148,7 @@ class MieleFan(MieleEntity, FanEntity):
                     translation_key="set_state_error",
                     translation_placeholders={
                         "entity": self.entity_id,
+                        "err_status": str(ex.status),
                     },
                 ) from ex
             self.device.state_ventilation_step = ventilation_step
@@ -171,6 +172,7 @@ class MieleFan(MieleEntity, FanEntity):
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
+                    "err_status": str(ex.status),
                 },
             ) from ex
 
@@ -188,6 +190,7 @@ class MieleFan(MieleEntity, FanEntity):
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
+                    "err_status": str(ex.status),
                 },
             ) from ex
 

--- a/homeassistant/components/miele/light.py
+++ b/homeassistant/components/miele/light.py
@@ -132,11 +132,11 @@ class MieleLight(MieleEntity, LightEntity):
                 self._device_id, {self.entity_description.light_type: mode}
             )
         except ClientResponseError as err:
+            _LOGGER.debug("Error setting light state for %s: %s", self.entity_id, err)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
-                    "err_status": str(err.status),
                 },
             ) from err

--- a/homeassistant/components/miele/light.py
+++ b/homeassistant/components/miele/light.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any, Final
 
-import aiohttp
+from aiohttp import ClientResponseError
 
 from homeassistant.components.light import (
     ColorMode,
@@ -131,11 +131,12 @@ class MieleLight(MieleEntity, LightEntity):
             await self.api.send_action(
                 self._device_id, {self.entity_description.light_type: mode}
             )
-        except aiohttp.ClientError as err:
+        except ClientResponseError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
+                    "err_status": str(err.status),
                 },
             ) from err

--- a/homeassistant/components/miele/services.py
+++ b/homeassistant/components/miele/services.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import logging
 from typing import cast
 
-import aiohttp
+from aiohttp import ClientResponseError
 import voluptuous as vol
 
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_TEMPERATURE
@@ -107,7 +107,7 @@ async def set_program(call: ServiceCall) -> None:
     data = {"programId": call.data[ATTR_PROGRAM_ID]}
     try:
         await api.set_program(serial_number, data)
-    except aiohttp.ClientResponseError as ex:
+    except ClientResponseError as ex:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="set_program_error",
@@ -137,7 +137,7 @@ async def set_program_oven(call: ServiceCall) -> None:
         data["temperature"] = call.data[ATTR_TEMPERATURE]
     try:
         await api.set_program(serial_number, data)
-    except aiohttp.ClientResponseError as ex:
+    except ClientResponseError as ex:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="set_program_oven_error",
@@ -157,7 +157,7 @@ async def get_programs(call: ServiceCall) -> ServiceResponse:
 
     try:
         programs = await api.get_programs(serial_number)
-    except aiohttp.ClientResponseError as ex:
+    except ClientResponseError as ex:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="get_programs_error",

--- a/homeassistant/components/miele/strings.json
+++ b/homeassistant/components/miele/strings.json
@@ -1098,7 +1098,7 @@
       "message": "'Set program on oven' action failed: {status} / {message}"
     },
     "set_state_error": {
-      "message": "Failed to set state for {entity}."
+      "message": "Failed to set state for {entity} - code: {err_status}."
     }
   },
   "services": {

--- a/homeassistant/components/miele/strings.json
+++ b/homeassistant/components/miele/strings.json
@@ -1098,7 +1098,7 @@
       "message": "'Set program on oven' action failed: {status} / {message}"
     },
     "set_state_error": {
-      "message": "Failed to set state for {entity} - code: {err_status}."
+      "message": "Failed to set state for {entity}."
     }
   },
   "services": {

--- a/homeassistant/components/miele/switch.py
+++ b/homeassistant/components/miele/switch.py
@@ -166,12 +166,12 @@ class MieleSwitch(MieleEntity, SwitchEntity):
         try:
             await self.api.send_action(self._device_id, mode)
         except ClientResponseError as err:
+            _LOGGER.debug("Error setting switch state for %s: %s", self.entity_id, err)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
-                    "err_status": str(err.status),
                 },
             ) from err
 
@@ -199,12 +199,12 @@ class MielePowerSwitch(MieleSwitch):
         try:
             await self.api.send_action(self._device_id, mode)
         except ClientResponseError as err:
+            _LOGGER.debug("Error setting switch state for %s: %s", self.entity_id, err)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
-                    "err_status": str(err.status),
                 },
             ) from err
         self.action.power_on_enabled = cast(bool, mode)

--- a/homeassistant/components/miele/switch.py
+++ b/homeassistant/components/miele/switch.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any, Final, cast
 
-import aiohttp
+from aiohttp import ClientResponseError
 from pymiele import MieleDevice
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
@@ -165,12 +165,13 @@ class MieleSwitch(MieleEntity, SwitchEntity):
         """Set switch to mode."""
         try:
             await self.api.send_action(self._device_id, mode)
-        except aiohttp.ClientError as err:
+        except ClientResponseError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
+                    "err_status": str(err.status),
                 },
             ) from err
 
@@ -197,12 +198,13 @@ class MielePowerSwitch(MieleSwitch):
         """Set switch to mode."""
         try:
             await self.api.send_action(self._device_id, mode)
-        except aiohttp.ClientError as err:
+        except ClientResponseError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
+                    "err_status": str(err.status),
                 },
             ) from err
         self.action.power_on_enabled = cast(bool, mode)

--- a/homeassistant/components/miele/vacuum.py
+++ b/homeassistant/components/miele/vacuum.py
@@ -195,6 +195,7 @@ class MieleVacuum(MieleEntity, StateVacuumEntity):
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
+                    "err_status": str(ex.status),
                 },
             ) from ex
 

--- a/homeassistant/components/miele/vacuum.py
+++ b/homeassistant/components/miele/vacuum.py
@@ -189,15 +189,15 @@ class MieleVacuum(MieleEntity, StateVacuumEntity):
         """Send action to the device."""
         try:
             await self.api.send_action(device_id, action)
-        except ClientResponseError as ex:
+        except ClientResponseError as err:
+            _LOGGER.debug("Error setting vacuum state for %s: %s", self.entity_id, err)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_state_error",
                 translation_placeholders={
                     "entity": self.entity_id,
-                    "err_status": str(ex.status),
                 },
-            ) from ex
+            ) from err
 
     async def async_clean_spot(self, **kwargs: Any) -> None:
         """Clean spot."""

--- a/tests/components/miele/test_climate.py
+++ b/tests/components/miele/test_climate.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from aiohttp import ClientError
+from aiohttp import ClientResponseError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -107,7 +107,9 @@ async def test_api_failure(
     setup_platform: MockConfigEntry,
 ) -> None:
     """Test handling of exception from API."""
-    mock_miele_client.set_target_temperature.side_effect = ClientError
+    mock_miele_client.set_target_temperature.side_effect = ClientResponseError(
+        "test", "Test"
+    )
 
     with pytest.raises(
         HomeAssistantError, match=f"Failed to set state for {ENTITY_ID}"

--- a/tests/components/miele/test_light.py
+++ b/tests/components/miele/test_light.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from aiohttp import ClientError
+from aiohttp import ClientResponseError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -84,7 +84,7 @@ async def test_api_failure(
     service: str,
 ) -> None:
     """Test handling of exception from API."""
-    mock_miele_client.send_action.side_effect = ClientError
+    mock_miele_client.send_action.side_effect = ClientResponseError("test", "Test")
 
     with pytest.raises(
         HomeAssistantError, match=f"Failed to set state for {ENTITY_ID}"

--- a/tests/components/miele/test_switch.py
+++ b/tests/components/miele/test_switch.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from aiohttp import ClientError
+from aiohttp import ClientResponseError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -99,7 +99,7 @@ async def test_api_failure(
     entity: str,
 ) -> None:
     """Test handling of exception from API."""
-    mock_miele_client.send_action.side_effect = ClientError
+    mock_miele_client.send_action.side_effect = ClientResponseError("test", "Test")
 
     with pytest.raises(HomeAssistantError, match=f"Failed to set state for {entity}"):
         await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve logging of failing action commands by adding http status code to relevant messages.

The background is that several users have contacted me recently about power on switches  and light switches behaving weirdly. By adding the https error in messages we can blaim Miele this time. They respond 500 = "server failure" while they mostly accept the command and forward correct action to the appliance.

Please consider this enhancement for next patch release as it will simplify troubleshooting.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
