### PR TITLE
Fix Z-Wave generating name before setting entity description

### DIFF
--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -71,8 +71,6 @@ class ZWaveBaseEntity(Entity):
             )
 
         # Entity class attributes
-        self._attr_name = self.generate_name()
-        self._attr_unique_id = get_unique_id(driver, self.info.primary_value.value_id)
         if isinstance(info, NewZwaveDiscoveryInfo):
             self.entity_description = info.entity_description
         else:
@@ -80,6 +78,8 @@ class ZWaveBaseEntity(Entity):
                 self._attr_entity_registry_enabled_default = enabled_default
             if (entity_category := info.entity_category) is not None:
                 self._attr_entity_category = entity_category
+        self._attr_name = self.generate_name()
+        self._attr_unique_id = get_unique_id(driver, self.info.primary_value.value_id)
         self._attr_assumed_state = self.info.assumed_state
         # device is precreated in main handler
         self._attr_device_info = DeviceInfo(


### PR DESCRIPTION
## Proposed change

This PR makes sure the entity description is set before the name is generated for Z-Wave entities discovered using the new schema. This fixes a potential issue for those, as the generated name is based on the provided entity description.

It doesn't lead to any actual issues at the moment, as the migrated binary sensor platform re-runs the name generation afterwards (with `include_value_name=True`). However, this could lead to a noticeable issue when we move more entities over to the new schema.

Noticed by Martin here: https://github.com/home-assistant/core/pull/156323#discussion_r2514137121

### Tests

When we move other entities over to the new schema, existing tests would show a regression if someone tries to switch the order again, so I don't think we need explicit test coverage for the call order at the moment.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
