### PR TITLE
Fix onkyo tests opening sockets

### DIFF
--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -32,7 +32,11 @@ def _receiver_display_name(receiver_info: ReceiverInfo) -> str:
     return f"{receiver_info.model_name} ({receiver_info.host})"
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
+@pytest.fixture(autouse=True)
+def mock_setup_entry(mock_setup_entry) -> None:
+    """Use async_setup_entry fixture in all tests."""
+
+
 async def test_manual(hass: HomeAssistant) -> None:
     """Test successful manual."""
     result = await hass.config_entries.flow.async_init(
@@ -79,7 +83,6 @@ async def test_manual(hass: HomeAssistant) -> None:
         (mock_discovery([RECEIVER_INFO]), "cannot_connect"),
     ],
 )
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_manual_recoverable_error(
     hass: HomeAssistant, mock_discovery: AbstractContextManager, error_reason: str
 ) -> None:
@@ -129,7 +132,6 @@ async def test_manual_recoverable_error(
     assert result["title"] == RECEIVER_INFO_2.model_name
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_manual_error(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -158,7 +160,6 @@ async def test_manual_error(
     assert result["reason"] == "already_configured"
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_eiscp_discovery(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -214,7 +215,6 @@ async def test_eiscp_discovery(
         (mock_discovery([RECEIVER_INFO]), "no_devices_found"),
     ],
 )
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_eiscp_discovery_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -291,7 +291,6 @@ async def test_eiscp_discovery_replace_ignored_entry(
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_ssdp_discovery(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -343,7 +342,6 @@ async def test_ssdp_discovery(
         (f"http://{RECEIVER_INFO.host}:8080", nullcontext(), "already_configured"),
     ],
 )
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_ssdp_discovery_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -371,7 +369,6 @@ async def test_ssdp_discovery_error(
     assert result["reason"] == error_reason
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_configure(hass: HomeAssistant) -> None:
     """Test receiver configure."""
     result = await hass.config_entries.flow.async_init(
@@ -442,7 +439,6 @@ async def test_configure(hass: HomeAssistant) -> None:
     }
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_reconfigure(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -479,7 +475,6 @@ async def test_reconfigure(
         assert mock_config_entry.options[option] == option_value
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_reconfigure_error(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -504,7 +499,6 @@ async def test_reconfigure_error(
     assert mock_config_entry.unique_id == old_unique_id
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
 @pytest.mark.parametrize(
     "ignore_missing_translations",
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
