### PR TITLE
Extend base jinja2 extension with hass requirement and tests

### DIFF
--- a/tests/helpers/template/extensions/test_base.py
+++ b/tests/helpers/template/extensions/test_base.py
@@ -1,0 +1,285 @@
+"""Test base template extension."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.helpers.template import TemplateEnvironment
+from homeassistant.helpers.template.extensions.base import (
+    BaseTemplateExtension,
+    TemplateFunction,
+)
+
+
+def test_hass_property_raises_when_hass_is_none() -> None:
+    """Test that accessing hass property raises RuntimeError when hass is None."""
+    # Create an environment without hass
+    env = TemplateEnvironment(None)
+
+    # Create a simple extension
+    extension = BaseTemplateExtension(env)
+
+    # Accessing hass property should raise RuntimeError
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Home Assistant instance is not available. "
+            "This property should only be used in extensions with "
+            "functions marked requires_hass=True."
+        ),
+    ):
+        _ = extension.hass
+
+
+def test_requires_hass_functions_not_registered_without_hass() -> None:
+    """Test that functions requiring hass are not registered when hass is None."""
+    # Create an environment without hass
+    env = TemplateEnvironment(None)
+
+    # Create a test function
+    def test_func() -> str:
+        return "test"
+
+    # Create extension with a function that requires hass
+    extension = BaseTemplateExtension(
+        env,
+        functions=[
+            TemplateFunction(
+                "test_func",
+                test_func,
+                as_global=True,
+                requires_hass=True,
+            ),
+        ],
+    )
+
+    # Function should not be registered
+    assert "test_func" not in env.globals
+    assert extension is not None  # Extension is created but function not registered
+
+
+def test_requires_hass_false_functions_registered_without_hass() -> None:
+    """Test that functions not requiring hass are registered even when hass is None."""
+    # Create an environment without hass
+    env = TemplateEnvironment(None)
+
+    # Create a test function
+    def test_func() -> str:
+        return "test"
+
+    # Create extension with a function that does not require hass
+    extension = BaseTemplateExtension(
+        env,
+        functions=[
+            TemplateFunction(
+                "test_func",
+                test_func,
+                as_global=True,
+                requires_hass=False,  # Explicitly False (default)
+            ),
+        ],
+    )
+
+    # Function should be registered
+    assert "test_func" in env.globals
+    assert extension is not None
+
+
+def test_limited_ok_functions_not_registered_in_limited_env() -> None:
+    """Test that functions with limited_ok=False are not registered in limited env."""
+    # Create a limited environment without hass
+    env = TemplateEnvironment(None, limited=True)
+
+    # Create test functions
+    def allowed_func() -> str:
+        return "allowed"
+
+    def restricted_func() -> str:
+        return "restricted"
+
+    # Create extension with both types of functions
+    extension = BaseTemplateExtension(
+        env,
+        functions=[
+            TemplateFunction(
+                "allowed_func",
+                allowed_func,
+                as_global=True,
+                limited_ok=True,  # Allowed in limited environments
+            ),
+            TemplateFunction(
+                "restricted_func",
+                restricted_func,
+                as_global=True,
+                limited_ok=False,  # Not allowed in limited environments
+            ),
+        ],
+    )
+
+    # Only the allowed function should be registered
+    assert "allowed_func" in env.globals
+    assert "restricted_func" not in env.globals
+    assert extension is not None
+
+
+def test_limited_ok_true_functions_registered_in_limited_env() -> None:
+    """Test that functions with limited_ok=True are registered in limited env."""
+    # Create a limited environment without hass
+    env = TemplateEnvironment(None, limited=True)
+
+    # Create a test function
+    def test_func() -> str:
+        return "test"
+
+    # Create extension with a function allowed in limited environments
+    extension = BaseTemplateExtension(
+        env,
+        functions=[
+            TemplateFunction(
+                "test_func",
+                test_func,
+                as_global=True,
+                limited_ok=True,  # Default is True
+            ),
+        ],
+    )
+
+    # Function should be registered
+    assert "test_func" in env.globals
+    assert extension is not None
+
+
+def test_function_registered_as_global() -> None:
+    """Test that functions can be registered as globals."""
+    env = TemplateEnvironment(None)
+
+    def test_func() -> str:
+        return "global"
+
+    extension = BaseTemplateExtension(
+        env,
+        functions=[
+            TemplateFunction(
+                "test_func",
+                test_func,
+                as_global=True,
+            ),
+        ],
+    )
+
+    # Function should be registered as a global
+    assert "test_func" in env.globals
+    assert env.globals["test_func"] is test_func
+    assert extension is not None
+
+
+def test_function_registered_as_filter() -> None:
+    """Test that functions can be registered as filters."""
+    env = TemplateEnvironment(None)
+
+    def test_filter(value: str) -> str:
+        return f"filtered_{value}"
+
+    extension = BaseTemplateExtension(
+        env,
+        functions=[
+            TemplateFunction(
+                "test_filter",
+                test_filter,
+                as_filter=True,
+            ),
+        ],
+    )
+
+    # Function should be registered as a filter
+    assert "test_filter" in env.filters
+    assert env.filters["test_filter"] is test_filter
+    # Should not be in globals since as_global=False
+    assert "test_filter" not in env.globals
+    assert extension is not None
+
+
+def test_function_registered_as_test() -> None:
+    """Test that functions can be registered as tests."""
+    env = TemplateEnvironment(None)
+
+    def test_check(value: str) -> bool:
+        return value == "test"
+
+    extension = BaseTemplateExtension(
+        env,
+        functions=[
+            TemplateFunction(
+                "test_check",
+                test_check,
+                as_test=True,
+            ),
+        ],
+    )
+
+    # Function should be registered as a test
+    assert "test_check" in env.tests
+    assert env.tests["test_check"] is test_check
+    # Should not be in globals or filters
+    assert "test_check" not in env.globals
+    assert "test_check" not in env.filters
+    assert extension is not None
+
+
+def test_function_registered_as_multiple_types() -> None:
+    """Test that functions can be registered as multiple types simultaneously."""
+    env = TemplateEnvironment(None)
+
+    def multi_func(value: str = "default") -> str:
+        return f"multi_{value}"
+
+    extension = BaseTemplateExtension(
+        env,
+        functions=[
+            TemplateFunction(
+                "multi_func",
+                multi_func,
+                as_global=True,
+                as_filter=True,
+                as_test=True,
+            ),
+        ],
+    )
+
+    # Function should be registered in all three places
+    assert "multi_func" in env.globals
+    assert env.globals["multi_func"] is multi_func
+    assert "multi_func" in env.filters
+    assert env.filters["multi_func"] is multi_func
+    assert "multi_func" in env.tests
+    assert env.tests["multi_func"] is multi_func
+    assert extension is not None
+
+
+def test_multiple_functions_registered() -> None:
+    """Test that multiple functions can be registered at once."""
+    env = TemplateEnvironment(None)
+
+    def func1() -> str:
+        return "one"
+
+    def func2() -> str:
+        return "two"
+
+    def func3() -> str:
+        return "three"
+
+    extension = BaseTemplateExtension(
+        env,
+        functions=[
+            TemplateFunction("func1", func1, as_global=True),
+            TemplateFunction("func2", func2, as_filter=True),
+            TemplateFunction("func3", func3, as_test=True),
+        ],
+    )
+
+    # All functions should be registered in their respective places
+    assert "func1" in env.globals
+    assert "func2" in env.filters
+    assert "func3" in env.tests
+    assert extension is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR enhances the template extension base infrastructure to better support Home Assistant-dependent template functions. It adds two new features to `TemplateFunction` and `BaseTemplateExtension`:

1. **`requires_hass` parameter**: Allows template functions to declare they need a Home Assistant instance, automatically skipping registration when `hass` is not available
2. **`hass` property**: Provides clean, type-safe access to the Home Assistant instance with proper error handling

These changes prepare the foundation for refactoring template functions (like `areas()`, `devices()`, `floors()`, etc.) from inline registrations into proper Jinja2 extensions, improving code organization and maintainability.

### Key additions:

- Added `requires_hass: bool = False` field to `TemplateFunction` dataclass
- Added automatic filtering in `BaseTemplateExtension.__init__` to skip `requires_hass=True` functions when `hass is None`
- Added `hass` property to `BaseTemplateExtension` that raises `RuntimeError` with helpful message when hass is unavailable
- Tests!

This is a non-breaking change that maintains backward compatibility while enabling cleaner future refactoring.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
