### PR TITLE
Ensure backwards compatibility for new-style configs in old triggers and conditions

### DIFF
--- a/homeassistant/helpers/automation.py
+++ b/homeassistant/helpers/automation.py
@@ -50,3 +50,29 @@ def move_top_level_schema_fields_to_options(
             options[key] = config.pop(key)
 
     return config
+
+
+def move_options_fields_to_top_level(
+    config: ConfigType, base_schema: vol.Schema
+) -> ConfigType:
+    """Move options fields to top-level.
+
+    This function is used to provide backwards compatibility for new-style configs.
+    If options field does not exist or is not a dict, the config is returned as-is.
+    """
+    options = config.get(CONF_OPTIONS)
+
+    if not isinstance(options, dict):
+        return config
+
+    new_config: ConfigType = config.copy()
+    new_config.pop(CONF_OPTIONS)
+
+    try:
+        new_config = base_schema(new_config)
+    except vol.Invalid:
+        return config
+
+    new_config.update(options)
+
+    return new_config

--- a/homeassistant/helpers/automation.py
+++ b/homeassistant/helpers/automation.py
@@ -34,7 +34,8 @@ def move_top_level_schema_fields_to_options(
 ) -> ConfigType:
     """Move top-level fields to options.
 
-    This function is used to help migrating old-style configs to new-style configs.
+    This function is used to help migrating old-style configs to new-style configs
+    for triggers and conditions.
     If options is already present, the config is returned as-is.
     """
     if CONF_OPTIONS in config:
@@ -57,8 +58,17 @@ def move_options_fields_to_top_level(
 ) -> ConfigType:
     """Move options fields to top-level.
 
-    This function is used to provide backwards compatibility for new-style configs.
-    If options field does not exist or is not a dict, the config is returned as-is.
+    This function is used to provide backwards compatibility for new-style configs
+    for triggers and conditions.
+
+    The config is returned as-is, if any of the following is true:
+    - options is not present
+    - options is not a dict
+    - the config with options field removed fails the base_schema validation (most
+    likely due to additional keys being present)
+
+    Those conditions are checked to make it so that only configs that have the structure
+    of the new-style are modified, whereas valid old-style configs are preserved.
     """
     options = config.get(CONF_OPTIONS)
 

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -206,7 +206,13 @@ async def _register_condition_platform(
             _LOGGER.exception("Error while notifying condition platform listener")
 
 
-_CONDITION_SCHEMA = cv.CONDITION_BASE_FULL_SCHEMA.extend(
+_CONDITION_BASE_SCHEMA = vol.Schema(
+    {
+        **cv.CONDITION_BASE_SCHEMA,
+        vol.Required(CONF_CONDITION): str,
+    }
+)
+_CONDITION_SCHEMA = _CONDITION_BASE_SCHEMA.extend(
     {
         vol.Optional(CONF_OPTIONS): object,
         vol.Optional(CONF_TARGET): cv.TARGET_FIELDS,
@@ -1046,7 +1052,7 @@ async def async_validate_condition_config(
             raise vol.Invalid(f"Invalid condition '{condition_key}' specified")
         return await condition_class.async_validate_complete_config(hass, config)
 
-    config = move_options_fields_to_top_level(config, cv.CONDITION_BASE_FULL_SCHEMA)
+    config = move_options_fields_to_top_level(config, _CONDITION_BASE_SCHEMA)
 
     if condition_key in ("numeric_state", "state"):
         validator = cast(

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1532,6 +1532,13 @@ CONDITION_BASE_SCHEMA: VolDictType = {
     vol.Optional(CONF_ENABLED): vol.Any(boolean, template),
 }
 
+CONDITION_BASE_FULL_SCHEMA = vol.Schema(
+    {
+        **CONDITION_BASE_SCHEMA,
+        vol.Required(CONF_CONDITION): str,
+    }
+)
+
 NUMERIC_STATE_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1532,13 +1532,6 @@ CONDITION_BASE_SCHEMA: VolDictType = {
     vol.Optional(CONF_ENABLED): vol.Any(boolean, template),
 }
 
-CONDITION_BASE_FULL_SCHEMA = vol.Schema(
-    {
-        **CONDITION_BASE_SCHEMA,
-        vol.Required(CONF_CONDITION): str,
-    }
-)
-
 NUMERIC_STATE_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -46,7 +46,11 @@ from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.yaml import load_yaml_dict
 
 from . import config_validation as cv, selector
-from .automation import get_absolute_description_key, get_relative_description_key
+from .automation import (
+    get_absolute_description_key,
+    get_relative_description_key,
+    move_options_fields_to_top_level,
+)
 from .integration_platform import async_process_integration_platforms
 from .selector import TargetSelector
 from .template import Template
@@ -497,8 +501,10 @@ async def async_validate_trigger_config(
                 raise vol.Invalid(f"Invalid trigger '{trigger_key}' specified")
             conf = await trigger.async_validate_complete_config(hass, conf)
         elif hasattr(platform, "async_validate_trigger_config"):
+            conf = move_options_fields_to_top_level(conf, cv.TRIGGER_BASE_SCHEMA)
             conf = await platform.async_validate_trigger_config(hass, conf)
         else:
+            conf = move_options_fields_to_top_level(conf, cv.TRIGGER_BASE_SCHEMA)
             conf = platform.TRIGGER_SCHEMA(conf)
         config.append(conf)
     return config

--- a/tests/helpers/test_automation.py
+++ b/tests/helpers/test_automation.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 from homeassistant.helpers.automation import (
     get_absolute_description_key,
     get_relative_description_key,
+    move_options_fields_to_top_level,
     move_top_level_schema_fields_to_options,
 )
 
@@ -106,3 +107,74 @@ async def test_move_schema_fields_to_options(
     assert (
         move_top_level_schema_fields_to_options(config, schema_dict) == expected_config
     )
+
+
+@pytest.mark.parametrize(
+    ("config", "expected_config"),
+    [
+        (
+            {
+                "platform": "test",
+                "options": {
+                    "entity": "sensor.test",
+                    "from": "open",
+                    "to": "closed",
+                    "for": {"hours": 1},
+                },
+            },
+            {
+                "platform": "test",
+                "entity": "sensor.test",
+                "from": "open",
+                "to": "closed",
+                "for": {"hours": 1},
+            },
+        ),
+        (
+            {
+                "platform": "test",
+                "entity": "sensor.test",
+                "from": "open",
+                "to": "closed",
+                "for": {"hours": 1},
+            },
+            {
+                "platform": "test",
+                "entity": "sensor.test",
+                "from": "open",
+                "to": "closed",
+                "for": {"hours": 1},
+            },
+        ),
+        (
+            {
+                "platform": "test",
+                "options": 456,
+            },
+            {
+                "platform": "test",
+                "options": 456,
+            },
+        ),
+        (
+            {
+                "platform": "test",
+                "options": {
+                    "entity": "sensor.test",
+                },
+                "extra_field": "extra_value",
+            },
+            {
+                "platform": "test",
+                "options": {
+                    "entity": "sensor.test",
+                },
+                "extra_field": "extra_value",
+            },
+        ),
+    ],
+)
+async def test_move_options_fields_to_top_level(config, expected_config) -> None:
+    """Test moving options fields to top-level."""
+    base_schema = vol.Schema({vol.Required("platform"): str})
+    assert move_options_fields_to_top_level(config, base_schema) == expected_config

--- a/tests/helpers/test_automation.py
+++ b/tests/helpers/test_automation.py
@@ -177,4 +177,6 @@ async def test_move_schema_fields_to_options(
 async def test_move_options_fields_to_top_level(config, expected_config) -> None:
     """Test moving options fields to top-level."""
     base_schema = vol.Schema({vol.Required("platform"): str})
+    original_config = config.copy()
     assert move_options_fields_to_top_level(config, base_schema) == expected_config
+    assert config == original_config  # Ensure original config is not modified

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -2170,7 +2170,7 @@ async def test_platform_multiple_conditions(hass: HomeAssistant) -> None:
         await condition.async_from_config(hass, config_3)
 
 
-async def test_platform_migrate_trigger(hass: HomeAssistant) -> None:
+async def test_platform_migrate_condition(hass: HomeAssistant) -> None:
     """Test a condition platform with a migration."""
 
     OPTIONS_SCHEMA_DICT = {
@@ -2236,6 +2236,29 @@ async def test_platform_migrate_trigger(hass: HomeAssistant) -> None:
         await async_validate_condition_config(hass, config_2_migrated)
         == config_2_migrated
     )
+
+
+async def test_platform_backwards_compatibility_for_new_style_configs(
+    hass: HomeAssistant,
+) -> None:
+    """Test backwards compatibility for old-style conditions with new-style configs."""
+    config_old_style = {
+        "condition": "numeric_state",
+        "entity_id": ["sensor.test"],
+        "above": 50,
+    }
+    result = await async_validate_condition_config(hass, config_old_style)
+    assert result == config_old_style
+
+    config_new_style = {
+        "condition": "numeric_state",
+        "options": {
+            "entity_id": ["sensor.test"],
+            "above": 50,
+        },
+    }
+    result = await async_validate_condition_config(hass, config_new_style)
+    assert result == config_old_style
 
 
 @pytest.mark.parametrize("enabled_value", [True, "{{ 1 == 1 }}"])

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -18,7 +18,7 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import trigger
+from homeassistant.helpers import config_validation as cv, trigger
 from homeassistant.helpers.automation import move_top_level_schema_fields_to_options
 from homeassistant.helpers.trigger import (
     DATA_PLUGGABLE_ACTIONS,
@@ -605,6 +605,35 @@ async def test_platform_migrate_trigger(hass: HomeAssistant) -> None:
     assert await async_validate_trigger_config(hass, config_2) == config_4
     assert await async_validate_trigger_config(hass, config_3) == config_3
     assert await async_validate_trigger_config(hass, config_4) == config_4
+
+
+async def test_platform_backwards_compatibility_for_new_style_configs(
+    hass: HomeAssistant,
+) -> None:
+    """Test backwards compatibility for old-style triggers with new-style configs."""
+
+    class MockTriggerPlatform:
+        """Mock trigger platform."""
+
+        TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
+            {
+                vol.Required("option_1"): str,
+                vol.Optional("option_2"): int,
+            }
+        )
+
+    mock_integration(hass, MockModule("test"))
+    mock_platform(hass, "test.trigger", MockTriggerPlatform())
+
+    config_old_style = [{"platform": "test", "option_1": "value_1", "option_2": 2}]
+    result = await async_validate_trigger_config(hass, config_old_style)
+    assert result == config_old_style
+
+    config_new_style = [
+        {"platform": "test", "options": {"option_1": "value_1", "option_2": 2}}
+    ]
+    result = await async_validate_trigger_config(hass, config_new_style)
+    assert result == config_old_style
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure backwards compatibility for new-style configs in old triggers and conditions.

The goal is to achieve greater uniformity in how the config of all triggers and conditions is structured.

#151314 and #152635 introduced an `options` field to new triggers and conditions.
It also added a mechanism to allow us to migrate old triggers and conditions into new-style, while keeping backwards compatibility with old automations still using the old-style configs.

This PR adds compatibility in the other direction. It allows to use new-style configs with the old-style (not yet migrated) triggers and conditions. This is important as not all our triggers and conditions are migrated at this point (in fact huge majority is not), but also because of the custom components, that we don't have direct way to migrate ourselves, but we do want to support also.

As an example, what this will allow is to use not just the old-style:
```
triggers:
  - id: sunrise
    trigger: sun
    event: sunrise
    offset: "1:00:00"
```
but also the new-style:
```
triggers:
  - id: sunrise
    trigger: sun
    options:
      event: sunrise
      offset: "1:00:00"
```
with the old not yet migrated `sun` trigger.

In the long run we want to migrate all the triggers and conditions to the new API. Once we migrate all of the core ones and provide the deprecation period for the custom component authors to do the same, we will be able to completely remove this code path.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #153818
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
