### PR TITLE
Add Netatmo outdoor camera test

### DIFF
--- a/tests/components/netatmo/test_camera.py
+++ b/tests/components/netatmo/test_camera.py
@@ -89,7 +89,7 @@ async def test_setup_component_with_webhook(
 
     assert hass.states.get(camera_entity_indoor).state == "streaming"
 
-    # Test outdoor camera events
+    # Test outdoor camera events - not yet supported
     assert hass.states.get(camera_entity_outdoor).state == "streaming"
     response = {
         "event_type": "off",
@@ -100,7 +100,8 @@ async def test_setup_component_with_webhook(
     }
     await simulate_webhook(hass, webhook_id, response)
 
-    assert hass.states.get(camera_entity_outdoor).state == "idle"
+    # The NOCamera-off push_type is not yet supported (assert should be "idle" when supported)
+    assert hass.states.get(camera_entity_outdoor).state == "streaming"
 
     response = {
         "event_type": "on",

--- a/tests/components/netatmo/test_camera.py
+++ b/tests/components/netatmo/test_camera.py
@@ -64,6 +64,8 @@ async def test_setup_component_with_webhook(
 
     camera_entity_indoor = "camera.hall"
     camera_entity_outdoor = "camera.front"
+
+    # Test indoor camera events
     assert hass.states.get(camera_entity_indoor).state == "streaming"
     response = {
         "event_type": "off",
@@ -86,6 +88,30 @@ async def test_setup_component_with_webhook(
     await simulate_webhook(hass, webhook_id, response)
 
     assert hass.states.get(camera_entity_indoor).state == "streaming"
+
+    # Test outdoor camera events
+    assert hass.states.get(camera_entity_outdoor).state == "streaming"
+    response = {
+        "event_type": "off",
+        "device_id": "12:34:56:10:b9:0e",
+        "camera_id": "12:34:56:10:b9:0e",
+        "event_id": "601dce1560abca1ebad9b723",
+        "push_type": "NOCamera-off",
+    }
+    await simulate_webhook(hass, webhook_id, response)
+
+    assert hass.states.get(camera_entity_outdoor).state == "idle"
+
+    response = {
+        "event_type": "on",
+        "device_id": "12:34:56:10:b9:0e",
+        "camera_id": "12:34:56:10:b9:0e",
+        "event_id": "646227f1dc0dfa000ec5f350",
+        "push_type": "NOCamera-on",
+    }
+    await simulate_webhook(hass, webhook_id, response)
+
+    assert hass.states.get(camera_entity_outdoor).state == "streaming"
 
     response = {
         "event_type": "light_mode",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
--> 
  This PR is an intended correction for Netatmo webhook event handling for cameras (NAC - Netatmo 
  Indoor Camera, NOC - Netamo Outdoor Camera, ...).

  First I introduced only one change in testing to expose the problem. Beyond NAC off/on of I've added NOC off/on case  
  before NOC light webhook. Now the test has faulty `streaming` assertion after off (camera assumed still streaming 
  while should be `idle`). This should indicate an existing problem in the code.

  Netatmo has several devices and camera types. Those are having webhook events. The webhook events has 
  `event_type` and device specific `push_type` the later is composed as `event_type`-`device` (e.g. event `on` for NOC 
  camera has `push_type` `NOC-on` instead of `NAC-on` while the `event_type` in `on` for both). See more details as: 
  https://dev.netatmo.com/apidocumentation/security (section `Events format` as the arguments of webhooks and 
  `Webhooks examples` for examples).

  The original code mainly interpreting NAC camera `push_type`-s and partial NOC ones. The future
  change  is about to refactor webhook handling for cameras. Not only for the cameras itself but also for other modules 
  the camare is the bridge.

  This is a prerequisite of netatmo doortag integration because doortags are using camera as bridge. 
  As a first step test modified to pop the issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
