### PR TITLE
Fix ZHA custom quirks friendly name priority

### DIFF
--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -66,7 +66,14 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
 
     @cached_property
     def name(self) -> str | UndefinedType | None:
-        """Return the name of the entity."""
+        """Return the name of the entity.
+
+        Built-in quirks have translations in HA, so those are used.
+        Custom quirks with new translation keys won't have translations.
+        For them, the fallback name should be used instead.
+        If a device class is set but no translation key,
+        the device class name is used.
+        """
         meta = self.entity_data.entity.info_object
         if meta.primary:
             self._attr_name = None

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -72,6 +72,7 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
             self._attr_name = None
             return super().name
 
+        # if we have a translation key or no device class name, use translation/fallback
         if meta.translation_key is not None or super().name in (UNDEFINED, None):
             # if we have a translation for this key, use it
             if (

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -79,7 +79,8 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
             self._attr_name = None
             return super().name
 
-        # if we have a translation key or no device class name, use translation/fallback
+        # if we have a translation key or no (device class) name,
+        # use translation or fallback name
         if meta.translation_key is not None or super().name in (UNDEFINED, None):
             # if we have a translation for this key, use it
             if (

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -79,21 +79,24 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
             self._attr_name = None
             return super().name
 
-        # if we have a translation key or no (device class) name,
-        # use translation or fallback name
-        if meta.translation_key is not None or super().name in (UNDEFINED, None):
-            # if we have a translation for this key, use it
-            if (
-                (translation_key := self._name_translation_key) is not None
-                and translation_key in self.platform_data.platform_translations
-            ):
-                return super().name
-            # a translation won't be available for custom quirks, so use fallback_name
-            if meta.fallback_name is not None:
-                self._attr_name = meta.fallback_name
-                return super().name
+        # If we do not have a fallback_name, use default behavior
+        if meta.fallback_name is None:
+            return super().name
 
-        # we should only reach this for the device class name at this point
+        # If we do not have a translation key, only use fallback_name
+        # if device class is also missing
+        if meta.translation_key is None:
+            if super().name in (UNDEFINED, None):
+                self._attr_name = meta.fallback_name
+            return super().name
+
+        # If we do have a translation key, only use fallback_name
+        # if translation is missing (custom quirks)
+        if not (
+            (translation_key := self._name_translation_key) is not None
+            and translation_key in self.platform_data.platform_translations
+        ):
+            self._attr_name = meta.fallback_name
         return super().name
 
     @property

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE, DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.typing import UNDEFINED, UndefinedType
+from homeassistant.helpers.typing import UndefinedType
 
 from .const import DOMAIN
 from .helpers import SIGNAL_REMOVE_ENTITIES, EntityData, convert_zha_error_to_ha_error
@@ -72,14 +72,15 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
             self._attr_name = None
             return super().name
 
-        original_name = super().name
-
-        if original_name not in (UNDEFINED, None) or meta.fallback_name is None:
-            return original_name
-
         # This is to allow local development and to register niche devices, since
         # their translation_key will probably never be added to `zha/strings.json`.
-        self._attr_name = meta.fallback_name
+        # The fallback name takes priority over the device class name.
+        if meta.fallback_name is not None and (
+            (translation_key := self._name_translation_key) is None
+            or translation_key not in self.platform_data.platform_translations
+        ):
+            self._attr_name = meta.fallback_name
+
         return super().name
 
     @property

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -640,12 +640,12 @@ async def test_sensor_name(
     hass: HomeAssistant,
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
-    translation_key,
-    fallback_name,
-    device_class,
-    unit,
-    entity_id_suffix,
-    expected_friendly_name_suffix,
+    translation_key: str | None,
+    fallback_name: str,
+    device_class: SensorDeviceClass | None,
+    unit: str | None,
+    entity_id_suffix: str,
+    expected_friendly_name_suffix: str,
 ) -> None:
     """Test ZHA entity name generation.
 

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -596,18 +596,21 @@ async def test_sensor_name(
     # For them, the fallback name should be used instead.
     (
         QuirkBuilder("Test Manf", "Test Model")
+        # This should use the fallback name:
         .sensor(
             "sw_build_id",
             general.Basic.cluster_id,
             translation_key="this_translation_key_is_not_translated",
             fallback_name="Software build",
         )
+        # This should use the translated string:
         .sensor(
             "date_code",
             general.Basic.cluster_id,
             translation_key="device_status",  # existing translation key
             fallback_name="I should not be used",
         )
+        # This should use the fallback name:
         .sensor(
             "product_url",
             general.Basic.cluster_id,
@@ -616,6 +619,7 @@ async def test_sensor_name(
             translation_key="this_translation_key_is_not_translated",
             fallback_name="Product url",
         )
+        # This should use the translated string:
         .sensor(
             "product_label",
             general.Basic.cluster_id,
@@ -623,6 +627,14 @@ async def test_sensor_name(
             unit=UnitOfTemperature.CELSIUS,
             translation_key="device_temperature",  # existing translation key
             fallback_name="I should not be used",
+        )
+        # This should use the device class name:
+        .sensor(
+            "location_desc",
+            general.Basic.cluster_id,
+            device_class=SensorDeviceClass.BATTERY,  # with device class
+            unit=PERCENTAGE,
+            fallback_name="I should not be used",  # no translation key
         )
         .add_to_registry()
     )
@@ -693,6 +705,16 @@ async def test_sensor_name(
     assert (
         hass_state_translation_device_class.attributes.get("friendly_name")
         == "Test Manf Test Model Device temperature"
+    )
+
+    entity_id_device_class_name = "sensor.test_manf_test_model_battery"
+    hass_state_device_class_name = hass.states.get(entity_id_device_class_name)
+    assert hass_state_device_class_name is not None
+
+    # Check that the friendly name uses the device class name.
+    assert (
+        hass_state_device_class_name.attributes.get("friendly_name")
+        == "Test Manf Test Model Battery"
     )
 
 

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -647,12 +647,18 @@ async def test_sensor_name(
     entity_id_suffix,
     expected_friendly_name_suffix,
 ) -> None:
-    """Test ZHA entity name generation."""
-    # Set up a v2 quirk sensor with translation key and fallback name.
-    # For built-in quirks, the translation keys exist in HA, so the translation is used.
-    # For quirks loaded as custom quirks, new translation keys won't be in HA.
-    # For them, the fallback name should be used instead.
-    # If a device class is set but no translation key, the device class name is used.
+    """Test ZHA entity name generation.
+
+    This test sets up a v2 quirks sensor with various combinations of
+    translation key, fallback name, and device class to verify that the
+    entity's friendly name is generated correctly.
+
+    Built-in quirks have translations in HA, so those are used.
+    Custom quirks with new translation keys won't have translations.
+    For them, the fallback name should be used instead.
+    If a device class is set but no translation key,
+    the device class name is used.
+    """
     (
         QuirkBuilder("Test Manf", "Test Model")
         .sensor(


### PR DESCRIPTION
## Proposed change

This PR fixes a long-standing issue in ZHA where entities generated from **custom quirks** incorrectly use the device class name, instead of the fallback name, when a translation key is set on them that does not exist in Home Assistant.

_Note: There is **no** issue with any built-in quirks. The issue only happens when explicitly loading custom quirks for development and testing, as these will not have their translation keys added to ZHA's `strings.json`. This is why this has been low-priority to fix._

This PR also adds tests with the various v2 quirk sensor definitions to make sure we cover all cases for the fixed naming.


### Explanation on how naming should work

- For built-in quirks, we always add translation key + string to `strings.json`. For these, `fallback_name` is never used.
- For custom quirks that use new translation keys, HA will not have a string/translation, so use `fallback_name`.
- If a device class is set and the translation key is explicitly **not** set, the device class name should be used.
- If a device class is set and a translation key is also set, the translation key should take priority.
  If there's no translation for the specified translation key, the fallback name should be used instead.
  -  We should NOT use the device class like we did before the changes from this PR. That was the issue due to `super().name` returning either the translated string (if it exists) (good) or the device class name if there was no translation (bad, as we don't know what we got: translation or device class name).

Note: `fallback_name` always has to be provided in the library (so that other projects can use v2 quirk metadata as well, without them needing to understand the HA concept of names for device classes).


### Fix

- To fix this behavior, we first use the default HA naming behavior if there's no `fallback_name`, like for non-quirks v2 entities.
- If a translation key is missing, we only use the fallback name if the HA default naming behavior does not return a proper result either. This can happen if no device class is set or if a custom quirk uses a device class for which no name is defined.
  - If the default behavior does return a proper name, we use that.
- But if there is a translation key, we use that, except for when the translation for it is missing. Then we use the fallback name instead.


<details><summary>Previous implementation (before order was swapped) (CLICK TO OPEN)</summary>
<p>

This was the small explanation for the previous implementation, before the order was changed in [`b9b80a0` (#156751)](https://github.com/home-assistant/core/pull/156751/commits/b9b80a09bbb93c697c0a5a537539af5412e8b8b0). It does the exact same, just in a bit of a different order. So, this might still be useful to look at:  

- To fix the behavior, we first check if a translation key is set for the entity OR if `super.name()` returns **no** name. (`super.name()` can only return the translation OR device class name)
  - If either are true, we want to present the user the translation (if it exists) for the translation key (if it exists).
  - If no translations exists, we need to fall back to the `fallback_name`. We can just show it at this point.
- If we did not show a translation OR fallback name before, we show the device class name at the end, using `super.name()`.
  (This is only done if we never intended to show a translation (or fallback name) in the first place, as this now only happens if `translation_key` is not set.)

</p>
</details> 




### Info

Supersedes:
- https://github.com/home-assistant/core/pull/152155 Thanks @epenet!

In order to check if a translation/string exists in HA, we need to check `self.platform_data.platform_translations` for the `translation_key`. This was the crucial step missing before epenet's PR above.

I'm aware ZHA is a bit special with this naming stuff, as it's (AFAIK) the only integration, where entities can be generated depending on info outside of HA that still supports translations, unlike MQTT/ESPHome/Z-Wave/... (again, AFAIK)
So, we kind of have to be slightly special here. I do think this is perfectly fine code-wise, even if it's a bit special.


### Why even fix this if it's only a custom quirks issue

This should massively improve the UX when creating new quirks and testing them as custom quirks, as the naming is now actually fixed (and the same when the quirk is upstream'ed). Before, this bug lead to users not using device classes, as they did not know this was only a bug until their quirk PR got merged.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
