### PR TITLE
Move oauth2_implementation_unavailable string to top level

### DIFF
--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -1236,6 +1236,9 @@
     "fetch_api_error": {
       "message": "Error obtaining data from the API: {error}"
     },
+    "oauth2_implementation_unavailable": {
+      "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
+    },
     "pause_program": {
       "message": "Error pausing program: {error}"
     },

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -1236,9 +1236,6 @@
     "fetch_api_error": {
       "message": "Error obtaining data from the API: {error}"
     },
-    "oauth2_implementation_unavailable": {
-      "message": "OAuth2 implementation temporarily unavailable, will retry"
-    },
     "pause_program": {
       "message": "Error pausing program: {error}"
     },

--- a/homeassistant/components/miele/strings.json
+++ b/homeassistant/components/miele/strings.json
@@ -1088,9 +1088,6 @@
     "invalid_target": {
       "message": "Invalid device targeted."
     },
-    "oauth2_implementation_unavailable": {
-      "message": "OAuth2 implementation unavailable, will retry"
-    },
     "set_program_error": {
       "message": "'Set program' action failed: {status} / {message}"
     },

--- a/homeassistant/components/miele/strings.json
+++ b/homeassistant/components/miele/strings.json
@@ -1088,6 +1088,9 @@
     "invalid_target": {
       "message": "Invalid device targeted."
     },
+    "oauth2_implementation_unavailable": {
+      "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
+    },
     "set_program_error": {
       "message": "'Set program' action failed: {status} / {message}"
     },

--- a/homeassistant/components/xbox/strings.json
+++ b/homeassistant/components/xbox/strings.json
@@ -98,6 +98,9 @@
     }
   },
   "exceptions": {
+    "oauth2_implementation_unavailable": {
+      "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
+    },
     "request_exception": {
       "message": "Failed to connect to Xbox Network"
     },

--- a/homeassistant/components/xbox/strings.json
+++ b/homeassistant/components/xbox/strings.json
@@ -98,9 +98,6 @@
     }
   },
   "exceptions": {
-    "oauth2_implementation_unavailable": {
-      "message": "OAuth2 implementation temporarily unavailable, will retry"
-    },
     "request_exception": {
       "message": "Failed to connect to Xbox Network"
     },

--- a/homeassistant/components/yolink/strings.json
+++ b/homeassistant/components/yolink/strings.json
@@ -133,6 +133,9 @@
     "invalid_config_entry": {
       "message": "Config entry not found or not loaded!"
     },
+    "oauth2_implementation_unavailable": {
+      "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
+    },
     "valve_inoperable_currently": {
       "message": "The Valve cannot be operated currently."
     }

--- a/homeassistant/components/yolink/strings.json
+++ b/homeassistant/components/yolink/strings.json
@@ -133,9 +133,6 @@
     "invalid_config_entry": {
       "message": "Config entry not found or not loaded!"
     },
-    "oauth2_implementation_unavailable": {
-      "message": "OAuth2 implementation temporarily unavailable, will retry"
-    },
     "valve_inoperable_currently": {
       "message": "The Valve cannot be operated currently."
     }

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -115,6 +115,11 @@
         "turned_on": "{entity_name} turned on"
       }
     },
+    "exceptions": {
+      "oauth2_implementation_unavailable": {
+        "message": "OAuth2 implementation unavailable, will retry"
+      }
+    },
     "generic": {
       "model": "Model",
       "ui_managed": "Managed via UI"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As suggested by @zweckj in [this PR](https://github.com/home-assistant/core/pull/156215/files/9f4e48c36040a4652872f72fb477af5476d11c52#r2510314101), this moves the OAuth2 error string to the top level so it only has to be translated once.

We'll probably need to do some more cleanup as there are a handful of open PRs.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
