### PR TITLE
Add websocket subscription support for calendar events

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -34,6 +34,7 @@ from homeassistant.core import (
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_point_in_time
@@ -77,6 +78,7 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA
 PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE
 SCAN_INTERVAL = datetime.timedelta(seconds=60)
+EVENT_LISTENER_DEBOUNCE_COOLDOWN = 1.0  # seconds
 
 # Don't support rrules more often than daily
 VALID_FREQS = {"DAILY", "WEEKLY", "MONTHLY", "YEARLY"}
@@ -529,6 +531,7 @@ class CalendarEntity(Entity):
         ]
         | None
     ) = None
+    _event_listener_debouncer: Debouncer[None] | None = None
 
     _attr_initial_color: str | None
 
@@ -598,8 +601,9 @@ class CalendarEntity(Entity):
         """
         super()._async_write_ha_state()
 
-        # Notify websocket subscribers of event changes
-        self.async_update_event_listeners()
+        # Notify websocket subscribers of event changes (debounced)
+        if self._event_listeners and self._event_listener_debouncer:
+            self._event_listener_debouncer.async_schedule_call()
         if self._alarm_unsubs is None:
             self._alarm_unsubs = []
         _LOGGER.debug(
@@ -648,6 +652,9 @@ class CalendarEntity(Entity):
         for unsub in self._alarm_unsubs or ():
             unsub()
         self._alarm_unsubs = None
+        if self._event_listener_debouncer:
+            self._event_listener_debouncer.async_cancel()
+            self._event_listener_debouncer = None
 
     @final
     @callback
@@ -664,6 +671,15 @@ class CalendarEntity(Entity):
         if self._event_listeners is None:
             self._event_listeners = []
 
+        if self._event_listener_debouncer is None:
+            self._event_listener_debouncer = Debouncer(
+                self.hass,
+                _LOGGER,
+                cooldown=EVENT_LISTENER_DEBOUNCE_COOLDOWN,
+                immediate=True,
+                function=self.async_update_event_listeners,
+            )
+
         listener_data = (start_date, end_date, event_listener)
         self._event_listeners.append(listener_data)
 
@@ -671,6 +687,9 @@ class CalendarEntity(Entity):
         def unsubscribe() -> None:
             if self._event_listeners:
                 self._event_listeners.remove(listener_data)
+            if not self._event_listeners and self._event_listener_debouncer:
+                self._event_listener_debouncer.async_cancel()
+                self._event_listener_debouncer = None
 
         return unsubscribe
 

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -596,6 +596,9 @@ class CalendarEntity(Entity):
         the current or upcoming event.
         """
         super()._async_write_ha_state()
+
+        # Notify websocket subscribers of event changes
+        self.async_update_event_listeners()
         if self._alarm_unsubs is None:
             self._alarm_unsubs = []
         _LOGGER.debug(
@@ -706,12 +709,6 @@ class CalendarEntity(Entity):
             for event in events
         ]
         listener(event_list)
-
-    @callback
-    def _async_write_ha_state(self) -> None:
-        """Notify event subscribers."""
-        super()._async_write_ha_state()
-        self.async_update_event_listeners()
 
     async def async_get_events(
         self,

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -697,7 +697,12 @@ class CalendarEntity(Entity):
                 for event in events
             ]
             listener(event_list)
-        except HomeAssistantError:
+        except HomeAssistantError as err:
+            _LOGGER.debug(
+                "Error fetching calendar events for %s: %s",
+                self.entity_id,
+                err,
+            )
             listener(None)
 
     @callback

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -320,6 +320,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     websocket_api.async_register_command(hass, handle_calendar_event_create)
     websocket_api.async_register_command(hass, handle_calendar_event_delete)
     websocket_api.async_register_command(hass, handle_calendar_event_update)
+    websocket_api.async_register_command(hass, handle_calendar_event_subscribe)
 
     component.async_register_entity_service(
         CREATE_EVENT_SERVICE,
@@ -517,6 +518,16 @@ class CalendarEntity(Entity):
     _entity_component_unrecorded_attributes = frozenset({"description"})
 
     _alarm_unsubs: list[CALLBACK_TYPE] | None = None
+    _event_listeners: (
+        list[
+            tuple[
+                datetime.datetime,
+                datetime.datetime,
+                Callable[[list[JsonValueType] | None], None],
+            ]
+        ]
+        | None
+    ) = None
 
     _attr_initial_color: str | None
 
@@ -633,6 +644,67 @@ class CalendarEntity(Entity):
         for unsub in self._alarm_unsubs or ():
             unsub()
         self._alarm_unsubs = None
+
+    @final
+    @callback
+    def async_subscribe_events(
+        self,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+        event_listener: Callable[[list[JsonValueType] | None], None],
+    ) -> CALLBACK_TYPE:
+        """Subscribe to calendar event updates.
+
+        Called by websocket API.
+        """
+        if self._event_listeners is None:
+            self._event_listeners = []
+
+        listener_data = (start_date, end_date, event_listener)
+        self._event_listeners.append(listener_data)
+
+        @callback
+        def unsubscribe() -> None:
+            if self._event_listeners:
+                self._event_listeners.remove(listener_data)
+
+        return unsubscribe
+
+    @final
+    @callback
+    def async_update_event_listeners(self) -> None:
+        """Push updated calendar events to all listeners."""
+        if not self._event_listeners:
+            return
+
+        for start_date, end_date, listener in self._event_listeners:
+            # Schedule the async event fetching
+            self.hass.async_create_task(
+                self._async_update_listener(start_date, end_date, listener)
+            )
+
+    async def _async_update_listener(
+        self,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+        listener: Callable[[list[JsonValueType] | None], None],
+    ) -> None:
+        """Fetch events and push to a single listener."""
+        try:
+            events = await self.async_get_events(self.hass, start_date, end_date)
+            event_list: list[JsonValueType] = [
+                dataclasses.asdict(event, dict_factory=_list_events_dict_factory)
+                for event in events
+            ]
+            listener(event_list)
+        except HomeAssistantError:
+            listener(None)
+
+    @callback
+    def _async_write_ha_state(self) -> None:
+        """Notify event subscribers."""
+        super()._async_write_ha_state()
+        self.async_update_event_listeners()
 
     async def async_get_events(
         self,
@@ -865,6 +937,53 @@ async def handle_calendar_event_update(
         connection.send_error(msg["id"], "failed", str(ex))
     else:
         connection.send_result(msg["id"])
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "calendar/event/subscribe",
+        vol.Required("entity_id"): cv.entity_domain(DOMAIN),
+        vol.Required("start"): cv.datetime,
+        vol.Required("end"): cv.datetime,
+    }
+)
+@websocket_api.async_response
+async def handle_calendar_event_subscribe(
+    hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Subscribe to calendar event updates."""
+    entity_id: str = msg["entity_id"]
+
+    if not (entity := hass.data[DATA_COMPONENT].get_entity(entity_id)):
+        connection.send_error(
+            msg["id"],
+            ERR_NOT_FOUND,
+            f"Calendar entity not found: {entity_id}",
+        )
+        return
+
+    start_date = dt_util.as_local(msg["start"])
+    end_date = dt_util.as_local(msg["end"])
+
+    @callback
+    def event_listener(events: list[JsonValueType] | None) -> None:
+        """Push updated calendar events to websocket."""
+        connection.send_message(
+            websocket_api.event_message(
+                msg["id"],
+                {
+                    "events": events,
+                },
+            )
+        )
+
+    connection.subscriptions[msg["id"]] = entity.async_subscribe_events(
+        start_date, end_date, event_listener
+    )
+    connection.send_result(msg["id"])
+
+    # Push an initial event list update
+    entity.async_update_event_listeners()
 
 
 def _validate_timespan(

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -644,6 +644,13 @@ class CalendarEntity(Entity):
             event.end_datetime_local,
         )
 
+    @callback
+    def _async_cancel_event_listener_debouncer(self) -> None:
+        """Cancel and clear the event listener debouncer."""
+        if self._event_listener_debouncer:
+            self._event_listener_debouncer.async_cancel()
+            self._event_listener_debouncer = None
+
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass.
 
@@ -652,9 +659,7 @@ class CalendarEntity(Entity):
         for unsub in self._alarm_unsubs or ():
             unsub()
         self._alarm_unsubs = None
-        if self._event_listener_debouncer:
-            self._event_listener_debouncer.async_cancel()
-            self._event_listener_debouncer = None
+        self._async_cancel_event_listener_debouncer()
 
     @final
     @callback
@@ -687,9 +692,8 @@ class CalendarEntity(Entity):
         def unsubscribe() -> None:
             if self._event_listeners:
                 self._event_listeners.remove(listener_data)
-            if not self._event_listeners and self._event_listener_debouncer:
-                self._event_listener_debouncer.async_cancel()
-                self._event_listener_debouncer = None
+            if not self._event_listeners:
+                self._async_cancel_event_listener_debouncer()
 
         return unsubscribe
 
@@ -1007,22 +1011,26 @@ async def handle_calendar_event_subscribe(
         )
         return
 
+    subscription_id = msg["id"]
+
     @callback
     def event_listener(events: list[JsonValueType] | None) -> None:
         """Push updated calendar events to websocket."""
+        if subscription_id not in connection.subscriptions:
+            return
         connection.send_message(
             websocket_api.event_message(
-                msg["id"],
+                subscription_id,
                 {
                     "events": events,
                 },
             )
         )
 
-    connection.subscriptions[msg["id"]] = entity.async_subscribe_events(
+    connection.subscriptions[subscription_id] = entity.async_subscribe_events(
         start_date, end_date, event_listener
     )
-    connection.send_result(msg["id"])
+    connection.send_result(subscription_id)
 
     # Push initial events only to the new subscriber
     entity.async_update_single_event_listener(start_date, end_date, event_listener)

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -692,11 +692,6 @@ class CalendarEntity(Entity):
         """Fetch events and push to a single listener."""
         try:
             events = await self.async_get_events(self.hass, start_date, end_date)
-            event_list: list[JsonValueType] = [
-                dataclasses.asdict(event, dict_factory=_list_events_dict_factory)
-                for event in events
-            ]
-            listener(event_list)
         except HomeAssistantError as err:
             _LOGGER.debug(
                 "Error fetching calendar events for %s: %s",
@@ -704,6 +699,13 @@ class CalendarEntity(Entity):
                 err,
             )
             listener(None)
+            return
+
+        event_list: list[JsonValueType] = [
+            dataclasses.asdict(event, dict_factory=_list_events_dict_factory)
+            for event in events
+        ]
+        listener(event_list)
 
     @callback
     def _async_write_ha_state(self) -> None:

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -17,6 +17,7 @@ import voluptuous as vol
 
 from homeassistant.components import frontend, http, websocket_api
 from homeassistant.components.websocket_api import (
+    ERR_INVALID_FORMAT,
     ERR_NOT_FOUND,
     ERR_NOT_SUPPORTED,
     ActiveConnection,
@@ -681,10 +682,20 @@ class CalendarEntity(Entity):
             return
 
         for start_date, end_date, listener in self._event_listeners:
-            # Schedule the async event fetching
-            self.hass.async_create_task(
-                self._async_update_listener(start_date, end_date, listener)
-            )
+            self.async_update_single_event_listener(start_date, end_date, listener)
+
+    @final
+    @callback
+    def async_update_single_event_listener(
+        self,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+        listener: Callable[[list[JsonValueType] | None], None],
+    ) -> None:
+        """Schedule an event fetch and push to a single listener."""
+        self.hass.async_create_task(
+            self._async_update_listener(start_date, end_date, listener)
+        )
 
     async def _async_update_listener(
         self,
@@ -969,6 +980,14 @@ async def handle_calendar_event_subscribe(
     start_date = dt_util.as_local(msg["start"])
     end_date = dt_util.as_local(msg["end"])
 
+    if start_date >= end_date:
+        connection.send_error(
+            msg["id"],
+            ERR_INVALID_FORMAT,
+            "Start must be before end",
+        )
+        return
+
     @callback
     def event_listener(events: list[JsonValueType] | None) -> None:
         """Push updated calendar events to websocket."""
@@ -986,8 +1005,8 @@ async def handle_calendar_event_subscribe(
     )
     connection.send_result(msg["id"])
 
-    # Push an initial event list update
-    entity.async_update_event_listeners()
+    # Push initial events only to the new subscriber
+    entity.async_update_single_event_listener(start_date, end_date, event_listener)
 
 
 def _validate_timespan(

--- a/homeassistant/components/local_calendar/calendar.py
+++ b/homeassistant/components/local_calendar/calendar.py
@@ -124,7 +124,6 @@ class LocalCalendarEntity(CalendarEntity):
             await self.hass.async_add_executor_job(event_store.add, event)
             await self._async_store()
         await self.async_update_ha_state(force_refresh=True)
-        self.async_update_event_listeners()
 
     async def async_delete_event(
         self,
@@ -147,7 +146,6 @@ class LocalCalendarEntity(CalendarEntity):
                 raise HomeAssistantError(f"Error while deleting event: {err}") from err
             await self._async_store()
         await self.async_update_ha_state(force_refresh=True)
-        self.async_update_event_listeners()
 
     async def async_update_event(
         self,
@@ -179,7 +177,6 @@ class LocalCalendarEntity(CalendarEntity):
                 raise HomeAssistantError(f"Error while updating event: {err}") from err
             await self._async_store()
         await self.async_update_ha_state(force_refresh=True)
-        self.async_update_event_listeners()
 
 
 def _parse_event(event: dict[str, Any]) -> Event:

--- a/homeassistant/components/local_calendar/calendar.py
+++ b/homeassistant/components/local_calendar/calendar.py
@@ -124,6 +124,7 @@ class LocalCalendarEntity(CalendarEntity):
             await self.hass.async_add_executor_job(event_store.add, event)
             await self._async_store()
         await self.async_update_ha_state(force_refresh=True)
+        self.async_update_event_listeners()
 
     async def async_delete_event(
         self,
@@ -146,6 +147,7 @@ class LocalCalendarEntity(CalendarEntity):
                 raise HomeAssistantError(f"Error while deleting event: {err}") from err
             await self._async_store()
         await self.async_update_ha_state(force_refresh=True)
+        self.async_update_event_listeners()
 
     async def async_update_event(
         self,
@@ -177,6 +179,7 @@ class LocalCalendarEntity(CalendarEntity):
                 raise HomeAssistantError(f"Error while updating event: {err}") from err
             await self._async_store()
         await self.async_update_ha_state(force_refresh=True)
+        self.async_update_event_listeners()
 
 
 def _parse_event(event: dict[str, Any]) -> Event:

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -715,3 +715,141 @@ async def test_calendar_initial_color_precedence(
 
     entity = TestCalendarEntity(description_color, attr_color)
     assert entity.initial_color == expected_color
+
+
+async def test_websocket_handle_subscribe_calendar_events(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    test_entities: list[MockCalendarEntity],
+) -> None:
+    """Test subscribing to calendar event updates via websocket."""
+    client = await hass_ws_client(hass)
+
+    start = dt_util.now()
+    end = start + timedelta(days=1)
+
+    await client.send_json_auto_id(
+        {
+            "type": "calendar/event/subscribe",
+            "entity_id": "calendar.calendar_1",
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    subscription_id = msg["id"]
+
+    # Should receive initial event list
+    msg = await client.receive_json()
+    assert msg["id"] == subscription_id
+    assert msg["type"] == "event"
+    assert "events" in msg["event"]
+    events = msg["event"]["events"]
+    assert len(events) == 1
+    assert events[0]["summary"] == "Future Event"
+
+
+async def test_websocket_subscribe_updates_on_state_change(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    test_entities: list[MockCalendarEntity],
+) -> None:
+    """Test that subscribers receive updates when calendar state changes."""
+    client = await hass_ws_client(hass)
+
+    start = dt_util.now()
+    end = start + timedelta(days=1)
+
+    await client.send_json_auto_id(
+        {
+            "type": "calendar/event/subscribe",
+            "entity_id": "calendar.calendar_1",
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    subscription_id = msg["id"]
+
+    # Receive initial event list
+    msg = await client.receive_json()
+    assert msg["id"] == subscription_id
+
+    # Add a new event and trigger state update
+    entity = test_entities[0]
+    entity.create_event(
+        start=start + timedelta(hours=2),
+        end=start + timedelta(hours=3),
+        summary="New Event",
+    )
+    entity.async_write_ha_state()
+    await hass.async_block_till_done()
+
+    # Should receive updated event list
+    msg = await client.receive_json()
+    assert msg["id"] == subscription_id
+    assert msg["type"] == "event"
+    events = msg["event"]["events"]
+    assert len(events) == 2
+    summaries = {event["summary"] for event in events}
+    assert "Future Event" in summaries
+    assert "New Event" in summaries
+
+
+async def test_websocket_subscribe_entity_not_found(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test subscribing to a non-existent calendar entity."""
+    client = await hass_ws_client(hass)
+
+    start = dt_util.now()
+    end = start + timedelta(days=1)
+
+    await client.send_json_auto_id(
+        {
+            "type": "calendar/event/subscribe",
+            "entity_id": "calendar.nonexistent",
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+        }
+    )
+    msg = await client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_found"
+    assert "Calendar entity not found" in msg["error"]["message"]
+
+
+async def test_websocket_subscribe_event_fetch_error(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    test_entities: list[MockCalendarEntity],
+) -> None:
+    """Test subscription handles event fetch errors gracefully."""
+    client = await hass_ws_client(hass)
+
+    start = dt_util.now()
+    end = start + timedelta(days=1)
+
+    # Set up entity to fail on async_get_events
+    test_entities[0].async_get_events.side_effect = HomeAssistantError("API Error")
+
+    await client.send_json_auto_id(
+        {
+            "type": "calendar/event/subscribe",
+            "entity_id": "calendar.calendar_1",
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    subscription_id = msg["id"]
+
+    # Should receive None for events due to error
+    msg = await client.receive_json()
+    assert msg["id"] == subscription_id
+    assert msg["type"] == "event"
+    assert msg["event"]["events"] is None

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -853,3 +853,29 @@ async def test_websocket_subscribe_event_fetch_error(
     assert msg["id"] == subscription_id
     assert msg["type"] == "event"
     assert msg["event"]["events"] is None
+
+
+async def test_websocket_subscribe_invalid_timespan(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    test_entities: list[MockCalendarEntity],
+) -> None:
+    """Test subscribing with start after end returns an error."""
+    client = await hass_ws_client(hass)
+
+    now = dt_util.now()
+    start = now + timedelta(days=1)
+    end = now
+
+    await client.send_json_auto_id(
+        {
+            "type": "calendar/event/subscribe",
+            "entity_id": "calendar.calendar_1",
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+        }
+    )
+    msg = await client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "invalid_format"
+    assert "Start must be before end" in msg["error"]["message"]

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Generator
 from datetime import timedelta
 from http import HTTPStatus
@@ -16,6 +17,7 @@ import voluptuous as vol
 from homeassistant.components.calendar import (
     CREATE_EVENT_SERVICE,
     DOMAIN,
+    EVENT_LISTENER_DEBOUNCE_COOLDOWN,
     SERVICE_GET_EVENTS,
     CalendarEntity,
     CalendarEntityDescription,
@@ -879,3 +881,70 @@ async def test_websocket_subscribe_invalid_timespan(
     assert not msg["success"]
     assert msg["error"]["code"] == "invalid_format"
     assert "Start must be before end" in msg["error"]["message"]
+
+
+async def test_websocket_subscribe_debounces_rapid_updates(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    test_entities: list[MockCalendarEntity],
+) -> None:
+    """Test that rapid state writes are debounced for event listeners."""
+    client = await hass_ws_client(hass)
+
+    start = dt_util.now()
+    end = start + timedelta(days=1)
+
+    await client.send_json_auto_id(
+        {
+            "type": "calendar/event/subscribe",
+            "entity_id": "calendar.calendar_1",
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    subscription_id = msg["id"]
+
+    # Receive initial event list
+    msg = await client.receive_json()
+    assert msg["id"] == subscription_id
+
+    entity = test_entities[0]
+    entity.async_get_events.reset_mock()
+
+    # Rapidly write state multiple times
+    for i in range(5):
+        entity.create_event(
+            start=start + timedelta(hours=i + 2),
+            end=start + timedelta(hours=i + 3),
+            summary=f"Rapid Event {i}",
+        )
+        entity.async_write_ha_state()
+
+    await hass.async_block_till_done()
+
+    # The debouncer with immediate=True fires the first call immediately
+    # and coalesces the rest into one call after the cooldown.
+    # Without debouncing this would be 5 calls.
+    assert entity.async_get_events.call_count == 1
+
+    # Wait for debounce cooldown to fire the trailing call
+    await asyncio.sleep(EVENT_LISTENER_DEBOUNCE_COOLDOWN + 0.1)
+    await hass.async_block_till_done()
+
+    # Should be exactly 2 total: immediate + one coalesced trailing call
+    assert entity.async_get_events.call_count == 2
+
+    # Drain messages: immediate update + trailing debounced update
+    messages: list[dict] = []
+    while True:
+        msg = await client.receive_json()
+        assert msg["id"] == subscription_id
+        assert msg["type"] == "event"
+        messages.append(msg)
+        if len(msg["event"]["events"]) == 6:  # 1 original + 5 rapid
+            break
+
+    # The final message has all events
+    assert len(messages[-1]["event"]["events"]) == 6

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Generator
 from datetime import timedelta
 from http import HTTPStatus
@@ -17,7 +16,6 @@ import voluptuous as vol
 from homeassistant.components.calendar import (
     CREATE_EVENT_SERVICE,
     DOMAIN,
-    EVENT_LISTENER_DEBOUNCE_COOLDOWN,
     SERVICE_GET_EVENTS,
     CalendarEntity,
     CalendarEntityDescription,
@@ -30,6 +28,7 @@ from homeassistant.util import dt as dt_util
 
 from .conftest import MockCalendarEntity, MockConfigEntry
 
+from tests.common import async_fire_time_changed
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
@@ -929,8 +928,8 @@ async def test_websocket_subscribe_debounces_rapid_updates(
     # Without debouncing this would be 5 calls.
     assert entity.async_get_events.call_count == 1
 
-    # Wait for debounce cooldown to fire the trailing call
-    await asyncio.sleep(EVENT_LISTENER_DEBOUNCE_COOLDOWN + 0.1)
+    # Advance time past the debounce cooldown to fire the trailing call
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
     await hass.async_block_till_done()
 
     # Should be exactly 2 total: immediate + one coalesced trailing call
@@ -938,13 +937,15 @@ async def test_websocket_subscribe_debounces_rapid_updates(
 
     # Drain messages: immediate update + trailing debounced update
     messages: list[dict] = []
-    while True:
+    for _ in range(10):
         msg = await client.receive_json()
         assert msg["id"] == subscription_id
         assert msg["type"] == "event"
         messages.append(msg)
         if len(msg["event"]["events"]) == 6:  # 1 original + 5 rapid
             break
+    else:
+        pytest.fail("Did not receive expected calendar event list with 6 events")
 
     # The final message has all events
     assert len(messages[-1]["event"]["events"]) == 6


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Real-time event updates for calendar entities via websocket subscription, similar to Todo and Weather entities.

Addresses cause of the polling workaround in https://github.com/home-assistant/frontend/pull/27565

Arch https://github.com/home-assistant/architecture/discussions/1306

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3035
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/27906

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
