### PR TITLE
Migrate Z-Wave event entity to new discovery schema

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -66,6 +66,7 @@ from .discovery_data_template import (
     NumericSensorDataTemplate,
 )
 from .entity import NewZwaveDiscoveryInfo
+from .event import DISCOVERY_SCHEMAS as EVENT_SCHEMAS
 from .models import (
     FirmwareVersionRange,
     NewZWaveDiscoverySchema,
@@ -77,6 +78,7 @@ from .models import (
 
 NEW_DISCOVERY_SCHEMAS: dict[Platform, list[NewZWaveDiscoverySchema]] = {
     Platform.BINARY_SENSOR: BINARY_SENSOR_SCHEMAS,
+    Platform.EVENT: EVENT_SCHEMAS,
 }
 SUPPORTED_PLATFORMS = tuple(NEW_DISCOVERY_SCHEMAS)
 
@@ -1163,15 +1165,6 @@ DISCOVERY_SCHEMAS = [
         ),
         allow_multi=True,
         entity_registry_enabled_default=False,
-    ),
-    # event
-    # stateful = False
-    ZWaveDiscoverySchema(
-        platform=Platform.EVENT,
-        hint="stateless",
-        primary_value=ZWaveValueDiscoverySchema(
-            stateful=False,
-        ),
     ),
     # button
     # Meter CC idle

--- a/homeassistant/components/zwave_js/event.py
+++ b/homeassistant/components/zwave_js/event.py
@@ -2,20 +2,35 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.value import Value, ValueNotification
 
-from homeassistant.components.event import DOMAIN as EVENT_DOMAIN, EventEntity
+from homeassistant.components.event import (
+    DOMAIN as EVENT_DOMAIN,
+    EventEntity,
+    EventEntityDescription,
+)
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import ATTR_VALUE, DOMAIN
-from .discovery import ZwaveDiscoveryInfo
-from .entity import ZWaveBaseEntity
-from .models import ZwaveJSConfigEntry
+from .entity import ZWaveBaseEntity, ZwaveDiscoveryInfo
+from .models import (
+    NewZWaveDiscoverySchema,
+    ZwaveJSConfigEntry,
+    ZWaveValueDiscoverySchema,
+)
 
 PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class NewValueNotificationZWaveJSEntityDescription(EventEntityDescription):
+    """Represent a Z-Wave JS event entity description."""
 
 
 async def async_setup_entry(
@@ -96,3 +111,17 @@ class ZwaveEventEntity(ZWaveBaseEntity, EventEntity):
                 lambda event: self._async_handle_event(event["value_notification"]),
             )
         )
+
+
+DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
+    NewZWaveDiscoverySchema(
+        platform=Platform.EVENT,
+        primary_value=ZWaveValueDiscoverySchema(
+            stateful=False,
+        ),
+        entity_description=NewValueNotificationZWaveJSEntityDescription(
+            key="value_notification",
+        ),
+        entity_class=ZwaveEventEntity,
+    ),
+]

--- a/homeassistant/components/zwave_js/event.py
+++ b/homeassistant/components/zwave_js/event.py
@@ -29,7 +29,7 @@ PARALLEL_UPDATES = 0
 
 
 @dataclass(frozen=True, kw_only=True)
-class NewValueNotificationZWaveJSEntityDescription(EventEntityDescription):
+class ValueNotificationZWaveJSEntityDescription(EventEntityDescription):
     """Represent a Z-Wave JS event entity description."""
 
 
@@ -119,7 +119,7 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         primary_value=ZWaveValueDiscoverySchema(
             stateful=False,
         ),
-        entity_description=NewValueNotificationZWaveJSEntityDescription(
+        entity_description=ValueNotificationZWaveJSEntityDescription(
             key="value_notification",
         ),
         entity_class=ZwaveEventEntity,

--- a/homeassistant/components/zwave_js/event.py
+++ b/homeassistant/components/zwave_js/event.py
@@ -46,12 +46,6 @@ async def async_setup_entry(
         """Add Z-Wave event entity."""
         driver = client.driver
         assert driver is not None  # Driver is ready before platforms are loaded.
-
-        assert isinstance(info, NewZwaveDiscoveryInfo)
-        assert isinstance(
-            info.entity_description, ValueNotificationZWaveJSEntityDescription
-        )
-
         entities: list[ZWaveBaseEntity] = [
             info.entity_class(config_entry, driver, info)
         ]

--- a/tests/components/zwave_js/test_event.py
+++ b/tests/components/zwave_js/test_event.py
@@ -6,9 +6,7 @@ from freezegun import freeze_time
 import pytest
 from zwave_js_server.event import Event
 
-from homeassistant.components.event import ATTR_EVENT_TYPE
-from homeassistant.components.zwave_js.const import ATTR_VALUE
-from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_UNKNOWN, Platform
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
@@ -66,13 +64,12 @@ async def test_basic(
 
     assert state
     assert state.state == dt_util.as_utc(fut).isoformat(timespec="milliseconds")
-    attributes = state.attributes
-    assert attributes[ATTR_EVENT_TYPE] == "Basic event value"
-    assert attributes[ATTR_VALUE] == 255
-    assert (
-        attributes[ATTR_FRIENDLY_NAME]
-        == "honeywell_in_wall_smart_fan_control Event value"
-    )
+    assert state.attributes == {
+        "friendly_name": "honeywell_in_wall_smart_fan_control Event value",
+        "event_type": "Basic event value",
+        "event_types": ["Basic event value"],
+        "value": 255,
+    }
 
 
 async def test_central_scene(
@@ -132,10 +129,20 @@ async def test_central_scene(
 
     assert state
     assert state.state == dt_util.as_utc(fut).isoformat(timespec="milliseconds")
-    attributes = state.attributes
-    assert attributes[ATTR_EVENT_TYPE] == "KeyReleased"
-    assert attributes[ATTR_VALUE] == 1
-    assert attributes[ATTR_FRIENDLY_NAME] == "Node 51 Scene 002"
+    assert state.attributes == {
+        "friendly_name": "Node 51 Scene 002",
+        "event_type": "KeyReleased",
+        "event_types": [
+            "KeyHeldDown",
+            "KeyPressed",
+            "KeyPressed2x",
+            "KeyPressed3x",
+            "KeyPressed4x",
+            "KeyPressed5x",
+            "KeyReleased",
+        ],
+        "value": 1,
+    }
 
     # Try invalid value
     event = Event(
@@ -183,7 +190,17 @@ async def test_central_scene(
 
     assert state
     assert state.state == dt_util.as_utc(fut).isoformat(timespec="milliseconds")
-    attributes = state.attributes
-    assert attributes[ATTR_EVENT_TYPE] == "KeyReleased"
-    assert attributes[ATTR_VALUE] == 1
-    assert attributes[ATTR_FRIENDLY_NAME] == "Node 51 Scene 002"
+    assert state.attributes == {
+        "friendly_name": "Node 51 Scene 002",
+        "event_type": "KeyReleased",
+        "event_types": [
+            "KeyHeldDown",
+            "KeyPressed",
+            "KeyPressed2x",
+            "KeyPressed3x",
+            "KeyPressed4x",
+            "KeyPressed5x",
+            "KeyReleased",
+        ],
+        "value": 1,
+    }

--- a/tests/components/zwave_js/test_event.py
+++ b/tests/components/zwave_js/test_event.py
@@ -8,7 +8,7 @@ from zwave_js_server.event import Event
 
 from homeassistant.components.event import ATTR_EVENT_TYPE
 from homeassistant.components.zwave_js.const import ATTR_VALUE
-from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
@@ -69,6 +69,10 @@ async def test_basic(
     attributes = state.attributes
     assert attributes[ATTR_EVENT_TYPE] == "Basic event value"
     assert attributes[ATTR_VALUE] == 255
+    assert (
+        attributes[ATTR_FRIENDLY_NAME]
+        == "honeywell_in_wall_smart_fan_control Event value"
+    )
 
 
 async def test_central_scene(
@@ -131,6 +135,7 @@ async def test_central_scene(
     attributes = state.attributes
     assert attributes[ATTR_EVENT_TYPE] == "KeyReleased"
     assert attributes[ATTR_VALUE] == 1
+    assert attributes[ATTR_FRIENDLY_NAME] == "Node 51 Scene 002"
 
     # Try invalid value
     event = Event(
@@ -181,3 +186,4 @@ async def test_central_scene(
     attributes = state.attributes
     assert attributes[ATTR_EVENT_TYPE] == "KeyReleased"
     assert attributes[ATTR_VALUE] == 1
+    assert attributes[ATTR_FRIENDLY_NAME] == "Node 51 Scene 002"


### PR DESCRIPTION
## Proposed change

This migrates the Z-Wave event entity to the v2 discovery schema to prepare for adding a base event entity class and another event entity class that supports Z-Wave notifications (as opposed to `ZwaveEventEntity` which currently only supports "value notifications").

The event entity tests have also been expanded to test all state attributes, including the name and different event type attributes, though we can remove that from this PR.
IMO checking all attributes is slightly better, as we wouldn't know if (e.g.) a device class has been accidentally to these event entities otherwise, especially since there are currently no snapshot tests for the different entity platforms.

It would be ideal if Martin can review this, since this differs a bit from the binary sensor migration, as we convert all possible schemas here (one) and don't have discovery schemas split between old and new. I've added a couple of questions/comments.

This is in preparation for:
- https://github.com/zwave-js/backlog/issues/135

This PR is similar to:
- https://github.com/home-assistant/core/pull/151146

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
