### PR TITLE
Fix velux scenes (naming and unique ids)

### DIFF
--- a/homeassistant/components/velux/quality_scale.yaml
+++ b/homeassistant/components/velux/quality_scale.yaml
@@ -19,9 +19,7 @@ rules:
     status: todo
     comment: subscribe is ok, unsubscribe needs to be added
   entity-unique-id: done
-  has-entity-name:
-    status: todo
-    comment: scenes need fixing
+  has-entity-name: done
   runtime-data: done
   test-before-configure: done
   test-before-setup:

--- a/homeassistant/components/velux/scene.py
+++ b/homeassistant/components/velux/scene.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
+from pyvlx import Scene as PyVLXScene
+
 from homeassistant.components.scene import Scene
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import VeluxConfigEntry
+from .const import DOMAIN
 
 PARALLEL_UPDATES = 1
 
@@ -20,22 +24,32 @@ async def async_setup_entry(
 ) -> None:
     """Set up the scenes for Velux platform."""
     pyvlx = config_entry.runtime_data
-
-    entities = [VeluxScene(scene) for scene in pyvlx.scenes]
-    async_add_entities(entities)
+    async_add_entities(
+        [VeluxScene(config_entry.entry_id, scene) for scene in pyvlx.scenes]
+    )
 
 
 class VeluxScene(Scene):
     """Representation of a Velux scene."""
 
-    def __init__(self, scene):
+    _attr_has_entity_name = True
+
+    # Note: there's currently no code to update the scenes dynamically if changed in
+    # the gateway. They're only loaded on integration setup (they're probably not
+    # used heavily anyway since it's a pain to set them up in the gateway and so
+    # much easier to use HA scenes).
+
+    def __init__(self, config_entry_id: str, scene: PyVLXScene) -> None:
         """Init velux scene."""
         self.scene = scene
+        # Renaming scenes in gateway keeps scene_id stable, we can use it as unique_id
+        self._attr_unique_id = f"{config_entry_id}_scene_{scene.scene_id}"
+        self._attr_name = scene.name
 
-    @property
-    def name(self):
-        """Return the name of the scene."""
-        return self.scene.name
+        # Associate scenes with the gateway device (where they are stored)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"gateway_{config_entry_id}")},
+        )
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""

--- a/tests/components/velux/conftest.py
+++ b/tests/components/velux/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from homeassistant.components.velux import DOMAIN
 from homeassistant.components.velux.binary_sensor import Window
 from homeassistant.components.velux.light import LighteningDevice
+from homeassistant.components.velux.scene import PyVLXScene as Scene
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 
@@ -91,10 +92,23 @@ def mock_light() -> AsyncMock:
 
 
 @pytest.fixture
-def mock_pyvlx(mock_window: MagicMock, mock_light: MagicMock) -> Generator[MagicMock]:
+def mock_scene() -> AsyncMock:
+    """Create a mock Velux scene."""
+    scene = AsyncMock(spec=Scene, autospec=True)
+    scene.name = "Test Scene"
+    scene.scene_id = "1234"
+    scene.scene = AsyncMock()
+    return scene
+
+
+@pytest.fixture
+def mock_pyvlx(
+    mock_window: MagicMock, mock_light: MagicMock, mock_scene: AsyncMock
+) -> Generator[MagicMock]:
     """Create the library mock and patch PyVLX."""
     pyvlx = MagicMock()
     pyvlx.nodes = [mock_window, mock_light]
+    pyvlx.scenes = [mock_scene]
     pyvlx.load_scenes = AsyncMock()
     pyvlx.load_nodes = AsyncMock()
     pyvlx.disconnect = AsyncMock()

--- a/tests/components/velux/snapshots/test_scene.ambr
+++ b/tests/components/velux/snapshots/test_scene.ambr
@@ -1,0 +1,49 @@
+# serializer version: 1
+# name: test_scene_snapshot[scene.klf_200_gateway_test_scene-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'scene',
+    'entity_category': None,
+    'entity_id': 'scene.klf_200_gateway_test_scene',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Test Scene',
+    'platform': 'velux',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_entry_id_scene_1234',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_scene_snapshot[scene.klf_200_gateway_test_scene-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'KLF 200 Gateway Test Scene',
+    }),
+    'context': <ANY>,
+    'entity_id': 'scene.klf_200_gateway_test_scene',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/velux/test_scene.py
+++ b/tests/components/velux/test_scene.py
@@ -1,0 +1,68 @@
+"""Test Velux scene entities."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN, SERVICE_TURN_ON
+from homeassistant.components.velux import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import AsyncMock, MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture
+def platform() -> Platform:
+    """Fixture to specify platform to test."""
+    return Platform.SCENE
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_scene_snapshot(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the scene entity (registry + state)."""
+    await snapshot_platform(
+        hass,
+        entity_registry,
+        snapshot,
+        mock_config_entry.entry_id,
+    )
+
+    # Get the scene entity setup and test device association
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    assert len(entity_entries) == 1
+    entry = entity_entries[0]
+
+    assert entry.device_id is not None
+    device_entry = device_registry.async_get(entry.device_id)
+    assert device_entry is not None
+    # Scenes are associated with the gateway device
+    assert (DOMAIN, f"gateway_{mock_config_entry.entry_id}") in device_entry.identifiers
+    assert device_entry.via_device_id is None
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_scene_activation(
+    hass: HomeAssistant,
+    mock_scene: AsyncMock,
+) -> None:
+    """Test successful scene activation."""
+
+    # activate the scene via service call
+    await hass.services.async_call(
+        SCENE_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "scene.klf_200_gateway_test_scene"},
+        blocking=True,
+    )
+
+    # Verify the run method was called
+    mock_scene.run.assert_awaited_once_with(wait_for_completion=False)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds `has_entity_name=True` to Velux scenes and creates unique ids for scenes. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
