### PR TITLE
Rename RuuviTag BLE to Ruuvi BLE

### DIFF
--- a/homeassistant/components/ruuvitag_ble/__init__.py
+++ b/homeassistant/components/ruuvitag_ble/__init__.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Ruuvitag BLE device from a config entry."""
+    """Set up Ruuvi BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
     data = RuuvitagBluetoothDeviceData()

--- a/homeassistant/components/ruuvitag_ble/manifest.json
+++ b/homeassistant/components/ruuvitag_ble/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ruuvitag_ble",
-  "name": "RuuviTag BLE",
+  "name": "Ruuvi BLE",
   "bluetooth": [
     {
       "connectable": false,

--- a/homeassistant/components/ruuvitag_ble/sensor.py
+++ b/homeassistant/components/ruuvitag_ble/sensor.py
@@ -191,7 +191,7 @@ async def async_setup_entry(
     entry: config_entries.ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the Ruuvitag BLE sensors."""
+    """Set up the Ruuvi BLE sensors."""
     coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
         entry.entry_id
     ]
@@ -210,7 +210,7 @@ class RuuvitagBluetoothSensorEntity(
     ],
     SensorEntity,
 ):
-    """Representation of a Ruuvitag BLE sensor."""
+    """Representation of a Ruuvi BLE sensor."""
 
     @property
     def native_value(self) -> int | float | None:

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5689,7 +5689,7 @@
           "integration_type": "hub",
           "config_flow": true,
           "iot_class": "local_push",
-          "name": "RuuviTag BLE"
+          "name": "Ruuvi BLE"
         }
       }
     },

--- a/tests/components/ruuvitag_ble/__init__.py
+++ b/tests/components/ruuvitag_ble/__init__.py
@@ -1,1 +1,1 @@
-"""Test package for RuuviTag BLE sensor integration."""
+"""Test package for Ruuvi BLE sensor integration."""

--- a/tests/components/ruuvitag_ble/fixtures.py
+++ b/tests/components/ruuvitag_ble/fixtures.py
@@ -1,4 +1,4 @@
-"""Fixtures for testing RuuviTag BLE."""
+"""Fixtures for testing Ruuvi BLE."""
 
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 

--- a/tests/components/ruuvitag_ble/test_sensor.py
+++ b/tests/components/ruuvitag_ble/test_sensor.py
@@ -1,4 +1,4 @@
-"""Test the Ruuvitag BLE sensors."""
+"""Test the Ruuvi BLE sensors."""
 
 from __future__ import annotations
 
@@ -35,7 +35,7 @@ async def test_sensors(
     snapshot: SnapshotAssertion,
     service_info: BluetoothServiceInfo,
 ) -> None:
-    """Test the RuuviTag BLE sensors."""
+    """Test the Ruuvi BLE sensors."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id=service_info.address)
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
## Proposed change

This PR proposes to change the human-visible name of the `ruuvitag_ble` integration from RuuviTag BLE to Ruuvi BLE, since the integration supports the new [Ruuvi Air](https://ruuvi.com/air/) sensors since #150435, #150436, #155678. The new name was greenlit with the Ruuvi folks.

As discussed on the HA Discord ("There was only one domain migration in existence, climacell -> tomorrowio and we just came to the conclusion that we don't want those"; see #68156...#78901), there's no great migration path to change the domain, etc. of an integration without pain, so that will remain `ruuvitag_ble` for now, even if more than tag devices are supported these days.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41761
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
  - https://github.com/home-assistant/home-assistant.io/pull/41761

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
