### PR TITLE
Log warning for incorrect Tuya enum values

### DIFF
--- a/homeassistant/components/tuya/diagnostics.py
+++ b/homeassistant/components/tuya/diagnostics.py
@@ -14,6 +14,7 @@ from homeassistant.util import dt as dt_util
 
 from . import TuyaConfigEntry
 from .const import DOMAIN, DPCode
+from .models import DEVICE_WARNINGS
 
 _REDACTED_DPCODES = {
     DPCode.ALARM_MESSAGE,
@@ -97,6 +98,7 @@ def _async_device_as_dict(
         "home_assistant": {},
         "set_up": device.set_up,
         "support_local": device.support_local,
+        "warnings": DEVICE_WARNINGS.get(device.id),
     }
 
     # Gather Tuya states

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -270,6 +270,7 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
     """Simple wrapper for EnumTypeData values."""
 
     DPTYPE = DPType.ENUM
+    _strict = False
 
     def read_device_status(self, device: CustomerDevice) -> str | None:
         """Read the device value for the dpcode.
@@ -287,6 +288,8 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
                 self.dpcode,
                 self.type_information.range,
             )
+            if self._strict:
+                return None
         return raw_value
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -11,7 +11,7 @@ from tuya_sharing import CustomerDevice
 
 from homeassistant.util.json import json_loads, json_loads_object
 
-from .const import DPCode, DPType
+from .const import LOGGER, DPCode, DPType
 from .util import parse_dptype, remap_value
 
 
@@ -279,9 +279,15 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
         """
         if (
             raw_value := self._read_device_status_raw(device)
-        ) in self.type_information.range:
-            return raw_value
-        return None
+        ) not in self.type_information.range:
+            # We should not reject these, at least until quirks are implemented
+            LOGGER.debug(
+                "Found invalid enum value `%s` for %s, expected one of %s",
+                raw_value,
+                self.dpcode,
+                self.type_information.range,
+            )
+        return raw_value
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
         """Convert a Home Assistant value back to a raw device value."""

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -277,9 +277,9 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
         Values outside of the list defined by the Enum type information will
         return None.
         """
-        if (
-            raw_value := self._read_device_status_raw(device)
-        ) not in self.type_information.range:
+        if (raw_value := self._read_device_status_raw(device)) is None:
+            return None
+        if raw_value not in self.type_information.range:
             # We should not reject these, at least until quirks are implemented
             LOGGER.debug(
                 "Found invalid enum value `%s` for %s, expected one of %s",

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -281,16 +281,17 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
         if (raw_value := self._read_device_status_raw(device)) is None:
             return None
         if raw_value not in self.type_information.range:
+            LOGGER.warning(
+                "Found invalid enum value `%s` for datapoint `%s` in product id `%s`,"
+                " expected one of `%s`; please report this defect to Tuya support",
+                raw_value,
+                self.dpcode,
+                device.product_id,
+                self.type_information.range,
+            )
             if self._strict:
                 return None
 
-            # We should not reject these, at least until quirks are implemented
-            LOGGER.debug(
-                "Found invalid enum value `%s` for %s, expected one of %s",
-                raw_value,
-                self.dpcode,
-                self.type_information.range,
-            )
         return raw_value
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -281,6 +281,9 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
         if (raw_value := self._read_device_status_raw(device)) is None:
             return None
         if raw_value not in self.type_information.range:
+            if self._strict:
+                return None
+
             # We should not reject these, at least until quirks are implemented
             LOGGER.debug(
                 "Found invalid enum value `%s` for %s, expected one of %s",
@@ -288,8 +291,6 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
                 self.dpcode,
                 self.type_information.range,
             )
-            if self._strict:
-                return None
         return raw_value
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -344,6 +344,12 @@ SELECTS[DeviceCategory.DGHSXJ] = SELECTS[DeviceCategory.SP]
 SELECTS[DeviceCategory.PC] = SELECTS[DeviceCategory.KG]
 
 
+class _DPCodeEnumStrictWrapper(DPCodeEnumWrapper):
+    """Strict validation of Tuya values."""
+
+    _strict = True
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: TuyaConfigEntry,
@@ -365,7 +371,7 @@ async def async_setup_entry(
                     )
                     for description in descriptions
                     if (
-                        dpcode_wrapper := DPCodeEnumWrapper.find_dpcode(
+                        dpcode_wrapper := _DPCodeEnumStrictWrapper.find_dpcode(
                             device, description.key, prefer_function=True
                         )
                     )
@@ -388,7 +394,7 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: SelectEntityDescription,
-        dpcode_wrapper: DPCodeEnumWrapper,
+        dpcode_wrapper: _DPCodeEnumStrictWrapper,
     ) -> None:
         """Init Tuya sensor."""
         super().__init__(device, device_manager)

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -344,12 +344,6 @@ SELECTS[DeviceCategory.DGHSXJ] = SELECTS[DeviceCategory.SP]
 SELECTS[DeviceCategory.PC] = SELECTS[DeviceCategory.KG]
 
 
-class _DPCodeEnumStrictWrapper(DPCodeEnumWrapper):
-    """Strict validation of Tuya values."""
-
-    _strict = True
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: TuyaConfigEntry,
@@ -371,7 +365,7 @@ async def async_setup_entry(
                     )
                     for description in descriptions
                     if (
-                        dpcode_wrapper := _DPCodeEnumStrictWrapper.find_dpcode(
+                        dpcode_wrapper := DPCodeEnumWrapper.find_dpcode(
                             device, description.key, prefer_function=True
                         )
                     )
@@ -394,7 +388,7 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: SelectEntityDescription,
-        dpcode_wrapper: _DPCodeEnumStrictWrapper,
+        dpcode_wrapper: DPCodeEnumWrapper,
     ) -> None:
         """Init Tuya sensor."""
         super().__init__(device, device_manager)

--- a/tests/components/tuya/snapshots/test_diagnostics.ambr
+++ b/tests/components/tuya/snapshots/test_diagnostics.ambr
@@ -298,6 +298,7 @@
     'terminal_id': '7cd96aff-6ec8-4006-b093-3dbff7947591',
     'time_zone': '+02:00',
     'update_time': '2024-12-02T20:08:56+00:00',
+    'warnings': None,
   })
 # ---
 # name: test_device_diagnostics[rqbj_4iqe2hsfyd86kwwc]
@@ -413,6 +414,167 @@
     'terminal_id': '7cd96aff-6ec8-4006-b093-3dbff7947591',
     'time_zone': '-04:00',
     'update_time': '2025-06-24T20:33:10+00:00',
+    'warnings': None,
+  })
+# ---
+# name: test_device_diagnostics[tdq_9htyiowaf5rtdhrv]
+  dict({
+    'active_time': '2024-09-08T13:46:46+00:00',
+    'category': 'tdq',
+    'create_time': '2024-09-08T13:46:46+00:00',
+    'disabled_by': None,
+    'disabled_polling': False,
+    'endpoint': 'https://apigw.tuyaeu.com',
+    'function': dict({
+      'countdown_1': dict({
+        'type': 'Integer',
+        'value': '{"unit":"s","min":0,"max":86400,"scale":0,"step":1}',
+      }),
+      'cycle_time': dict({
+        'type': 'String',
+        'value': '{"maxlen":255}',
+      }),
+      'random_time': dict({
+        'type': 'String',
+        'value': '{"maxlen":255}',
+      }),
+      'relay_status': dict({
+        'type': 'Enum',
+        'value': '{"range":["0","1","2"]}',
+      }),
+      'remote_add': dict({
+        'type': 'Raw',
+        'value': '{}',
+      }),
+      'remote_list': dict({
+        'type': 'Raw',
+        'value': '{}',
+      }),
+      'switch_1': dict({
+        'type': 'Boolean',
+        'value': '{}',
+      }),
+      'switch_inching': dict({
+        'type': 'String',
+        'value': '{"maxlen":255}',
+      }),
+      'switch_type': dict({
+        'type': 'Enum',
+        'value': '{"range":["flip","sync","button"]}',
+      }),
+    }),
+    'home_assistant': dict({
+      'disabled': False,
+      'disabled_by': None,
+      'entities': list([
+        dict({
+          'device_class': None,
+          'disabled': False,
+          'disabled_by': None,
+          'entity_category': 'config',
+          'icon': None,
+          'original_device_class': None,
+          'original_icon': None,
+          'state': dict({
+            'attributes': dict({
+              'friendly_name': 'Framboisiers Power on behavior',
+              'options': list([
+                '0',
+                '1',
+                '2',
+              ]),
+            }),
+            'entity_id': 'select.framboisiers_power_on_behavior',
+            'state': 'unknown',
+          }),
+          'unit_of_measurement': None,
+        }),
+        dict({
+          'device_class': None,
+          'disabled': False,
+          'disabled_by': None,
+          'entity_category': None,
+          'icon': None,
+          'original_device_class': 'outlet',
+          'original_icon': None,
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'outlet',
+              'friendly_name': 'Framboisiers Switch 1',
+            }),
+            'entity_id': 'switch.framboisiers_switch_1',
+            'state': 'off',
+          }),
+          'unit_of_measurement': None,
+        }),
+      ]),
+      'name': 'Framboisiers',
+      'name_by_user': None,
+    }),
+    'id': 'vrhdtr5fawoiyth9qdt',
+    'mqtt_connected': True,
+    'name': 'Framboisiers',
+    'online': True,
+    'product_id': '9htyiowaf5rtdhrv',
+    'product_name': '1-433',
+    'set_up': True,
+    'status': dict({
+      'countdown_1': 0,
+      'cycle_time': '',
+      'random_time': '',
+      'relay_status': 2,
+      'remote_add': '',
+      'remote_list': 'AA==',
+      'switch_1': False,
+      'switch_inching': 'AAAC',
+      'switch_type': 'button',
+    }),
+    'status_range': dict({
+      'countdown_1': dict({
+        'type': 'Integer',
+        'value': '{"unit":"s","min":0,"max":86400,"scale":0,"step":1}',
+      }),
+      'cycle_time': dict({
+        'type': 'String',
+        'value': '{"maxlen":255}',
+      }),
+      'random_time': dict({
+        'type': 'String',
+        'value': '{"maxlen":255}',
+      }),
+      'relay_status': dict({
+        'type': 'Enum',
+        'value': '{"range":["0","1","2"]}',
+      }),
+      'remote_add': dict({
+        'type': 'Raw',
+        'value': '{}',
+      }),
+      'remote_list': dict({
+        'type': 'Raw',
+        'value': '{}',
+      }),
+      'switch_1': dict({
+        'type': 'Boolean',
+        'value': '{}',
+      }),
+      'switch_inching': dict({
+        'type': 'String',
+        'value': '{"maxlen":255}',
+      }),
+      'switch_type': dict({
+        'type': 'Enum',
+        'value': '{"range":["flip","sync","button"]}',
+      }),
+    }),
+    'sub': False,
+    'support_local': True,
+    'terminal_id': '7cd96aff-6ec8-4006-b093-3dbff7947591',
+    'time_zone': '+02:00',
+    'update_time': '2024-09-08T13:46:46+00:00',
+    'warnings': list([
+      'enum_out_range|relay_status|2',
+    ]),
   })
 # ---
 # name: test_entry_diagnostics[rqbj_4iqe2hsfyd86kwwc]
@@ -525,6 +687,7 @@
         'support_local': True,
         'time_zone': '-04:00',
         'update_time': '2025-06-24T20:33:10+00:00',
+        'warnings': None,
       }),
     ]),
     'disabled_by': None,

--- a/tests/components/tuya/test_diagnostics.py
+++ b/tests/components/tuya/test_diagnostics.py
@@ -45,8 +45,9 @@ async def test_entry_diagnostics(
 @pytest.mark.parametrize(
     "mock_device_code",
     [
-        "mal_gyitctrjj1kefxp2",
         "rqbj_4iqe2hsfyd86kwwc",
+        "mal_gyitctrjj1kefxp2",  # with redacted dpcodes
+        "tdq_9htyiowaf5rtdhrv",  # with bad enum warnings
     ],
 )
 async def test_device_diagnostics(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- always return `None` if the enum value is not present in the range
- log warning for each invalid value encountered
- keep track of already logged warnings - to avoid log spamming
- add logged warnings to the diagnostic dump

Originally based on discussion in #156054

(validation introduced in #156277)

cc @heindrichpaul


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
