### PR TITLE
Add update entity to AdGUard Home

### DIFF
--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -45,7 +45,7 @@ SERVICE_REFRESH_SCHEMA = vol.Schema(
     {vol.Optional(CONF_FORCE, default=False): cv.boolean}
 )
 
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.UPDATE]
 type AdGuardConfigEntry = ConfigEntry[AdGuardData]
 
 

--- a/homeassistant/components/adguard/update.py
+++ b/homeassistant/components/adguard/update.py
@@ -1,0 +1,64 @@
+"""AdGurad Home Update platform."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import AdGuardConfigEntry, AdGuardData
+from .const import DOMAIN
+from .entity import AdGuardHomeEntity
+
+SCAN_INTERVAL = timedelta(seconds=300)
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: AdGuardConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up AdGuard Home update entity based on a config entry."""
+    data = entry.runtime_data
+
+    if (await data.client.update.update_available()).disabled:
+        return
+
+    async_add_entities([AdGuardHomeUpdate(data, entry)], True)
+
+
+class AdGuardHomeUpdate(AdGuardHomeEntity, UpdateEntity):
+    """Defines a AdGuard Home update."""
+
+    _attr_supported_features = UpdateEntityFeature.INSTALL
+
+    def __init__(
+        self,
+        data: AdGuardData,
+        entry: AdGuardConfigEntry,
+    ) -> None:
+        """Initialize AdGuard Home update."""
+        super().__init__(data, entry)
+
+        self._attr_unique_id = "_".join(
+            [DOMAIN, self.adguard.host, str(self.adguard.port), "update"]
+        )
+
+    async def _adguard_update(self) -> None:
+        """Update AdGuard Home entity."""
+        value = await self.adguard.update.update_available()
+        self._attr_installed_version = self.data.version
+        self._attr_latest_version = value.new_version
+        self._attr_release_summary = value.announcement
+        self._attr_release_url = value.announcement_url
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install latest update."""
+        await self.adguard.update.begin_update()
+        self.hass.config_entries.async_schedule_reload(self._entry.entry_id)

--- a/homeassistant/components/adguard/update.py
+++ b/homeassistant/components/adguard/update.py
@@ -35,6 +35,7 @@ class AdGuardHomeUpdate(AdGuardHomeEntity, UpdateEntity):
     """Defines a AdGuard Home update."""
 
     _attr_supported_features = UpdateEntityFeature.INSTALL
+    _attr_name = None
 
     def __init__(
         self,

--- a/homeassistant/components/adguard/update.py
+++ b/homeassistant/components/adguard/update.py
@@ -1,4 +1,4 @@
-"""AdGurad Home Update platform."""
+"""AdGuard Home Update platform."""
 
 from __future__ import annotations
 
@@ -32,7 +32,7 @@ async def async_setup_entry(
 
 
 class AdGuardHomeUpdate(AdGuardHomeEntity, UpdateEntity):
-    """Defines a AdGuard Home update."""
+    """Defines an AdGuard Home update."""
 
     _attr_supported_features = UpdateEntityFeature.INSTALL
     _attr_name = None

--- a/homeassistant/components/adguard/update.py
+++ b/homeassistant/components/adguard/update.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any
 
+from adguardhome import AdGuardHomeError
+
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AdGuardConfigEntry, AdGuardData
@@ -61,5 +64,8 @@ class AdGuardHomeUpdate(AdGuardHomeEntity, UpdateEntity):
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install latest update."""
-        await self.adguard.update.begin_update()
+        try:
+            await self.adguard.update.begin_update()
+        except AdGuardHomeError as err:
+            raise HomeAssistantError(f"Failed to install update: {err}") from err
         self.hass.config_entries.async_schedule_reload(self._entry.entry_id)

--- a/tests/components/adguard/__init__.py
+++ b/tests/components/adguard/__init__.py
@@ -1,1 +1,25 @@
 """Tests for the AdGuard Home integration."""
+
+from homeassistant.const import CONTENT_TYPE_JSON
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+async def setup_integration(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+
+    aioclient_mock.get(
+        "https://127.0.0.1:3000/control/status",
+        json={"version": "v0.107.50"},
+        headers={"Content-Type": CONTENT_TYPE_JSON},
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/adguard/conftest.py
+++ b/tests/components/adguard/conftest.py
@@ -1,0 +1,32 @@
+"""Common fixtures for the adguard tests."""
+
+import pytest
+
+from homeassistant.components.adguard import DOMAIN
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Mock a config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "127.0.0.1",
+            CONF_PORT: 3000,
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_SSL: True,
+            CONF_VERIFY_SSL: True,
+        },
+        title="AdGuard Home",
+    )

--- a/tests/components/adguard/snapshots/test_update.ambr
+++ b/tests/components/adguard/snapshots/test_update.ambr
@@ -1,0 +1,61 @@
+# serializer version: 1
+# name: test_update[update.adguard_home-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'update',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'update.adguard_home',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'adguard',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <UpdateEntityFeature: 1>,
+    'translation_key': None,
+    'unique_id': 'adguard_127.0.0.1_3000_update',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_update[update.adguard_home-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'auto_update': False,
+      'display_precision': 0,
+      'entity_picture': 'https://brands.home-assistant.io/_/adguard/icon.png',
+      'friendly_name': 'AdGuard Home',
+      'in_progress': False,
+      'installed_version': 'v0.107.50',
+      'latest_version': 'v0.107.59',
+      'release_summary': 'AdGuard Home v0.107.59 is now available!',
+      'release_url': 'https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.59',
+      'skipped_version': None,
+      'supported_features': <UpdateEntityFeature: 1>,
+      'title': None,
+      'update_percentage': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'update.adguard_home',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/adguard/test_update.py
+++ b/tests/components/adguard/test_update.py
@@ -92,7 +92,6 @@ async def test_update_install(
         blocking=True,
     )
 
-    assert len(aioclient_mock.mock_calls) == 3  # 1 for install, 2 for reload
     assert aioclient_mock.mock_calls[0][0] == "POST"
     assert (
         str(aioclient_mock.mock_calls[0][1]) == "https://127.0.0.1:3000/control/update"
@@ -133,7 +132,6 @@ async def test_update_install_failed(
             blocking=True,
         )
 
-    assert len(aioclient_mock.mock_calls) == 1  # 1 for install, no entry reload
     assert aioclient_mock.mock_calls[0][0] == "POST"
     assert (
         str(aioclient_mock.mock_calls[0][1]) == "https://127.0.0.1:3000/control/update"

--- a/tests/components/adguard/test_update.py
+++ b/tests/components/adguard/test_update.py
@@ -1,0 +1,58 @@
+"""Tests for the AdGuard Home config flow."""
+
+from unittest.mock import patch
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import CONTENT_TYPE_JSON, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+async def test_update(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the adguard update platform."""
+    aioclient_mock.post(
+        "https://127.0.0.1:3000/control/version.json",
+        json={
+            "new_version": "v0.107.59",
+            "announcement": "AdGuard Home v0.107.59 is now available!",
+            "announcement_url": "https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.59",
+            "can_autoupdate": True,
+            "disabled": False,
+        },
+        headers={"Content-Type": CONTENT_TYPE_JSON},
+    )
+
+    with patch("homeassistant.components.adguard.PLATFORMS", [Platform.UPDATE]):
+        await setup_integration(hass, mock_config_entry, aioclient_mock)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_update_disabled(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the adguard update is disabled."""
+    aioclient_mock.post(
+        "https://127.0.0.1:3000/control/version.json",
+        json={"disabled": True},
+        headers={"Content-Type": CONTENT_TYPE_JSON},
+    )
+
+    with patch("homeassistant.components.adguard.PLATFORMS", [Platform.UPDATE]):
+        await setup_integration(hass, mock_config_entry, aioclient_mock)
+
+    assert not hass.states.async_all()

--- a/tests/components/adguard/test_update.py
+++ b/tests/components/adguard/test_update.py
@@ -1,4 +1,4 @@
-"""Tests for the AdGuard Home config flow."""
+"""Tests for the AdGuard Home update entity."""
 
 from unittest.mock import patch
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds an update entity to the adguard integration. It is not available for docker based installations (_so also not for the AdGuard Home add-on_).

<img width="641" height="410" alt="image" src="https://github.com/user-attachments/assets/a30cab74-7a91-4674-9fc8-a9e7fc4572c7" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41809
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
