### PR TITLE
Add external scene activation detection to Hue integration

### DIFF
--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -9,7 +9,6 @@ from aiohue.v2.controllers.events import EventType
 from aiohue.v2.controllers.scenes import ScenesController
 from aiohue.v2.models.scene import (
     Scene as HueScene,
-    SceneActiveStatus,
     ScenePut as HueScenePut,
 )
 from aiohue.v2.models.smart_scene import SmartScene as HueSmartScene, SmartSceneState

--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -89,7 +89,7 @@ async def async_setup_entry(
                 vol.Coerce(int), vol.Range(min=1, max=255)
             ),
         },
-        "_async_activate",
+        "async_activate",
     )
 
 
@@ -193,7 +193,7 @@ class HueSceneEntity(HueSceneEntityBase):
             return True
         return False
 
-    async def _async_activate(self, **kwargs: Any) -> None:
+    async def async_activate(self, **kwargs: Any) -> None:
         """Activate Hue scene."""
         transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))
         # the options below are advanced only
@@ -276,7 +276,7 @@ class HueSmartSceneEntity(HueSceneEntityBase):
 
         super().on_update()
 
-    async def _async_activate(self, **kwargs: Any) -> None:
+    async def async_activate(self, **kwargs: Any) -> None:
         """Activate Hue Smart scene."""
         # kwargs accepted for BaseScene contract but not used for smart scenes
         _ = kwargs

--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -52,7 +52,9 @@ async def async_setup_entry(
 
     # add entities for all scenes
     @callback
-    def async_add_entity(resource: HueScene | HueSmartScene) -> None:
+    def async_add_entity(
+        event_type: EventType, resource: HueScene | HueSmartScene
+    ) -> None:
         """Add entity from Hue resource."""
         if isinstance(resource, HueSmartScene):
             async_add_entities([HueSmartSceneEntity(bridge, api.scenes, resource)])
@@ -61,7 +63,7 @@ async def async_setup_entry(
 
     # add all current items in controller
     for item in api.scenes:
-        async_add_entity(item)
+        async_add_entity(EventType.RESOURCE_ADDED, item)
 
     # register listener for new items only
     # (scene activation detection is handled by on_update() on existing entities)

--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -156,13 +156,14 @@ class HueSceneEntityBase(HueBaseEntity, BaseScene):
         """
         # Only track activations for regular scenes (HueScene)
         if isinstance(self.resource, HueScene):
-            current_last_recall = (
-                self.resource.status.last_recall if self.resource.status else None
-            )
-
             # Only record activation if last_recall timestamp has changed
             if (
-                current_last_recall is not None
+                (
+                    current_last_recall := (
+                        self.resource.status.last_recall if self.resource.status else None
+                    )
+                )
+                is not None
                 and current_last_recall != self._previous_last_recall
             ):
                 self._async_record_activation()

--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -155,14 +155,10 @@ class HueSceneEntity(HueSceneEntityBase):
         """
         # Only record activation if last_recall timestamp has changed
         if (
-            (
-                current_last_recall := (
-                    self.resource.status.last_recall if self.resource.status else None
-                )
+            current_last_recall := (
+                self.resource.status.last_recall if self.resource.status else None
             )
-            is not None
-            and current_last_recall != self._previous_last_recall
-        ):
+        ) is not None and current_last_recall != self._previous_last_recall:
             self._async_record_activation()
 
         # Update tracked timestamp

--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -7,17 +7,11 @@ from typing import Any
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
 from aiohue.v2.controllers.scenes import ScenesController
-from aiohue.v2.models.scene import (
-    Scene as HueScene,
-    ScenePut as HueScenePut,
-)
+from aiohue.v2.models.scene import Scene as HueScene, ScenePut as HueScenePut
 from aiohue.v2.models.smart_scene import SmartScene as HueSmartScene, SmartSceneState
 import voluptuous as vol
 
-from homeassistant.components.scene import (
-    ATTR_TRANSITION,
-    Scene as BaseScene,
-)
+from homeassistant.components.scene import ATTR_TRANSITION, Scene as BaseScene
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import (


### PR DESCRIPTION
## Proposed change

Add support for detecting Hue scene activations from external sources (Hue mobile app, physical buttons, voice assistants, Hue automations) in addition to Home Assistant-initiated activations.

**Problem:** Currently, Hue scene entities only update their state when activated through Home Assistant. External activations via Hue app, physical switches, or voice assistants are not reflected in HA.

**Solution:**
- For regular scenes: Track `status.last_recall` timestamp changes
- For smart scenes: Track state transitions (INACTIVE → ACTIVE)
- Inherit from `BaseScene` instead of `SceneEntity` to enable state recording

This follows the same pattern as KNX scene activation detection (PR #151218).

**Testing:** Comprehensive testing on real Philips Hue bridge confirmed:
- No false activations when lights in active scenes are modified
- External activations correctly detected and recorded
- HA-initiated activations work as before

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Closes https://github.com/orgs/home-assistant/discussions/1446
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr