### PR TITLE
Prevent sensor updates caused by fluctuating “last seen” timestamps in Xbox integration

### DIFF
--- a/homeassistant/components/xbox/coordinator.py
+++ b/homeassistant/components/xbox/coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta
 from http import HTTPStatus
 import logging
 
@@ -243,7 +243,7 @@ class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
                         translation_key="request_exception",
                     ) from e
                 title_data[person.xuid] = title.titles[0]
-
+            person.last_seen_date_time_utc = self.last_seen_timestamp(person)
         if (
             self.current_friends - (new_friends := set(presence_data))
             or not self.current_friends
@@ -252,6 +252,22 @@ class XboxUpdateCoordinator(DataUpdateCoordinator[XboxData]):
         self.current_friends = new_friends
 
         return XboxData(new_console_data, presence_data, title_data)
+
+    def last_seen_timestamp(self, person: Person) -> datetime | None:
+        """Returns the most recent of two timestamps."""
+
+        # The Xbox API constantly fluctuates the "last seen" timestamp between two close values,
+        # causing unnecessary updates. We only accept the most recent one as valild to prevent this.
+        if not (prev_data := self.data.presence.get(person.xuid)):
+            return person.last_seen_date_time_utc
+
+        prev_dt = prev_data.last_seen_date_time_utc
+        cur_dt = person.last_seen_date_time_utc
+
+        if prev_dt and cur_dt:
+            return max(prev_dt, cur_dt)
+
+        return cur_dt
 
     def remove_stale_devices(self, xuids: set[str]) -> None:
         """Remove stale devices from registry."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The last seen value returned by the Xbox integration fluctuates between 2 date values, mostly some seconds apart, sometimes several minutes. This results in sensor updates constantly being triggered. To prevent this, we consider only the newer of two values as a valid last seen timestamp

I suggest to add this to the **2025.11.2** release

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #156144
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
