### PR TITLE
Refactor device classes for LCN

### DIFF
--- a/homeassistant/components/lcn/entity.py
+++ b/homeassistant/components/lcn/entity.py
@@ -2,6 +2,8 @@
 
 from collections.abc import Callable
 
+from pypck.device import DeviceConnection
+
 from homeassistant.const import CONF_ADDRESS, CONF_DOMAIN, CONF_NAME
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
@@ -10,7 +12,6 @@ from homeassistant.helpers.typing import ConfigType
 from .const import CONF_DOMAIN_DATA, DOMAIN
 from .helpers import (
     AddressType,
-    DeviceConnectionType,
     InputType,
     LcnConfigEntry,
     generate_unique_id,
@@ -23,7 +24,7 @@ class LcnEntity(Entity):
     """Parent class for all entities associated with the LCN component."""
 
     _attr_has_entity_name = True
-    device_connection: DeviceConnectionType
+    device_connection: DeviceConnection
 
     def __init__(
         self,

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -11,6 +11,7 @@ from typing import cast
 
 import pypck
 from pypck.connection import PchkConnectionManager
+from pypck.device import DeviceConnection
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -48,7 +49,7 @@ class LcnRuntimeData:
     connection: PchkConnectionManager
     """Connection to PCHK host."""
 
-    device_connections: dict[str, DeviceConnectionType]
+    device_connections: dict[str, DeviceConnection]
     """Logical addresses of devices connected to the host."""
 
     add_entities_callbacks: dict[str, Callable[[Iterable[ConfigType]], None]]
@@ -59,7 +60,6 @@ class LcnRuntimeData:
 type LcnConfigEntry = ConfigEntry[LcnRuntimeData]
 
 type AddressType = tuple[int, int, bool]
-type DeviceConnectionType = pypck.module.ModuleConnection | pypck.module.GroupConnection
 
 type InputType = type[pypck.inputs.Input]
 
@@ -82,11 +82,11 @@ DOMAIN_LOOKUP = {
 
 def get_device_connection(
     hass: HomeAssistant, address: AddressType, config_entry: LcnConfigEntry
-) -> DeviceConnectionType:
+) -> DeviceConnection:
     """Return a lcn device_connection."""
     host_connection = config_entry.runtime_data.connection
     addr = pypck.lcn_addr.LcnAddr(*address)
-    return host_connection.get_address_conn(addr)
+    return host_connection.get_device_connection(addr)
 
 
 def get_resource(domain_name: str, domain_data: ConfigType) -> str:
@@ -246,7 +246,7 @@ def register_lcn_address_devices(
 
 
 async def async_update_device_config(
-    device_connection: DeviceConnectionType, device_config: ConfigType
+    device_connection: DeviceConnection, device_config: ConfigType
 ) -> None:
     """Fill missing values in device_config with infos from LCN bus."""
     # fetch serial info if device is module

--- a/homeassistant/components/lcn/manifest.json
+++ b/homeassistant/components/lcn/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "loggers": ["pypck"],
   "quality_scale": "bronze",
-  "requirements": ["pypck==0.9.2", "lcn-frontend==0.2.7"]
+  "requirements": ["pypck==0.9.3", "lcn-frontend==0.2.7"]
 }

--- a/homeassistant/components/lcn/services.py
+++ b/homeassistant/components/lcn/services.py
@@ -3,6 +3,7 @@
 from enum import StrEnum, auto
 
 import pypck
+from pypck.device import DeviceConnection
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -48,7 +49,7 @@ from .const import (
     VAR_UNITS,
     VARIABLES,
 )
-from .helpers import DeviceConnectionType, LcnConfigEntry, is_states_string
+from .helpers import LcnConfigEntry, is_states_string
 
 
 class LcnServiceCall:
@@ -65,7 +66,7 @@ class LcnServiceCall:
         """Initialize service call."""
         self.hass = hass
 
-    def get_device_connection(self, service: ServiceCall) -> DeviceConnectionType:
+    def get_device_connection(self, service: ServiceCall) -> DeviceConnection:
         """Get address connection object."""
         entries: list[LcnConfigEntry] = self.hass.config_entries.async_loaded_entries(
             DOMAIN

--- a/homeassistant/components/lcn/websocket.py
+++ b/homeassistant/components/lcn/websocket.py
@@ -7,6 +7,7 @@ from functools import wraps
 from typing import Any, Final
 
 import lcn_frontend as lcn_panel
+from pypck.device import DeviceConnection
 import voluptuous as vol
 
 from homeassistant.components import panel_custom, websocket_api
@@ -37,7 +38,6 @@ from .const import (
     DOMAIN,
 )
 from .helpers import (
-    DeviceConnectionType,
     LcnConfigEntry,
     async_update_device_config,
     generate_unique_id,
@@ -182,7 +182,7 @@ async def websocket_scan_devices(
     host_connection = config_entry.runtime_data.connection
     await host_connection.scan_modules()
 
-    for device_connection in host_connection.address_conns.values():
+    for device_connection in host_connection.device_connections.values():
         if not device_connection.is_group:
             await async_create_or_update_device_in_config_entry(
                 hass, device_connection, config_entry
@@ -421,7 +421,7 @@ async def websocket_delete_entity(
 
 async def async_create_or_update_device_in_config_entry(
     hass: HomeAssistant,
-    device_connection: DeviceConnectionType,
+    device_connection: DeviceConnection,
     config_entry: LcnConfigEntry,
 ) -> None:
     """Create or update device in config_entry according to given device_connection."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2269,7 +2269,7 @@ pypaperless==4.1.1
 pypca==0.0.7
 
 # homeassistant.components.lcn
-pypck==0.9.2
+pypck==0.9.3
 
 # homeassistant.components.pglab
 pypglab==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1892,7 +1892,7 @@ pypalazzetti==0.1.20
 pypaperless==4.1.1
 
 # homeassistant.components.lcn
-pypck==0.9.2
+pypck==0.9.3
 
 # homeassistant.components.pglab
 pypglab==0.0.5

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pypck
 from pypck import lcn_defs
-from pypck.module import GroupConnection, ModuleConnection, Serials
+from pypck.device import DeviceConnection, Serials
 import pytest
 
 from homeassistant.components.lcn import PchkConnectionManager
@@ -22,7 +22,7 @@ from tests.common import MockConfigEntry, load_fixture
 LATEST_CONFIG_ENTRY_VERSION = (LcnFlowHandler.VERSION, LcnFlowHandler.MINOR_VERSION)
 
 
-class MockModuleConnection(ModuleConnection):
+class MockDeviceConnection(DeviceConnection):
     """Fake a LCN module connection."""
 
     request_name = AsyncMock(return_value="TestModule")
@@ -49,12 +49,6 @@ class MockModuleConnection(ModuleConnection):
         self._serials_known.set()
 
 
-class MockGroupConnection(GroupConnection):
-    """Fake a LCN group connection."""
-
-    send_command = AsyncMock(return_value=True)
-
-
 class MockPchkConnectionManager(PchkConnectionManager):
     """Fake connection handler."""
 
@@ -67,15 +61,10 @@ class MockPchkConnectionManager(PchkConnectionManager):
     async def async_close(self) -> None:
         """Mock closing a connection to PCHK."""
 
-    @patch.object(pypck.connection, "ModuleConnection", MockModuleConnection)
-    def get_module_conn(self, addr):
-        """Get LCN module connection."""
-        return super().get_module_conn(addr)
-
-    @patch.object(pypck.connection, "GroupConnection", MockGroupConnection)
-    def get_group_conn(self, addr):
-        """Get LCN group connection."""
-        return super().get_group_conn(addr)
+    @patch.object(pypck.connection, "DeviceConnection", MockDeviceConnection)
+    def get_device_connection(self, addr):
+        """Get LCN device connection."""
+        return super().get_device_connection(addr)
 
     scan_modules = AsyncMock()
     send_command = AsyncMock()

--- a/tests/components/lcn/test_climate.py
+++ b/tests/components/lcn/test_climate.py
@@ -29,7 +29,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MockConfigEntry, MockModuleConnection, init_integration
+from .conftest import MockConfigEntry, MockDeviceConnection, init_integration
 
 from tests.common import snapshot_platform
 
@@ -51,7 +51,7 @@ async def test_set_hvac_mode_heat(hass: HomeAssistant, entry: MockConfigEntry) -
     """Test the hvac mode is set to heat."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "lock_regulator") as lock_regulator:
+    with patch.object(MockDeviceConnection, "lock_regulator") as lock_regulator:
         await hass.services.async_call(
             DOMAIN_CLIMATE,
             SERVICE_SET_HVAC_MODE,
@@ -106,7 +106,7 @@ async def test_set_hvac_mode_off(hass: HomeAssistant, entry: MockConfigEntry) ->
     """Test the hvac mode is set off."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "lock_regulator") as lock_regulator:
+    with patch.object(MockDeviceConnection, "lock_regulator") as lock_regulator:
         state = hass.states.get("climate.testmodule_climate1")
         state.state = HVACMode.HEAT
 
@@ -154,7 +154,7 @@ async def test_set_temperature(hass: HomeAssistant, entry: MockConfigEntry) -> N
     """Test the temperature is set."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "var_abs") as var_abs:
+    with patch.object(MockDeviceConnection, "var_abs") as var_abs:
         state = hass.states.get("climate.testmodule_climate1")
         state.state = HVACMode.HEAT
 

--- a/tests/components/lcn/test_cover.py
+++ b/tests/components/lcn/test_cover.py
@@ -32,7 +32,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MockConfigEntry, MockModuleConnection, init_integration
+from .conftest import MockConfigEntry, MockDeviceConnection, init_integration
 
 from tests.common import snapshot_platform
 
@@ -60,7 +60,7 @@ async def test_outputs_open(hass: HomeAssistant, entry: MockConfigEntry) -> None
     await init_integration(hass, entry)
 
     with patch.object(
-        MockModuleConnection, "control_motor_outputs"
+        MockDeviceConnection, "control_motor_outputs"
     ) as control_motor_outputs:
         state = hass.states.get(COVER_OUTPUTS)
         assert state is not None
@@ -109,7 +109,7 @@ async def test_outputs_close(hass: HomeAssistant, entry: MockConfigEntry) -> Non
     await init_integration(hass, entry)
 
     with patch.object(
-        MockModuleConnection, "control_motor_outputs"
+        MockDeviceConnection, "control_motor_outputs"
     ) as control_motor_outputs:
         await hass.services.async_call(
             DOMAIN_COVER,
@@ -161,7 +161,7 @@ async def test_outputs_stop(hass: HomeAssistant, entry: MockConfigEntry) -> None
     await init_integration(hass, entry)
 
     with patch.object(
-        MockModuleConnection, "control_motor_outputs"
+        MockDeviceConnection, "control_motor_outputs"
     ) as control_motor_outputs:
         await hass.services.async_call(
             DOMAIN_COVER,
@@ -209,7 +209,7 @@ async def test_relays_open(hass: HomeAssistant, entry: MockConfigEntry) -> None:
     await init_integration(hass, entry)
 
     with patch.object(
-        MockModuleConnection, "control_motor_relays"
+        MockDeviceConnection, "control_motor_relays"
     ) as control_motor_relays:
         state = hass.states.get(COVER_RELAYS)
         assert state is not None
@@ -258,7 +258,7 @@ async def test_relays_close(hass: HomeAssistant, entry: MockConfigEntry) -> None
     await init_integration(hass, entry)
 
     with patch.object(
-        MockModuleConnection, "control_motor_relays"
+        MockDeviceConnection, "control_motor_relays"
     ) as control_motor_relays:
         await hass.services.async_call(
             DOMAIN_COVER,
@@ -310,7 +310,7 @@ async def test_relays_stop(hass: HomeAssistant, entry: MockConfigEntry) -> None:
     await init_integration(hass, entry)
 
     with patch.object(
-        MockModuleConnection, "control_motor_relays"
+        MockDeviceConnection, "control_motor_relays"
     ) as control_motor_relays:
         await hass.services.async_call(
             DOMAIN_COVER,
@@ -375,7 +375,7 @@ async def test_relays_set_position(
     await init_integration(hass, entry)
 
     with patch.object(
-        MockModuleConnection, "control_motor_relays_position"
+        MockDeviceConnection, "control_motor_relays_position"
     ) as control_motor_relays_position:
         state = hass.states.get(entity_id)
         assert state is not None

--- a/tests/components/lcn/test_light.py
+++ b/tests/components/lcn/test_light.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MockConfigEntry, MockModuleConnection, init_integration
+from .conftest import MockConfigEntry, MockDeviceConnection, init_integration
 
 from tests.common import snapshot_platform
 
@@ -51,7 +51,7 @@ async def test_output_turn_on(hass: HomeAssistant, entry: MockConfigEntry) -> No
     """Test the output light turns on."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "toggle_output") as toggle_output:
+    with patch.object(MockDeviceConnection, "toggle_output") as toggle_output:
         # command failed
         toggle_output.return_value = False
 
@@ -92,7 +92,7 @@ async def test_output_turn_on_with_attributes(
     """Test the output light turns on."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "dim_output") as dim_output:
+    with patch.object(MockDeviceConnection, "dim_output") as dim_output:
         dim_output.return_value = True
 
         await hass.services.async_call(
@@ -117,7 +117,7 @@ async def test_output_turn_off(hass: HomeAssistant, entry: MockConfigEntry) -> N
     """Test the output light turns off."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "toggle_output") as toggle_output:
+    with patch.object(MockDeviceConnection, "toggle_output") as toggle_output:
         await hass.services.async_call(
             DOMAIN_LIGHT,
             SERVICE_TURN_ON,
@@ -163,7 +163,7 @@ async def test_relay_turn_on(hass: HomeAssistant, entry: MockConfigEntry) -> Non
     """Test the relay light turns on."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "control_relays") as control_relays:
+    with patch.object(MockDeviceConnection, "control_relays") as control_relays:
         states = [RelayStateModifier.NOCHANGE] * 8
         states[0] = RelayStateModifier.ON
 
@@ -205,7 +205,7 @@ async def test_relay_turn_off(hass: HomeAssistant, entry: MockConfigEntry) -> No
     """Test the relay light turns off."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "control_relays") as control_relays:
+    with patch.object(MockDeviceConnection, "control_relays") as control_relays:
         states = [RelayStateModifier.NOCHANGE] * 8
         states[0] = RelayStateModifier.OFF
 

--- a/tests/components/lcn/test_scene.py
+++ b/tests/components/lcn/test_scene.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MockConfigEntry, MockModuleConnection, init_integration
+from .conftest import MockConfigEntry, MockDeviceConnection, init_integration
 
 from tests.common import snapshot_platform
 
@@ -39,7 +39,7 @@ async def test_scene_activate(
 ) -> None:
     """Test the scene is activated."""
     await init_integration(hass, entry)
-    with patch.object(MockModuleConnection, "activate_scene") as activate_scene:
+    with patch.object(MockDeviceConnection, "activate_scene") as activate_scene:
         await hass.services.async_call(
             DOMAIN_SCENE,
             SERVICE_TURN_ON,

--- a/tests/components/lcn/test_services.py
+++ b/tests/components/lcn/test_services.py
@@ -35,7 +35,7 @@ from homeassistant.setup import async_setup_component
 
 from .conftest import (
     MockConfigEntry,
-    MockModuleConnection,
+    MockDeviceConnection,
     get_device,
     init_integration,
 )
@@ -49,7 +49,7 @@ async def test_service_output_abs(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "dim_output") as dim_output:
+    with patch.object(MockDeviceConnection, "dim_output") as dim_output:
         await hass.services.async_call(
             DOMAIN,
             LcnService.OUTPUT_ABS,
@@ -73,7 +73,7 @@ async def test_service_output_rel(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "rel_output") as rel_output:
+    with patch.object(MockDeviceConnection, "rel_output") as rel_output:
         await hass.services.async_call(
             DOMAIN,
             LcnService.OUTPUT_REL,
@@ -96,7 +96,7 @@ async def test_service_output_toggle(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "toggle_output") as toggle_output:
+    with patch.object(MockDeviceConnection, "toggle_output") as toggle_output:
         await hass.services.async_call(
             DOMAIN,
             LcnService.OUTPUT_TOGGLE,
@@ -119,7 +119,7 @@ async def test_service_relays(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "control_relays") as control_relays:
+    with patch.object(MockDeviceConnection, "control_relays") as control_relays:
         await hass.services.async_call(
             DOMAIN,
             LcnService.RELAYS,
@@ -137,7 +137,7 @@ async def test_service_relays(
 
     # wrong states string
     with (
-        patch.object(MockModuleConnection, "control_relays") as control_relays,
+        patch.object(MockDeviceConnection, "control_relays") as control_relays,
         pytest.raises(HomeAssistantError) as exc_info,
     ):
         await hass.services.async_call(
@@ -161,7 +161,7 @@ async def test_service_led(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "control_led") as control_led:
+    with patch.object(MockDeviceConnection, "control_led") as control_led:
         await hass.services.async_call(
             DOMAIN,
             LcnService.LED,
@@ -187,7 +187,7 @@ async def test_service_var_abs(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "var_abs") as var_abs:
+    with patch.object(MockDeviceConnection, "var_abs") as var_abs:
         await hass.services.async_call(
             DOMAIN,
             LcnService.VAR_ABS,
@@ -213,7 +213,7 @@ async def test_service_var_rel(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "var_rel") as var_rel:
+    with patch.object(MockDeviceConnection, "var_rel") as var_rel:
         await hass.services.async_call(
             DOMAIN,
             LcnService.VAR_REL,
@@ -243,7 +243,7 @@ async def test_service_var_reset(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "var_reset") as var_reset:
+    with patch.object(MockDeviceConnection, "var_reset") as var_reset:
         await hass.services.async_call(
             DOMAIN,
             LcnService.VAR_RESET,
@@ -265,7 +265,7 @@ async def test_service_lock_regulator(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "lock_regulator") as lock_regulator:
+    with patch.object(MockDeviceConnection, "lock_regulator") as lock_regulator:
         await hass.services.async_call(
             DOMAIN,
             LcnService.LOCK_REGULATOR,
@@ -288,7 +288,7 @@ async def test_service_send_keys(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "send_keys") as send_keys:
+    with patch.object(MockDeviceConnection, "send_keys") as send_keys:
         await hass.services.async_call(
             DOMAIN,
             LcnService.SEND_KEYS,
@@ -323,7 +323,7 @@ async def test_service_send_keys_hit_deferred(
 
     # success
     with patch.object(
-        MockModuleConnection, "send_keys_hit_deferred"
+        MockDeviceConnection, "send_keys_hit_deferred"
     ) as send_keys_hit_deferred:
         await hass.services.async_call(
             DOMAIN,
@@ -344,7 +344,7 @@ async def test_service_send_keys_hit_deferred(
     # wrong key action
     with (
         patch.object(
-            MockModuleConnection, "send_keys_hit_deferred"
+            MockDeviceConnection, "send_keys_hit_deferred"
         ) as send_keys_hit_deferred,
         pytest.raises(ServiceValidationError) as exc_info,
     ):
@@ -372,7 +372,7 @@ async def test_service_lock_keys(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "lock_keys") as lock_keys:
+    with patch.object(MockDeviceConnection, "lock_keys") as lock_keys:
         await hass.services.async_call(
             DOMAIN,
             LcnService.LOCK_KEYS,
@@ -391,7 +391,7 @@ async def test_service_lock_keys(
 
     # wrong states string
     with (
-        patch.object(MockModuleConnection, "lock_keys") as lock_keys,
+        patch.object(MockDeviceConnection, "lock_keys") as lock_keys,
         pytest.raises(HomeAssistantError) as exc_info,
     ):
         await hass.services.async_call(
@@ -418,7 +418,7 @@ async def test_service_lock_keys_tab_a_temporary(
 
     # success
     with patch.object(
-        MockModuleConnection, "lock_keys_tab_a_temporary"
+        MockDeviceConnection, "lock_keys_tab_a_temporary"
     ) as lock_keys_tab_a_temporary:
         await hass.services.async_call(
             DOMAIN,
@@ -442,7 +442,7 @@ async def test_service_lock_keys_tab_a_temporary(
     # wrong table
     with (
         patch.object(
-            MockModuleConnection, "lock_keys_tab_a_temporary"
+            MockDeviceConnection, "lock_keys_tab_a_temporary"
         ) as lock_keys_tab_a_temporary,
         pytest.raises(ServiceValidationError) as exc_info,
     ):
@@ -470,7 +470,7 @@ async def test_service_dyn_text(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "dyn_text") as dyn_text:
+    with patch.object(MockDeviceConnection, "dyn_text") as dyn_text:
         await hass.services.async_call(
             DOMAIN,
             LcnService.DYN_TEXT,
@@ -493,7 +493,7 @@ async def test_service_pck(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "pck") as pck:
+    with patch.object(MockDeviceConnection, "pck") as pck:
         await hass.services.async_call(
             DOMAIN,
             LcnService.PCK,

--- a/tests/components/lcn/test_switch.py
+++ b/tests/components/lcn/test_switch.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MockConfigEntry, MockModuleConnection, init_integration
+from .conftest import MockConfigEntry, MockDeviceConnection, init_integration
 
 from tests.common import snapshot_platform
 
@@ -55,7 +55,7 @@ async def test_output_turn_on(hass: HomeAssistant, entry: MockConfigEntry) -> No
     """Test the output switch turns on."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "dim_output") as dim_output:
+    with patch.object(MockDeviceConnection, "dim_output") as dim_output:
         # command failed
         dim_output.return_value = False
 
@@ -92,7 +92,7 @@ async def test_output_turn_off(hass: HomeAssistant, entry: MockConfigEntry) -> N
     """Test the output switch turns off."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "dim_output") as dim_output:
+    with patch.object(MockDeviceConnection, "dim_output") as dim_output:
         await hass.services.async_call(
             DOMAIN_SWITCH,
             SERVICE_TURN_ON,
@@ -136,7 +136,7 @@ async def test_relay_turn_on(hass: HomeAssistant, entry: MockConfigEntry) -> Non
     """Test the relay switch turns on."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "control_relays") as control_relays:
+    with patch.object(MockDeviceConnection, "control_relays") as control_relays:
         states = [RelayStateModifier.NOCHANGE] * 8
         states[0] = RelayStateModifier.ON
 
@@ -176,7 +176,7 @@ async def test_relay_turn_off(hass: HomeAssistant, entry: MockConfigEntry) -> No
     """Test the relay switch turns off."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "control_relays") as control_relays:
+    with patch.object(MockDeviceConnection, "control_relays") as control_relays:
         states = [RelayStateModifier.NOCHANGE] * 8
         states[0] = RelayStateModifier.OFF
 
@@ -225,7 +225,7 @@ async def test_regulatorlock_turn_on(
     """Test the regulator lock switch turns on."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "lock_regulator") as lock_regulator:
+    with patch.object(MockDeviceConnection, "lock_regulator") as lock_regulator:
         # command failed
         lock_regulator.return_value = False
 
@@ -264,7 +264,7 @@ async def test_regulatorlock_turn_off(
     """Test the regulator lock switch turns off."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "lock_regulator") as lock_regulator:
+    with patch.object(MockDeviceConnection, "lock_regulator") as lock_regulator:
         await hass.services.async_call(
             DOMAIN_SWITCH,
             SERVICE_TURN_ON,
@@ -308,7 +308,7 @@ async def test_keylock_turn_on(hass: HomeAssistant, entry: MockConfigEntry) -> N
     """Test the keylock switch turns on."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "lock_keys") as lock_keys:
+    with patch.object(MockDeviceConnection, "lock_keys") as lock_keys:
         states = [KeyLockStateModifier.NOCHANGE] * 8
         states[0] = KeyLockStateModifier.ON
 
@@ -348,7 +348,7 @@ async def test_keylock_turn_off(hass: HomeAssistant, entry: MockConfigEntry) -> 
     """Test the keylock switch turns off."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "lock_keys") as lock_keys:
+    with patch.object(MockDeviceConnection, "lock_keys") as lock_keys:
         states = [KeyLockStateModifier.NOCHANGE] * 8
         states[0] = KeyLockStateModifier.OFF
 

--- a/tests/components/lcn/test_websocket.py
+++ b/tests/components/lcn/test_websocket.py
@@ -118,7 +118,7 @@ async def test_lcn_devices_scan_command(
     """Test lcn/devices/scan command."""
     # add new module which is not stored in config_entry
     lcn_connection = await init_integration(hass, entry)
-    lcn_connection.get_address_conn(LcnAddr(0, 10, False))
+    lcn_connection.get_device_connection(LcnAddr(0, 10, False))
 
     client = await hass_ws_client(hass)
     await client.send_json_auto_id({**SCAN_PAYLOAD, "entry_id": entry.entry_id})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
The underlying library for the LCN integration (`pypck`) combined the interface classes for LCN "modules" and "groups" into "devices" (`ModuleConnection` & `GroupConnection` -> `DeviceConnection`).
This change needs some adaptions in the integration code.

Dependency upgrade of `pypck`:

Release notes: https://github.com/alengwenus/pypck/releases
Code changes: https://github.com/alengwenus/pypck/compare/0.9.2..0.9.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
