### PR TITLE
Exempt `wsproto` from license check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ on:
         type: boolean
 
 env:
-  CACHE_VERSION: 1
+  CACHE_VERSION: 2
   UV_CACHE_VERSION: 1
   MYPY_CACHE_VERSION: 1
   HA_SHORT_VERSION: "2025.12"

--- a/script/licenses.py
+++ b/script/licenses.py
@@ -203,6 +203,7 @@ EXCEPTIONS = {
     "sharp_aquos_rc",  # https://github.com/jmoore987/sharp_aquos_rc/pull/14
     "tapsaff",  # https://github.com/bazwilliams/python-taps-aff/pull/5
     "ujson",  # https://github.com/ultrajson/ultrajson/blob/main/LICENSE.txt
+    "wsproto",  # https://github.com/python-hyper/wsproto/pull/194
 }
 
 # fmt: off


### PR DESCRIPTION
## Proposed change

This (temporarily) exempts `wsproto` from the license check until the MIT license identifier is added back with:
- https://github.com/python-hyper/wsproto/pull/194

The CI cache version is also bumped, as this isn't a dependency we pin ourselves.
(it was knocked down to `1` a few weeks ago with https://github.com/home-assistant/core/pull/154988, so bumping to `2`).

The currently cached CI venv still uses an older library version from 2022: [1.2.0](https://github.com/python-hyper/wsproto/releases/tag/1.2.0).
So, we've not started seeing the failures on `dev`, yet. See the sections below where the issue appeared.

### Background

The MIT license is still present: [python-hyper/wsproto/LICENSE](https://github.com/python-hyper/wsproto/blob/main/LICENSE), but both the (incorrect) identifier and (correct) classifier were dropped when moving from `setup.py` to `pyproject.toml` with https://github.com/python-hyper/wsproto/commit/d7ed47fd63d03a536e1f2404aa179110b668ec51, released with [v1.3.0](https://github.com/python-hyper/wsproto/releases/tag/1.3.0).

### Spotted in

This failure was spotted here:
- specifically in this run: https://github.com/home-assistant/core/actions/runs/19281627214/job/55133800958?pr=156414#step:7:29
- in this PR: https://github.com/home-assistant/core/pull/156414

### Usage in HA

This transitive dependency is required by three integrations: `ambient_network`, `tami4`, and `yalexs_ble`.

<details><summary>Dependency usage (CLICK TO OPEN)</summary>
<p>

```java
aioambient==2024.8.0  # ambient_network integration
├── python-engineio [required: >=3.13.1,<5.0.0, installed: 4.12.3]
│   └── simple-websocket [required: >=0.10.0, installed: 1.1.0]
│       └── wsproto [required: Any, installed: 1.3.0]
│           └── h11 [required: >=0.16.0,<1, installed: 0.16.0]
├── python-socketio [required: >=4.6,<6.0, installed: 5.14.3]
│   ├── bidict [required: >=0.21.0, installed: 0.23.1]
│   └── python-engineio [required: >=4.11.0, installed: 4.12.3]
│       └── simple-websocket [required: >=0.10.0, installed: 1.1.0]
│           └── wsproto [required: Any, installed: 1.3.0]
│               └── h11 [required: >=0.16.0,<1, installed: 0.16.0]
└── [...]

Tami4EdgeAPI==3.0  # tami4 integration
├── PyPasser [required: Any, installed: 0.0.5]
│   ├── [...]
│   └── selenium [required: Any, installed: 4.38.0]
│       ├── trio-websocket [required: >=0.12.2,<1.0, installed: 0.12.2]
│       │   ├── [...]
│       │   └── wsproto [required: >=0.14, installed: 1.3.0]
│       │       └── h11 [required: >=0.16.0,<1, installed: 0.16.0]
│       └── [...]
└── [...]

yalexs==9.2.0  # yalexs_ble integration
├── python-socketio [required: >=5.11.3, installed: 5.14.3]
│   ├── bidict [required: >=0.21.0, installed: 0.23.1]
│   └── python-engineio [required: >=4.11.0, installed: 4.12.3]
│       └── simple-websocket [required: >=0.10.0, installed: 1.1.0]
│           └── wsproto [required: Any, installed: 1.3.0]
│               └── h11 [required: >=0.16.0,<1, installed: 0.16.0]
└── [...]
```

</p>
</details> 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
