### PR TITLE
Add Samsung CE Audio Volume Level Number to Smartthings

### DIFF
--- a/homeassistant/components/smartthings/entity.py
+++ b/homeassistant/components/smartthings/entity.py
@@ -21,6 +21,8 @@ from homeassistant.helpers.entity import Entity
 from . import FullDevice
 from .const import DOMAIN, MAIN
 
+type CommandArgument = int | str | list[Any] | dict[str, Any] | None
+
 
 class SmartThingsEntity(Entity):
     """Defines a SmartThings entity."""
@@ -100,7 +102,7 @@ class SmartThingsEntity(Entity):
         self,
         capability: Capability,
         command: Command,
-        argument: int | str | list[Any] | dict[str, Any] | None = None,
+        argument: CommandArgument = None,
     ) -> None:
         """Execute a command on the device."""
         kwargs = {}

--- a/homeassistant/components/smartthings/strings.json
+++ b/homeassistant/components/smartthings/strings.json
@@ -133,6 +133,9 @@
       }
     },
     "number": {
+      "audio_volume_level": {
+        "name": "Audio volume level"
+      },
       "cool_select_plus_temperature": {
         "name": "CoolSelect+ temperature"
       },
@@ -640,6 +643,9 @@
       },
       "keep_fresh_mode": {
         "name": "Keep fresh mode"
+      },
+      "mute": {
+        "name": "Mute"
       },
       "power_cool": {
         "name": "Power cool"

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -49,7 +49,7 @@ class SmartThingsSwitchEntityDescription(SwitchEntityDescription):
 
     status_attribute: Attribute
     component_translation_key: dict[str, str] | None = None
-    on_value: str | int = "on"
+    on_key: str | int = "on"
     on_command: Command = Command.ON
     on_command_argument: CommandArgument = None
     off_command: Command = Command.OFF
@@ -100,7 +100,7 @@ CAPABILITY_TO_COMMAND_SWITCHES: dict[
         translation_key="mute",
         status_attribute=Attribute.VOLUME_LEVEL,
         command=Command.SET_VOLUME_LEVEL,
-        on_value=0,
+        on_key=0,
         on_command_argument=0,
         off_command_argument=1,
         entity_category=EntityCategory.CONFIG,
@@ -151,7 +151,7 @@ CAPABILITY_TO_SWITCHES: dict[Capability | str, SmartThingsSwitchEntityDescriptio
         key=Capability.SAMSUNG_CE_POWER_COOL,
         translation_key="power_cool",
         status_attribute=Attribute.ACTIVATED,
-        on_value="True",
+        on_key="True",
         on_command=Command.ACTIVATE,
         off_command=Command.DEACTIVATE,
         entity_category=EntityCategory.CONFIG,
@@ -160,7 +160,7 @@ CAPABILITY_TO_SWITCHES: dict[Capability | str, SmartThingsSwitchEntityDescriptio
         key=Capability.SAMSUNG_CE_POWER_FREEZE,
         translation_key="power_freeze",
         status_attribute=Attribute.ACTIVATED,
-        on_value="True",
+        on_key="True",
         on_command=Command.ACTIVATE,
         off_command=Command.DEACTIVATE,
         entity_category=EntityCategory.CONFIG,
@@ -326,7 +326,7 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
             self.get_attribute_value(
                 self.switch_capability, self.entity_description.status_attribute
             )
-            == self.entity_description.on_value
+            == self.entity_description.on_key
         )
 
 

--- a/homeassistant/components/smartthings/util.py
+++ b/homeassistant/components/smartthings/util.py
@@ -1,5 +1,7 @@
 """Utility functions for SmartThings integration."""
 
+from pysmartthings import Attribute, Capability
+
 from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.script import scripts_with_entity
 from homeassistant.core import HomeAssistant
@@ -10,6 +12,7 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 
+from . import FullDevice
 from .const import DOMAIN
 
 
@@ -82,3 +85,21 @@ def get_automations_and_scripts_using_entity(
         for entity_id in entities
         if (item := entity_reg.async_get(entity_id))
     ]
+
+
+def get_range_options_count(
+    device: FullDevice, component: str, capability: Capability, attribute: Attribute
+) -> int:
+    """Get the number of options in a range attribute."""
+    value = device.status[component][capability][attribute].value
+    assert isinstance(value, dict)
+    minimum = value.get("minimum", None)
+    maximum = value.get("maximum", None)
+    step = value.get("step", None)
+    if minimum is None or maximum is None or step is None:
+        raise ValueError("Missing range options")
+    assert isinstance(minimum, int)
+    assert isinstance(maximum, int)
+    assert isinstance(step, int)
+
+    return len(range(minimum, maximum + 1, step))

--- a/tests/components/smartthings/snapshots/test_number.ambr
+++ b/tests/components/smartthings/snapshots/test_number.ambr
@@ -410,6 +410,120 @@
     'state': '2.0',
   })
 # ---
+# name: test_all_entities[da_rvc_map_01011][number.robot_vacuum_audio_volume_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 3,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.robot_vacuum_audio_volume_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Audio volume level',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_volume_level',
+    'unique_id': '05accb39-2017-c98b-a5ab-04a81f4d3d9a_main_audio_volume_level_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_rvc_map_01011][number.robot_vacuum_audio_volume_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Robot vacuum Audio volume level',
+      'max': 3,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.robot_vacuum_audio_volume_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_all_entities[da_wm_wd_01011][number.trockner_audio_volume_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 3,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.trockner_audio_volume_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Audio volume level',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_volume_level',
+    'unique_id': '3d39866c-7716-5259-44f0-fd7025efd85f_main_audio_volume_level_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_wm_wd_01011][number.trockner_audio_volume_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Trockner Audio volume level',
+      'max': 3,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.trockner_audio_volume_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3',
+  })
+# ---
 # name: test_all_entities[da_wm_wm_000001][number.washer_rinse_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -524,6 +638,63 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
+  })
+# ---
+# name: test_all_entities[da_wm_wm_01011][number.machine_a_laver_audio_volume_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 1,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.machine_a_laver_audio_volume_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Audio volume level',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_volume_level',
+    'unique_id': 'b854ca5f-dc54-140d-6349-758b4d973c41_main_audio_volume_level_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_wm_wm_01011][number.machine_a_laver_audio_volume_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Machine à Laver Audio volume level',
+      'max': 1,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.machine_a_laver_audio_volume_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
   })
 # ---
 # name: test_all_entities[da_wm_wm_01011][number.machine_a_laver_rinse_cycles-entry]

--- a/tests/components/smartthings/snapshots/test_switch.ambr
+++ b/tests/components/smartthings/snapshots/test_switch.ambr
@@ -1295,6 +1295,54 @@
     'state': 'off',
   })
 # ---
+# name: test_all_entities[da_wm_wm_01011][switch.machine_a_laver_mute-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.machine_a_laver_mute',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Mute',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mute',
+    'unique_id': 'b854ca5f-dc54-140d-6349-758b4d973c41_main_samsungce.audioVolumeLevel_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_wm_wm_01011][switch.machine_a_laver_mute-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Machine à Laver Mute',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.machine_a_laver_mute',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_all_entities[generic_ef00_v1][switch.thermostat_kuche-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Hey. I need this to quiet my dishwasher at night so it doesn't make any unnecessary noise.

This option is also available in Samsung SmartThings Android app and have the following note:
"Error or important notifications sound won't turn off even if the dishwasher is muted"
<img width="400" alt="image" src="https://github.com/user-attachments/assets/0445a756-0c0d-4fbf-ad3c-6130dd83fbb9" />

In my devce, only 0 and 1 values ​​are available, but I see that we have fixtures for other fixtures that have a wider range, so I used the number entity.

I see that Samsung already released official capability for volume control: https://developer.smartthings.com/docs/devices/capabilities/capabilities-reference#audioVolume
but I don't have device to tests it. Can I add it without tests? This capability has two difference:
- name of command - `SET_VOLUME_LEVEL` vs `SET_VOLUME`
-  unit - `None` vs `%`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/core/pull/156642
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
