### PR TITLE
Remove redundant Z-Wave binary sensor `entity_description` arg

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -393,9 +393,7 @@ async def async_setup_entry(
             and is_valid_notification_binary_sensor(info)
         ):
             entities.extend(
-                ZWaveNotificationBinarySensor(
-                    config_entry, driver, info, state_key, info.entity_description
-                )
+                ZWaveNotificationBinarySensor(config_entry, driver, info, state_key)
                 for state_key in info.primary_value.metadata.states
                 if int(state_key) not in info.entity_description.not_states
                 and (


### PR DESCRIPTION
## Proposed change

This PR removes providing the `entity_description` explicitly for Z-Wave binary sensors created from the new discovery info.

We only need to explicitly provide the `entity_description` for binary sensors created from the old discovery schema.
For reference, see the base Z-Wave entity `ZWaveBaseEntity`. It already sets `entity_description` when the new discovery info is used to create the entity:

https://github.com/home-assistant/core/blob/160810c69d2e974145997363a42fede81f14b213/homeassistant/components/zwave_js/entity.py#L76-L77

Above is called first. Then, `ZWaveNotificationBinarySensor` sets the entity description here (currently a second time for sensors using the new schema):

https://github.com/home-assistant/core/blob/160810c69d2e974145997363a42fede81f14b213/homeassistant/components/zwave_js/binary_sensor.py#L521-L522

### Why

Now, I'm not sure if this was explicitly added for some reason? If we want to streamline all Z-Wave entity classes using the new discovery info, we should drop providing the argument unnecessarily IMO, like done in this PR.

If we want to align the binary sensor classes regardless if old or new discovery info is used, we can close this PR.
When we eventually migrate all other binary sensor entities to the new discovery schema, we can just fully drop the additional parameter from the class then.

However, when working on the event platform, I needed to check why I didn't need to explicitly set the `entity_description` myself there, just like it's done for all binary sensors, even those created from the new discovery schema. So, that's why this PR exists. Currently, the `entity_description` is just (unnecessarily) set twice for sensors using the new discovery info.

Noticed whilst working on:
- https://github.com/home-assistant/core/pull/156320

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
