### PR TITLE
Add HVAC action support for BSBLAN climate entity

### DIFF
--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -126,11 +126,11 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac action."""
+        action = self.coordinator.data.state.hvac_action
         if not action or not isinstance(action.value, int):
-        return None
-
-    	category = get_hvac_action_category(action.value)
-    	return HVACAction(category.name.lower())
+            return None
+        category = get_hvac_action_category(action.value)
+        return HVACAction(category.name.lower())
 
     @property
     def preset_mode(self) -> str | None:

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -126,16 +126,11 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac action."""
-        action = self.coordinator.data.state.hvac_action
-        if action is None or action.value in (None, ""):
-            return None
+        if not action or not isinstance(action.value, int):
+        return None
 
-        status_code = action.value
-        if not isinstance(status_code, int):
-            return None
-
-        category = get_hvac_action_category(status_code)
-        return HVACAction(category.name.lower())
+    	category = get_hvac_action_category(action.value)
+    	return HVACAction(category.name.lower())
 
     @property
     def preset_mode(self) -> str | None:

--- a/tests/components/bsblan/snapshots/test_climate.ambr
+++ b/tests/components/bsblan/snapshots/test_climate.ambr
@@ -51,6 +51,7 @@
     'attributes': ReadOnlyDict({
       'current_temperature': 18.6,
       'friendly_name': 'BSB-LAN',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
       'hvac_modes': list([
         <HVACMode.AUTO: 'auto'>,
         <HVACMode.HEAT: 'heat'>,
@@ -126,6 +127,7 @@
     'attributes': ReadOnlyDict({
       'current_temperature': 18.6,
       'friendly_name': 'BSB-LAN',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
       'hvac_modes': list([
         <HVACMode.AUTO: 'auto'>,
         <HVACMode.HEAT: 'heat'>,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request adds support for reporting the current HVAC action in the BSBLAN climate integration, along with robust handling and testing for various edge cases. The main changes include implementing the `hvac_action` property, updating tests and snapshots to reflect the new attribute, and ensuring the integration gracefully handles invalid or missing values.

**BSBLAN climate integration enhancements:**

* Added a new `hvac_action` property to the BSBLAN climate entity, which maps the device's status code to a Home Assistant `HVACAction` using the `get_hvac_action_category` helper. This allows the UI and automations to reflect the current action (e.g., heating, cooling, idle). [[1]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L7-R7) [[2]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729R16) [[3]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729R126-R139)

**Testing improvements:**

* Updated and extended tests in `test_climate.py` to:
  - Verify correct mapping of device status codes to `HVACAction`.
  - Ensure the property handles `None`, empty, and malformed values gracefully.
  - Confirm the use of the library's mapping and fallback behavior for unknown codes. [[1]](diffhunk://#diff-e99598f290cd7f09b0b7e7a7af12e01a1f6afe5328bb1375ae81b1b39676abadL6-R6) [[2]](diffhunk://#diff-e99598f290cd7f09b0b7e7a7af12e01a1f6afe5328bb1375ae81b1b39676abadR20) [[3]](diffhunk://#diff-e99598f290cd7f09b0b7e7a7af12e01a1f6afe5328bb1375ae81b1b39676abadR94-R166)
* Updated test snapshots to include the new `hvac_action` attribute in climate entity states. [[1]](diffhunk://#diff-cc9fa53a1745b489def0aee471e5a01a86c34f0f15ff10864ab2ae3c75614aa0R54) [[2]](diffhunk://#diff-cc9fa53a1745b489def0aee471e5a01a86c34f0f15ff10864ab2ae3c75614aa0R130)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
