### PR TITLE
Fix status checks in Matter binary sensors

### DIFF
--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -377,9 +377,9 @@ DISCOVERY_SCHEMAS = [
             key="PumpStatusRunning",
             translation_key="pump_running",
             device_class=BinarySensorDeviceClass.RUNNING,
-            device_to_ha=lambda x: (
+            device_to_ha=lambda x: bool(
                 x
-                == clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kRunning
+                & clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kRunning
             ),
         ),
         entity_class=MatterBinarySensor,
@@ -395,8 +395,8 @@ DISCOVERY_SCHEMAS = [
             translation_key="dishwasher_alarm_inflow",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            device_to_ha=lambda x: (
-                x == clusters.DishwasherAlarm.Bitmaps.AlarmBitmap.kInflowError
+            device_to_ha=lambda x: bool(
+                x & clusters.DishwasherAlarm.Bitmaps.AlarmBitmap.kInflowError
             ),
         ),
         entity_class=MatterBinarySensor,
@@ -410,8 +410,8 @@ DISCOVERY_SCHEMAS = [
             translation_key="alarm_door",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            device_to_ha=lambda x: (
-                x == clusters.DishwasherAlarm.Bitmaps.AlarmBitmap.kDoorError
+            device_to_ha=lambda x: bool(
+                x & clusters.DishwasherAlarm.Bitmaps.AlarmBitmap.kDoorError
             ),
         ),
         entity_class=MatterBinarySensor,
@@ -478,8 +478,8 @@ DISCOVERY_SCHEMAS = [
             translation_key="alarm_door",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            device_to_ha=lambda x: (
-                x == clusters.RefrigeratorAlarm.Bitmaps.AlarmBitmap.kDoorOpen
+            device_to_ha=lambda x: bool(
+                x & clusters.RefrigeratorAlarm.Bitmaps.AlarmBitmap.kDoorOpen
             ),
         ),
         entity_class=MatterBinarySensor,

--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -353,17 +353,13 @@ DISCOVERY_SCHEMAS = [
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
             # DeviceFault or SupplyFault bit enabled
-            device_to_ha={
-                clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kDeviceFault: True,
-                clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kSupplyFault: True,
-                clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kSpeedLow: False,
-                clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kSpeedHigh: False,
-                clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kLocalOverride: False,
-                clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kRunning: False,
-                clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kRemotePressure: False,
-                clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kRemoteFlow: False,
-                clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kRemoteTemperature: False,
-            }.get,
+            device_to_ha=lambda x: bool(
+                x
+                & (
+                    clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kDeviceFault
+                    | clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kSupplyFault
+                )
+            ),
         ),
         entity_class=MatterBinarySensor,
         required_attributes=(

--- a/tests/components/matter/test_binary_sensor.py
+++ b/tests/components/matter/test_binary_sensor.py
@@ -270,10 +270,27 @@ async def test_dishwasher_alarm(
     state = hass.states.get("binary_sensor.dishwasher_door_alarm")
     assert state
 
+    # set DoorAlarm alarm
     set_node_attribute(matter_node, 1, 93, 2, 4)
     await trigger_subscription_callback(hass, matter_client)
 
     state = hass.states.get("binary_sensor.dishwasher_door_alarm")
+    assert state
+    assert state.state == "on"
+
+    # clear DoorAlarm alarm
+    set_node_attribute(matter_node, 1, 93, 2, 0)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get("binary_sensor.dishwasher_inflow_alarm")
+    assert state
+    assert state.state == "off"
+
+    # set InflowError alarm
+    set_node_attribute(matter_node, 1, 93, 2, 1)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get("binary_sensor.dishwasher_inflow_alarm")
     assert state
     assert state.state == "on"
 

--- a/tests/components/matter/test_binary_sensor.py
+++ b/tests/components/matter/test_binary_sensor.py
@@ -239,11 +239,12 @@ async def test_pump(
     assert state
     assert state.state == "off"
 
-    # PumpStatus --> DeviceFault bit
+    # Initial state: kRunning bit only (no fault bits) should be off
     state = hass.states.get("binary_sensor.mock_pump_problem")
     assert state
-    assert state.state == "unknown"
+    assert state.state == "off"
 
+    # Set DeviceFault bit
     set_node_attribute(matter_node, 1, 512, 16, 1)
     await trigger_subscription_callback(hass, matter_client)
 
@@ -251,7 +252,14 @@ async def test_pump(
     assert state
     assert state.state == "on"
 
-    # PumpStatus --> SupplyFault bit
+    # Clear all bits - problem sensor should be off
+    set_node_attribute(matter_node, 1, 512, 16, 0)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get("binary_sensor.mock_pump_problem")
+    assert state
+    assert state.state == "off"
+
+    # Set SupplyFault bit
     set_node_attribute(matter_node, 1, 512, 16, 2)
     await trigger_subscription_callback(hass, matter_client)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor device_to_ha lambdas to use bitwise AND for status checks in Matter binary sensors:
- DishwasherAlarm cluster
- RefrigeratorAlarm cluster
- PumpConfigurationAndControl cluster
  - Fixed the initial state expectation from "unknown" to "off" (when kRunning bit is set but no fault bits)
  - Fixed the logic after clearing all bits to expect "off" instead of "on"
  - Added clearer comments explaining each test step

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
