### PR TITLE
Revert "Return target in trigger description command"

### DIFF
--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -805,8 +805,6 @@ async def async_get_all_descriptions(
             continue
 
         description = {"fields": yaml_description.get("fields", {})}
-        if (target := yaml_description.get("target")) is not None:
-            description["target"] = target
 
         new_descriptions_cache[missing_trigger] = description
 

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -647,9 +647,14 @@ async def test_async_get_all_descriptions(
     """Test async_get_all_descriptions."""
     tag_trigger_descriptions = """
         _:
-          target:
+          fields:
             entity:
-              domain: alarm_control_panel
+              selector:
+                entity:
+                  filter:
+                    domain: alarm_control_panel
+                    supported_features:
+                      - alarm_control_panel.AlarmControlPanelEntityFeature.ARM_HOME
         """
 
     assert await async_setup_component(hass, DOMAIN_SUN, {})
@@ -739,14 +744,22 @@ async def test_async_get_all_descriptions(
             }
         },
         "tag": {
-            "target": {
-                "entity": [
-                    {
-                        "domain": ["alarm_control_panel"],
-                    }
-                ],
-            },
-            "fields": {},
+            "fields": {
+                "entity": {
+                    "selector": {
+                        "entity": {
+                            "filter": [
+                                {
+                                    "domain": ["alarm_control_panel"],
+                                    "supported_features": [1],
+                                }
+                            ],
+                            "multiple": False,
+                            "reorder": False,
+                        },
+                    },
+                },
+            }
         },
     }
 
@@ -878,5 +891,6 @@ async def test_subscribe_triggers(
     trigger.async_subscribe_platform_events(hass, good_subscriber)
 
     assert await async_setup_component(hass, "sun", {})
+
     assert trigger_events == [{"sun"}]
     assert "Error while notifying trigger platform listener" in caplog.text


### PR DESCRIPTION
Reverts home-assistant/core#156766

This is already implemented by PR #153841 on the feature branch `dev_target_triggers_conditions`. I suggest we revert this and get the feature branch merged.