### PR TITLE
Bump universal-silabs-flasher to v0.1.0

### DIFF
--- a/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
@@ -76,8 +76,14 @@ class ZBT2FirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
     """Mixin for Home Assistant Connect ZBT-2 firmware methods."""
 
     context: ConfigFlowContext
-    BOOTLOADER_RESET_METHODS = [ResetTarget.RTS_DTR]
+
     ZIGBEE_BAUDRATE = 460800
+    BOOTLOADER_RESET_METHODS = [ResetTarget.RTS_DTR]
+    APPLICATION_PROBE_METHODS = [
+        (ApplicationType.GECKO_BOOTLOADER, 115200),
+        (ApplicationType.EZSP, ZIGBEE_BAUDRATE),
+        (ApplicationType.SPINEL, 460800),
+    ]
 
     async def async_step_install_zigbee_firmware(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
@@ -78,7 +78,10 @@ class ZBT2FirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
     context: ConfigFlowContext
 
     ZIGBEE_BAUDRATE = 460800
-    BOOTLOADER_RESET_METHODS = [ResetTarget.RTS_DTR]
+
+    # Early ZBT-2 samples used RTS/DTR to trigger the bootloader, later ones use the
+    # baudrate method. Since the two are mutually exclusive we just use both.
+    BOOTLOADER_RESET_METHODS = [ResetTarget.RTS_DTR, ResetTarget.BAUDRATE]
     APPLICATION_PROBE_METHODS = [
         (ApplicationType.GECKO_BOOTLOADER, 115200),
         (ApplicationType.EZSP, ZIGBEE_BAUDRATE),

--- a/homeassistant/components/homeassistant_connect_zbt2/update.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/update.py
@@ -14,7 +14,6 @@ from homeassistant.components.homeassistant_hardware.update import (
 from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
-    ResetTarget,
 )
 from homeassistant.components.update import UpdateDeviceClass
 from homeassistant.const import EntityCategory
@@ -24,6 +23,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import HomeAssistantConnectZBT2ConfigEntry
+from .config_flow import ZBT2FirmwareMixin
 from .const import DOMAIN, FIRMWARE, FIRMWARE_VERSION, HARDWARE_NAME, SERIAL_NUMBER
 
 _LOGGER = logging.getLogger(__name__)
@@ -134,7 +134,8 @@ async def async_setup_entry(
 class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
     """Connect ZBT-2 firmware update entity."""
 
-    bootloader_reset_methods = [ResetTarget.RTS_DTR]
+    BOOTLOADER_RESET_METHODS = ZBT2FirmwareMixin.BOOTLOADER_RESET_METHODS
+    APPLICATION_PROBE_METHODS = ZBT2FirmwareMixin.APPLICATION_PROBE_METHODS
 
     def __init__(
         self,

--- a/homeassistant/components/homeassistant_hardware/manifest.json
+++ b/homeassistant/components/homeassistant_hardware/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://www.home-assistant.io/integrations/homeassistant_hardware",
   "integration_type": "system",
   "requirements": [
-    "universal-silabs-flasher==0.0.37",
+    "universal-silabs-flasher==0.1.0",
     "ha-silabs-firmware-client==0.3.0"
   ]
 }

--- a/homeassistant/components/homeassistant_hardware/update.py
+++ b/homeassistant/components/homeassistant_hardware/update.py
@@ -86,7 +86,8 @@ class BaseFirmwareUpdateEntity(
 
     # Subclasses provide the mapping between firmware types and entity descriptions
     entity_description: FirmwareUpdateEntityDescription
-    bootloader_reset_methods: list[ResetTarget] = []
+    BOOTLOADER_RESET_METHODS: list[ResetTarget]
+    APPLICATION_PROBE_METHODS: list[tuple[ApplicationType, int]]
 
     _attr_supported_features = (
         UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
@@ -278,7 +279,8 @@ class BaseFirmwareUpdateEntity(
                 device=self._current_device,
                 fw_data=fw_data,
                 expected_installed_firmware_type=self.entity_description.expected_firmware_type,
-                bootloader_reset_methods=self.bootloader_reset_methods,
+                bootloader_reset_methods=self.BOOTLOADER_RESET_METHODS,
+                application_probe_methods=self.APPLICATION_PROBE_METHODS,
                 progress_callback=self._update_progress,
                 domain=self._config_entry.domain,
             )

--- a/homeassistant/components/homeassistant_hardware/util.py
+++ b/homeassistant/components/homeassistant_hardware/util.py
@@ -378,6 +378,15 @@ async def async_flash_silabs_firmware(
     domain: str = DOMAIN,
 ) -> FirmwareInfo:
     """Flash firmware to the SiLabs device."""
+    if not any(
+        method == expected_installed_firmware_type
+        for method, _ in application_probe_methods
+    ):
+        raise ValueError(
+            f"Expected installed firmware type {expected_installed_firmware_type!r}"
+            f" not in application probe methods {application_probe_methods!r}"
+        )
+
     async with async_firmware_update_context(hass, device, domain):
         firmware_info = await guess_firmware_info(hass, device)
         _LOGGER.debug("Identified firmware info: %s", firmware_info)

--- a/homeassistant/components/homeassistant_hardware/util.py
+++ b/homeassistant/components/homeassistant_hardware/util.py
@@ -311,8 +311,8 @@ async def guess_firmware_info(hass: HomeAssistant, device_path: str) -> Firmware
 async def probe_silabs_firmware_info(
     device: str,
     *,
-    bootloader_reset_methods: Sequence[ResetTarget] = (),
-    application_probe_methods: Sequence[tuple[ApplicationType, int]] = (),
+    bootloader_reset_methods: Sequence[ResetTarget],
+    application_probe_methods: Sequence[tuple[ApplicationType, int]],
 ) -> FirmwareInfo | None:
     """Probe the running firmware on a SiLabs device."""
     flasher = Flasher(
@@ -350,8 +350,8 @@ async def probe_silabs_firmware_info(
 async def probe_silabs_firmware_type(
     device: str,
     *,
-    bootloader_reset_methods: Sequence[ResetTarget] = (),
-    application_probe_methods: Sequence[tuple[ApplicationType, int]] = (),
+    bootloader_reset_methods: Sequence[ResetTarget],
+    application_probe_methods: Sequence[tuple[ApplicationType, int]],
 ) -> ApplicationType | None:
     """Probe the running firmware type on a SiLabs device."""
 
@@ -371,8 +371,8 @@ async def async_flash_silabs_firmware(
     device: str,
     fw_data: bytes,
     expected_installed_firmware_type: ApplicationType,
-    bootloader_reset_methods: Sequence[ResetTarget] = (),
-    application_probe_methods: Sequence[tuple[ApplicationType, int]] = (),
+    bootloader_reset_methods: Sequence[ResetTarget],
+    application_probe_methods: Sequence[tuple[ApplicationType, int]],
     progress_callback: Callable[[int, int], None] | None = None,
     *,
     domain: str = DOMAIN,

--- a/homeassistant/components/homeassistant_hardware/util.py
+++ b/homeassistant/components/homeassistant_hardware/util.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import AsyncIterator, Callable, Iterable, Sequence
+from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 from enum import StrEnum
@@ -309,15 +309,20 @@ async def guess_firmware_info(hass: HomeAssistant, device_path: str) -> Firmware
 
 
 async def probe_silabs_firmware_info(
-    device: str, *, probe_methods: Iterable[ApplicationType] | None = None
+    device: str,
+    *,
+    bootloader_reset_methods: Sequence[ResetTarget] = (),
+    application_probe_methods: Sequence[tuple[ApplicationType, int]] = (),
 ) -> FirmwareInfo | None:
     """Probe the running firmware on a SiLabs device."""
     flasher = Flasher(
         device=device,
-        **(
-            {"probe_methods": [m.as_flasher_application_type() for m in probe_methods]}
-            if probe_methods
-            else {}
+        probe_methods=tuple(
+            (m.as_flasher_application_type(), baudrate)
+            for m, baudrate in application_probe_methods
+        ),
+        bootloader_reset=tuple(
+            m.as_flasher_reset_target() for m in bootloader_reset_methods
         ),
     )
 
@@ -343,11 +348,18 @@ async def probe_silabs_firmware_info(
 
 
 async def probe_silabs_firmware_type(
-    device: str, *, probe_methods: Iterable[ApplicationType] | None = None
+    device: str,
+    *,
+    bootloader_reset_methods: Sequence[ResetTarget] = (),
+    application_probe_methods: Sequence[tuple[ApplicationType, int]] = (),
 ) -> ApplicationType | None:
     """Probe the running firmware type on a SiLabs device."""
 
-    fw_info = await probe_silabs_firmware_info(device, probe_methods=probe_methods)
+    fw_info = await probe_silabs_firmware_info(
+        device,
+        bootloader_reset_methods=bootloader_reset_methods,
+        application_probe_methods=application_probe_methods,
+    )
     if fw_info is None:
         return None
 
@@ -360,6 +372,7 @@ async def async_flash_silabs_firmware(
     fw_data: bytes,
     expected_installed_firmware_type: ApplicationType,
     bootloader_reset_methods: Sequence[ResetTarget] = (),
+    application_probe_methods: Sequence[tuple[ApplicationType, int]] = (),
     progress_callback: Callable[[int, int], None] | None = None,
     *,
     domain: str = DOMAIN,
@@ -373,11 +386,9 @@ async def async_flash_silabs_firmware(
 
         flasher = Flasher(
             device=device,
-            probe_methods=(
-                ApplicationType.GECKO_BOOTLOADER.as_flasher_application_type(),
-                ApplicationType.EZSP.as_flasher_application_type(),
-                ApplicationType.SPINEL.as_flasher_application_type(),
-                ApplicationType.CPC.as_flasher_application_type(),
+            probe_methods=tuple(
+                (m.as_flasher_application_type(), baudrate)
+                for m, baudrate in application_probe_methods
             ),
             bootloader_reset=tuple(
                 m.as_flasher_reset_target() for m in bootloader_reset_methods
@@ -401,7 +412,12 @@ async def async_flash_silabs_firmware(
 
             probed_firmware_info = await probe_silabs_firmware_info(
                 device,
-                probe_methods=(expected_installed_firmware_type,),
+                bootloader_reset_methods=bootloader_reset_methods,
+                application_probe_methods=tuple(
+                    (m.as_flasher_application_type(), baudrate)
+                    for m, baudrate in application_probe_methods
+                    if m == expected_installed_firmware_type
+                ),
             )
 
         if probed_firmware_info is None:

--- a/homeassistant/components/homeassistant_hardware/util.py
+++ b/homeassistant/components/homeassistant_hardware/util.py
@@ -413,11 +413,12 @@ async def async_flash_silabs_firmware(
             probed_firmware_info = await probe_silabs_firmware_info(
                 device,
                 bootloader_reset_methods=bootloader_reset_methods,
-                application_probe_methods=tuple(
-                    (m.as_flasher_application_type(), baudrate)
-                    for m, baudrate in application_probe_methods
-                    if m == expected_installed_firmware_type
-                ),
+                # Only probe for the expected installed firmware type
+                application_probe_methods=[
+                    (method, baudrate)
+                    for method, baudrate in application_probe_methods
+                    if method == expected_installed_firmware_type
+                ],
             )
 
         if probed_firmware_info is None:

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.components.homeassistant_hardware.helpers import (
 from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
+    ResetTarget,
 )
 from homeassistant.components.usb import (
     usb_service_info_from_device,
@@ -78,6 +79,20 @@ class SkyConnectFirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
     """Mixin for Home Assistant SkyConnect firmware methods."""
 
     context: ConfigFlowContext
+
+    ZIGBEE_BAUDRATE = 115200
+    # There is no hardware bootloader trigger
+    BOOTLOADER_RESET_METHODS: list[ResetTarget] = []
+    APPLICATION_PROBE_METHODS = [
+        (ApplicationType.GECKO_BOOTLOADER, 115200),
+        (ApplicationType.EZSP, ZIGBEE_BAUDRATE),
+        (ApplicationType.SPINEL, 460800),
+        # CPC baudrates can be removed once multiprotocol is removed
+        (ApplicationType.CPC, 115200),
+        (ApplicationType.CPC, 230400),
+        (ApplicationType.CPC, 460800),
+        (ApplicationType.ROUTER, 115200),
+    ]
 
     def _get_translation_placeholders(self) -> dict[str, str]:
         """Shared translation placeholders."""

--- a/homeassistant/components/homeassistant_sky_connect/update.py
+++ b/homeassistant/components/homeassistant_sky_connect/update.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import HomeAssistantSkyConnectConfigEntry
+from .config_flow import SkyConnectFirmwareMixin
 from .const import (
     DOMAIN,
     FIRMWARE,
@@ -151,8 +152,8 @@ async def async_setup_entry(
 class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
     """SkyConnect firmware update entity."""
 
-    # The ZBT-1 does not have a hardware bootloader trigger
-    bootloader_reset_methods = []
+    BOOTLOADER_RESET_METHODS = SkyConnectFirmwareMixin.BOOTLOADER_RESET_METHODS
+    APPLICATION_PROBE_METHODS = SkyConnectFirmwareMixin.APPLICATION_PROBE_METHODS
 
     def __init__(
         self,

--- a/homeassistant/components/homeassistant_yellow/config_flow.py
+++ b/homeassistant/components/homeassistant_yellow/config_flow.py
@@ -157,7 +157,11 @@ class HomeAssistantYellowConfigFlow(
         assert self._device is not None
 
         # We do not actually use any portion of `BaseFirmwareConfigFlow` beyond this
-        self._probed_firmware_info = await probe_silabs_firmware_info(self._device)
+        self._probed_firmware_info = await probe_silabs_firmware_info(
+            self._device,
+            bootloader_reset_methods=self.BOOTLOADER_RESET_METHODS,
+            application_probe_methods=self.APPLICATION_PROBE_METHODS,
+        )
 
         # Kick off ZHA hardware discovery automatically if Zigbee firmware is running
         if (

--- a/homeassistant/components/homeassistant_yellow/config_flow.py
+++ b/homeassistant/components/homeassistant_yellow/config_flow.py
@@ -82,7 +82,18 @@ else:
 class YellowFirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
     """Mixin for Home Assistant Yellow firmware methods."""
 
+    ZIGBEE_BAUDRATE = 115200
     BOOTLOADER_RESET_METHODS = [ResetTarget.YELLOW]
+    APPLICATION_PROBE_METHODS = [
+        (ApplicationType.GECKO_BOOTLOADER, 115200),
+        (ApplicationType.EZSP, ZIGBEE_BAUDRATE),
+        (ApplicationType.SPINEL, 460800),
+        # CPC baudrates can be removed once multiprotocol is removed
+        (ApplicationType.CPC, 115200),
+        (ApplicationType.CPC, 230400),
+        (ApplicationType.CPC, 460800),
+        (ApplicationType.ROUTER, 115200),
+    ]
 
     async def async_step_install_zigbee_firmware(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/homeassistant_yellow/update.py
+++ b/homeassistant/components/homeassistant_yellow/update.py
@@ -14,7 +14,6 @@ from homeassistant.components.homeassistant_hardware.update import (
 from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
-    ResetTarget,
 )
 from homeassistant.components.update import UpdateDeviceClass
 from homeassistant.const import EntityCategory
@@ -24,6 +23,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import HomeAssistantYellowConfigEntry
+from .config_flow import YellowFirmwareMixin
 from .const import DOMAIN, FIRMWARE, FIRMWARE_VERSION, MANUFACTURER, MODEL, RADIO_DEVICE
 
 _LOGGER = logging.getLogger(__name__)
@@ -150,7 +150,8 @@ async def async_setup_entry(
 class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
     """Yellow firmware update entity."""
 
-    bootloader_reset_methods = [ResetTarget.YELLOW]  # Triggers a GPIO reset
+    BOOTLOADER_RESET_METHODS = YellowFirmwareMixin.BOOTLOADER_RESET_METHODS
+    APPLICATION_PROBE_METHODS = YellowFirmwareMixin.APPLICATION_PROBE_METHODS
 
     def __init__(
         self,

--- a/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
+++ b/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
@@ -80,6 +80,9 @@ async def warn_on_wrong_silabs_firmware(hass: HomeAssistant, device: str) -> boo
             (ApplicationType.EZSP, 460800),
             (ApplicationType.SPINEL, 460800),
             (ApplicationType.CPC, 460800),
+            (ApplicationType.CPC, 230400),
+            (ApplicationType.CPC, 115200),
+            (ApplicationType.ROUTER, 115200),
         ],
     )
 

--- a/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
+++ b/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
@@ -71,7 +71,17 @@ async def warn_on_wrong_silabs_firmware(hass: HomeAssistant, device: str) -> boo
     if device.startswith("socket://"):
         return False
 
-    app_type = await probe_silabs_firmware_type(device)
+    app_type = await probe_silabs_firmware_type(
+        device,
+        bootloader_reset_methods=(),
+        application_probe_methods=[
+            (ApplicationType.GECKO_BOOTLOADER, 115200),
+            (ApplicationType.EZSP, 115200),
+            (ApplicationType.EZSP, 460800),
+            (ApplicationType.SPINEL, 460800),
+            (ApplicationType.CPC, 460800),
+        ],
+    )
 
     if app_type is None:
         # Failed to probe, we can't tell if the wrong firmware is installed

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3047,7 +3047,7 @@ unifi_ap==0.0.2
 unifiled==0.11
 
 # homeassistant.components.homeassistant_hardware
-universal-silabs-flasher==0.0.37
+universal-silabs-flasher==0.1.0
 
 # homeassistant.components.upb
 upb-lib==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2514,7 +2514,7 @@ ultraheat-api==0.5.7
 unifi-discovery==1.2.0
 
 # homeassistant.components.homeassistant_hardware
-universal-silabs-flasher==0.0.37
+universal-silabs-flasher==0.1.0
 
 # homeassistant.components.upb
 upb-lib==0.6.1

--- a/tests/components/homeassistant_connect_zbt2/test_config_flow.py
+++ b/tests/components/homeassistant_connect_zbt2/test_config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.components.homeassistant_hardware.helpers import (
 from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
+    ResetTarget,
 )
 from homeassistant.components.usb import USBDevice
 from homeassistant.config_entries import ConfigFlowResult
@@ -367,7 +368,10 @@ async def test_options_flow(
 
     # Verify async_flash_silabs_firmware was called with ZBT-2's reset methods
     assert flash_mock.call_count == 1
-    assert flash_mock.mock_calls[0].kwargs["bootloader_reset_methods"] == ["rts_dtr"]
+    assert flash_mock.mock_calls[0].kwargs["bootloader_reset_methods"] == [
+        ResetTarget.RTS_DTR,
+        ResetTarget.BAUDRATE,
+    ]
 
     flows = hass.config_entries.flow.async_progress()
 

--- a/tests/components/homeassistant_hardware/test_config_flow.py
+++ b/tests/components/homeassistant_hardware/test_config_flow.py
@@ -304,6 +304,7 @@ def mock_firmware_info(
         fw_data: bytes,
         expected_installed_firmware_type: ApplicationType,
         bootloader_reset_methods: Sequence[ResetTarget] = (),
+        application_probe_methods: Sequence[tuple[ApplicationType, int]] = (),
         progress_callback: Callable[[int, int], None] | None = None,
         *,
         domain: str = "homeassistant_hardware",

--- a/tests/components/homeassistant_hardware/test_update.py
+++ b/tests/components/homeassistant_hardware/test_update.py
@@ -173,7 +173,12 @@ async def mock_async_setup_update_entities(
 class MockFirmwareUpdateEntity(BaseFirmwareUpdateEntity):
     """Mock SkyConnect firmware update entity."""
 
-    bootloader_reset_methods = []
+    BOOTLOADER_RESET_METHODS = [ResetTarget.RTS_DTR]
+    APPLICATION_PROBE_METHODS = [
+        (ApplicationType.GECKO_BOOTLOADER, 115200),
+        (ApplicationType.EZSP, 115200),
+        (ApplicationType.SPINEL, 460800),
+    ]
 
     def __init__(
         self,
@@ -320,6 +325,7 @@ async def test_update_entity_installation(
         fw_data: bytes,
         expected_installed_firmware_type: ApplicationType,
         bootloader_reset_methods: Sequence[ResetTarget] = (),
+        application_probe_methods: Sequence[tuple[ApplicationType, int]] = (),
         progress_callback: Callable[[int, int], None] | None = None,
         *,
         domain: str = "homeassistant_hardware",

--- a/tests/components/homeassistant_hardware/test_util.py
+++ b/tests/components/homeassistant_hardware/test_util.py
@@ -502,7 +502,11 @@ async def test_probe_silabs_firmware_info(
         "homeassistant.components.homeassistant_hardware.util.Flasher",
         return_value=mock_flasher,
     ):
-        result = await probe_silabs_firmware_info("/dev/ttyUSB0")
+        result = await probe_silabs_firmware_info(
+            "/dev/ttyUSB0",
+            bootloader_reset_methods=(),
+            application_probe_methods=(),
+        )
         assert result == expected_fw_info
 
 
@@ -531,7 +535,11 @@ async def test_probe_silabs_firmware_type(
         autospec=True,
         return_value=probe_result,
     ):
-        result = await probe_silabs_firmware_type("/dev/ttyUSB0")
+        result = await probe_silabs_firmware_type(
+            "/dev/ttyUSB0",
+            bootloader_reset_methods=(),
+            application_probe_methods=(),
+        )
         assert result == expected
 
 
@@ -597,6 +605,7 @@ async def test_async_flash_silabs_firmware(hass: HomeAssistant) -> None:
             fw_data=b"firmware contents",
             expected_installed_firmware_type=ApplicationType.SPINEL,
             bootloader_reset_methods=(),
+            application_probe_methods=(),
             progress_callback=progress_callback,
         )
 
@@ -660,6 +669,7 @@ async def test_async_flash_silabs_firmware_flash_failure(hass: HomeAssistant) ->
             fw_data=b"firmware contents",
             expected_installed_firmware_type=ApplicationType.SPINEL,
             bootloader_reset_methods=(),
+            application_probe_methods=(),
         )
 
     # Both owning integrations/addons are stopped and restarted
@@ -720,6 +730,7 @@ async def test_async_flash_silabs_firmware_probe_failure(hass: HomeAssistant) ->
             fw_data=b"firmware contents",
             expected_installed_firmware_type=ApplicationType.SPINEL,
             bootloader_reset_methods=(),
+            application_probe_methods=(),
         )
 
     # Both owning integrations/addons are stopped and restarted

--- a/tests/components/homeassistant_hardware/test_util.py
+++ b/tests/components/homeassistant_hardware/test_util.py
@@ -23,6 +23,7 @@ from homeassistant.components.homeassistant_hardware.util import (
     FirmwareInfo,
     OwningAddon,
     OwningIntegration,
+    ResetTarget,
     async_flash_silabs_firmware,
     get_otbr_addon_firmware_info,
     guess_firmware_info,
@@ -504,8 +505,11 @@ async def test_probe_silabs_firmware_info(
     ):
         result = await probe_silabs_firmware_info(
             "/dev/ttyUSB0",
-            bootloader_reset_methods=(),
-            application_probe_methods=(),
+            bootloader_reset_methods=[ResetTarget.RTS_DTR],
+            application_probe_methods=[
+                (ApplicationType.EZSP, 460800),
+                (ApplicationType.SPINEL, 460800),
+            ],
         )
         assert result == expected_fw_info
 
@@ -537,8 +541,11 @@ async def test_probe_silabs_firmware_type(
     ):
         result = await probe_silabs_firmware_type(
             "/dev/ttyUSB0",
-            bootloader_reset_methods=(),
-            application_probe_methods=(),
+            bootloader_reset_methods=[ResetTarget.RTS_DTR],
+            application_probe_methods=[
+                (ApplicationType.EZSP, 460800),
+                (ApplicationType.SPINEL, 460800),
+            ],
         )
         assert result == expected
 
@@ -604,8 +611,11 @@ async def test_async_flash_silabs_firmware(hass: HomeAssistant) -> None:
             device="/dev/ttyUSB0",
             fw_data=b"firmware contents",
             expected_installed_firmware_type=ApplicationType.SPINEL,
-            bootloader_reset_methods=(),
-            application_probe_methods=(),
+            bootloader_reset_methods=[ResetTarget.RTS_DTR],
+            application_probe_methods=[
+                (ApplicationType.EZSP, 460800),
+                (ApplicationType.SPINEL, 460800),
+            ],
             progress_callback=progress_callback,
         )
 
@@ -614,7 +624,9 @@ async def test_async_flash_silabs_firmware(hass: HomeAssistant) -> None:
 
     # Verify Flasher was called with correct bootloader_reset parameter
     assert flasher_mock.call_count == 1
-    assert flasher_mock.mock_calls[0].kwargs["bootloader_reset"] == ()
+    assert flasher_mock.mock_calls[0].kwargs["bootloader_reset"] == (
+        ResetTarget.RTS_DTR,
+    )
 
     # Both owning integrations/addons are stopped and restarted
     assert owner1.temporarily_stop.mock_calls == [
@@ -668,8 +680,11 @@ async def test_async_flash_silabs_firmware_flash_failure(hass: HomeAssistant) ->
             device="/dev/ttyUSB0",
             fw_data=b"firmware contents",
             expected_installed_firmware_type=ApplicationType.SPINEL,
-            bootloader_reset_methods=(),
-            application_probe_methods=(),
+            bootloader_reset_methods=[ResetTarget.RTS_DTR],
+            application_probe_methods=[
+                (ApplicationType.EZSP, 460800),
+                (ApplicationType.SPINEL, 460800),
+            ],
         )
 
     # Both owning integrations/addons are stopped and restarted
@@ -729,8 +744,11 @@ async def test_async_flash_silabs_firmware_probe_failure(hass: HomeAssistant) ->
             device="/dev/ttyUSB0",
             fw_data=b"firmware contents",
             expected_installed_firmware_type=ApplicationType.SPINEL,
-            bootloader_reset_methods=(),
-            application_probe_methods=(),
+            bootloader_reset_methods=[ResetTarget.RTS_DTR],
+            application_probe_methods=[
+                (ApplicationType.EZSP, 460800),
+                (ApplicationType.SPINEL, 460800),
+            ],
         )
 
     # Both owning integrations/addons are stopped and restarted

--- a/tests/components/homeassistant_hardware/test_util.py
+++ b/tests/components/homeassistant_hardware/test_util.py
@@ -625,7 +625,7 @@ async def test_async_flash_silabs_firmware(hass: HomeAssistant) -> None:
     # Verify Flasher was called with correct bootloader_reset parameter
     assert flasher_mock.call_count == 1
     assert flasher_mock.mock_calls[0].kwargs["bootloader_reset"] == (
-        ResetTarget.RTS_DTR,
+        ResetTarget.RTS_DTR.as_flasher_reset_target(),
     )
 
     # Both owning integrations/addons are stopped and restarted

--- a/tests/components/homeassistant_hardware/test_util.py
+++ b/tests/components/homeassistant_hardware/test_util.py
@@ -644,6 +644,28 @@ async def test_async_flash_silabs_firmware(hass: HomeAssistant) -> None:
     ]
 
 
+async def test_async_flash_silabs_firmware_expected_type_not_probed(
+    hass: HomeAssistant,
+) -> None:
+    """Test firmware flashing requires probing config to exist for firmware type."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Expected installed firmware type .*? not in application probe methods .*?"
+        ),
+    ):
+        await async_flash_silabs_firmware(
+            hass=hass,
+            device="/dev/ttyUSB0",
+            fw_data=b"firmware contents",
+            expected_installed_firmware_type=ApplicationType.SPINEL,
+            bootloader_reset_methods=[ResetTarget.RTS_DTR],
+            application_probe_methods=[
+                (ApplicationType.EZSP, 460800),
+            ],
+        )
+
+
 async def test_async_flash_silabs_firmware_flash_failure(hass: HomeAssistant) -> None:
     """Test async_flash_silabs_firmware flash failure."""
     await async_setup_component(hass, "homeassistant_hardware", {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump universal-silabs-flasher from 0.0.37 to [0.1.0](https://github.com/NabuCasa/universal-silabs-flasher/releases/tag/v0.1.0). This release improves communication with OpenThread RCP firmware and provides a new API to speed up probing during firmware flashing. Our approach is now:

1. Identify firmware type when setting up the adapter (to avoid unnecessarily downgrading or reinstalling the current firmware). This is now optimized per-adapter by omitting unused firmware+baudrate configurations (e.g. CPC firmware for the ZBT-2)
2. If we cannot detect the firmware type or the detected firmware is lower than the recommended, we perform a firmware upgrade. This directly uses the bootloader trigger (when available), removing unnecessary waiting.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
