### PR TITLE
Add async_get_intents to conversation

### DIFF
--- a/homeassistant/components/conversation/const.py
+++ b/homeassistant/components/conversation/const.py
@@ -34,3 +34,23 @@ class ConversationEntityFeature(IntFlag):
 
 METADATA_CUSTOM_SENTENCE = "hass_custom_sentence"
 METADATA_CUSTOM_FILE = "hass_custom_file"
+SENTENCE_TRIGGER_INTENT_NAME = "HassSentenceTrigger"
+CUSTOM_SENTENCES_DIR_NAME = "custom_sentences"
+
+
+class IntentSource(IntFlag):
+    """Source of intents and sentence templates."""
+
+    SENTENCE_TRIGGERS = 1
+    """Sentence triggers in automations."""
+
+    CONVERSATION_CONFIG = 2
+    """YAML configuration for conversation component."""
+
+    CUSTOM_SENTENCES = 4
+    """YAML files in config/custom_sentences."""
+
+    BUILTIN_SENTENCES = 8
+    """Sentences from home-assistant-intents package."""
+
+    ALL = SENTENCE_TRIGGERS | CONVERSATION_CONFIG | CUSTOM_SENTENCES | BUILTIN_SENTENCES

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -3,6 +3,8 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+from hassil.expression import TextChunk
+from hassil.intents import TextSlotList
 import pytest
 from syrupy.assertion import SnapshotAssertion
 import voluptuous as vol
@@ -17,10 +19,17 @@ from homeassistant.components.conversation import (
     default_agent,
 )
 from homeassistant.components.conversation.const import HOME_ASSISTANT_AGENT
+from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import intent
+from homeassistant.helpers import (
+    area_registry as ar,
+    entity_registry as er,
+    floor_registry as fr,
+    intent,
+)
 from homeassistant.setup import async_setup_component
 
 from . import MockAgent
@@ -437,7 +446,7 @@ async def test_async_get_intents_bad_language(hass: HomeAssistant) -> None:
 
 
 async def test_async_get_intents_language_region(hass: HomeAssistant) -> None:
-    """Test getting available intents with a regtional language code."""
+    """Test getting available intents with a regional language code."""
     assert await async_setup_component(hass, "homeassistant", {})
     assert await async_setup_component(hass, "conversation", {})
 
@@ -446,3 +455,61 @@ async def test_async_get_intents_language_region(hass: HomeAssistant) -> None:
     # built-in and custom sentences for "en" are included
     for intent_name in ("HassTurnOn", "OrderBeer"):
         assert intent_name in intents.intents
+
+
+async def test_async_get_intents_lists(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test that intents contain name/area/floor lists."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "conversation", {})
+
+    # Create a light in an area on a floor
+    floor_ground = floor_registry.async_create("ground")
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(
+        area_kitchen.id, name="kitchen", floor_id=floor_ground.floor_id
+    )
+    kitchen_light = entity_registry.async_get_or_create("light", "demo", "light1234")
+    kitchen_light = entity_registry.async_update_entity(
+        kitchen_light.entity_id, area_id=area_kitchen.id
+    )
+    hass.states.async_set(
+        kitchen_light.entity_id, "off", {ATTR_FRIENDLY_NAME: "demo light"}
+    )
+
+    # Add a second unexposed light
+    unexposed_light = entity_registry.async_get_or_create("light", "demo", "light5678")
+    unexposed_light = entity_registry.async_update_entity(
+        unexposed_light.entity_id, area_id=area_kitchen.id
+    )
+    hass.states.async_set(
+        unexposed_light.entity_id, "off", {ATTR_FRIENDLY_NAME: "unexposed light"}
+    )
+    async_expose_entity(hass, conversation.DOMAIN, unexposed_light.entity_id, False)
+
+    # name/area/floor lists should reflect state of registries
+    intents = await conversation.async_get_intents(hass, "en")
+
+    name_list = intents.slot_lists.get("name")
+    assert isinstance(name_list, TextSlotList)
+
+    # 1 exposed light
+    assert len(name_list.values) == 1
+    assert name_list.values[0].text_in == TextChunk("demo light")
+    assert name_list.values[0].context == {"domain": "light"}
+
+    # 1 area
+    area_list = intents.slot_lists.get("area")
+    assert isinstance(area_list, TextSlotList)
+    assert len(area_list.values) == 1
+    assert area_list.values[0].text_in == TextChunk("kitchen")
+
+    # 1 floor
+    floor_list = intents.slot_lists.get("floor")
+    assert isinstance(floor_list, TextSlotList)
+    assert len(floor_list.values) == 1
+    assert floor_list.values[0].text_in == TextChunk("ground")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new function `async_get_intents` to the `conversation` integration. This will allow other integrations (such as `wyoming`) to gather sentence templates from various sources:

* Sentence triggers from automations
* YAML configuration for `conversation`
* YAML files from `config/custom_sentences` directory
* Builtin intents from `home-assistant-intents` package

The list of exposed entities is available in the `name` slot list, and all areas/floors are available in their respective lists.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
