### PR TITLE
Relax Reolink update interval and timeout for big installs

### DIFF
--- a/homeassistant/components/reolink/update.py
+++ b/homeassistant/components/reolink/update.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from . import DEVICE_UPDATE_INTERVAL
+from . import DEVICE_UPDATE_INTERVAL_MIN, DEVICE_UPDATE_INTERVAL_PER_CAM
 from .const import DOMAIN
 from .entity import (
     ReolinkChannelCoordinatorEntity,
@@ -221,7 +221,10 @@ class ReolinkUpdateBaseEntity(
 
     async def _resume_update_coordinator(self, *args: Any) -> None:
         """Resume updating the states using the data update coordinator (after reboots)."""
-        self._reolink_data.device_coordinator.update_interval = DEVICE_UPDATE_INTERVAL
+        self._reolink_data.device_coordinator.update_interval = max(
+            DEVICE_UPDATE_INTERVAL_MIN,
+            DEVICE_UPDATE_INTERVAL_PER_CAM * self._host.api.num_cameras,
+        )
         try:
             await self._reolink_data.device_coordinator.async_refresh()
         finally:

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -106,6 +106,7 @@ def _init_host_mock(host_mock: MagicMock) -> None:
     host_mock.protocol = "rtsp"
     host_mock.channels = [0]
     host_mock.stream_channels = [0]
+    host_mock.num_cameras = 1
     host_mock.new_devices = False
     host_mock.sw_version_update_required = False
     host_mock.hardware_version = "IPC_00000"

--- a/tests/components/reolink/test_binary_sensor.py
+++ b/tests/components/reolink/test_binary_sensor.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 
-from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL
+from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL_MIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
@@ -35,7 +35,7 @@ async def test_motion_sensor(
     assert hass.states.get(entity_id).state == STATE_ON
 
     reolink_host.motion_detected.return_value = False
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -69,7 +69,7 @@ async def test_smart_ai_sensor(
     assert hass.states.get(entity_id).state == STATE_ON
 
     reolink_host.baichuan.smart_ai_state.return_value = False
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -94,7 +94,7 @@ async def test_index_sensor(
     assert hass.states.get(entity_id).state == STATE_ON
 
     reolink_host.baichuan.io_input_state.return_value = False
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -16,7 +16,7 @@ from reolink_aio.exceptions import (
 )
 
 from homeassistant import config_entries
-from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL
+from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL_MIN
 from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
 from homeassistant.components.reolink.const import (
     CONF_BC_ONLY,
@@ -564,7 +564,7 @@ async def test_dhcp_ip_update_aborted_if_wrong_mac(
 
     # ensure the last_update_succes is False for the device_coordinator.
     reolink_host.get_states.side_effect = ReolinkError("Test error")
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -661,7 +661,7 @@ async def test_dhcp_ip_update(
 
     # ensure the last_update_succes is False for the device_coordinator.
     reolink_host.get_states.side_effect = ReolinkError("Test error")
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/reolink/test_host.py
+++ b/tests/components/reolink/test_host.py
@@ -10,7 +10,7 @@ import pytest
 from reolink_aio.enums import SubType
 from reolink_aio.exceptions import NotSupportedError, ReolinkError, SubscriptionError
 
-from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL
+from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL_MIN
 from homeassistant.components.reolink.host import (
     FIRST_ONVIF_LONG_POLL_TIMEOUT,
     FIRST_ONVIF_TIMEOUT,
@@ -258,7 +258,7 @@ async def test_renew(
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
 
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -266,7 +266,7 @@ async def test_renew(
 
     reolink_host.renew.side_effect = SubscriptionError("Test error")
 
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -275,7 +275,7 @@ async def test_renew(
     reolink_host.subscribe.reset_mock()
     reolink_host.subscribe.side_effect = SubscriptionError("Test error")
 
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -341,7 +341,7 @@ async def test_long_poll_stop_when_push(
     webhook_id = config_entry.runtime_data.host.webhook_id
     await client.post(f"/api/webhook/{webhook_id}")
 
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -14,7 +14,7 @@ from reolink_aio.exceptions import (
 )
 
 from homeassistant.components.reolink import (
-    DEVICE_UPDATE_INTERVAL,
+    DEVICE_UPDATE_INTERVAL_MIN,
     FIRMWARE_UPDATE_INTERVAL,
     NUM_CRED_ERRORS,
 )
@@ -174,7 +174,7 @@ async def test_credential_error_three(
     issue_id = f"config_entry_reauth_{DOMAIN}_{config_entry.entry_id}"
     for _ in range(NUM_CRED_ERRORS):
         assert (HOMEASSISTANT_DOMAIN, issue_id) not in issue_registry.issues
-        freezer.tick(DEVICE_UPDATE_INTERVAL)
+        freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
@@ -917,7 +917,7 @@ async def test_new_device_discovered(
     assert reolink_host.logout.call_count == 0
     reolink_host.new_devices = True
 
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -988,7 +988,7 @@ async def test_LoginPrivacyModeError(
     reolink_host.baichuan.check_subscribe_events.reset_mock()
     assert reolink_host.baichuan.check_subscribe_events.call_count == 0
 
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/reolink/test_select.py
+++ b/tests/components/reolink/test_select.py
@@ -7,7 +7,7 @@ import pytest
 from reolink_aio.api import Chime
 from reolink_aio.exceptions import InvalidParameterError, ReolinkError
 
-from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL
+from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL_MIN
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
@@ -68,7 +68,7 @@ async def test_floodlight_mode_select(
         )
 
     reolink_host.whiteled_mode.return_value = -99  # invalid value
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -142,7 +142,7 @@ async def test_host_scene_select(
         )
 
     reolink_host.baichuan.active_scene = "Invalid value"
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -202,7 +202,7 @@ async def test_chime_select(
     # Test unavailable
     reolink_chime.event_info = {}
     reolink_chime.update_enums()
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/reolink/test_switch.py
+++ b/tests/components/reolink/test_switch.py
@@ -7,7 +7,7 @@ import pytest
 from reolink_aio.api import Chime
 from reolink_aio.exceptions import ReolinkError
 
-from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL
+from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL_MIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
@@ -45,7 +45,7 @@ async def test_switch(
     assert hass.states.get(entity_id).state == STATE_ON
 
     reolink_host.audio_record.return_value = False
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -91,7 +91,7 @@ async def test_switch(
     reolink_host.set_audio.reset_mock(side_effect=True)
 
     reolink_host.camera_online.return_value = False
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -118,7 +118,7 @@ async def test_host_switch(
     assert hass.states.get(entity_id).state == STATE_ON
 
     reolink_host.email_enabled.return_value = False
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -183,7 +183,7 @@ async def test_chime_switch(
     assert hass.states.get(entity_id).state == STATE_ON
 
     reolink_chime.led_state = False
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -248,7 +248,7 @@ async def test_rule_switch(
     assert hass.states.get(entity_id).state == STATE_ON
 
     reolink_host.baichuan.rule_enabled.return_value = False
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    freezer.tick(DEVICE_UPDATE_INTERVAL_MIN)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Relax Reolink update interval and timeout for big installs. For NVRs with many cameras connected, there are much more HTTP/TCP requests to be made so its expected that a update can take longer.
Specifically on a RLN36, there can be up to 36 cameras connected, each with many entities.

Specifically with 19 cameras connected I am seeing  
 42 TCP requests and 339 HTTP commands (in chunks of 35 commands) to get a full status update of all entities. This typically takes about 65 seconds but can go up to 140 seconds if the NVR is busy with other stuff and has 1 or two timeouts that need re-trying (and then succeed).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/155755
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41762
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
