### PR TITLE
Extend base jinja2 extension with limited template errors

### DIFF
--- a/tests/helpers/template/extensions/test_base.py
+++ b/tests/helpers/template/extensions/test_base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.template import TemplateEnvironment
 from homeassistant.helpers.template.extensions.base import (
     BaseTemplateExtension,
@@ -123,7 +124,7 @@ def test_limited_ok_functions_not_registered_in_limited_env() -> None:
     # The restricted function should be registered but raise TemplateError
     assert "restricted_func" in env.globals
     with pytest.raises(
-        Exception,  # TemplateError
+        TemplateError,
         match="Use of 'restricted_func' is not supported in limited templates",
     ):
         env.globals["restricted_func"]()

--- a/tests/helpers/template/extensions/test_base.py
+++ b/tests/helpers/template/extensions/test_base.py
@@ -86,7 +86,7 @@ def test_requires_hass_false_functions_registered_without_hass() -> None:
 
 
 def test_limited_ok_functions_not_registered_in_limited_env() -> None:
-    """Test that functions with limited_ok=False are not registered in limited env."""
+    """Test that functions with limited_ok=False raise error in limited env."""
     # Create a limited environment without hass
     env = TemplateEnvironment(None, limited=True)
 
@@ -116,9 +116,18 @@ def test_limited_ok_functions_not_registered_in_limited_env() -> None:
         ],
     )
 
-    # Only the allowed function should be registered
+    # The allowed function should be registered and work
     assert "allowed_func" in env.globals
-    assert "restricted_func" not in env.globals
+    assert env.globals["allowed_func"]() == "allowed"
+
+    # The restricted function should be registered but raise TemplateError
+    assert "restricted_func" in env.globals
+    with pytest.raises(
+        Exception,  # TemplateError
+        match="Use of 'restricted_func' is not supported in limited templates",
+    ):
+        env.globals["restricted_func"]()
+
     assert extension is not None
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

his PR enhances the base Jinja2 template extension to provide better error messages when restricted functions are used in limited template environments.

Previously, when a template function had `limited_ok=False`, it would simply not be registered in limited environments, resulting in generic "undefined" errors when users tried to use them. This differs from the behavior of limited template functions that are defined the old fashioned way, which did throw this.

This PR aligns the old behavior in the newer extension approach; and is a needed piece before I can start migrating template methods that rely on this functionality.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
