### PR TITLE
Strict typing for lcn integration

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from functools import partial
 import logging
+from typing import cast
 
 import pypck
 from pypck.connection import (
@@ -48,7 +49,6 @@ from .const import (
 )
 from .helpers import (
     AddressType,
-    InputType,
     LcnConfigEntry,
     LcnRuntimeData,
     async_update_config_entry,
@@ -285,7 +285,7 @@ def _async_fire_access_control_event(
     hass: HomeAssistant,
     device: dr.DeviceEntry | None,
     address: AddressType,
-    inp: InputType,
+    inp: pypck.inputs.ModStatusAccessControl,
 ) -> None:
     """Fire access control event (transponder, transmitter, fingerprint, codelock)."""
     event_data = {
@@ -299,7 +299,11 @@ def _async_fire_access_control_event(
 
     if inp.periphery == pypck.lcn_defs.AccessControlPeriphery.TRANSMITTER:
         event_data.update(
-            {"level": inp.level, "key": inp.key, "action": inp.action.value}
+            {
+                "level": inp.level,
+                "key": inp.key,
+                "action": cast(pypck.lcn_defs.KeyAction, inp.action).value,
+            }
         )
 
     event_name = f"lcn_{inp.periphery.value.lower()}"
@@ -310,7 +314,7 @@ def _async_fire_send_keys_event(
     hass: HomeAssistant,
     device: dr.DeviceEntry | None,
     address: AddressType,
-    inp: InputType,
+    inp: pypck.inputs.ModSendKeysHost,
 ) -> None:
     """Fire send_keys event."""
     for table, action in enumerate(inp.actions):

--- a/homeassistant/components/lcn/climate.py
+++ b/homeassistant/components/lcn/climate.py
@@ -100,8 +100,6 @@ class LcnClimate(LcnEntity, ClimateEntity):
         self._max_temp = config[CONF_DOMAIN_DATA][CONF_MAX_TEMP]
         self._min_temp = config[CONF_DOMAIN_DATA][CONF_MIN_TEMP]
 
-        self._current_temperature = None
-        self._target_temperature = None
         self._is_on = True
 
         self._attr_hvac_modes = [HVACMode.HEAT]
@@ -120,16 +118,6 @@ class LcnClimate(LcnEntity, ClimateEntity):
         if self.unit == pypck.lcn_defs.VarUnit.FAHRENHEIT:
             return UnitOfTemperature.FAHRENHEIT
         return UnitOfTemperature.CELSIUS
-
-    @property
-    def current_temperature(self) -> float | None:
-        """Return the current temperature."""
-        return self._current_temperature
-
-    @property
-    def target_temperature(self) -> float | None:
-        """Return the temperature we try to reach."""
-        return self._target_temperature
 
     @property
     def hvac_mode(self) -> HVACMode:
@@ -166,7 +154,7 @@ class LcnClimate(LcnEntity, ClimateEntity):
             ):
                 return
             self._is_on = False
-            self._target_temperature = None
+            self._attr_target_temperature = None
             self.async_write_ha_state()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -178,7 +166,7 @@ class LcnClimate(LcnEntity, ClimateEntity):
             self.setpoint, temperature, self.unit
         ):
             return
-        self._target_temperature = temperature
+        self._attr_target_temperature = temperature
         self.async_write_ha_state()
 
     async def async_update(self) -> None:
@@ -198,10 +186,14 @@ class LcnClimate(LcnEntity, ClimateEntity):
             return
 
         if input_obj.get_var() == self.variable:
-            self._current_temperature = input_obj.get_value().to_var_unit(self.unit)
+            self._attr_current_temperature = float(
+                input_obj.get_value().to_var_unit(self.unit)
+            )
         elif input_obj.get_var() == self.setpoint:
             self._is_on = not input_obj.get_value().is_locked_regulator()
             if self._is_on:
-                self._target_temperature = input_obj.get_value().to_var_unit(self.unit)
+                self._attr_target_temperature = float(
+                    input_obj.get_value().to_var_unit(self.unit)
+                )
 
         self.async_write_ha_state()

--- a/homeassistant/components/lcn/config_flow.py
+++ b/homeassistant/components/lcn/config_flow.py
@@ -120,7 +120,7 @@ class LcnFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 errors={CONF_BASE: error},
             )
 
-        data: dict = {
+        data: dict[str, Any] = {
             **user_input,
             CONF_DEVICES: [],
             CONF_ENTITIES: [],

--- a/homeassistant/components/lcn/entity.py
+++ b/homeassistant/components/lcn/entity.py
@@ -35,7 +35,7 @@ class LcnEntity(Entity):
         self.config = config
         self.config_entry = config_entry
         self.address: AddressType = config[CONF_ADDRESS]
-        self._unregister_for_inputs: Callable | None = None
+        self._unregister_for_inputs: Callable[[], None] | None = None
         self._name: str = config[CONF_NAME]
         self._attr_device_info = DeviceInfo(
             identifiers={

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -61,7 +61,7 @@ type LcnConfigEntry = ConfigEntry[LcnRuntimeData]
 
 type AddressType = tuple[int, int, bool]
 
-type InputType = type[pypck.inputs.Input]
+type InputType = pypck.inputs.Input
 
 # Regex for address validation
 PATTERN_ADDRESS = re.compile(
@@ -269,10 +269,10 @@ async def async_update_device_config(
     if device_config[CONF_NAME] != "":
         return
 
-    device_name = ""
+    device_name: str | None = None
     if not is_group:
         device_name = await device_connection.request_name()
-    if is_group or device_name == "":
+    if is_group or device_name is None:
         module_type = "Group" if is_group else "Module"
         device_name = (
             f"{module_type} "

--- a/homeassistant/components/lcn/manifest.json
+++ b/homeassistant/components/lcn/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "loggers": ["pypck"],
   "quality_scale": "bronze",
-  "requirements": ["pypck==0.9.3", "lcn-frontend==0.2.7"]
+  "requirements": ["pypck==0.9.4", "lcn-frontend==0.2.7"]
 }

--- a/homeassistant/components/lcn/quality_scale.yaml
+++ b/homeassistant/components/lcn/quality_scale.yaml
@@ -74,4 +74,4 @@ rules:
     status: exempt
     comment: |
       Integration is not making any HTTP requests.
-  strict-typing: todo
+  strict-typing: done

--- a/homeassistant/components/lcn/sensor.py
+++ b/homeassistant/components/lcn/sensor.py
@@ -156,6 +156,8 @@ class LcnVariableSensor(LcnEntity, SensorEntity):
 class LcnLedLogicSensor(LcnEntity, SensorEntity):
     """Representation of a LCN sensor for leds and logicops."""
 
+    source: pypck.lcn_defs.LedPort | pypck.lcn_defs.LogicOpPort
+
     def __init__(self, config: ConfigType, config_entry: LcnConfigEntry) -> None:
         """Initialize the LCN sensor."""
         super().__init__(config, config_entry)

--- a/homeassistant/components/lcn/websocket.py
+++ b/homeassistant/components/lcn/websocket.py
@@ -104,7 +104,9 @@ def get_config_entry(
 
     @wraps(func)
     async def get_entry(
-        hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
     ) -> None:
         """Get config_entry."""
         if not (config_entry := hass.config_entries.async_get_entry(msg["entry_id"])):
@@ -124,7 +126,7 @@ def get_config_entry(
 async def websocket_get_device_configs(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
-    msg: dict,
+    msg: dict[str, Any],
     config_entry: LcnConfigEntry,
 ) -> None:
     """Get device configs."""
@@ -144,7 +146,7 @@ async def websocket_get_device_configs(
 async def websocket_get_entity_configs(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
-    msg: dict,
+    msg: dict[str, Any],
     config_entry: LcnConfigEntry,
 ) -> None:
     """Get entities configs."""
@@ -175,7 +177,7 @@ async def websocket_get_entity_configs(
 async def websocket_scan_devices(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
-    msg: dict,
+    msg: dict[str, Any],
     config_entry: LcnConfigEntry,
 ) -> None:
     """Scan for new devices."""
@@ -207,7 +209,7 @@ async def websocket_scan_devices(
 async def websocket_add_device(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
-    msg: dict,
+    msg: dict[str, Any],
     config_entry: LcnConfigEntry,
 ) -> None:
     """Add a device."""
@@ -253,7 +255,7 @@ async def websocket_add_device(
 async def websocket_delete_device(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
-    msg: dict,
+    msg: dict[str, Any],
     config_entry: LcnConfigEntry,
 ) -> None:
     """Delete a device."""
@@ -315,7 +317,7 @@ async def websocket_delete_device(
 async def websocket_add_entity(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
-    msg: dict,
+    msg: dict[str, Any],
     config_entry: LcnConfigEntry,
 ) -> None:
     """Add an entity."""
@@ -381,7 +383,7 @@ async def websocket_add_entity(
 async def websocket_delete_entity(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
-    msg: dict,
+    msg: dict[str, Any],
     config_entry: LcnConfigEntry,
 ) -> None:
     """Delete an entity."""
@@ -451,7 +453,7 @@ async def async_create_or_update_device_in_config_entry(
 
 
 def get_entity_entry(
-    hass: HomeAssistant, entity_config: dict, config_entry: LcnConfigEntry
+    hass: HomeAssistant, entity_config: dict[str, Any], config_entry: LcnConfigEntry
 ) -> er.RegistryEntry | None:
     """Get entity RegistryEntry from entity_config."""
     entity_registry = er.async_get(hass)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2269,7 +2269,7 @@ pypaperless==4.1.1
 pypca==0.0.7
 
 # homeassistant.components.lcn
-pypck==0.9.3
+pypck==0.9.4
 
 # homeassistant.components.pglab
 pypglab==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1892,7 +1892,7 @@ pypalazzetti==0.1.20
 pypaperless==4.1.1
 
 # homeassistant.components.lcn
-pypck==0.9.3
+pypck==0.9.4
 
 # homeassistant.components.pglab
 pypglab==0.0.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Underlying package for lcn integration (`pypck`) supports strict typing in latest version. Fixed integration code and set the `strict-typing` flag in `quality_scale.yaml`.

Dependency upgrade of pypck:

Release notes: https://github.com/alengwenus/pypck/releases
Code changes: https://github.com/alengwenus/pypck/compare/0.9.3..0.9.4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
