### PR TITLE
Delay creation of some Omada device entities when devices are not connected

### DIFF
--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from tplink_omada_client.definitions import GatewayPortMode, LinkStatus, PoEMode
+from tplink_omada_client.definitions import (
+    DeviceStatusCategory,
+    GatewayPortMode,
+    LinkStatus,
+    PoEMode,
+)
 from tplink_omada_client.devices import (
     OmadaDevice,
     OmadaGatewayPortConfig,
     OmadaGatewayPortStatus,
+    OmadaListDevice,
 )
 
 from homeassistant.components.binary_sensor import (
@@ -18,6 +24,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OmadaConfigEntry
@@ -33,22 +40,30 @@ async def async_setup_entry(
     """Set up binary sensors."""
     controller = config_entry.runtime_data
 
-    gateway_coordinator = controller.gateway_coordinator
-    if not gateway_coordinator:
-        return
+    async def _create_gateway_port_entities(device: OmadaListDevice) -> list[Entity]:
+        gateway_coordinator = controller.gateway_coordinator
+        if not gateway_coordinator:
+            return []
 
-    entities: list[OmadaDeviceEntity] = []
-    for gateway in gateway_coordinator.data.values():
-        entities.extend(
-            OmadaGatewayPortBinarySensor(
-                gateway_coordinator, gateway, p.port_number, desc
+        entities: list[Entity] = []
+        gateway = gateway_coordinator.data.get(device.mac)
+        if gateway:
+            entities.extend(
+                OmadaGatewayPortBinarySensor(
+                    gateway_coordinator, gateway, p.port_number, desc
+                )
+                for p in gateway.port_configs
+                for desc in GATEWAY_PORT_SENSORS
+                if desc.exists_func(p)
             )
-            for p in gateway.port_configs
-            for desc in GATEWAY_PORT_SENSORS
-            if desc.exists_func(p)
-        )
+        return entities
 
-    async_add_entities(entities)
+    await controller.async_register_device_entities(
+        async_add_entities,
+        lambda device: device.type == "gateway"
+        and device.status_category == DeviceStatusCategory.CONNECTED,
+        _create_gateway_port_entities,
+    )
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -43,7 +43,8 @@ async def async_setup_entry(
     async def _create_gateway_port_entities(device: OmadaListDevice) -> list[Entity]:
         gateway_coordinator = controller.gateway_coordinator
         if not gateway_coordinator:
-            return []
+            # Unreachable as coordinator would be created if gateway device exists.
+            return []  # pragma: no cover
 
         entities: list[Entity] = []
         gateway = gateway_coordinator.data.get(device.mac)

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -9,8 +9,6 @@ from tplink_omada_client import OmadaSiteClient
 from tplink_omada_client.devices import OmadaListDevice, OmadaSwitch
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 if TYPE_CHECKING:
     from . import OmadaConfigEntry
@@ -63,9 +61,8 @@ class OmadaSiteController:
 
     async def async_register_device_entities(
         self,
-        add_entities: AddConfigEntryEntitiesCallback,
         device_filter: Callable[[OmadaListDevice], bool],
-        entity_callback: Callable[[OmadaListDevice], Awaitable[list[Entity]]],
+        entity_callback: Callable[[OmadaListDevice], Awaitable[None]],
     ) -> None:
         """Register entities for devices matching the given filter.
 
@@ -73,9 +70,8 @@ class OmadaSiteController:
         currently in a queryable state.
 
         Args:
-            add_entities: Callback to add entities to Home Assistant.
             device_filter: Function that returns True if a device should be processed.
-            entity_callback: Given an Omada device, returns a list of entities to create.
+            entity_callback: Given a discovered Omada device, creates entities for that device.
         """
         # Track which devices have been processed already
         processed_devices: set[str] = set()
@@ -91,13 +87,9 @@ class OmadaSiteController:
             if not devices_to_process:
                 return
 
-            entities: list = []
             for device in devices_to_process:
                 processed_devices.add(device.mac)
-                device_entities = await entity_callback(device)
-                entities.extend(device_entities)
-
-            add_entities(entities)
+                await entity_callback(device)
 
         @callback
         def _handle_devices_update() -> None:

--- a/homeassistant/components/tplink_omada/sensor.py
+++ b/homeassistant/components/tplink_omada/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -64,11 +65,20 @@ async def async_setup_entry(
 
     devices_coordinator = controller.devices_coordinator
 
-    async_add_entities(
-        OmadaDeviceSensor(devices_coordinator, device, desc)
-        for device in devices_coordinator.data.values()
-        for desc in OMADA_DEVICE_SENSORS
-        if desc.exists_func(device)
+    async def _create_device_sensor_entities(
+        device: OmadaListDevice,
+    ) -> list[Entity]:
+        """Create sensor entities for a device."""
+        return [
+            OmadaDeviceSensor(devices_coordinator, device, desc)
+            for desc in OMADA_DEVICE_SENSORS
+            if desc.exists_func(device)
+        ]
+
+    await controller.async_register_device_entities(
+        async_add_entities,
+        lambda _: True,
+        _create_device_sensor_entities,
     )
 
 

--- a/homeassistant/components/tplink_omada/sensor.py
+++ b/homeassistant/components/tplink_omada/sensor.py
@@ -16,7 +16,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -67,16 +66,17 @@ async def async_setup_entry(
 
     async def _create_device_sensor_entities(
         device: OmadaListDevice,
-    ) -> list[Entity]:
+    ) -> None:
         """Create sensor entities for a device."""
-        return [
-            OmadaDeviceSensor(devices_coordinator, device, desc)
-            for desc in OMADA_DEVICE_SENSORS
-            if desc.exists_func(device)
-        ]
+        async_add_entities(
+            [
+                OmadaDeviceSensor(devices_coordinator, device, desc)
+                for desc in OMADA_DEVICE_SENSORS
+                if desc.exists_func(device)
+            ]
+        )
 
     await controller.async_register_device_entities(
-        async_add_entities,
         lambda _: True,
         _create_device_sensor_entities,
     )

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -13,12 +13,18 @@ from tplink_omada_client import (
     PortProfileOverrides,
     SwitchPortSettings,
 )
-from tplink_omada_client.definitions import GatewayPortMode, PoEMode, PortType
+from tplink_omada_client.definitions import (
+    DeviceStatusCategory,
+    GatewayPortMode,
+    PoEMode,
+    PortType,
+)
 from tplink_omada_client.devices import (
     OmadaDevice,
     OmadaGateway,
     OmadaGatewayPortConfig,
     OmadaGatewayPortStatus,
+    OmadaListDevice,
     OmadaSwitch,
     OmadaSwitchPortDetails,
 )
@@ -26,6 +32,7 @@ from tplink_omada_client.devices import (
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OmadaConfigEntry
@@ -45,18 +52,17 @@ async def async_setup_entry(
 ) -> None:
     """Set up switches."""
     controller = config_entry.runtime_data
-    omada_client = controller.omada_client
 
-    # Naming fun. Omada switches, as in the network hardware
-    network_switches = await omada_client.get_switches()
-
-    entities: list = []
-    for switch in [
-        ns for ns in network_switches if ns.device_capabilities.supports_poe
-    ]:
+    async def _create_switch_port_entities(
+        device: OmadaListDevice,
+    ) -> list[Entity]:
+        """Create entities for a switch's ports."""
+        omada_client = controller.omada_client
+        switch = await omada_client.get_switch(device)
         coordinator = controller.get_switch_port_coordinator(switch)
         await coordinator.async_request_refresh()
 
+        entities: list[Entity] = []
         entities.extend(
             OmadaDevicePortSwitchEntity[
                 OmadaSwitchPortCoordinator, OmadaSwitch, OmadaSwitchPortDetails
@@ -72,10 +78,26 @@ async def async_setup_entry(
             for desc in SWITCH_PORT_DETAILS_SWITCHES
             if desc.exists_func(switch, port)
         )
+        return entities
 
-    gateway_coordinator = controller.gateway_coordinator
-    if gateway_coordinator:
-        for gateway in gateway_coordinator.data.values():
+    # Register switch port entities for switches that are connected, such that we can determine the port information
+    await controller.async_register_device_entities(
+        async_add_entities,
+        device_filter=lambda d: (
+            d.type == "switch" and d.status_category == DeviceStatusCategory.CONNECTED
+        ),
+        entity_callback=_create_switch_port_entities,
+    )
+
+    # Set up gateway port switches
+    async def _create_gateway_port_entities(
+        device: OmadaListDevice,
+    ) -> list[Entity]:
+        """Create entities for a gateway's ports."""
+        entities: list[Entity] = []
+        gateway_coordinator = controller.gateway_coordinator
+        if gateway_coordinator:
+            gateway = gateway_coordinator.data[device.mac]
             entities.extend(
                 OmadaDevicePortSwitchEntity[
                     OmadaGatewayCoordinator, OmadaGateway, OmadaGatewayPortStatus
@@ -92,8 +114,15 @@ async def async_setup_entry(
                 for desc in GATEWAY_PORT_CONFIG_SWITCHES
                 if desc.exists_func(gateway, p)
             )
+        return entities
 
-    async_add_entities(entities)
+    await controller.async_register_device_entities(
+        async_add_entities,
+        device_filter=lambda d: (
+            d.type == "gateway" and d.status_category == DeviceStatusCategory.CONNECTED
+        ),
+        entity_callback=_create_gateway_port_entities,
+    )
 
 
 def _get_switch_port_base_name(port: OmadaSwitchPortDetails) -> str:
@@ -184,7 +213,9 @@ SWITCH_PORT_DETAILS_SWITCHES: list[OmadaSwitchPortSwitchEntityDescription] = [
         key="poe",
         translation_key="poe_control",
         exists_func=(
-            lambda d, p: d.device_capabilities.supports_poe and p.type != PortType.SFP
+            lambda d, p: d.device_capabilities.supports_poe
+            and p.supports_poe
+            and p.type != PortType.SFP
         ),
         set_func=(
             lambda client, device, port, enable: client.update_switch_port(

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -55,7 +55,7 @@ async def async_setup_entry(
 
     async def _create_switch_port_entities(
         device: OmadaListDevice,
-    ) -> list[Entity]:
+    ) -> None:
         """Create entities for a switch's ports."""
         omada_client = controller.omada_client
         switch = await omada_client.get_switch(device)
@@ -78,11 +78,10 @@ async def async_setup_entry(
             for desc in SWITCH_PORT_DETAILS_SWITCHES
             if desc.exists_func(switch, port)
         )
-        return entities
+        async_add_entities(entities)
 
     # Register switch port entities for switches that are connected, such that we can determine the port information
     await controller.async_register_device_entities(
-        async_add_entities,
         device_filter=lambda d: (
             d.type == "switch" and d.status_category == DeviceStatusCategory.CONNECTED
         ),
@@ -92,7 +91,7 @@ async def async_setup_entry(
     # Set up gateway port switches
     async def _create_gateway_port_entities(
         device: OmadaListDevice,
-    ) -> list[Entity]:
+    ) -> None:
         """Create entities for a gateway's ports."""
         entities: list[Entity] = []
         gateway_coordinator = controller.gateway_coordinator
@@ -114,10 +113,9 @@ async def async_setup_entry(
                 for desc in GATEWAY_PORT_CONFIG_SWITCHES
                 if desc.exists_func(gateway, p)
             )
-        return entities
+        async_add_entities(entities)
 
     await controller.async_register_device_entities(
-        async_add_entities,
         device_filter=lambda d: (
             d.type == "gateway" and d.status_category == DeviceStatusCategory.CONNECTED
         ),

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -69,6 +69,7 @@ async def mock_omada_site_client(hass: HomeAssistant) -> AsyncGenerator[AsyncMoc
     )
     switch1 = OmadaSwitch(switch1_data)
     site_client.get_switches = AsyncMock(return_value=[switch1])
+    site_client.get_switch = AsyncMock(return_value=switch1)
 
     devices_data = json.loads(await async_load_fixture(hass, "devices.json", DOMAIN))
     devices = [OmadaListDevice(d) for d in devices_data]

--- a/tests/components/tplink_omada/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tplink_omada/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,981 @@
+# serializer version: 1
+# name: test_entities[binary_sensor.test_router_port_10_lan_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_10_lan_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 10 LAN status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lan_status',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_10_lan_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_10_lan_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 10 LAN status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_10_lan_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_10_poe_delivery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_10_poe_delivery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Port 10 PoE delivery',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'poe_delivery',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_10_poe_delivery',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_10_poe_delivery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test Router Port 10 PoE delivery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_10_poe_delivery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_11_lan_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_11_lan_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 11 LAN status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lan_status',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_11_lan_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_11_lan_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 11 LAN status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_11_lan_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_11_poe_delivery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_11_poe_delivery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Port 11 PoE delivery',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'poe_delivery',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_11_poe_delivery',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_11_poe_delivery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test Router Port 11 PoE delivery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_11_poe_delivery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_12_lan_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_12_lan_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 12 LAN status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lan_status',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_12_lan_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_12_lan_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 12 LAN status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_12_lan_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_12_poe_delivery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_12_poe_delivery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Port 12 PoE delivery',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'poe_delivery',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_12_poe_delivery',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_12_poe_delivery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test Router Port 12 PoE delivery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_12_poe_delivery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_1_lan_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_1_lan_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 1 LAN status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lan_status',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_1_lan_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_1_lan_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 1 LAN status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_1_lan_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_2_lan_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_2_lan_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 2 LAN status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lan_status',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_2_lan_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_2_lan_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 2 LAN status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_2_lan_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_4_internet_link-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_4_internet_link',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 4 Internet link',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wan_link',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_4_wan_link',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_4_internet_link-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 4 Internet link',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_4_internet_link',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_4_online_detection-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_4_online_detection',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 4 online detection',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'online_detection',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_4_online_detection',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_4_online_detection-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 4 online detection',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_4_online_detection',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_5_lan_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_5_lan_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 5 LAN status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lan_status',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_5_lan_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_5_lan_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 5 LAN status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_5_lan_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_5_poe_delivery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_5_poe_delivery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Port 5 PoE delivery',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'poe_delivery',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_5_poe_delivery',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_5_poe_delivery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test Router Port 5 PoE delivery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_5_poe_delivery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_6_lan_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_6_lan_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 6 LAN status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lan_status',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_6_lan_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_6_lan_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 6 LAN status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_6_lan_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_6_poe_delivery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_6_poe_delivery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Port 6 PoE delivery',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'poe_delivery',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_6_poe_delivery',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_6_poe_delivery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test Router Port 6 PoE delivery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_6_poe_delivery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_7_lan_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_7_lan_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 7 LAN status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lan_status',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_7_lan_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_7_lan_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 7 LAN status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_7_lan_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_7_poe_delivery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_7_poe_delivery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Port 7 PoE delivery',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'poe_delivery',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_7_poe_delivery',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_7_poe_delivery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test Router Port 7 PoE delivery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_7_poe_delivery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_8_lan_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_8_lan_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 8 LAN status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lan_status',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_8_lan_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_8_lan_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 8 LAN status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_8_lan_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_8_poe_delivery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_8_poe_delivery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Port 8 PoE delivery',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'poe_delivery',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_8_poe_delivery',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_8_poe_delivery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test Router Port 8 PoE delivery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_8_poe_delivery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_9_lan_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_9_lan_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Port 9 LAN status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lan_status',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_9_lan_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_9_lan_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Test Router Port 9 LAN status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_9_lan_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_9_poe_delivery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_router_port_9_poe_delivery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Port 9 PoE delivery',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'poe_delivery',
+    'unique_id': 'AA-BB-CC-DD-EE-FF_9_poe_delivery',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_router_port_9_poe_delivery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test Router Port 9 PoE delivery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_router_port_9_poe_delivery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/tplink_omada/test_binary_sensor.py
+++ b/tests/components/tplink_omada/test_binary_sensor.py
@@ -1,0 +1,143 @@
+"""Tests for TP-Link Omada sensor entities."""
+
+from datetime import timedelta
+import json
+from unittest.mock import MagicMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from tplink_omada_client.definitions import DeviceStatus, DeviceStatusCategory
+from tplink_omada_client.devices import OmadaListDevice
+
+from homeassistant.components.tplink_omada.const import DOMAIN
+from homeassistant.components.tplink_omada.coordinator import POLL_DEVICES
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    load_fixture,
+    snapshot_platform,
+)
+
+POLL_INTERVAL = timedelta(seconds=POLL_DEVICES)
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> MockConfigEntry:
+    """Set up the TP-Link Omada integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.tplink_omada.PLATFORMS", ["binary_sensor"]):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    return mock_config_entry
+
+
+async def test_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the creation of the TP-Link Omada binary sensor entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
+
+
+async def test_no_gateway_creates_no_port_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    mock_omada_site_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that if there is no gateway, no gateway port sensors are created."""
+
+    _remove_test_device(mock_omada_site_client, 0)
+
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.tplink_omada.PLATFORMS", ["binary_sensor"]):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_omada_site_client.get_gateway.assert_not_called()
+
+
+async def test_disconnected_device_sensor_not_registered(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    mock_omada_site_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that if the gateway is not connected to the controller, gateway entities are not created."""
+
+    _set_test_device_status(
+        mock_omada_site_client,
+        0,
+        DeviceStatus.DISCONNECTED.value,
+        DeviceStatusCategory.DISCONNECTED.value,
+    )
+
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.tplink_omada.PLATFORMS", ["binary_sensor"]):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_id = "binary_sensor.test_router_port_1_lan_status"
+    entity = hass.states.get(entity_id)
+    assert entity is None
+
+    # "Connect" the gateway
+    _set_test_device_status(
+        mock_omada_site_client,
+        0,
+        DeviceStatus.CONNECTED.value,
+        DeviceStatusCategory.CONNECTED.value,
+    )
+
+    freezer.tick(POLL_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    entity = hass.states.get(entity_id)
+    assert entity is not None
+    assert entity.state == "off"
+
+    mock_omada_site_client.get_gateway.assert_called_once_with("AA-BB-CC-DD-EE-FF")
+
+
+def _set_test_device_status(
+    mock_omada_site_client: MagicMock,
+    dev_index: int,
+    status: int,
+    status_category: int,
+) -> None:
+    devices_data = json.loads(load_fixture("devices.json", DOMAIN))
+    devices_data[dev_index]["status"] = status
+    devices_data[dev_index]["statusCategory"] = status_category
+    devices = [OmadaListDevice(d) for d in devices_data]
+
+    mock_omada_site_client.get_devices.reset_mock()
+    mock_omada_site_client.get_devices.return_value = devices
+
+
+def _remove_test_device(
+    mock_omada_site_client: MagicMock,
+    dev_index: int,
+) -> None:
+    devices_data = json.loads(load_fixture("devices.json", DOMAIN))
+    del devices_data[dev_index]
+    devices = [OmadaListDevice(d) for d in devices_data]
+
+    mock_omada_site_client.get_devices.reset_mock()
+    mock_omada_site_client.get_devices.return_value = devices

--- a/tests/components/tplink_omada/test_config_flow.py
+++ b/tests/components/tplink_omada/test_config_flow.py
@@ -43,7 +43,9 @@ async def test_form_single_site(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
+    assert "type" in result
     assert result["type"] is FlowResultType.FORM
+    assert "errors" in result
     assert result["errors"] == {}
 
     with (
@@ -64,8 +66,11 @@ async def test_form_single_site(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
+    assert "type" in result2
     assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert "title" in result2
     assert result2["title"] == "OC200 (Display Name)"
+    assert "data" in result2
     assert result2["data"] == MOCK_ENTRY_DATA
     assert len(mock_setup_entry.mock_calls) == 1
     mocked_validate.assert_called_once_with(hass, MOCK_USER_DATA)
@@ -76,8 +81,11 @@ async def test_form_multiple_sites(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
+    assert "type" in result
     assert result["type"] is FlowResultType.FORM
+    assert "step_id" in result
     assert result["step_id"] == "user"
+    assert "errors" in result
     assert result["errors"] == {}
 
     with (
@@ -100,7 +108,9 @@ async def test_form_multiple_sites(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
+    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
+    assert "step_id" in result2
     assert result2["step_id"] == "site"
 
     with patch(
@@ -115,8 +125,11 @@ async def test_form_multiple_sites(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
+    assert "type" in result3
     assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert "title" in result3
     assert result3["title"] == "OC200 (Site 2)"
+    assert "data" in result3
     assert result3["data"] == {
         "host": "https://fake.omada.host",
         "verify_ssl": True,
@@ -142,7 +155,9 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
+    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
+    assert "errors" in result2
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
@@ -161,7 +176,9 @@ async def test_form_api_error(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
+    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
+    assert "errors" in result2
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -180,7 +197,9 @@ async def test_form_generic_exception(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
+    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
+    assert "errors" in result2
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -199,7 +218,9 @@ async def test_form_unsupported_controller(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
+    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
+    assert "errors" in result2
     assert result2["errors"] == {"base": "unsupported_controller"}
 
 
@@ -218,7 +239,9 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
+    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
+    assert "errors" in result2
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -237,7 +260,9 @@ async def test_form_no_sites(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
+    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
+    assert "errors" in result2
     assert result2["errors"] == {"base": "no_sites_found"}
 
 
@@ -253,7 +278,9 @@ async def test_async_step_reauth_success(hass: HomeAssistant) -> None:
 
     result = await mock_entry.start_reauth_flow(hass)
 
+    assert "type" in result
     assert result["type"] is FlowResultType.FORM
+    assert "step_id" in result
     assert result["step_id"] == "reauth_confirm"
 
     with patch(
@@ -267,7 +294,9 @@ async def test_async_step_reauth_success(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
+    assert "type" in result2
     assert result2["type"] is FlowResultType.ABORT
+    assert "reason" in result2
     assert result2["reason"] == "reauth_successful"
     mocked_validate.assert_called_once_with(
         hass,
@@ -293,7 +322,9 @@ async def test_async_step_reauth_invalid_auth(hass: HomeAssistant) -> None:
 
     result = await mock_entry.start_reauth_flow(hass)
 
+    assert "type" in result
     assert result["type"] is FlowResultType.FORM
+    assert "step_id" in result
     assert result["step_id"] == "reauth_confirm"
 
     with patch(
@@ -305,8 +336,11 @@ async def test_async_step_reauth_invalid_auth(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reauth_confirm"
+    assert "type" in result2
+    assert result2["type"] is FlowResultType.FORM
+    assert "step_id" in result2
+    assert result2["step_id"] == "reauth_confirm"
+    assert "errors" in result2
     assert result2["errors"] == {"base": "invalid_auth"}
 
 

--- a/tests/components/tplink_omada/test_config_flow.py
+++ b/tests/components/tplink_omada/test_config_flow.py
@@ -43,9 +43,7 @@ async def test_form_single_site(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert "type" in result
     assert result["type"] is FlowResultType.FORM
-    assert "errors" in result
     assert result["errors"] == {}
 
     with (
@@ -66,11 +64,8 @@ async def test_form_single_site(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert "type" in result2
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert "title" in result2
     assert result2["title"] == "OC200 (Display Name)"
-    assert "data" in result2
     assert result2["data"] == MOCK_ENTRY_DATA
     assert len(mock_setup_entry.mock_calls) == 1
     mocked_validate.assert_called_once_with(hass, MOCK_USER_DATA)
@@ -81,11 +76,8 @@ async def test_form_multiple_sites(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert "type" in result
     assert result["type"] is FlowResultType.FORM
-    assert "step_id" in result
     assert result["step_id"] == "user"
-    assert "errors" in result
     assert result["errors"] == {}
 
     with (
@@ -108,9 +100,7 @@ async def test_form_multiple_sites(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
-    assert "step_id" in result2
     assert result2["step_id"] == "site"
 
     with patch(
@@ -125,11 +115,8 @@ async def test_form_multiple_sites(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert "type" in result3
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert "title" in result3
     assert result3["title"] == "OC200 (Site 2)"
-    assert "data" in result3
     assert result3["data"] == {
         "host": "https://fake.omada.host",
         "verify_ssl": True,
@@ -155,9 +142,7 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
-    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
-    assert "errors" in result2
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
@@ -176,9 +161,7 @@ async def test_form_api_error(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
-    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
-    assert "errors" in result2
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -197,9 +180,7 @@ async def test_form_generic_exception(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
-    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
-    assert "errors" in result2
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -218,9 +199,7 @@ async def test_form_unsupported_controller(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
-    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
-    assert "errors" in result2
     assert result2["errors"] == {"base": "unsupported_controller"}
 
 
@@ -239,9 +218,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
-    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
-    assert "errors" in result2
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -260,9 +237,7 @@ async def test_form_no_sites(hass: HomeAssistant) -> None:
             MOCK_USER_DATA,
         )
 
-    assert "type" in result2
     assert result2["type"] is FlowResultType.FORM
-    assert "errors" in result2
     assert result2["errors"] == {"base": "no_sites_found"}
 
 
@@ -278,9 +253,7 @@ async def test_async_step_reauth_success(hass: HomeAssistant) -> None:
 
     result = await mock_entry.start_reauth_flow(hass)
 
-    assert "type" in result
     assert result["type"] is FlowResultType.FORM
-    assert "step_id" in result
     assert result["step_id"] == "reauth_confirm"
 
     with patch(
@@ -294,9 +267,7 @@ async def test_async_step_reauth_success(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert "type" in result2
     assert result2["type"] is FlowResultType.ABORT
-    assert "reason" in result2
     assert result2["reason"] == "reauth_successful"
     mocked_validate.assert_called_once_with(
         hass,
@@ -322,9 +293,7 @@ async def test_async_step_reauth_invalid_auth(hass: HomeAssistant) -> None:
 
     result = await mock_entry.start_reauth_flow(hass)
 
-    assert "type" in result
     assert result["type"] is FlowResultType.FORM
-    assert "step_id" in result
     assert result["step_id"] == "reauth_confirm"
 
     with patch(
@@ -336,11 +305,8 @@ async def test_async_step_reauth_invalid_auth(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert "type" in result2
-    assert result2["type"] is FlowResultType.FORM
-    assert "step_id" in result2
-    assert result2["step_id"] == "reauth_confirm"
-    assert "errors" in result2
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
     assert result2["errors"] == {"base": "invalid_auth"}
 
 

--- a/tests/components/tplink_omada/test_sensor.py
+++ b/tests/components/tplink_omada/test_sensor.py
@@ -8,7 +8,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from tplink_omada_client.definitions import DeviceStatus, DeviceStatusCategory
-from tplink_omada_client.devices import OmadaGatewayPortStatus, OmadaListDevice
+from tplink_omada_client.devices import OmadaListDevice
 
 from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.coordinator import POLL_DEVICES
@@ -74,7 +74,7 @@ async def test_device_specific_status(
     await hass.async_block_till_done()
 
     entity = hass.states.get(entity_id)
-    assert entity.state == "adopt_failed"
+    assert entity and entity.state == "adopt_failed"
 
 
 async def test_device_category_status(
@@ -100,14 +100,14 @@ async def test_device_category_status(
     await hass.async_block_till_done()
 
     entity = hass.states.get(entity_id)
-    assert entity.state == "pending"
+    assert entity and entity.state == "pending"
 
 
 def _set_test_device_status(
     mock_omada_site_client: MagicMock,
     status: int,
     status_category: int,
-) -> OmadaGatewayPortStatus:
+) -> None:
     devices_data = json.loads(load_fixture("devices.json", DOMAIN))
     devices_data[1]["status"] = status
     devices_data[1]["statusCategory"] = status_category

--- a/tests/components/tplink_omada/test_switch.py
+++ b/tests/components/tplink_omada/test_switch.py
@@ -103,7 +103,7 @@ async def test_gateway_connect_ipv4_switch(
     await hass.async_block_till_done()
 
     entity = hass.states.get(entity_id)
-    assert entity.state == "off"
+    assert entity and entity.state == "off"
 
     mock_omada_site_client.set_gateway_wan_port_connect_state.reset_mock()
     mock_omada_site_client.set_gateway_wan_port_connect_state.return_value = (
@@ -120,7 +120,7 @@ async def test_gateway_connect_ipv4_switch(
     await hass.async_block_till_done()
 
     entity = hass.states.get(entity_id)
-    assert entity.state == "on"
+    assert entity and entity.state == "on"
 
 
 async def test_gateway_port_poe_switch(
@@ -150,7 +150,7 @@ async def test_gateway_port_poe_switch(
     await hass.async_block_till_done()
 
     entity = hass.states.get(entity_id)
-    assert entity.state == "off"
+    assert entity and entity.state == "off"
 
     mock_omada_site_client.set_gateway_port_settings.reset_mock()
     mock_omada_site_client.set_gateway_port_settings.return_value = port_config
@@ -161,7 +161,7 @@ async def test_gateway_port_poe_switch(
     await hass.async_block_till_done()
 
     entity = hass.states.get(entity_id)
-    assert entity.state == "on"
+    assert entity and entity.state == "on"
 
 
 async def test_gateway_wan_port_has_no_poe_switch(
@@ -196,7 +196,7 @@ async def test_gateway_api_fail_disables_switch_entities(
     """Test gateway connected switches."""
     entity_id = "switch.test_router_port_4_internet_connected"
     entity = hass.states.get(entity_id)
-    assert entity == snapshot
+    assert entity and entity == snapshot
     assert entity.state == "on"
 
     mock_omada_site_client.get_gateway.reset_mock()
@@ -206,7 +206,7 @@ async def test_gateway_api_fail_disables_switch_entities(
     await hass.async_block_till_done()
 
     entity = hass.states.get(entity_id)
-    assert entity.state == "unavailable"
+    assert entity and entity.state == "unavailable"
 
 
 async def test_gateway_port_change_disables_switch_entities(
@@ -222,7 +222,7 @@ async def test_gateway_port_change_disables_switch_entities(
 
     entity_id = "switch.test_router_port_4_internet_connected"
     entity = hass.states.get(entity_id)
-    assert entity == snapshot
+    assert entity and entity == snapshot
     assert entity.state == "on"
 
     mock_omada_site_client.get_gateway.reset_mock()
@@ -233,7 +233,7 @@ async def test_gateway_port_change_disables_switch_entities(
     await hass.async_block_till_done()
 
     entity = hass.states.get(entity_id)
-    assert entity.state == "unavailable"
+    assert entity and entity.state == "unavailable"
 
 
 async def _test_poe_switch(
@@ -285,7 +285,7 @@ async def _test_poe_switch(
     async_fire_time_changed(hass, utcnow() + UPDATE_INTERVAL)
     await hass.async_block_till_done()
     entity = hass.states.get(entity_id)
-    assert entity.state == "off"
+    assert entity and entity.state == "off"
 
     mock_omada_site_client.update_switch_port.reset_mock()
     mock_omada_site_client.update_switch_port.return_value = await _update_port_details(
@@ -303,7 +303,7 @@ async def _test_poe_switch(
     async_fire_time_changed(hass, utcnow() + UPDATE_INTERVAL)
     await hass.async_block_till_done()
     entity = hass.states.get(entity_id)
-    assert entity.state == "on"
+    assert entity and entity.state == "on"
 
 
 async def _update_port_details(
@@ -312,7 +312,7 @@ async def _update_port_details(
     poe_enabled: bool,
 ) -> OmadaSwitchPortDetails:
     switch_ports = await mock_omada_site_client.get_switch_ports()
-    port_details: OmadaSwitchPortDetails = None
+    port_details: OmadaSwitchPortDetails | None = None
     for details in switch_ports:
         if details.port == port_num:
             port_details = details
@@ -338,8 +338,10 @@ def _get_updated_gateway_port_status(
     return OmadaGatewayPortStatus(gateway_data["portStats"][port])
 
 
-def call_service(hass: HomeAssistant, service: str, entity_id: str) -> ServiceResponse:
+async def call_service(
+    hass: HomeAssistant, service: str, entity_id: str
+) -> ServiceResponse:
     """Call any service on entity."""
-    return hass.services.async_call(
+    return await hass.services.async_call(
         switch.DOMAIN, service, {ATTR_ENTITY_ID: entity_id}, blocking=True
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Omada integration tries to create entities for all of the devices attached at integration startup. However, if any of the devices connected to the Omada controller are not present - e.g. restarting or still in the process of being provisioned,
the Omada API only returns limited data for each device. This causes the startup code to fail, because it can't determine the necessary entities to create for each device. This means no entities get created for the device until the integration is restarted, and other device's entities may also not get created.

To fix this, we need to wait for the Omada devices to return to the Connected state before attempting to add many of the  device's entities. We can let basic entities (e.g. the "connection state" sensor) through, even for missing devices.

I achieved this by moving the responsibility for calling `add_entitites` into the Controller class that manages the coordinators. It felt similar to what the Unifi integration is doing, although that has the benefit of a websocket API that Omada doesn't have. We have a coordinator that is already polling the Omada device list, so it seemed best to centralise this registration logic. Each callback maintains its own list of device macs that it has already created entities for. This is necessary because I didn't want to search the entity list for entities each time the device list has a trivial update.

If this isn't "the way", I'm happy to change it!

The practical upshot of this change is this also adds support for dynamic registration of new devices - e.g. dynamic discovery of new access points or switches, which granted won't appear very often, but it's still a nice feature to have.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - Fixes one of the problems reported in this thread: fixes #155249.
  - Sorry, there is a tiny drive-by fix for this issue that crept in here too: fixes #156115
- This PR is related to issue: 
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
