### PR TITLE
Reduce nested loops in SmartThings integration

### DIFF
--- a/homeassistant/components/smartthings/binary_sensor.py
+++ b/homeassistant/components/smartthings/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Generator, Iterable
 from dataclasses import dataclass
 
 from pysmartthings import Attribute, Capability, Category, SmartThings, Status
@@ -203,17 +203,26 @@ async def async_setup_entry(
             entry_data.client,
             device,
             description,
-            capability,
+            sensor_capability,
             attribute,
             component,
         )
+        # iterate over all devices for this config entry
         for device in entry_data.devices.values()
-        for capability, attribute_map in CAPABILITY_TO_SENSORS.items()
-        for attribute, description in attribute_map.items()
-        for component in device.status
+        # iterate over components on the device and their reported capabilities
+        for component, device_capabilities in device.status.items()
+        # iterate over all supported SmartThings capability -> sensor mappings
+        for sensor_capability, sensor_attributes in CAPABILITY_TO_SENSORS.items()
+        # only consider capabilities that the device actually reports for this component
+        if sensor_capability in device_capabilities
+        # iterate over attributes and their entity descriptions for the capability
+        for attribute, description in sensor_attributes.items()
+        # apply final filters:
+        #  - component must be the main component or have a translation mapping
+        #  - optional exists_fn must approve the entity for this component/status
+        #  - optional category filter must match the device's main component category
         if (
-            capability in device.status[component]
-            and (
+            (
                 component == MAIN
                 or (
                     description.component_translation_key is not None

--- a/homeassistant/components/smartthings/binary_sensor.py
+++ b/homeassistant/components/smartthings/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from pysmartthings import Attribute, Capability, Category, SmartThings, Status

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Generator, Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, cast
@@ -1129,6 +1129,28 @@ UNITS = {
 }
 
 
+def _iter_sensor_candidates(
+    devices: Iterable[FullDevice],
+) -> Generator[
+    tuple[FullDevice, str, Capability, Attribute, SmartThingsSensorEntityDescription]
+]:
+    return (
+        (device, component, capability, attribute, description)
+        # iterate over all devices for this config entry
+        for device in devices
+        # iterate over components on the device and their reported capabilities
+        for component, capabilities in device.status.items()
+        # iterate over all supported SmartThings capability -> sensor mappings
+        for capability, attributes in CAPABILITY_TO_SENSORS.items()
+        # only consider capabilities that the device actually reports for this component
+        if capability in capabilities
+        # iterate over attributes and their entity descriptions for the capability
+        for attribute, descriptions in attributes.items()
+        # iterate over all descriptions for the attribute
+        for description in descriptions
+    )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: SmartThingsConfigEntry,
@@ -1139,80 +1161,73 @@ async def async_setup_entry(
     entities = []
 
     entity_registry = er.async_get(hass)
+    for (
+        device,
+        component,
+        capability,
+        attribute,
+        description,
+    ) in _iter_sensor_candidates(entry_data.devices.values()):
+        # Skip sensors based on capability ignore list
+        if description.capability_ignore_list and any(
+            all(capability in device.status[MAIN] for capability in capability_list)
+            for capability_list in description.capability_ignore_list
+        ):
+            continue
 
-    for device in entry_data.devices.values():  # pylint: disable=too-many-nested-blocks
-        for capability, attributes in CAPABILITY_TO_SENSORS.items():
-            for component, capabilities in device.status.items():
-                if capability in capabilities:
-                    for attribute, descriptions in attributes.items():
-                        for description in descriptions:
-                            if (
-                                (
-                                    not description.capability_ignore_list
-                                    or not any(
-                                        all(
-                                            capability in device.status[MAIN]
-                                            for capability in capability_list
-                                        )
-                                        for capability_list in description.capability_ignore_list
-                                    )
-                                )
-                                and (
-                                    not description.exists_fn
-                                    or (
-                                        component == MAIN
-                                        and description.exists_fn(
-                                            device.status[MAIN][capability][attribute]
-                                        )
-                                    )
-                                )
-                                and (
-                                    component == MAIN
-                                    or (
-                                        description.component_fn is not None
-                                        and description.component_fn(component)
-                                    )
-                                )
-                            ):
-                                if (
-                                    description.deprecated
-                                    and (
-                                        deprecation_info := description.deprecated(
-                                            device.status[MAIN]
-                                        )
-                                    )
-                                    is not None
-                                ):
-                                    version, reason = deprecation_info
-                                    if deprecate_entity(
-                                        hass,
-                                        entity_registry,
-                                        SENSOR_DOMAIN,
-                                        f"{device.device.device_id}_{MAIN}_{capability}_{attribute}_{description.key}",
-                                        f"deprecated_{reason}",
-                                        version,
-                                    ):
-                                        entities.append(
-                                            SmartThingsSensor(
-                                                entry_data.client,
-                                                device,
-                                                description,
-                                                MAIN,
-                                                capability,
-                                                attribute,
-                                            )
-                                        )
-                                    continue
-                                entities.append(
-                                    SmartThingsSensor(
-                                        entry_data.client,
-                                        device,
-                                        description,
-                                        component,
-                                        capability,
-                                        attribute,
-                                    )
-                                )
+        # Only include sensors if no exists_fn OR (component is MAIN and exists_fn returns True)
+        if description.exists_fn and not (
+            component == MAIN
+            and description.exists_fn(device.status[MAIN][capability][attribute])
+        ):
+            continue
+
+        # Skip sensors based on component function
+        # Main component is always included
+        # Other components are included only if the component_fn returns True
+        if not (
+            component == MAIN
+            or (description.component_fn and description.component_fn(component))
+        ):
+            continue
+
+        # Handle deprecated sensors
+        if (
+            description.deprecated
+            and (deprecation_info := description.deprecated(device.status[MAIN]))
+            is not None
+        ):
+            version, reason = deprecation_info
+            if deprecate_entity(
+                hass,
+                entity_registry,
+                SENSOR_DOMAIN,
+                f"{device.device.device_id}_{MAIN}_{capability}_{attribute}_{description.key}",
+                f"deprecated_{reason}",
+                version,
+            ):
+                entities.append(
+                    SmartThingsSensor(
+                        entry_data.client,
+                        device,
+                        description,
+                        MAIN,
+                        capability,
+                        attribute,
+                    )
+                )
+            continue
+        # Finally, create the sensor entity
+        entities.append(
+            SmartThingsSensor(
+                entry_data.client,
+                device,
+                description,
+                component,
+                capability,
+                attribute,
+            )
+        )
 
     async_add_entities(entities)
 

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -1168,23 +1168,24 @@ async def async_setup_entry(
         attribute,
         description,
     ) in _iter_sensor_candidates(entry_data.devices.values()):
-        # Skip sensors based on capability ignore list
+        # Skip sensors when a description defines capability ignore lists
+        # and the device's main component reports all capabilities in any list
         if description.capability_ignore_list and any(
             all(capability in device.status[MAIN] for capability in capability_list)
             for capability_list in description.capability_ignore_list
         ):
             continue
 
-        # Only include sensors if no exists_fn OR (component is MAIN and exists_fn returns True)
+        # Only create the sensor if the description's exists_fn (when provided)
+        # confirms the attribute's value on the main component is present and allowed
         if description.exists_fn and not (
             component == MAIN
             and description.exists_fn(device.status[MAIN][capability][attribute])
         ):
             continue
 
-        # Skip sensors based on component function
-        # Main component is always included
-        # Other components are included only if the component_fn returns True
+        # Only create the sensor for the main component or for components
+        # explicitly allowed by the description's component_fn
         if not (
             component == MAIN
             or (description.component_fn and description.component_fn(component))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Hey,

I’ve been digging through the SmartThings entity-creation logic and the amount of nested loops and conditions made it really hard to follow what’s actually happening.
So I cleaned it up a bit to make the flow clearer and easier to maintain.

What I changed

* **binary_sensor.py**
  Added comments explaining what each part of the iteration is doing, and added early-exit checks so we don’t walk through unnecessary branches of the loop.

* **sensor.py**
  Moved the nested iteration into a separate generator function to flatten the structure and make the logic easier to scan.
  The generator keeps the same overall shape and uses list-comprehension-style iteration - I know this is preferred in HA and it keeps things consistent with the rest of the codebase.
  Also added comments so the intention behind each loop is obvious.

### Why this helps

* The code is much easier to understand at a glance.
* Less indentation, fewer “pyramid” if-blocks.
* Iteration is more efficient thanks to early exits.
* Both platforms now follow the same iteration pattern.

Best regards,
Kamil


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
