### PR TITLE
Add time synchronization feature to BSB-Lan integration

### DIFF
--- a/homeassistant/components/bsblan/icons.json
+++ b/homeassistant/components/bsblan/icons.json
@@ -2,6 +2,9 @@
   "services": {
     "set_hot_water_schedule": {
       "service": "mdi:calendar-clock"
+    },
+    "sync_time": {
+      "service": "mdi:timer-sync-outline"
     }
   }
 }

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 
@@ -30,8 +31,9 @@ ATTR_FRIDAY_SLOTS = "friday_slots"
 ATTR_SATURDAY_SLOTS = "saturday_slots"
 ATTR_SUNDAY_SLOTS = "sunday_slots"
 
-# Service name
+# Service names
 SERVICE_SET_HOT_WATER_SCHEDULE = "set_hot_water_schedule"
+SERVICE_SYNC_TIME = "sync_time"
 
 
 # Schema for a single time slot
@@ -203,6 +205,74 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
     await entry.runtime_data.slow_coordinator.async_request_refresh()
 
 
+async def async_sync_time(service_call: ServiceCall) -> None:
+    """Synchronize BSB-LAN device time with Home Assistant."""
+    device_id: str = service_call.data[ATTR_DEVICE_ID]
+
+    # Get the device and config entry
+    device_registry = dr.async_get(service_call.hass)
+    device_entry = device_registry.async_get(device_id)
+
+    if device_entry is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_device_id",
+            translation_placeholders={"device_id": device_id},
+        )
+
+    # Find the config entry for this device
+    matching_entries: list[BSBLanConfigEntry] = [
+        entry
+        for entry in service_call.hass.config_entries.async_entries(DOMAIN)
+        if entry.entry_id in device_entry.config_entries
+    ]
+
+    if not matching_entries:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="no_config_entry_for_device",
+            translation_placeholders={"device_id": device_entry.name or device_id},
+        )
+
+    entry = matching_entries[0]
+
+    # Verify the config entry is loaded
+    if entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="config_entry_not_loaded",
+            translation_placeholders={"device_name": device_entry.name or device_id},
+        )
+
+    client = entry.runtime_data.client
+
+    try:
+        # Get current device time
+        device_time = await client.time()
+        current_time = dt_util.now()
+        current_time_str = current_time.strftime("%d.%m.%Y %H:%M:%S")
+
+        # Only sync if device time differs from HA time
+        if device_time.time.value != current_time_str:
+            await client.set_time(current_time_str)
+    except BSBLANError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="sync_time_failed",
+            translation_placeholders={
+                "device_name": device_entry.name or device_id,
+                "error": str(err),
+            },
+        ) from err
+
+
+SYNC_TIME_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
+    }
+)
+
+
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Register the BSB-Lan services."""
@@ -211,4 +281,11 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_SET_HOT_WATER_SCHEDULE,
         set_hot_water_schedule,
         schema=SERVICE_SET_HOT_WATER_SCHEDULE_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SYNC_TIME,
+        async_sync_time,
+        schema=SYNC_TIME_SCHEMA,
     )

--- a/homeassistant/components/bsblan/services.yaml
+++ b/homeassistant/components/bsblan/services.yaml
@@ -1,3 +1,12 @@
+sync_time:
+  fields:
+    device_id:
+      required: true
+      example: "abc123device456"
+      selector:
+        device:
+          integration: bsblan
+
 set_hot_water_schedule:
   fields:
     device_id:

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -79,9 +79,6 @@
     "invalid_device_id": {
       "message": "Invalid device ID: {device_id}"
     },
-    "invalid_time_format": {
-      "message": "Invalid time format provided"
-    },
     "no_config_entry_for_device": {
       "message": "No configuration entry found for device: {device_id}"
     },
@@ -108,6 +105,9 @@
     },
     "setup_general_error": {
       "message": "An unknown error occurred while retrieving static device data"
+    },
+    "sync_time_failed": {
+      "message": "Failed to sync time for {device_name}: {error}"
     }
   },
   "services": {
@@ -148,6 +148,16 @@
         }
       },
       "name": "Set hot water schedule"
+    },
+    "sync_time": {
+      "description": "Synchronize Home Assistant time to the BSB-Lan device. Only updates if device time differs from Home Assistant time.",
+      "fields": {
+        "device_id": {
+          "description": "The BSB-LAN device to sync time for.",
+          "name": "Device"
+        }
+      },
+      "name": "Sync time"
     }
   }
 }

--- a/tests/components/bsblan/fixtures/time.json
+++ b/tests/components/bsblan/fixtures/time.json
@@ -1,0 +1,11 @@
+{
+  "time": {
+    "name": "Time",
+    "value": "14.11.2025 10:30:00",
+    "unit": "",
+    "desc": "",
+    "dataType": 0,
+    "readonly": 0,
+    "error": 0
+  }
+}

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -4,7 +4,8 @@ from datetime import time
 from typing import Any
 from unittest.mock import MagicMock
 
-from bsblan import BSBLANError, DaySchedule, TimeSlot
+from bsblan import BSBLANError, DaySchedule, DeviceTime, TimeSlot
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
 
@@ -16,6 +17,7 @@ from homeassistant.components.bsblan.services import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 
@@ -174,9 +176,22 @@ async def test_invalid_device_id(
     assert exc_info.value.translation_key == "invalid_device_id"
 
 
+@pytest.mark.parametrize(
+    ("service_name", "service_data"),
+    [
+        (
+            SERVICE_SET_HOT_WATER_SCHEDULE,
+            {"monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}]},
+        ),
+        ("sync_time", {}),
+    ],
+    ids=["set_hot_water_schedule", "sync_time"],
+)
 async def test_no_config_entry_for_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    service_name: str,
+    service_data: dict[str, Any],
 ) -> None:
     """Test error when device has no matching BSB-LAN config entry."""
     # Create a different config entry (not for bsblan)
@@ -196,11 +211,8 @@ async def test_no_config_entry_for_device(
     with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
-            {
-                "device_id": device_entry.id,
-                "monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}],
-            },
+            service_name,
+            {"device_id": device_entry.id, **service_data},
             blocking=True,
         )
 
@@ -421,3 +433,198 @@ async def test_async_setup_services(
 
     # Verify service is now registered
     assert hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
+
+
+async def test_sync_time_service(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the sync_time service."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Get the device
+    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    assert device is not None
+
+    # Mock device time that differs from HA time
+    mock_bsblan.time.return_value = DeviceTime.from_json(
+        '{"time": {"name": "Time", "value": "01.01.2020 00:00:00", "unit": "", "desc": "", "dataType": 0, "readonly": 0, "error": 0}}'
+    )
+
+    # Call the service
+    await hass.services.async_call(
+        DOMAIN,
+        "sync_time",
+        {"device_id": device.id},
+        blocking=True,
+    )
+
+    # Verify time() was called to check current device time
+    assert mock_bsblan.time.called
+
+    # Verify set_time() was called with current HA time
+    current_time_str = dt_util.now().strftime("%d.%m.%Y %H:%M:%S")
+    mock_bsblan.set_time.assert_called_once_with(current_time_str)
+
+
+async def test_sync_time_service_no_update_when_same(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the sync_time service doesn't update when time matches."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Get the device
+    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    assert device is not None
+
+    # Mock device time that matches HA time
+    current_time_str = dt_util.now().strftime("%d.%m.%Y %H:%M:%S")
+    mock_bsblan.time.return_value = DeviceTime.from_json(
+        f'{{"time": {{"name": "Time", "value": "{current_time_str}", "unit": "", "desc": "", "dataType": 0, "readonly": 0, "error": 0}}}}'
+    )
+
+    # Call the service
+    await hass.services.async_call(
+        DOMAIN,
+        "sync_time",
+        {"device_id": device.id},
+        blocking=True,
+    )
+
+    # Verify time() was called
+    assert mock_bsblan.time.called
+
+    # Verify set_time() was NOT called since times match
+    assert not mock_bsblan.set_time.called
+
+
+async def test_sync_time_service_error_handling(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the sync_time service handles errors gracefully."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Get the device
+    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    assert device is not None
+
+    # Mock time() to raise an error
+    mock_bsblan.time.side_effect = BSBLANError("Connection failed")
+
+    # Call the service - should raise HomeAssistantError
+    with pytest.raises(HomeAssistantError, match="Failed to sync time"):
+        await hass.services.async_call(
+            DOMAIN,
+            "sync_time",
+            {"device_id": device.id},
+            blocking=True,
+        )
+
+
+async def test_sync_time_service_set_time_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the sync_time service handles set_time errors."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Get the device
+    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    assert device is not None
+
+    # Mock device time that differs
+    mock_bsblan.time.return_value = DeviceTime.from_json(
+        '{"time": {"name": "Time", "value": "01.01.2020 00:00:00", "unit": "", "desc": "", "dataType": 0, "readonly": 0, "error": 0}}'
+    )
+
+    # Mock set_time() to raise an error
+    mock_bsblan.set_time.side_effect = BSBLANError("Write failed")
+
+    # Call the service - should raise HomeAssistantError
+    with pytest.raises(HomeAssistantError, match="Failed to sync time"):
+        await hass.services.async_call(
+            DOMAIN,
+            "sync_time",
+            {"device_id": device.id},
+            blocking=True,
+        )
+
+
+async def test_sync_time_service_entry_not_found(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test the sync_time service raises error for non-existent device."""
+    # Set up the entry (this registers the service)
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Call the service with a non-existent device ID
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "sync_time",
+            {"device_id": "non_existent_device_id"},
+            blocking=True,
+        )
+
+
+async def test_sync_time_service_entry_not_loaded(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the sync_time service raises error for unloaded entry."""
+    # Set up the first entry (this registers the service)
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Create a second unloaded entry
+    unloaded_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Unloaded BSBLAN",
+        data=mock_config_entry.data.copy(),
+        unique_id="unloaded_unique_id",
+    )
+    unloaded_entry.add_to_hass(hass)
+    # Don't call async_setup on this entry, so it stays NOT_LOADED
+
+    # Manually register a device for this unloaded entry
+    unloaded_device = device_registry.async_get_or_create(
+        config_entry_id=unloaded_entry.entry_id,
+        identifiers={(DOMAIN, "unloaded_device_mac")},
+        name="Unloaded Device",
+    )
+
+    # Call the service with the device from the unloaded entry - should raise error
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "sync_time",
+            {"device_id": unloaded_device.id},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request adds a new `sync_time` service to the BSB-LAN integration in Home Assistant, allowing users to synchronize the time on their BSB-LAN device with Home Assistant. The implementation includes service registration, validation, error handling, user-facing descriptions, and comprehensive tests.

**Key changes:**

**New Service Implementation:**

- Added the `sync_time` service, which updates the BSB-LAN device time to match Home Assistant, only performing the update if the times differ. This includes schema validation, device/config entry checks, and error handling for device communication issues. [[1]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225L33-R36) [[2]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225R208-R275) [[3]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225R285-R291) [[4]](diffhunk://#diff-d160a8d7c6df7e9888daf56e8211877ed14c17e26bf3f0e3ffc350eaf1af56e7R1-R9) [[5]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310R108-R110)

- Registered an appropriate Material Design Icon for the new service in `icons.json`.

**User Interface and Documentation:**

- Updated `services.yaml` and `strings.json` to document the new service, including its description, fields, and error messages for failed sync attempts. [[1]](diffhunk://#diff-d160a8d7c6df7e9888daf56e8211877ed14c17e26bf3f0e3ffc350eaf1af56e7R1-R9) [[2]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310R151-R160) [[3]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310R108-R110)

**Testing:**

- Added extensive tests for the `sync_time` service, covering successful syncs, no-op when times match, error conditions (such as device or entry not found, or device communication failures), and service registration. Also added a device time fixture for test consistency. [[1]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L7-R8) [[2]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582R20) [[3]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582R179-R194) [[4]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L199-R215) [[5]](diffhunk://#diff-84005992c25dc553fda481e224f5d32c21f795548491d2ed92d5217ce2eaccc8R1-R11) [[6]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582R436-R630)

These changes ensure that users can reliably keep their BSB-LAN device clocks in sync with Home Assistant, with clear feedback and robust error handling.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41789
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
