### PR TITLE
Use pytest.mark.freeze_time in habitica tests

### DIFF
--- a/tests/components/habitica/test_calendar.py
+++ b/tests/components/habitica/test_calendar.py
@@ -3,7 +3,6 @@
 from collections.abc import Generator
 from unittest.mock import patch
 
-from freezegun.api import freeze_time
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -33,7 +32,7 @@ async def set_tz(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("habitica")
-@freeze_time("2024-09-20T22:00:00.000Z")
+@pytest.mark.freeze_time("2024-09-20T22:00:00.000Z")
 async def test_calendar_platform(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/components/habitica/test_notify.py
+++ b/tests/components/habitica/test_notify.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 from aiohttp import ClientError
-from freezegun.api import FrozenDateTimeFactory, freeze_time
+from freezegun.api import FrozenDateTimeFactory
 from habiticalib import HabiticaGroupMembersResponse
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -82,7 +82,7 @@ async def test_notify_platform(
         ),
     ],
 )
-@freeze_time("2025-08-13T00:00:00+00:00")
+@pytest.mark.freeze_time("2025-08-13T00:00:00+00:00")
 async def test_send_message(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/components/habitica/test_services.py
+++ b/tests/components/habitica/test_services.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 from aiohttp import ClientError
-from freezegun.api import freeze_time
 from habiticalib import (
     Checklist,
     Direction,
@@ -1845,7 +1844,7 @@ async def test_create_todo(
     ],
 )
 @pytest.mark.usefixtures("mock_uuid4")
-@freeze_time("2025-02-25T22:00:00.000Z")
+@pytest.mark.freeze_time("2025-02-25T22:00:00.000Z")
 async def test_update_daily(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
@@ -2023,7 +2022,7 @@ async def test_update_daily(
     ],
 )
 @pytest.mark.usefixtures("mock_uuid4")
-@freeze_time("2025-02-25T22:00:00.000Z")
+@pytest.mark.freeze_time("2025-02-25T22:00:00.000Z")
 async def test_create_daily(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
@@ -2064,7 +2063,7 @@ async def test_create_daily(
     ],
 )
 @pytest.mark.usefixtures("mock_uuid4")
-@freeze_time("2025-02-25T22:00:00.000Z")
+@pytest.mark.freeze_time("2025-02-25T22:00:00.000Z")
 async def test_update_daily_service_validation_errors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `pytest.mark.freeze_time` instead of `freezegun.freeze_time` in habitica tests

This ensures time is frozen during the entire test, including when setting up and tearing down test fixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
