### PR TITLE
Fix NINA flow tests to end a final state

### DIFF
--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -88,12 +88,12 @@ def prepare_user_input(
 
 def create_schema(
     regions: dict[str, dict[str, Any]], existing_data: dict[str, Any] | None = None
-) -> VolDictType:
+) -> vol.Schema:
     """Create the schema for the flows."""
     if existing_data is None:
         existing_data = {}
 
-    return {
+    schema_dict: VolDictType = {
         **{
             vol.Optional(
                 region, default=existing_data.get(region, [])
@@ -123,6 +123,8 @@ def create_schema(
             )
         ),
     }
+
+    return vol.Schema(schema_dict)
 
 
 class NinaConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -182,7 +184,7 @@ class NinaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(create_schema(self.regions)),
+            data_schema=create_schema(self.regions),
             errors=errors,
         )
 
@@ -280,6 +282,6 @@ class OptionsFlowHandler(OptionsFlowWithReload):
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(create_schema(self.regions, self.data)),
+            data_schema=create_schema(self.regions, self.data),
             errors=errors,
         )

--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -116,10 +116,10 @@ class NinaConfigFlow(ConfigFlow, domain=DOMAIN):
                     await nina.getAllRegionalCodes()
                 )
             except ApiError:
-                errors["base"] = "cannot_connect"
+                return self.async_abort(reason="no_fetch")
             except Exception as err:  # noqa: BLE001
                 _LOGGER.exception("Unexpected exception: %s", err)
-                errors["base"] = "unknown"
+                return self.async_abort(reason="unknown")
 
             self.regions = split_regions(self._all_region_codes_sorted, self.regions)
 
@@ -209,10 +209,10 @@ class OptionsFlowHandler(OptionsFlowWithReload):
                     await nina.getAllRegionalCodes()
                 )
             except ApiError:
-                errors["base"] = "cannot_connect"
+                return self.async_abort(reason="no_fetch")
             except Exception as err:  # noqa: BLE001
                 _LOGGER.exception("Unexpected exception: %s", err)
-                errors["base"] = "unknown"
+                return self.async_abort(reason="unknown")
 
             self.regions = split_regions(self._all_region_codes_sorted, self.regions)
 

--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -117,8 +117,8 @@ class NinaConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
             except ApiError:
                 return self.async_abort(reason="no_fetch")
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.exception("Unexpected exception: %s", err)
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Unexpected exception")
                 return self.async_abort(reason="unknown")
 
             self.regions = split_regions(self._all_region_codes_sorted, self.regions)
@@ -210,8 +210,8 @@ class OptionsFlowHandler(OptionsFlowWithReload):
                 )
             except ApiError:
                 return self.async_abort(reason="no_fetch")
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.exception("Unexpected exception: %s", err)
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Unexpected exception")
                 return self.async_abort(reason="unknown")
 
             self.regions = split_regions(self._all_region_codes_sorted, self.regions)

--- a/homeassistant/components/nina/strings.json
+++ b/homeassistant/components/nina/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "abort": {
-      "no_fetch": "Cannot fetch city or counties",
+      "no_fetch": "Cannot connect to NINA service to fetch city or counties. Please try again later.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "error": {

--- a/homeassistant/components/nina/strings.json
+++ b/homeassistant/components/nina/strings.json
@@ -51,9 +51,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "no_selection": "[%key:component::nina::config::error::no_selection%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "no_selection": "[%key:component::nina::config::error::no_selection%]"
     },
     "step": {
       "init": {

--- a/homeassistant/components/nina/strings.json
+++ b/homeassistant/components/nina/strings.json
@@ -1,9 +1,11 @@
 {
   "config": {
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "no_selection": "Please select at least one city/county",
+    "abort": {
+      "no_fetch": "Cannot fetch city or counties",
       "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "error": {
+      "no_selection": "Please select at least one city/county"
     },
     "step": {
       "user": {
@@ -44,6 +46,10 @@
     }
   },
   "options": {
+    "abort": {
+      "no_fetch": "[%key:component::nina::config::abort::no_fetch%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "no_selection": "[%key:component::nina::config::error::no_selection%]",

--- a/tests/components/nina/test_config_flow.py
+++ b/tests/components/nina/test_config_flow.py
@@ -199,7 +199,10 @@ async def test_options_flow_init(hass: HomeAssistant) -> None:
                 CONST_REGION_M_TO_Q: [],
                 CONST_REGION_R_TO_U: [],
                 CONST_REGION_V_TO_Z: [],
-                CONF_FILTERS: {},
+                CONF_FILTERS: {
+                    CONF_HEADLINE_FILTER: ".*corona.*",
+                    CONF_AREA_FILTER: ".*",
+                },
             },
         )
 
@@ -273,7 +276,10 @@ async def test_options_flow_with_no_selection(hass: HomeAssistant) -> None:
                 CONST_REGION_M_TO_Q: [],
                 CONST_REGION_R_TO_U: [],
                 CONST_REGION_V_TO_Z: [],
-                CONF_FILTERS: {},
+                CONF_FILTERS: {
+                    CONF_HEADLINE_FILTER: ".*corona.*",
+                    CONF_AREA_FILTER: ".*",
+                },
             },
         )
 

--- a/tests/components/nina/test_config_flow.py
+++ b/tests/components/nina/test_config_flow.py
@@ -78,8 +78,8 @@ async def test_step_user_connection_error(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data=deepcopy(DUMMY_DATA)
         )
 
-        assert result["type"] is FlowResultType.FORM
-        assert result["errors"] == {"base": "cannot_connect"}
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "no_fetch"
 
 
 async def test_step_user_unexpected_exception(hass: HomeAssistant) -> None:
@@ -92,9 +92,8 @@ async def test_step_user_unexpected_exception(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data=deepcopy(DUMMY_DATA)
         )
 
-        assert result["type"] is FlowResultType.FORM
-        assert result["errors"] == {"base": "unknown"}
-        hass.config_entries.flow.async_abort(result["flow_id"])
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "unknown"
 
 
 async def test_step_user(hass: HomeAssistant) -> None:
@@ -291,8 +290,8 @@ async def test_options_flow_connection_error(hass: HomeAssistant) -> None:
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] is FlowResultType.FORM
-        assert result["errors"] == {"base": "cannot_connect"}
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "no_fetch"
 
 
 async def test_options_flow_unexpected_exception(hass: HomeAssistant) -> None:
@@ -321,9 +320,8 @@ async def test_options_flow_unexpected_exception(hass: HomeAssistant) -> None:
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-        assert result["type"] is FlowResultType.FORM
-        assert result["errors"] == {"base": "unknown"}
-        hass.config_entries.options.async_abort(result["flow_id"])
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "unknown"
 
 
 async def test_options_flow_entity_removal(

--- a/tests/components/nina/test_config_flow.py
+++ b/tests/components/nina/test_config_flow.py
@@ -139,6 +139,11 @@ async def test_step_user_no_selection(hass: HomeAssistant) -> None:
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == "NINA"
+        assert result["data"] == deepcopy(DUMMY_DATA) | {
+            CONF_REGIONS: {
+                "095760000000": "Allersberg, M (Roth - Bayern) + Büchenbach (Roth - Bayern)"
+            }
+        }
 
 
 async def test_step_user_already_configured(hass: HomeAssistant) -> None:
@@ -273,6 +278,19 @@ async def test_options_flow_with_no_selection(hass: HomeAssistant) -> None:
         )
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["data"] == {}
+
+        assert dict(config_entry.data) == {
+            CONF_FILTERS: deepcopy(DUMMY_DATA[CONF_FILTERS]),
+            CONF_MESSAGE_SLOTS: deepcopy(DUMMY_DATA[CONF_MESSAGE_SLOTS]),
+            CONST_REGION_A_TO_D: ["095760000000_0"],
+            CONST_REGION_E_TO_H: [],
+            CONST_REGION_I_TO_L: [],
+            CONST_REGION_M_TO_Q: [],
+            CONST_REGION_R_TO_U: [],
+            CONST_REGION_V_TO_Z: [],
+            CONF_REGIONS: {"095760000000": "Allersberg, M (Roth - Bayern)"},
+        }
 
 
 async def test_options_flow_connection_error(hass: HomeAssistant) -> None:

--- a/tests/components/nina/test_config_flow.py
+++ b/tests/components/nina/test_config_flow.py
@@ -107,7 +107,7 @@ async def test_step_user(hass: HomeAssistant) -> None:
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == "NINA"
-        assert result["data"] == deepcopy(DUMMY_DATA) | {
+        assert result["data"] == DUMMY_DATA | {
             CONF_REGIONS: {
                 "095760000000": "Allersberg, M (Roth - Bayern) + Büchenbach (Roth - Bayern)"
             }
@@ -139,7 +139,7 @@ async def test_step_user_no_selection(hass: HomeAssistant) -> None:
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == "NINA"
-        assert result["data"] == deepcopy(DUMMY_DATA) | {
+        assert result["data"] == DUMMY_DATA | {
             CONF_REGIONS: {
                 "095760000000": "Allersberg, M (Roth - Bayern) + Büchenbach (Roth - Bayern)"
             }
@@ -210,8 +210,8 @@ async def test_options_flow_init(hass: HomeAssistant) -> None:
         assert result["data"] == {}
 
         assert dict(config_entry.data) == {
-            CONF_FILTERS: deepcopy(DUMMY_DATA[CONF_FILTERS]),
-            CONF_MESSAGE_SLOTS: deepcopy(DUMMY_DATA[CONF_MESSAGE_SLOTS]),
+            CONF_FILTERS: DUMMY_DATA[CONF_FILTERS],
+            CONF_MESSAGE_SLOTS: DUMMY_DATA[CONF_MESSAGE_SLOTS],
             CONST_REGION_A_TO_D: ["072350000000_1"],
             CONST_REGION_E_TO_H: [],
             CONST_REGION_I_TO_L: [],
@@ -287,8 +287,8 @@ async def test_options_flow_with_no_selection(hass: HomeAssistant) -> None:
         assert result["data"] == {}
 
         assert dict(config_entry.data) == {
-            CONF_FILTERS: deepcopy(DUMMY_DATA[CONF_FILTERS]),
-            CONF_MESSAGE_SLOTS: deepcopy(DUMMY_DATA[CONF_MESSAGE_SLOTS]),
+            CONF_FILTERS: DUMMY_DATA[CONF_FILTERS],
+            CONF_MESSAGE_SLOTS: DUMMY_DATA[CONF_MESSAGE_SLOTS],
             CONST_REGION_A_TO_D: ["095760000000_0"],
             CONST_REGION_E_TO_H: [],
             CONST_REGION_I_TO_L: [],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update the tests for the flows to always end in a final state to also test the recovery after an error.
Update the flows to abort on unrecoverable errors.

This pr is need to get NINA to bronze (#155191)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
