### PR TITLE
Add support for tuya doorbell events

### DIFF
--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from base64 import b64decode
+from dataclasses import dataclass
+from typing import Any
+
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.event import (
@@ -14,70 +18,166 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import TuyaConfigEntry
-from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .const import LOGGER, TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
-from .models import DPCodeEnumWrapper
+from .models import (
+    DPCodeBase64Wrapper,
+    DPCodeEnumWrapper,
+    DPCodeStringWrapper,
+    DPCodeTypeInformationWrapper,
+)
+
+
+class _TuyaEventWrapper(DPCodeTypeInformationWrapper):
+    """Base class for Tuya event wrappers."""
+
+    @property
+    def event_types(self) -> list[str]:
+        """Return the event types for the DP code."""
+        return ["triggered"]
+
+    def get_event_type(
+        self, device: CustomerDevice, updated_status_properties: list[str] | None
+    ) -> str | None:
+        """Return the event type."""
+        if (
+            updated_status_properties is None
+            or self.dpcode not in updated_status_properties
+        ):
+            return None
+        return "triggered"
+
+    def get_event_attributes(self, device: CustomerDevice) -> dict[str, Any] | None:
+        """Return the event attributes."""
+        return None
+
+
+class _EventEnumWrapper(DPCodeEnumWrapper, _TuyaEventWrapper):
+    """Wrapper for event enum DP codes."""
+
+    @property
+    def event_types(self) -> list[str]:
+        """Return the event types for the enum."""
+        return self.type_information.range
+
+    def get_event_type(
+        self, device: CustomerDevice, updated_status_properties: list[str] | None
+    ) -> str | None:
+        """Return the triggered event type."""
+        if (
+            updated_status_properties is None
+            or self.dpcode not in updated_status_properties
+        ):
+            return None
+        return self.read_device_status(device)
+
+
+class _AlarmMessageWrapper(DPCodeStringWrapper, _TuyaEventWrapper):
+    """Wrapper for a STRING message on DPCode.ALARM_MESSAGE."""
+
+    def get_event_attributes(self, device: CustomerDevice) -> dict[str, Any] | None:
+        """Return the event attributes for the enum."""
+        if (raw_value := self._read_device_status_raw(device)) is None:
+            return None
+        LOGGER.warning("_AlarmMessageWrapper: %s", raw_value)
+        return {"message": b64decode(raw_value).decode("utf-8")}
+
+
+class _DoorbellPicWrapper(DPCodeBase64Wrapper, _TuyaEventWrapper):
+    """Wrapper for a RAW message on DPCode.DOORBELL_PIC.
+
+    It is expected that the RAW data is base64/utf8 encoded URL of the picture.
+    """
+
+    def get_event_attributes(self, device: CustomerDevice) -> dict[str, Any] | None:
+        """Return the event attributes for the enum."""
+        if (raw_value := self._read_device_status_raw(device)) is None:
+            return None
+        LOGGER.warning("_DoorbellPicWrapper: %s", raw_value)
+        return {"message": b64decode(raw_value).decode("utf-8")}
+
+
+@dataclass(frozen=True)
+class TuyaEventEntityDescription(EventEntityDescription):
+    """Describe a Tuya Event entity."""
+
+    wrapper_class: type[_TuyaEventWrapper] = _EventEnumWrapper
+
 
 # All descriptions can be found here. Mostly the Enum data types in the
 # default status set of each category (that don't have a set instruction)
 # end up being events.
-EVENTS: dict[DeviceCategory, tuple[EventEntityDescription, ...]] = {
+EVENTS: dict[DeviceCategory, tuple[TuyaEventEntityDescription, ...]] = {
+    DeviceCategory.SP: (
+        TuyaEventEntityDescription(
+            key=DPCode.ALARM_MESSAGE,
+            device_class=EventDeviceClass.DOORBELL,
+            translation_key="doorbell_message",
+            wrapper_class=_AlarmMessageWrapper,
+        ),
+        TuyaEventEntityDescription(
+            key=DPCode.DOORBELL_PIC,
+            device_class=EventDeviceClass.DOORBELL,
+            translation_key="doorbell_picture",
+            wrapper_class=_DoorbellPicWrapper,
+        ),
+    ),
     DeviceCategory.WXKG: (
-        EventEntityDescription(
+        TuyaEventEntityDescription(
             key=DPCode.SWITCH_MODE1,
             device_class=EventDeviceClass.BUTTON,
             translation_key="numbered_button",
             translation_placeholders={"button_number": "1"},
         ),
-        EventEntityDescription(
+        TuyaEventEntityDescription(
             key=DPCode.SWITCH_MODE2,
             device_class=EventDeviceClass.BUTTON,
             translation_key="numbered_button",
             translation_placeholders={"button_number": "2"},
         ),
-        EventEntityDescription(
+        TuyaEventEntityDescription(
             key=DPCode.SWITCH_MODE3,
             device_class=EventDeviceClass.BUTTON,
             translation_key="numbered_button",
             translation_placeholders={"button_number": "3"},
         ),
-        EventEntityDescription(
+        TuyaEventEntityDescription(
             key=DPCode.SWITCH_MODE4,
             device_class=EventDeviceClass.BUTTON,
             translation_key="numbered_button",
             translation_placeholders={"button_number": "4"},
         ),
-        EventEntityDescription(
+        TuyaEventEntityDescription(
             key=DPCode.SWITCH_MODE5,
             device_class=EventDeviceClass.BUTTON,
             translation_key="numbered_button",
             translation_placeholders={"button_number": "5"},
         ),
-        EventEntityDescription(
+        TuyaEventEntityDescription(
             key=DPCode.SWITCH_MODE6,
             device_class=EventDeviceClass.BUTTON,
             translation_key="numbered_button",
             translation_placeholders={"button_number": "6"},
         ),
-        EventEntityDescription(
+        TuyaEventEntityDescription(
             key=DPCode.SWITCH_MODE7,
             device_class=EventDeviceClass.BUTTON,
             translation_key="numbered_button",
             translation_placeholders={"button_number": "7"},
         ),
-        EventEntityDescription(
+        TuyaEventEntityDescription(
             key=DPCode.SWITCH_MODE8,
             device_class=EventDeviceClass.BUTTON,
             translation_key="numbered_button",
             translation_placeholders={"button_number": "8"},
         ),
-        EventEntityDescription(
+        TuyaEventEntityDescription(
             key=DPCode.SWITCH_MODE9,
             device_class=EventDeviceClass.BUTTON,
             translation_key="numbered_button",
             translation_placeholders={"button_number": "9"},
         ),
-    )
+    ),
 }
 
 
@@ -102,8 +202,8 @@ async def async_setup_entry(
                     )
                     for description in descriptions
                     if (
-                        dpcode_wrapper := DPCodeEnumWrapper.find_dpcode(
-                            device, description.key, prefer_function=True
+                        dpcode_wrapper := description.wrapper_class.find_dpcode(
+                            device, description.key
                         )
                     )
                 )
@@ -127,14 +227,14 @@ class TuyaEventEntity(TuyaEntity, EventEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: EventEntityDescription,
-        dpcode_wrapper: DPCodeEnumWrapper,
+        dpcode_wrapper: _TuyaEventWrapper,
     ) -> None:
         """Init Tuya event entity."""
         super().__init__(device, device_manager)
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._dpcode_wrapper = dpcode_wrapper
-        self._attr_event_types = dpcode_wrapper.type_information.range
+        self._attr_event_types = dpcode_wrapper.event_types
 
     async def _handle_state_update(
         self,
@@ -142,11 +242,14 @@ class TuyaEventEntity(TuyaEntity, EventEntity):
         dp_timestamps: dict | None = None,
     ) -> None:
         if (
-            updated_status_properties is None
-            or self._dpcode_wrapper.dpcode not in updated_status_properties
-            or (value := self._dpcode_wrapper.read_device_status(self.device)) is None
-        ):
+            event_type := self._dpcode_wrapper.get_event_type(
+                self.device, updated_status_properties
+            )
+        ) is None:
             return
 
-        self._trigger_event(value)
+        self._trigger_event(
+            event_type,
+            self._dpcode_wrapper.get_event_attributes(self.device),
+        )
         self.async_write_ha_state()

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -76,7 +76,7 @@ class _AlarmMessageWrapper(DPCodeStringWrapper, _DPCodeEventWrapper):
     """Wrapper for a STRING message on DPCode.ALARM_MESSAGE."""
 
     def get_event_attributes(self, device: CustomerDevice) -> dict[str, Any] | None:
-        """Return the event attributes for the enum."""
+        """Return the event attributes for the alarm message."""
         if (raw_value := self._read_device_status_raw(device)) is None:
             return None
         return {"message": b64decode(raw_value).decode("utf-8")}
@@ -89,7 +89,7 @@ class _DoorbellPicWrapper(DPCodeBase64Wrapper, _DPCodeEventWrapper):
     """
 
     def get_event_attributes(self, device: CustomerDevice) -> dict[str, Any] | None:
-        """Return the event attributes for the enum."""
+        """Return the event attributes for the doorbell picture."""
         if (raw_value := self._read_device_status_raw(device)) is None:
             return None
         return {"message": b64decode(raw_value).decode("utf-8")}

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 import base64
 from dataclasses import dataclass
 from typing import Any, Literal, Self, cast, overload
@@ -136,10 +135,11 @@ _TYPE_INFORMATION_MAPPINGS: dict[DPType, type[TypeInformation]] = {
     DPType.INTEGER: IntegerTypeData,
     DPType.JSON: TypeInformation,
     DPType.RAW: TypeInformation,
+    DPType.STRING: TypeInformation,
 }
 
 
-class DPCodeWrapper(ABC):
+class DPCodeWrapper:
     """Base DPCode wrapper.
 
     Used as a common interface for referring to a DPCode, and
@@ -160,12 +160,12 @@ class DPCodeWrapper(ABC):
         """
         return device.status.get(self.dpcode)
 
-    @abstractmethod
     def read_device_status(self, device: CustomerDevice) -> Any | None:
         """Read the device value for the dpcode.
 
         The raw device status is converted to a Home Assistant value.
         """
+        raise NotImplementedError
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
         """Convert a Home Assistant value back to a raw device value.
@@ -324,6 +324,16 @@ class DPCodeIntegerWrapper(DPCodeTypeInformationWrapper[IntegerTypeData]):
             f"Value `{new_value}` (converted from `{value}`) out of range:"
             f" ({self.type_information.min}-{self.type_information.max})"
         )
+
+
+class DPCodeStringWrapper(DPCodeTypeInformationWrapper[TypeInformation]):
+    """Wrapper to extract information from a STRING value."""
+
+    DPTYPE = DPType.STRING
+
+    def read_device_status(self, device: CustomerDevice) -> str | None:
+        """Read the device value for the dpcode."""
+        return self._read_device_status_raw(device)
 
 
 class DPCodeBitmapBitWrapper(DPCodeWrapper):

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -117,6 +117,12 @@
       }
     },
     "event": {
+      "doorbell_message": {
+        "name": "Doorbell message"
+      },
+      "doorbell_picture": {
+        "name": "Doorbell picture"
+      },
       "numbered_button": {
         "name": "Button {button_number}",
         "state_attributes": {

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -214,6 +214,9 @@ async def _create_device(hass: HomeAssistant, mock_device_code: str) -> Customer
             (dp_type := device.function.get(key)) and dp_type.type == "Json"
         ):
             device.status[key] = json_dumps(value)
+        if value == "**REDACTED**":
+            # It was redacted, which may cause issue with b64decode
+            device.status[key] = ""
     return device
 
 

--- a/tests/components/tuya/snapshots/test_event.ambr
+++ b/tests/components/tuya/snapshots/test_event.ambr
@@ -1,4 +1,26 @@
 # serializer version: 1
+# name: test_alarm_message_event[event.intercom_doorbell_message-alarm_message-eyJzb21lIjogImpzb24iLCAicmFuZG9tIjogImRhdGEifQ==-sp_csr2fqitalj5o0tq]
+  ReadOnlyDict({
+    'device_class': 'doorbell',
+    'event_type': 'triggered',
+    'event_types': list([
+      'triggered',
+    ]),
+    'friendly_name': 'Intercom Doorbell message',
+    'message': '{"some": "json", "random": "data"}',
+  })
+# ---
+# name: test_alarm_message_event[event.intercom_doorbell_picture-doorbell_pic-aHR0cHM6Ly9zb21lLXBpY3R1cmUtdXJsLmNvbS9pbWFnZS5qcGc=-sp_csr2fqitalj5o0tq]
+  ReadOnlyDict({
+    'device_class': 'doorbell',
+    'event_type': 'triggered',
+    'event_types': list([
+      'triggered',
+    ]),
+    'friendly_name': 'Intercom Doorbell picture',
+    'message': 'https://some-picture-url.com/image.jpg',
+  })
+# ---
 # name: test_platform_setup_and_discovery[event.bathroom_smart_switch_button_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -172,6 +194,470 @@
     }),
     'context': <ANY>,
     'entity_id': 'event.bouton_tempo_exterieur_button_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-01T12:14:15.000+00:00',
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.burocam_doorbell_message-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'triggered',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.burocam_doorbell_message',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_icon': None,
+    'original_name': 'Doorbell message',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'doorbell_message',
+    'unique_id': 'tuya.svjjuwykgijjedurpsalarm_message',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.burocam_doorbell_message-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'doorbell',
+      'event_type': 'triggered',
+      'event_types': list([
+        'triggered',
+      ]),
+      'friendly_name': 'Bürocam Doorbell message',
+      'message': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.burocam_doorbell_message',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-01T12:14:15.000+00:00',
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.c9_doorbell_message-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'triggered',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.c9_doorbell_message',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_icon': None,
+    'original_name': 'Doorbell message',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'doorbell_message',
+    'unique_id': 'tuya.fjdyw5ld2f5f5ddspsalarm_message',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.c9_doorbell_message-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'doorbell',
+      'event_type': 'triggered',
+      'event_types': list([
+        'triggered',
+      ]),
+      'friendly_name': 'C9 Doorbell message',
+      'message': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.c9_doorbell_message',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-01T12:14:15.000+00:00',
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.c9_doorbell_picture-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'triggered',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.c9_doorbell_picture',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_icon': None,
+    'original_name': 'Doorbell picture',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'doorbell_picture',
+    'unique_id': 'tuya.fjdyw5ld2f5f5ddspsdoorbell_pic',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.c9_doorbell_picture-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'doorbell',
+      'event_type': 'triggered',
+      'event_types': list([
+        'triggered',
+      ]),
+      'friendly_name': 'C9 Doorbell picture',
+      'message': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.c9_doorbell_picture',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-01T12:14:15.000+00:00',
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.garage_camera_doorbell_message-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'triggered',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.garage_camera_doorbell_message',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_icon': None,
+    'original_name': 'Doorbell message',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'doorbell_message',
+    'unique_id': 'tuya.53fnjncm3jywuaznpsalarm_message',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.garage_camera_doorbell_message-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'doorbell',
+      'event_type': 'triggered',
+      'event_types': list([
+        'triggered',
+      ]),
+      'friendly_name': 'Garage Camera Doorbell message',
+      'message': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.garage_camera_doorbell_message',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-01T12:14:15.000+00:00',
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.intercom_doorbell_message-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'triggered',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.intercom_doorbell_message',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_icon': None,
+    'original_name': 'Doorbell message',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'doorbell_message',
+    'unique_id': 'tuya.qt0o5jlatiqf2rscpsalarm_message',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.intercom_doorbell_message-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'doorbell',
+      'event_type': 'triggered',
+      'event_types': list([
+        'triggered',
+      ]),
+      'friendly_name': 'Intercom Doorbell message',
+      'message': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.intercom_doorbell_message',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-01T12:14:15.000+00:00',
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.intercom_doorbell_picture-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'triggered',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.intercom_doorbell_picture',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_icon': None,
+    'original_name': 'Doorbell picture',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'doorbell_picture',
+    'unique_id': 'tuya.qt0o5jlatiqf2rscpsdoorbell_pic',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.intercom_doorbell_picture-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'doorbell',
+      'event_type': 'triggered',
+      'event_types': list([
+        'triggered',
+      ]),
+      'friendly_name': 'Intercom Doorbell picture',
+      'message': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.intercom_doorbell_picture',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-01T12:14:15.000+00:00',
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.mirilla_puerta_doorbell_message-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'triggered',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.mirilla_puerta_doorbell_message',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_icon': None,
+    'original_name': 'Doorbell message',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'doorbell_message',
+    'unique_id': 'tuya.i6xywcsymer1kmb6psalarm_message',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.mirilla_puerta_doorbell_message-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'doorbell',
+      'event_type': 'triggered',
+      'event_types': list([
+        'triggered',
+      ]),
+      'friendly_name': 'Mirilla puerta Doorbell message',
+      'message': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.mirilla_puerta_doorbell_message',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-01T12:14:15.000+00:00',
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.mirilla_puerta_doorbell_picture-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'triggered',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.mirilla_puerta_doorbell_picture',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_icon': None,
+    'original_name': 'Doorbell picture',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'doorbell_picture',
+    'unique_id': 'tuya.i6xywcsymer1kmb6psdoorbell_pic',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[event.mirilla_puerta_doorbell_picture-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'doorbell',
+      'event_type': 'triggered',
+      'event_types': list([
+        'triggered',
+      ]),
+      'friendly_name': 'Mirilla puerta Doorbell picture',
+      'message': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.mirilla_puerta_doorbell_picture',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Alternative to #155982

This one makes clearer use of the new `wrapper` classes (see #156232)

Based on initial work by @asafhas 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
