### PR TITLE
Bump tplink-omada-api to 1.5.3

### DIFF
--- a/homeassistant/components/tplink_omada/manifest.json
+++ b/homeassistant/components/tplink_omada/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tplink_omada",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "requirements": ["tplink-omada-client==1.4.4"]
+  "requirements": ["tplink-omada-client==1.5.3"]
 }

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, Generic, TypeVar
 
-from tplink_omada_client import OmadaSiteClient, SwitchPortOverrides
+from tplink_omada_client import (
+    GatewayPortSettings,
+    OmadaSiteClient,
+    PortProfileOverrides,
+    SwitchPortSettings,
+)
 from tplink_omada_client.definitions import GatewayPortMode, PoEMode, PortType
 from tplink_omada_client.devices import (
     OmadaDevice,
@@ -17,7 +22,6 @@ from tplink_omada_client.devices import (
     OmadaSwitch,
     OmadaSwitchPortDetails,
 )
-from tplink_omada_client.omadasiteclient import GatewayPortSettings
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
@@ -184,7 +188,12 @@ SWITCH_PORT_DETAILS_SWITCHES: list[OmadaSwitchPortSwitchEntityDescription] = [
         ),
         set_func=(
             lambda client, device, port, enable: client.update_switch_port(
-                device, port, overrides=SwitchPortOverrides(enable_poe=enable)
+                device,
+                port,
+                settings=SwitchPortSettings(
+                    profile_override_enabled=True,
+                    profile_overrides=PortProfileOverrides(enable_poe=enable),
+                ),
             )
         ),
         update_func=lambda p: p.poe_mode != PoEMode.DISABLED,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3005,7 +3005,7 @@ total-connect-client==2025.5
 tp-connected==0.0.4
 
 # homeassistant.components.tplink_omada
-tplink-omada-client==1.4.4
+tplink-omada-client==1.5.3
 
 # homeassistant.components.transmission
 transmission-rpc==7.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2478,7 +2478,7 @@ toonapi==0.3.0
 total-connect-client==2025.5
 
 # homeassistant.components.tplink_omada
-tplink-omada-client==1.4.4
+tplink-omada-client==1.5.3
 
 # homeassistant.components.transmission
 transmission-rpc==7.0.3

--- a/tests/components/tplink_omada/test_switch.py
+++ b/tests/components/tplink_omada/test_switch.py
@@ -5,7 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from syrupy.assertion import SnapshotAssertion
-from tplink_omada_client import SwitchPortOverrides
+from tplink_omada_client import SwitchPortSettings
 from tplink_omada_client.definitions import PoEMode
 from tplink_omada_client.devices import (
     OmadaGateway,
@@ -249,14 +249,16 @@ async def _test_poe_switch(
         device: OmadaSwitch,
         switch_port_details: OmadaSwitchPortDetails,
         poe_enabled: bool,
-        overrides: SwitchPortOverrides = None,
+        settings: SwitchPortSettings,
     ) -> None:
         assert device
         assert device.mac == network_switch_mac
         assert switch_port_details
         assert switch_port_details.port == port_num
-        assert overrides
-        assert overrides.enable_poe == poe_enabled
+        assert settings
+        assert settings.profile_override_enabled
+        assert settings.profile_overrides
+        assert settings.profile_overrides.enable_poe == poe_enabled
 
     entity = hass.states.get(entity_id)
     assert entity == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump `tplink-omada-client` package to add support for Omada 6.x controllers and improve stability.

[Changelog](https://github.com/MarkGodwin/tplink-omada-api/compare/release/v1.4.4...release/v1.5.3)

The API has changed slightly to remove unwanted side effects when changing port settings, so a tiny change to the calling code was also necessary.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #155249
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
