### PR TITLE
Fix Shelly Bluetooth discovery for Gen3/Gen4 devices without advertised names

### DIFF
--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -7,7 +7,10 @@ from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, Final
 
-from aioshelly.ble.manufacturer_data import has_rpc_over_ble
+from aioshelly.ble.manufacturer_data import (
+    has_rpc_over_ble,
+    parse_shelly_manufacturer_data,
+)
 from aioshelly.ble.provisioning import async_provision_wifi, async_scan_wifi_networks
 from aioshelly.block_device import BlockDevice
 from aioshelly.common import ConnectionOptions, get_info
@@ -358,8 +361,29 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
         """Handle bluetooth discovery."""
-        # Parse MAC address from the Bluetooth device name
-        if not (mac := mac_address_from_name(discovery_info.name)):
+        # Try to parse MAC address from the Bluetooth device name
+        # If not found, try to get it from manufacturer data
+        device_name = discovery_info.name
+        if (
+            not (mac := mac_address_from_name(device_name))
+            and (
+                parsed := parse_shelly_manufacturer_data(
+                    discovery_info.manufacturer_data
+                )
+            )
+            and (mac_with_colons := parsed.get("mac"))
+            and isinstance(mac_with_colons, str)
+        ):
+            # parse_shelly_manufacturer_data returns MAC with colons (e.g., "CC:BA:97:C2:D6:72")
+            # Convert to format without colons to match mac_address_from_name output
+            mac = mac_with_colons.replace(":", "")
+            # For devices without a Shelly name, use a more descriptive name
+            # Gen4 devices advertise MAC address as name instead of "ShellyXXX-MACADDR"
+            # Future improvement: if aioshelly adds model_id to device type mapping,
+            # we could use a better name like "ShellyPlus2PM-{mac}" instead of "Shelly-{mac}"
+            device_name = f"Shelly-{mac}"
+
+        if not mac:
             return self.async_abort(reason="invalid_discovery_info")
 
         # Check if RPC-over-BLE is enabled - required for WiFi provisioning
@@ -384,7 +408,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
         self.device_name = discovery_info.name
         self.context.update(
             {
-                "title_placeholders": {"name": discovery_info.name},
+                "title_placeholders": {"name": device_name},
             }
         )
 

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -378,7 +378,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
             # Convert to format without colons to match mac_address_from_name output
             mac = mac_with_colons.replace(":", "")
             # For devices without a Shelly name, use a more descriptive name
-            # Gen4 devices advertise MAC address as name instead of "ShellyXXX-MACADDR"
+            # Gen3/4 devices advertise MAC address as name instead of "ShellyXXX-MACADDR"
             # Future improvement: if aioshelly adds model_id to device type mapping,
             # we could use a better name like "ShellyPlus2PM-{mac}" instead of "Shelly-{mac}"
             device_name = f"Shelly-{mac}"

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, Final
 
+from aioshelly.ble import get_name_from_model_id
 from aioshelly.ble.manufacturer_data import (
     has_rpc_over_ble,
     parse_shelly_manufacturer_data,
@@ -377,11 +378,17 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
             # parse_shelly_manufacturer_data returns MAC with colons (e.g., "CC:BA:97:C2:D6:72")
             # Convert to format without colons to match mac_address_from_name output
             mac = mac_with_colons.replace(":", "")
-            # For devices without a Shelly name, use a more descriptive name
+            # For devices without a Shelly name, use model name from model ID if available
             # Gen3/4 devices advertise MAC address as name instead of "ShellyXXX-MACADDR"
-            # Future improvement: if aioshelly adds model_id to device type mapping,
-            # we could use a better name like "ShellyPlus2PM-{mac}" instead of "Shelly-{mac}"
-            device_name = f"Shelly-{mac}"
+            if (
+                (model_id := parsed.get("model_id"))
+                and isinstance(model_id, int)
+                and (model_name := get_name_from_model_id(model_id))
+            ):
+                # Remove spaces from model name (e.g., "Shelly 1 Mini Gen4" -> "Shelly1MiniGen4")
+                device_name = f"{model_name.replace(' ', '')}-{mac}"
+            else:
+                device_name = f"Shelly-{mac}"
 
         if not mac:
             return self.async_abort(reason="invalid_discovery_info")

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -405,7 +405,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
         if not self.ble_device:
             return self.async_abort(reason="cannot_connect")
 
-        self.device_name = discovery_info.name
+        self.device_name = device_name
         self.context.update(
             {
                 "title_placeholders": {"name": device_name},

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -4,6 +4,9 @@
   "bluetooth": [
     {
       "local_name": "Shelly*"
+    },
+    {
+      "manufacturer_id": 2985
     }
   ],
   "codeowners": ["@bieniu", "@thecode", "@chemelli74", "@bdraco"],

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -707,6 +707,10 @@ BLUETOOTH: Final[list[dict[str, bool | str | int | list[int]]]] = [
         "local_name": "Shelly*",
     },
     {
+        "domain": "shelly",
+        "manufacturer_id": 2985,
+    },
+    {
         "domain": "snooz",
         "local_name": "Snooz*",
     },

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -2102,8 +2102,9 @@ async def test_bluetooth_discovery_mac_in_manufacturer_data(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
     # MAC from manufacturer data: 70d6c297bacc (reversed) = CC:BA:97:C2:D6:70 = CCBA97C2D670
-    # Device name should be formatted as Shelly-<full MAC> to match Gen2 format
-    assert result["description_placeholders"]["name"] == "Shelly-CCBA97C2D670"
+    # Model ID 0x1030 = Shelly 1 Mini Gen4
+    # Device name should use model name from model ID: Shelly1MiniGen4-<MAC>
+    assert result["description_placeholders"]["name"] == "Shelly1MiniGen4-CCBA97C2D670"
 
 
 @pytest.mark.usefixtures("mock_rpc_device", "mock_zeroconf")

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -93,6 +93,8 @@ BLE_MANUFACTURER_DATA_NO_RPC = {
 BLE_MANUFACTURER_DATA_WITH_MAC = {
     0x0BA9: bytes.fromhex("0105000b30100a70d6c297bacc")
 }  # Flags (0x01, 0x05, 0x00), Model (0x0b, 0x30, 0x10), MAC (0x0a, 0x70, 0xd6, 0xc2, 0x97, 0xba, 0xcc)
+# Device WiFi MAC: 70d6c297bacc (little-endian) -> CCBA97C2D670 (reversed to big-endian)
+# BLE MAC is typically device MAC + 2: CCBA97C2D670 + 2 = CC:BA:97:C2:D6:72
 
 BLE_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     name="ShellyPlus2PM-C049EF8873E8",

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -155,16 +155,16 @@ BLE_DISCOVERY_INFO_INVALID_NAME = BluetoothServiceInfoBleak(
 )
 
 BLE_DISCOVERY_INFO_MAC_IN_MANUFACTURER_DATA = BluetoothServiceInfoBleak(
-    name="CC:BA:97:C2:D6:70",  # MAC address as name (newer devices)
-    address="CC:BA:97:C2:D6:70",
+    name="CC:BA:97:C2:D6:72",  # BLE address as name (newer devices)
+    address="CC:BA:97:C2:D6:72",  # BLE address may differ from device MAC
     rssi=-32,
     manufacturer_data=BLE_MANUFACTURER_DATA_WITH_MAC,
     service_uuids=[],
     service_data={},
     source="local",
     device=generate_ble_device(
-        address="CC:BA:97:C2:D6:70",
-        name="CC:BA:97:C2:D6:70",
+        address="CC:BA:97:C2:D6:72",
+        name="CC:BA:97:C2:D6:72",
     ),
     advertisement=generate_advertisement_data(
         manufacturer_data=BLE_MANUFACTURER_DATA_WITH_MAC,

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -155,16 +155,16 @@ BLE_DISCOVERY_INFO_INVALID_NAME = BluetoothServiceInfoBleak(
 )
 
 BLE_DISCOVERY_INFO_MAC_IN_MANUFACTURER_DATA = BluetoothServiceInfoBleak(
-    name="CC:BA:97:C2:D6:72",  # MAC address as name (newer devices)
-    address="CC:BA:97:C2:D6:72",
+    name="CC:BA:97:C2:D6:70",  # MAC address as name (newer devices)
+    address="CC:BA:97:C2:D6:70",
     rssi=-32,
     manufacturer_data=BLE_MANUFACTURER_DATA_WITH_MAC,
     service_uuids=[],
     service_data={},
     source="local",
     device=generate_ble_device(
-        address="CC:BA:97:C2:D6:72",
-        name="CC:BA:97:C2:D6:72",
+        address="CC:BA:97:C2:D6:70",
+        name="CC:BA:97:C2:D6:70",
     ),
     advertisement=generate_advertisement_data(
         manufacturer_data=BLE_MANUFACTURER_DATA_WITH_MAC,

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -2099,9 +2099,9 @@ async def test_bluetooth_discovery_mac_in_manufacturer_data(
     # Should successfully extract MAC from manufacturer data
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
-    # MAC from manufacturer data: 70d6c297bacc (bytes) = 70:D6:C2:97:BA:CC = 70D6C297BACC
+    # MAC from manufacturer data: 70d6c297bacc (reversed) = CC:BA:97:C2:D6:70 = CCBA97C2D670
     # Device name should be formatted as Shelly-<full MAC> to match Gen2 format
-    assert result["description_placeholders"]["name"] == "Shelly-70D6C297BACC"
+    assert result["description_placeholders"]["name"] == "Shelly-CCBA97C2D670"
 
 
 @pytest.mark.usefixtures("mock_rpc_device", "mock_zeroconf")


### PR DESCRIPTION
## Proposed change

Fix Bluetooth discovery for newer Shelly devices (Gen3/Gen4) that don't advertise a name in their BLE advertisements. When no name is advertised, the Bluetooth stack defaults to using the MAC address as the name, so these devices appear with a name like "CC:BA:97:C2:D6:72" instead of the traditional "ShellyXXX-MACADDR" format used by Gen2 devices.

When the Shelly integration was originally built and tested with Gen2 devices, all devices included "Shelly" in their advertised name. Gen3/Gen4 devices don't advertise a name, which causes the Bluetooth stack to default to the MAC address. However, these devices do include the MAC address and model ID in the manufacturer data (Allterco manufacturer ID 0x0BA9 / 2985).

This PR adds:
1. Manufacturer ID-based discovery (0x0BA9) in manifest.json
2. MAC address extraction from manufacturer data when not present in the device name
3. Model ID lookup to provide descriptive device names (e.g., "Shelly1MiniGen4-CCBA97C2D670" instead of "Shelly-CCBA97C2D670")
4. Fallback to generic "Shelly-{MAC}" for devices without model IDs
5. Test coverage for the new discovery path

## Example

**Gen4 Device Discovery (Shelly 1 Mini Gen4):**
- BLE name advertised: `CC:BA:97:C2:D6:72` (just MAC address)
- Manufacturer data contains: MAC + Model ID 0x1030
- Shows "Shelly1MiniGen4-CCBA97C2D670" in config flow

**Gen2 Device Discovery (unchanged):**
- BLE name advertised: `ShellyPlus2PM-C049EF8873E8`
- **Behavior**: Uses advertised name (no changes)

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- Link to documentation pull request: N/A (no user-facing documentation changes needed)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
