### PR TITLE
Refactor parametrize_trigger_states test helper

### DIFF
--- a/tests/components/__init__.py
+++ b/tests/components/__init__.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterable
 import itertools
+from typing import TypedDict
 
 from homeassistant.const import (
     ATTR_AREA_ID,
@@ -105,13 +106,20 @@ def parametrize_target_entities(domain: str) -> list[tuple[dict, str, int]]:
     ]
 
 
+class StateDescription(TypedDict):
+    """Test state and expected service call count."""
+
+    state: str | None
+    count: int
+
+
 def parametrize_trigger_states(
     trigger: str, target_states: Iterable[str], other_states: Iterable[str]
-) -> list[tuple[str, list[tuple[str | None, int]]]]:
+) -> list[tuple[str, list[StateDescription]]]:
     """Parametrize states and expected service call counts.
 
     Returns a list of tuples with (trigger, list of states),
-    where states is a list of tuples (state to set, expected service call count).
+    where states is a list of StateDescription dicts.
     """
     return [
         # Initial state None
@@ -119,7 +127,12 @@ def parametrize_trigger_states(
             trigger,
             list(
                 itertools.chain.from_iterable(
-                    ((None, 0), (target_state, 0), (other_state, 0), (target_state, 1))
+                    (
+                        {"state": None, "count": 0},
+                        {"state": target_state, "count": 0},
+                        {"state": other_state, "count": 0},
+                        {"state": target_state, "count": 1},
+                    )
                     for target_state in target_states
                     for other_state in other_states
                 )
@@ -132,10 +145,10 @@ def parametrize_trigger_states(
             list(
                 itertools.chain.from_iterable(
                     (
-                        (other_state, 0),
-                        (target_state, 1),
-                        (other_state, 0),
-                        (target_state, 1),
+                        {"state": other_state, "count": 0},
+                        {"state": target_state, "count": 1},
+                        {"state": other_state, "count": 0},
+                        {"state": target_state, "count": 1},
                     )
                     for target_state in target_states
                     for other_state in other_states
@@ -148,10 +161,10 @@ def parametrize_trigger_states(
             list(
                 itertools.chain.from_iterable(
                     (
-                        (target_state, 0),
-                        (target_state, 0),
-                        (other_state, 0),
-                        (target_state, 1),
+                        {"state": target_state, "count": 0},
+                        {"state": target_state, "count": 0},
+                        {"state": other_state, "count": 0},
+                        {"state": target_state, "count": 1},
                     )
                     for target_state in target_states
                     for other_state in other_states
@@ -164,10 +177,10 @@ def parametrize_trigger_states(
             list(
                 itertools.chain.from_iterable(
                     (
-                        (STATE_UNAVAILABLE, 0),
-                        (target_state, 0),
-                        (other_state, 0),
-                        (target_state, 1),
+                        {"state": STATE_UNAVAILABLE, "count": 0},
+                        {"state": target_state, "count": 0},
+                        {"state": other_state, "count": 0},
+                        {"state": target_state, "count": 1},
                     )
                     for target_state in target_states
                     for other_state in other_states
@@ -179,10 +192,10 @@ def parametrize_trigger_states(
             list(
                 itertools.chain.from_iterable(
                     (
-                        (STATE_UNKNOWN, 0),
-                        (target_state, 0),
-                        (other_state, 0),
-                        (target_state, 1),
+                        {"state": STATE_UNKNOWN, "count": 0},
+                        {"state": target_state, "count": 0},
+                        {"state": other_state, "count": 0},
+                        {"state": target_state, "count": 1},
                     )
                     for target_state in target_states
                     for other_state in other_states

--- a/tests/components/alarm_control_panel/test_trigger.py
+++ b/tests/components/alarm_control_panel/test_trigger.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.components import (
+    StateDescription,
     arm_trigger,
     parametrize_target_entities,
     parametrize_trigger_states,
@@ -56,7 +57,7 @@ async def test_alarm_control_panel_state_trigger_behavior_any(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the alarm control panel state trigger fires when any alarm control panel state changes to a specific state."""
     await async_setup_component(hass, "alarm_control_panel", {})
@@ -65,24 +66,24 @@ async def test_alarm_control_panel_state_trigger_behavior_any(
 
     # Set all alarm control panels, including the tested one, to the initial state
     for eid in target_alarm_control_panels:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Check if changing other alarm control panels also triggers
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
-        assert len(service_calls) == (entities_in_target - 1) * expected_calls
+        assert len(service_calls) == (entities_in_target - 1) * state["count"]
         service_calls.clear()
 
 
@@ -113,7 +114,7 @@ async def test_alarm_control_panel_state_trigger_behavior_first(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int, list[str]]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the alarm control panel state trigger fires when the first alarm control panel changes to a specific state."""
     await async_setup_component(hass, "alarm_control_panel", {})
@@ -122,22 +123,22 @@ async def test_alarm_control_panel_state_trigger_behavior_first(
 
     # Set all alarm control panels, including the tested one, to the initial state
     for eid in target_alarm_control_panels:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "first"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Triggering other alarm control panels should not cause the trigger to fire again
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
@@ -169,7 +170,7 @@ async def test_alarm_control_panel_state_trigger_behavior_last(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the alarm_control_panel state trigger fires when the last alarm_control_panel changes to a specific state."""
     await async_setup_component(hass, "alarm_control_panel", {})
@@ -178,20 +179,20 @@ async def test_alarm_control_panel_state_trigger_behavior_last(
 
     # Set all alarm control panels, including the tested one, to the initial state
     for eid in target_alarm_control_panels:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "last"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
+    for state in states[1:]:
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
-        set_or_remove_state(hass, entity_id, state)
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()

--- a/tests/components/assist_satellite/test_trigger.py
+++ b/tests/components/assist_satellite/test_trigger.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.components import (
+    StateDescription,
     arm_trigger,
     parametrize_target_entities,
     parametrize_trigger_states,
@@ -66,7 +67,7 @@ async def test_assist_satellite_state_trigger_behavior_any(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the assist satellite state trigger fires when any assist satellite state changes to a specific state."""
     await async_setup_component(hass, "assist_satellite", {})
@@ -75,24 +76,24 @@ async def test_assist_satellite_state_trigger_behavior_any(
 
     # Set all assist satellites, including the tested one, to the initial state
     for eid in target_assist_satellites:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Check if changing other assist satellites also triggers
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
-        assert len(service_calls) == (entities_in_target - 1) * expected_calls
+        assert len(service_calls) == (entities_in_target - 1) * state["count"]
         service_calls.clear()
 
 
@@ -133,7 +134,7 @@ async def test_assist_satellite_state_trigger_behavior_first(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int, list[str]]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the assist satellite state trigger fires when the first assist satellite changes to a specific state."""
     await async_setup_component(hass, "assist_satellite", {})
@@ -142,22 +143,22 @@ async def test_assist_satellite_state_trigger_behavior_first(
 
     # Set all assist satellites, including the tested one, to the initial state
     for eid in target_assist_satellites:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "first"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Triggering other assist satellites should not cause the trigger to fire again
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
@@ -199,7 +200,7 @@ async def test_assist_satellite_state_trigger_behavior_last(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the assist_satellite state trigger fires when the last assist_satellite changes to a specific state."""
     await async_setup_component(hass, "assist_satellite", {})
@@ -208,20 +209,20 @@ async def test_assist_satellite_state_trigger_behavior_last(
 
     # Set all assist satellites, including the tested one, to the initial state
     for eid in target_assist_satellites:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "last"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
+    for state in states[1:]:
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
-        set_or_remove_state(hass, entity_id, state)
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()

--- a/tests/components/climate/test_trigger.py
+++ b/tests/components/climate/test_trigger.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.components import (
+    StateDescription,
     arm_trigger,
     parametrize_attribute_trigger_states,
     parametrize_target_entities,
@@ -52,7 +53,7 @@ async def test_climate_state_trigger_behavior_any(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the climate state trigger fires when any climate state changes to a specific state."""
     await async_setup_component(hass, "climate", {})
@@ -61,24 +62,24 @@ async def test_climate_state_trigger_behavior_any(
 
     # Set all climates, including the tested climate, to the initial state
     for eid in target_climates:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Check if changing other climates also triggers
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
-        assert len(service_calls) == (entities_in_target - 1) * expected_calls
+        assert len(service_calls) == (entities_in_target - 1) * state["count"]
         service_calls.clear()
 
 
@@ -157,7 +158,7 @@ async def test_climate_state_trigger_behavior_first(
     entities_in_target: int,
     entity_id: str,
     trigger: str,
-    states: list[tuple[str, int, list[str]]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the climate state trigger fires when the first climate changes to a specific state."""
     await async_setup_component(hass, "climate", {})
@@ -166,22 +167,22 @@ async def test_climate_state_trigger_behavior_first(
 
     # Set all climates, including the tested climate, to the initial state
     for eid in target_climates:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "first"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Triggering other climates should not cause the trigger to fire again
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
@@ -260,7 +261,7 @@ async def test_climate_state_trigger_behavior_last(
     entities_in_target: int,
     entity_id: str,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the climate state trigger fires when the last climate changes to a specific state."""
     await async_setup_component(hass, "climate", {})
@@ -269,20 +270,20 @@ async def test_climate_state_trigger_behavior_last(
 
     # Set all climates, including the tested climate, to the initial state
     for eid in target_climates:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "last"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
+    for state in states[1:]:
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
-        set_or_remove_state(hass, entity_id, state)
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()

--- a/tests/components/fan/test_trigger.py
+++ b/tests/components/fan/test_trigger.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.components import (
+    StateDescription,
     arm_trigger,
     parametrize_target_entities,
     parametrize_trigger_states,
@@ -45,7 +46,7 @@ async def test_fan_state_trigger_behavior_any(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the fan state trigger fires when any fan state changes to a specific state."""
     await async_setup_component(hass, "fan", {})
@@ -54,24 +55,24 @@ async def test_fan_state_trigger_behavior_any(
 
     # Set all fans, including the tested fan, to the initial state
     for eid in target_fans:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Check if changing other fans also triggers
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
-        assert len(service_calls) == (entities_in_target - 1) * expected_calls
+        assert len(service_calls) == (entities_in_target - 1) * state["count"]
         service_calls.clear()
 
 
@@ -94,7 +95,7 @@ async def test_fan_state_trigger_behavior_first(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int, list[str]]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the fan state trigger fires when the first fan changes to a specific state."""
     await async_setup_component(hass, "fan", {})
@@ -103,22 +104,22 @@ async def test_fan_state_trigger_behavior_first(
 
     # Set all fans, including the tested fan, to the initial state
     for eid in target_fans:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "first"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Triggering other fans should not cause the trigger to fire again
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
@@ -142,7 +143,7 @@ async def test_fan_state_trigger_behavior_last(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the fan state trigger fires when the last fan changes to a specific state."""
     await async_setup_component(hass, "fan", {})
@@ -151,20 +152,20 @@ async def test_fan_state_trigger_behavior_last(
 
     # Set all fans, including the tested fan, to the initial state
     for eid in target_fans:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "last"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
+    for state in states[1:]:
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
-        set_or_remove_state(hass, entity_id, state)
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()

--- a/tests/components/light/test_trigger.py
+++ b/tests/components/light/test_trigger.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.components import (
+    StateDescription,
     arm_trigger,
     parametrize_target_entities,
     parametrize_trigger_states,
@@ -45,7 +46,7 @@ async def test_light_state_trigger_behavior_any(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the light state trigger fires when any light state changes to a specific state."""
     await async_setup_component(hass, "light", {})
@@ -54,24 +55,24 @@ async def test_light_state_trigger_behavior_any(
 
     # Set all lights, including the tested light, to the initial state
     for eid in target_lights:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Check if changing other lights also triggers
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
-        assert len(service_calls) == (entities_in_target - 1) * expected_calls
+        assert len(service_calls) == (entities_in_target - 1) * state["count"]
         service_calls.clear()
 
 
@@ -94,7 +95,7 @@ async def test_light_state_trigger_behavior_first(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int, list[str]]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the light state trigger fires when the first light changes to a specific state."""
     await async_setup_component(hass, "light", {})
@@ -103,22 +104,22 @@ async def test_light_state_trigger_behavior_first(
 
     # Set all lights, including the tested light, to the initial state
     for eid in target_lights:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "first"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Triggering other lights should not cause the trigger to fire again
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
@@ -142,7 +143,7 @@ async def test_light_state_trigger_behavior_last(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the light state trigger fires when the last light changes to a specific state."""
     await async_setup_component(hass, "light", {})
@@ -151,20 +152,20 @@ async def test_light_state_trigger_behavior_last(
 
     # Set all lights, including the tested light, to the initial state
     for eid in target_lights:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "last"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
+    for state in states[1:]:
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
-        set_or_remove_state(hass, entity_id, state)
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()

--- a/tests/components/media_player/test_trigger.py
+++ b/tests/components/media_player/test_trigger.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.components import (
+    StateDescription,
     arm_trigger,
     parametrize_target_entities,
     parametrize_trigger_states,
@@ -53,7 +54,7 @@ async def test_media_player_state_trigger_behavior_any(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the media player state trigger fires when any media player state changes to a specific state."""
     await async_setup_component(hass, "media_player", {})
@@ -62,24 +63,24 @@ async def test_media_player_state_trigger_behavior_any(
 
     # Set all media players, including the tested media player, to the initial state
     for eid in target_media_players:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Check if changing other media players also triggers
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
-        assert len(service_calls) == (entities_in_target - 1) * expected_calls
+        assert len(service_calls) == (entities_in_target - 1) * state["count"]
         service_calls.clear()
 
 
@@ -109,7 +110,7 @@ async def test_media_player_state_trigger_behavior_first(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int, list[str]]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the media player state trigger fires when the first media player changes to a specific state."""
     await async_setup_component(hass, "media_player", {})
@@ -118,22 +119,22 @@ async def test_media_player_state_trigger_behavior_first(
 
     # Set all media players, including the tested media player, to the initial state
     for eid in target_media_players:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "first"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
-        set_or_remove_state(hass, entity_id, state)
+    for state in states[1:]:
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()
 
         # Triggering other media players should not cause the trigger to fire again
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
@@ -164,7 +165,7 @@ async def test_media_player_state_trigger_behavior_last(
     entity_id: str,
     entities_in_target: int,
     trigger: str,
-    states: list[tuple[str, int]],
+    states: list[StateDescription],
 ) -> None:
     """Test that the media player state trigger fires when the last media player changes to a specific state."""
     await async_setup_component(hass, "media_player", {})
@@ -173,20 +174,20 @@ async def test_media_player_state_trigger_behavior_last(
 
     # Set all media players, including the tested media player, to the initial state
     for eid in target_media_players:
-        set_or_remove_state(hass, eid, states[0][0])
+        set_or_remove_state(hass, eid, states[0]["state"])
         await hass.async_block_till_done()
 
     await arm_trigger(hass, trigger, {"behavior": "last"}, trigger_target_config)
 
-    for state, expected_calls in states[1:]:
+    for state in states[1:]:
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, state)
+            set_or_remove_state(hass, other_entity_id, state["state"])
             await hass.async_block_till_done()
         assert len(service_calls) == 0
 
-        set_or_remove_state(hass, entity_id, state)
+        set_or_remove_state(hass, entity_id, state["state"])
         await hass.async_block_till_done()
-        assert len(service_calls) == expected_calls
+        assert len(service_calls) == state["count"]
         for service_call in service_calls:
             assert service_call.data[CONF_ENTITY_ID] == entity_id
         service_calls.clear()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor `parametrize_trigger_states` test helper to return list of dicts instead of list of tuples.

The change is intended to improve readability and maintainability of the test code

The very similar test helper `parametrize_attribute_trigger_states` will be updated in a follow-up PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
