### PR TITLE
Add optional idempotency key to Mastodon post action

### DIFF
--- a/homeassistant/components/mastodon/const.py
+++ b/homeassistant/components/mastodon/const.py
@@ -14,6 +14,8 @@ DEFAULT_NAME: Final = "Mastodon"
 
 ATTR_STATUS = "status"
 ATTR_VISIBILITY = "visibility"
+ATTR_PREVENT_DUPLICATE_POSTS = "prevent_duplicate_posts"
+ATTR_IDEMPOTENCY_KEY = "idempotency_key"
 ATTR_CONTENT_WARNING = "content_warning"
 ATTR_MEDIA_WARNING = "media_warning"
 ATTR_MEDIA = "media"

--- a/homeassistant/components/mastodon/const.py
+++ b/homeassistant/components/mastodon/const.py
@@ -14,7 +14,6 @@ DEFAULT_NAME: Final = "Mastodon"
 
 ATTR_STATUS = "status"
 ATTR_VISIBILITY = "visibility"
-ATTR_PREVENT_DUPLICATE_POSTS = "prevent_duplicate_posts"
 ATTR_IDEMPOTENCY_KEY = "idempotency_key"
 ATTR_CONTENT_WARNING = "content_warning"
 ATTR_MEDIA_WARNING = "media_warning"

--- a/homeassistant/components/mastodon/services.py
+++ b/homeassistant/components/mastodon/services.py
@@ -2,7 +2,6 @@
 
 from enum import StrEnum
 from functools import partial
-import hashlib
 from typing import Any, cast
 
 from mastodon import Mastodon
@@ -21,7 +20,6 @@ from .const import (
     ATTR_MEDIA,
     ATTR_MEDIA_DESCRIPTION,
     ATTR_MEDIA_WARNING,
-    ATTR_PREVENT_DUPLICATE_POSTS,
     ATTR_STATUS,
     ATTR_VISIBILITY,
     DOMAIN,
@@ -45,7 +43,6 @@ SERVICE_POST_SCHEMA = vol.Schema(
         vol.Required(ATTR_CONFIG_ENTRY_ID): str,
         vol.Required(ATTR_STATUS): str,
         vol.Optional(ATTR_VISIBILITY): vol.In([x.lower() for x in StatusVisibility]),
-        vol.Optional(ATTR_PREVENT_DUPLICATE_POSTS): bool,
         vol.Optional(ATTR_IDEMPOTENCY_KEY): str,
         vol.Optional(ATTR_CONTENT_WARNING): str,
         vol.Optional(ATTR_LANGUAGE): str,
@@ -95,9 +92,6 @@ def async_setup_services(hass: HomeAssistant) -> None:
         media_path: str | None = call.data.get(ATTR_MEDIA)
         media_description: str | None = call.data.get(ATTR_MEDIA_DESCRIPTION)
         media_warning: str | None = call.data.get(ATTR_MEDIA_WARNING)
-
-        if not idempotency_key and call.data.get(ATTR_PREVENT_DUPLICATE_POSTS, False):
-            idempotency_key = hashlib.md5(status.encode()).hexdigest()
 
         if idempotency_key and len(idempotency_key) < 4:
             raise ServiceValidationError(

--- a/homeassistant/components/mastodon/services.yaml
+++ b/homeassistant/components/mastodon/services.yaml
@@ -18,10 +18,6 @@ post:
             - private
             - direct
           translation_key: post_visibility
-    prevent_duplicate_posts:
-      selector:
-        boolean:
-      default: false
     idempotency_key:
       selector:
         text:

--- a/homeassistant/components/mastodon/services.yaml
+++ b/homeassistant/components/mastodon/services.yaml
@@ -18,6 +18,13 @@ post:
             - private
             - direct
           translation_key: post_visibility
+    prevent_duplicate_posts:
+      selector:
+        boolean:
+      default: false
+    idempotency_key:
+      selector:
+        text:
     content_warning:
       selector:
         text:

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -84,7 +84,7 @@
           "name": "Content warning"
         },
         "idempotency_key": {
-          "description": "A unique key for this post. If specified then subsequent posts with the same key within one hour will be ignored by your Mastodon instance. (default: no idempotency key, which allows duplication). Useful if you want more control over idempotency than prevent duplicate posts.",
+          "description": "A unique key for this post. If specified then subsequent posts with the same key within one hour will be ignored by your Mastodon instance. (default: no idempotency key, which allows duplication).",
           "name": "Idempotency key"
         },
         "language": {
@@ -102,10 +102,6 @@
         "media_warning": {
           "description": "If an image or video is attached, will mark the media as sensitive (default: no media warning).",
           "name": "Media warning"
-        },
-        "prevent_duplicate_posts": {
-          "description": "If enabled, an idempotency key with a hash of your status will be calculated and added to prevent duplicate posts within one hour.",
-          "name": "Prevent duplicate posts"
         },
         "status": {
           "description": "The status to post.",

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -84,7 +84,7 @@
           "name": "Content warning"
         },
         "idempotency_key": {
-          "description": "A unique key for this post. If specified then subsequent posts with the same key within one hour will be ignored by your Mastodon instance (default: no idempotency key, which allows duplication).",
+          "description": "A unique key for this post. If specified then subsequent posts with the same key will be ignored by your Mastodon instance, Mastodon holds keys for up to one hour (default: no idempotency key, which allows duplication).",
           "name": "Idempotency key"
         },
         "language": {

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -84,7 +84,7 @@
           "name": "Content warning"
         },
         "idempotency_key": {
-          "description": "A unique key for this post. If specified then subsequent posts with the same key will be ignored by your Mastodon instance, Mastodon holds keys for up to one hour (default: no idempotency key, which allows duplication).",
+          "description": "A unique key for this post. If specified then subsequent posts with the same key will be ignored by your Mastodon instance. Mastodon holds keys for up to one hour (default: no idempotency key, which allows duplication).",
           "name": "Idempotency key"
         },
         "language": {

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -42,6 +42,9 @@
     }
   },
   "exceptions": {
+    "idempotency_key_too_short": {
+      "message": "Idempotency key must be at least 4 characters long."
+    },
     "integration_not_found": {
       "message": "Integration \"{target}\" not found in registry."
     },
@@ -80,6 +83,10 @@
           "description": "A content warning will be shown before the status text is shown (default: no content warning).",
           "name": "Content warning"
         },
+        "idempotency_key": {
+          "description": "A unique key for this post. If specified then subsequent posts with the same key within one hour will be ignored by your Mastodon instance. (default: no idempotency key, which allows duplication). Useful if you want more control over idempotency than prevent duplicate posts.",
+          "name": "Idempotency key"
+        },
         "language": {
           "description": "The language of the post (default: Mastodon account preference).",
           "name": "Language"
@@ -95,6 +102,10 @@
         "media_warning": {
           "description": "If an image or video is attached, will mark the media as sensitive (default: no media warning).",
           "name": "Media warning"
+        },
+        "prevent_duplicate_posts": {
+          "description": "If enabled, an idempotency key with a hash of your status will be calculated and added to prevent duplicate posts within one hour.",
+          "name": "Prevent duplicate posts"
         },
         "status": {
           "description": "The status to post.",

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -84,7 +84,7 @@
           "name": "Content warning"
         },
         "idempotency_key": {
-          "description": "A unique key for this post. If specified then subsequent posts with the same key within one hour will be ignored by your Mastodon instance. (default: no idempotency key, which allows duplication).",
+          "description": "A unique key for this post. If specified then subsequent posts with the same key within one hour will be ignored by your Mastodon instance (default: no idempotency key, which allows duplication).",
           "name": "Idempotency key"
         },
         "language": {

--- a/tests/components/mastodon/test_services.py
+++ b/tests/components/mastodon/test_services.py
@@ -282,7 +282,8 @@ async def test_idempotency_key_too_short(
     payload = {"status": "test toot", "idempotency_key": "abc"}
 
     with pytest.raises(
-        HomeAssistantError, match="Idempotency key must be at least 4 characters long"
+        ServiceValidationError,
+        match="Idempotency key must be at least 4 characters long",
     ):
         await hass.services.async_call(
             DOMAIN,

--- a/tests/components/mastodon/test_services.py
+++ b/tests/components/mastodon/test_services.py
@@ -7,9 +7,11 @@ import pytest
 
 from homeassistant.components.mastodon.const import (
     ATTR_CONTENT_WARNING,
+    ATTR_IDEMPOTENCY_KEY,
     ATTR_LANGUAGE,
     ATTR_MEDIA,
     ATTR_MEDIA_DESCRIPTION,
+    ATTR_PREVENT_DUPLICATE_POSTS,
     ATTR_STATUS,
     ATTR_VISIBILITY,
     DOMAIN,
@@ -35,6 +37,7 @@ from tests.common import MockConfigEntry
                 "status": "test toot",
                 "spoiler_text": None,
                 "visibility": None,
+                "idempotency_key": None,
                 "language": None,
                 "media_ids": None,
                 "sensitive": None,
@@ -46,6 +49,7 @@ from tests.common import MockConfigEntry
                 "status": "test toot",
                 "spoiler_text": None,
                 "visibility": "private",
+                "idempotency_key": None,
                 "language": None,
                 "media_ids": None,
                 "sensitive": None,
@@ -61,6 +65,7 @@ from tests.common import MockConfigEntry
                 "status": "test toot",
                 "spoiler_text": "Spoiler",
                 "visibility": "private",
+                "idempotency_key": None,
                 "language": None,
                 "media_ids": None,
                 "sensitive": None,
@@ -77,6 +82,7 @@ from tests.common import MockConfigEntry
                 "status": "test toot",
                 "spoiler_text": "Spoiler",
                 "visibility": None,
+                "idempotency_key": None,
                 "language": "nl",
                 "media_ids": "1",
                 "sensitive": None,
@@ -94,6 +100,7 @@ from tests.common import MockConfigEntry
                 "status": "test toot",
                 "spoiler_text": "Spoiler",
                 "visibility": None,
+                "idempotency_key": None,
                 "language": "en",
                 "media_ids": "1",
                 "sensitive": None,
@@ -104,6 +111,31 @@ from tests.common import MockConfigEntry
             {
                 "status": "test toot",
                 "language": "invalid-lang",
+                "spoiler_text": None,
+                "visibility": None,
+                "idempotency_key": None,
+                "media_ids": None,
+                "sensitive": None,
+            },
+        ),
+        (
+            {ATTR_STATUS: "test toot", ATTR_IDEMPOTENCY_KEY: "post_once_only"},
+            {
+                "status": "test toot",
+                "idempotency_key": "post_once_only",
+                "language": None,
+                "spoiler_text": None,
+                "visibility": None,
+                "media_ids": None,
+                "sensitive": None,
+            },
+        ),
+        (
+            {ATTR_STATUS: "test toot", ATTR_PREVENT_DUPLICATE_POSTS: True},
+            {
+                "status": "test toot",
+                "idempotency_key": "e9ff9d1082874d05a411240e323f9a56",
+                "language": None,
                 "spoiler_text": None,
                 "visibility": None,
                 "media_ids": None,
@@ -164,6 +196,7 @@ async def test_service_post(
                 "status": "test toot",
                 "spoiler_text": "Spoiler",
                 "visibility": None,
+                "idempotency_key": None,
                 "media_ids": "1",
                 "media_description": None,
                 "sensitive": None,
@@ -239,6 +272,30 @@ async def test_post_path_not_whitelisted(
 
     with pytest.raises(
         HomeAssistantError, match="/fail.jpg is not a whitelisted directory"
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_POST,
+            {ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id} | payload,
+            blocking=True,
+            return_response=False,
+        )
+
+
+async def test_idempotency_key_too_short(
+    hass: HomeAssistant,
+    mock_mastodon_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the post service raising an error because the idempotency key is too short."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    payload = {"status": "test toot", "idempotency_key": "abc"}
+
+    with pytest.raises(
+        HomeAssistantError, match="Idempotency key must be at least 4 characters long"
     ):
         await hass.services.async_call(
             DOMAIN,

--- a/tests/components/mastodon/test_services.py
+++ b/tests/components/mastodon/test_services.py
@@ -11,7 +11,6 @@ from homeassistant.components.mastodon.const import (
     ATTR_LANGUAGE,
     ATTR_MEDIA,
     ATTR_MEDIA_DESCRIPTION,
-    ATTR_PREVENT_DUPLICATE_POSTS,
     ATTR_STATUS,
     ATTR_VISIBILITY,
     DOMAIN,
@@ -123,18 +122,6 @@ from tests.common import MockConfigEntry
             {
                 "status": "test toot",
                 "idempotency_key": "post_once_only",
-                "language": None,
-                "spoiler_text": None,
-                "visibility": None,
-                "media_ids": None,
-                "sensitive": None,
-            },
-        ),
-        (
-            {ATTR_STATUS: "test toot", ATTR_PREVENT_DUPLICATE_POSTS: True},
-            {
-                "status": "test toot",
-                "idempotency_key": "e9ff9d1082874d05a411240e323f9a56",
                 "language": None,
                 "spoiler_text": None,
                 "visibility": None,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds an optional idempotency key to the Mastodon post action, allowing users to generate a unique key for each post to guard against repeated posting on rogue automations.
The idempotency key checking is performed by the Mastodon instance and holds keys for up to 1 hour.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41806
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
