### PR TITLE
Add binary_sensor platform to pooldose integration

### DIFF
--- a/homeassistant/components/pooldose/__init__.py
+++ b/homeassistant/components/pooldose/__init__.py
@@ -17,7 +17,7 @@ from .coordinator import PooldoseConfigEntry, PooldoseCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: PooldoseConfigEntry) -> bool:

--- a/homeassistant/components/pooldose/binary_sensor.py
+++ b/homeassistant/components/pooldose/binary_sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING, cast
 
@@ -21,75 +20,70 @@ from .entity import PooldoseEntity
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, kw_only=True)
-class PooldoseBinarySensorEntityDescription(BinarySensorEntityDescription):
-    """Describes PoolDose binary sensor entity."""
-
-
-BINARY_SENSOR_DESCRIPTIONS: tuple[PooldoseBinarySensorEntityDescription, ...] = (
-    PooldoseBinarySensorEntityDescription(
+BINARY_SENSOR_DESCRIPTIONS: tuple[BinarySensorEntityDescription, ...] = (
+    BinarySensorEntityDescription(
         key="pump_alarm",
         translation_key="pump_alarm",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    PooldoseBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="ph_level_alarm",
         translation_key="ph_level_alarm",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    PooldoseBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="orp_level_alarm",
         translation_key="orp_level_alarm",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    PooldoseBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="flow_rate_alarm",
         translation_key="flow_rate_alarm",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    PooldoseBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="alarm_ofa_ph",
         translation_key="alarm_ofa_ph",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    PooldoseBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="alarm_ofa_orp",
         translation_key="alarm_ofa_orp",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    PooldoseBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="alarm_ofa_cl",
         translation_key="alarm_ofa_cl",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    PooldoseBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="relay_alarm",
         translation_key="relay_alarm",
         device_class=BinarySensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    PooldoseBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="relay_aux1",
         translation_key="relay_aux1",
         device_class=BinarySensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
-    PooldoseBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="relay_aux2",
         translation_key="relay_aux2",
         device_class=BinarySensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
-    PooldoseBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="relay_aux3",
         translation_key="relay_aux3",
         device_class=BinarySensorDeviceClass.POWER,
@@ -127,8 +121,6 @@ async def async_setup_entry(
 
 class PooldoseBinarySensor(PooldoseEntity, BinarySensorEntity):
     """Binary sensor entity for the Seko PoolDose Python API."""
-
-    entity_description: PooldoseBinarySensorEntityDescription
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/pooldose/binary_sensor.py
+++ b/homeassistant/components/pooldose/binary_sensor.py
@@ -91,11 +91,6 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PooldoseBinarySensorEntityDescription, ...] = 
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     PooldoseBinarySensorEntityDescription(
-        key="pump_monitoring",
-        translation_key="pump_monitoring",
-        device_class=BinarySensorDeviceClass.RUNNING,
-    ),
-    PooldoseBinarySensorEntityDescription(
         key="flow_rate_reed_sensor",
         translation_key="flow_rate_reed_sensor",
         device_class=BinarySensorDeviceClass.OPENING,

--- a/homeassistant/components/pooldose/binary_sensor.py
+++ b/homeassistant/components/pooldose/binary_sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -131,9 +131,7 @@ class PooldoseBinarySensor(PooldoseEntity, BinarySensorEntity):
     entity_description: PooldoseBinarySensorEntityDescription
 
     @property
-    def is_on(self) -> bool | None:
+    def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
-        data = self.get_data()
-        if data is not None:
-            return data["value"]
-        return None
+        data = cast(dict, self.get_data())
+        return cast(bool, data["value"])

--- a/homeassistant/components/pooldose/binary_sensor.py
+++ b/homeassistant/components/pooldose/binary_sensor.py
@@ -79,22 +79,19 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PooldoseBinarySensorEntityDescription, ...] = 
         key="relay_aux1",
         translation_key="relay_aux1",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     PooldoseBinarySensorEntityDescription(
         key="relay_aux2",
         translation_key="relay_aux2",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     PooldoseBinarySensorEntityDescription(
         key="relay_aux3",
         translation_key="relay_aux3",
         entity_category=EntityCategory.DIAGNOSTIC,
-    ),
-    PooldoseBinarySensorEntityDescription(
-        key="flow_rate_reed_sensor",
-        translation_key="flow_rate_reed_sensor",
-        device_class=BinarySensorDeviceClass.OPENING,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
 )
 

--- a/homeassistant/components/pooldose/binary_sensor.py
+++ b/homeassistant/components/pooldose/binary_sensor.py
@@ -72,24 +72,27 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PooldoseBinarySensorEntityDescription, ...] = 
     PooldoseBinarySensorEntityDescription(
         key="relay_alarm",
         translation_key="relay_alarm",
-        device_class=BinarySensorDeviceClass.PROBLEM,
+        device_class=BinarySensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     PooldoseBinarySensorEntityDescription(
         key="relay_aux1",
         translation_key="relay_aux1",
+        device_class=BinarySensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     PooldoseBinarySensorEntityDescription(
         key="relay_aux2",
         translation_key="relay_aux2",
+        device_class=BinarySensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     PooldoseBinarySensorEntityDescription(
         key="relay_aux3",
         translation_key="relay_aux3",
+        device_class=BinarySensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),

--- a/homeassistant/components/pooldose/entity.py
+++ b/homeassistant/components/pooldose/entity.py
@@ -68,6 +68,11 @@ class PooldoseEntity(CoordinatorEntity[PooldoseCoordinator]):
             coordinator.config_entry.data.get(CONF_MAC),
         )
 
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.get_data() is not None
+
     def get_data(self) -> ValueDict | None:
         """Get data for this entity, only if available."""
         platform_data = self.coordinator.data[self.platform_name]

--- a/homeassistant/components/pooldose/icons.json
+++ b/homeassistant/components/pooldose/icons.json
@@ -1,11 +1,79 @@
 {
   "entity": {
+    "binary_sensor": {
+      "alarm_ofa_cl": {
+        "default": "mdi:clock-alert-outline",
+        "state": {
+          "on": "mdi:clock-alert"
+        }
+      },
+      "alarm_ofa_orp": {
+        "default": "mdi:clock-alert-outline",
+        "state": {
+          "on": "mdi:clock-alert"
+        }
+      },
+      "alarm_ofa_ph": {
+        "default": "mdi:clock-alert-outline",
+        "state": {
+          "on": "mdi:clock-alert"
+        }
+      },
+      "flow_rate_alarm": {
+        "default": "mdi:autorenew",
+        "state": {
+          "on": "mdi:autorenew-off"
+        }
+      },
+      "orp_level_alarm": {
+        "default": "mdi:flask",
+        "state": {
+          "on": "mdi:flask-empty"
+        }
+      },
+      "ph_level_alarm": {
+        "default": "mdi:flask",
+        "state": {
+          "on": "mdi:flask-empty"
+        }
+      },
+      "pump_alarm": {
+        "default": "mdi:pump",
+        "state": {
+          "on": "mdi:pump-off"
+        }
+      },
+      "relay_alarm": {
+        "default": "mdi:electric-switch-closed",
+        "state": {
+          "on": "mdi:electric-switch"
+        }
+      },
+      "relay_aux1": {
+        "default": "mdi:electric-switch-closed",
+        "state": {
+          "on": "mdi:electric-switch"
+        }
+      },
+      "relay_aux2": {
+        "default": "mdi:electric-switch-closed",
+        "state": {
+          "on": "mdi:electric-switch"
+        }
+      },
+      "relay_aux3": {
+        "default": "mdi:electric-switch-closed",
+        "state": {
+          "on": "mdi:electric-switch"
+        }
+      }
+    },
     "sensor": {
       "cl": {
         "default": "mdi:pool"
       },
       "cl_type_dosing": {
-        "default": "mdi:flask"
+        "default": "mdi:beaker"
       },
       "flow_rate": {
         "default": "mdi:pipe-valve"
@@ -29,7 +97,7 @@
         "default": "mdi:form-select"
       },
       "orp_type_dosing": {
-        "default": "mdi:flask"
+        "default": "mdi:beaker"
       },
       "peristaltic_cl_dosing": {
         "default": "mdi:pump"
@@ -50,7 +118,7 @@
         "default": "mdi:form-select"
       },
       "ph_type_dosing": {
-        "default": "mdi:flask"
+        "default": "mdi:beaker"
       }
     }
   }

--- a/homeassistant/components/pooldose/strings.json
+++ b/homeassistant/components/pooldose/strings.json
@@ -56,16 +56,16 @@
         "name": "Recirculation"
       },
       "relay_alarm": {
-        "name": "Alarm Relay"
+        "name": "Alarm relay status"
       },
       "relay_aux1": {
-        "name": "Auxiliary relay 1"
+        "name": "Auxiliary relay 1 status"
       },
       "relay_aux2": {
-        "name": "Auxiliary relay 2"
+        "name": "Auxiliary relay 2 status"
       },
       "relay_aux3": {
-        "name": "Auxiliary relay 3"
+        "name": "Auxiliary relay 3 status"
       }
     },
     "sensor": {

--- a/homeassistant/components/pooldose/strings.json
+++ b/homeassistant/components/pooldose/strings.json
@@ -53,10 +53,7 @@
         "name": "pH tank level"
       },
       "pump_alarm": {
-        "name": "Recirculation pump"
-      },
-      "pump_monitoring": {
-        "name": "Pump monitoring"
+        "name": "Recirculation"
       },
       "relay_alarm": {
         "name": "Alarm Relay"

--- a/homeassistant/components/pooldose/strings.json
+++ b/homeassistant/components/pooldose/strings.json
@@ -33,6 +33,44 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "alarm_ofa_cl": {
+        "name": "Chlorine tank level"
+      },
+      "alarm_ofa_orp": {
+        "name": "ORP overfeed"
+      },
+      "alarm_ofa_ph": {
+        "name": "pH overfeed"
+      },
+      "flow_rate_alarm": {
+        "name": "Flow rate"
+      },
+      "orp_level_alarm": {
+        "name": "ORP tank level"
+      },
+      "ph_level_alarm": {
+        "name": "pH tank level"
+      },
+      "pump_alarm": {
+        "name": "Recirculation pump"
+      },
+      "pump_monitoring": {
+        "name": "Pump monitoring"
+      },
+      "relay_alarm": {
+        "name": "Alarm Relay"
+      },
+      "relay_aux1": {
+        "name": "Auxiliary relay 1"
+      },
+      "relay_aux2": {
+        "name": "Auxiliary relay 2"
+      },
+      "relay_aux3": {
+        "name": "Auxiliary relay 3"
+      }
+    },
     "sensor": {
       "cl": {
         "name": "Chlorine"

--- a/tests/components/pooldose/fixtures/instantvalues.json
+++ b/tests/components/pooldose/fixtures/instantvalues.json
@@ -98,6 +98,24 @@
     },
     "relay_aux2": {
       "value": false
+    },
+    "relay_aux3": {
+      "value": false
+    },
+    "alarm_ofa_ph": {
+      "value": false
+    },
+    "alarm_ofa_orp": {
+      "value": false
+    },
+    "alarm_ofa_cl": {
+      "value": false
+    },
+    "pump_monitoring": {
+      "value": true
+    },
+    "flow_rate_reed_sensor": {
+      "value": false
     }
   },
   "number": {

--- a/tests/components/pooldose/fixtures/instantvalues.json
+++ b/tests/components/pooldose/fixtures/instantvalues.json
@@ -111,9 +111,6 @@
     "alarm_ofa_cl": {
       "value": false
     },
-    "pump_monitoring": {
-      "value": true
-    },
     "flow_rate_reed_sensor": {
       "value": false
     }

--- a/tests/components/pooldose/fixtures/instantvalues.json
+++ b/tests/components/pooldose/fixtures/instantvalues.json
@@ -110,9 +110,6 @@
     },
     "alarm_ofa_cl": {
       "value": false
-    },
-    "flow_rate_reed_sensor": {
-      "value": false
     }
   },
   "number": {

--- a/tests/components/pooldose/fixtures/instantvalues.json
+++ b/tests/components/pooldose/fixtures/instantvalues.json
@@ -90,7 +90,7 @@
     "flow_rate_alarm": {
       "value": false
     },
-    "alarm_relay": {
+    "relay_alarm": {
       "value": true
     },
     "relay_aux1": {

--- a/tests/components/pooldose/snapshots/test_binary_sensor.ambr
+++ b/tests/components/pooldose/snapshots/test_binary_sensor.ambr
@@ -241,55 +241,6 @@
     'state': 'off',
   })
 # ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_opening-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.pool_device_opening',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <BinarySensorDeviceClass.OPENING: 'opening'>,
-    'original_icon': None,
-    'original_name': 'Opening',
-    'platform': 'pooldose',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'flow_rate_reed_sensor',
-    'unique_id': 'TEST123456789_flow_rate_reed_sensor',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_opening-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'opening',
-      'friendly_name': 'Pool Device Opening',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.pool_device_opening',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_all_binary_sensors[binary_sensor.pool_device_orp_overfeed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -486,7 +437,7 @@
     'state': 'off',
   })
 # ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_recirculation_pump-entry]
+# name: test_all_binary_sensors[binary_sensor.pool_device_recirculation-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -499,7 +450,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.pool_device_recirculation_pump',
+    'entity_id': 'binary_sensor.pool_device_recirculation',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -511,7 +462,7 @@
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
     'original_icon': None,
-    'original_name': 'Recirculation pump',
+    'original_name': 'Recirculation',
     'platform': 'pooldose',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -521,14 +472,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_recirculation_pump-state]
+# name: test_all_binary_sensors[binary_sensor.pool_device_recirculation-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Pool Device Recirculation pump',
+      'friendly_name': 'Pool Device Recirculation',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.pool_device_recirculation_pump',
+    'entity_id': 'binary_sensor.pool_device_recirculation',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/pooldose/snapshots/test_binary_sensor.ambr
+++ b/tests/components/pooldose/snapshots/test_binary_sensor.ambr
@@ -486,55 +486,6 @@
     'state': 'off',
   })
 # ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_pump_monitoring-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': None,
-    'entity_id': 'binary_sensor.pool_device_pump_monitoring',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
-    'original_icon': None,
-    'original_name': 'Pump monitoring',
-    'platform': 'pooldose',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'pump_monitoring',
-    'unique_id': 'TEST123456789_pump_monitoring',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_pump_monitoring-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'running',
-      'friendly_name': 'Pool Device Pump monitoring',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.pool_device_pump_monitoring',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
 # name: test_all_binary_sensors[binary_sensor.pool_device_recirculation_pump-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/pooldose/snapshots/test_binary_sensor.ambr
+++ b/tests/components/pooldose/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,586 @@
+# serializer version: 1
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Auxiliary relay 1',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_aux1',
+    'unique_id': 'TEST123456789_relay_aux1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pool Device Auxiliary relay 1',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Auxiliary relay 2',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_aux2',
+    'unique_id': 'TEST123456789_relay_aux2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pool Device Auxiliary relay 2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Auxiliary relay 3',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_aux3',
+    'unique_id': 'TEST123456789_relay_aux3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pool Device Auxiliary relay 3',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_chlorine_tank_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_chlorine_tank_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Chlorine tank level',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'alarm_ofa_cl',
+    'unique_id': 'TEST123456789_alarm_ofa_cl',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_chlorine_tank_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Pool Device Chlorine tank level',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_chlorine_tank_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_flow_rate-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_flow_rate',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Flow rate',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'flow_rate_alarm',
+    'unique_id': 'TEST123456789_flow_rate_alarm',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_flow_rate-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Pool Device Flow rate',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_flow_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_opening-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_opening',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.OPENING: 'opening'>,
+    'original_icon': None,
+    'original_name': 'Opening',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'flow_rate_reed_sensor',
+    'unique_id': 'TEST123456789_flow_rate_reed_sensor',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_opening-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'opening',
+      'friendly_name': 'Pool Device Opening',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_opening',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_orp_overfeed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_orp_overfeed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'ORP overfeed',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'alarm_ofa_orp',
+    'unique_id': 'TEST123456789_alarm_ofa_orp',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_orp_overfeed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Pool Device ORP overfeed',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_orp_overfeed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_orp_tank_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_orp_tank_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'ORP tank level',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'orp_level_alarm',
+    'unique_id': 'TEST123456789_orp_level_alarm',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_orp_tank_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Pool Device ORP tank level',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_orp_tank_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_ph_overfeed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_ph_overfeed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'pH overfeed',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'alarm_ofa_ph',
+    'unique_id': 'TEST123456789_alarm_ofa_ph',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_ph_overfeed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Pool Device pH overfeed',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_ph_overfeed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_ph_tank_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_ph_tank_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'pH tank level',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ph_level_alarm',
+    'unique_id': 'TEST123456789_ph_level_alarm',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_ph_tank_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Pool Device pH tank level',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_ph_tank_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_pump_monitoring-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.pool_device_pump_monitoring',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Pump monitoring',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pump_monitoring',
+    'unique_id': 'TEST123456789_pump_monitoring',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_pump_monitoring-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Pool Device Pump monitoring',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_pump_monitoring',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_recirculation_pump-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_recirculation_pump',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Recirculation pump',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pump_alarm',
+    'unique_id': 'TEST123456789_pump_alarm',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_recirculation_pump-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Pool Device Recirculation pump',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_recirculation_pump',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/pooldose/snapshots/test_binary_sensor.ambr
+++ b/tests/components/pooldose/snapshots/test_binary_sensor.ambr
@@ -1,4 +1,53 @@
 # serializer version: 1
+# name: test_all_binary_sensors[binary_sensor.pool_device_alarm_relay_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_alarm_relay_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Alarm relay status',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_alarm',
+    'unique_id': 'TEST123456789_relay_alarm',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_alarm_relay_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Pool Device Alarm relay status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_alarm_relay_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -41,6 +90,55 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.pool_device_auxiliary_relay_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_1_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_1_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Auxiliary relay 1 status',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_aux1',
+    'unique_id': 'TEST123456789_relay_aux1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_1_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Pool Device Auxiliary relay 1 status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_1_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -95,6 +193,55 @@
     'state': 'off',
   })
 # ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_2_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_2_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Auxiliary relay 2 status',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_aux2',
+    'unique_id': 'TEST123456789_relay_aux2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_2_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Pool Device Auxiliary relay 2 status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_2_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -137,6 +284,55 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.pool_device_auxiliary_relay_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_3_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_3_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Auxiliary relay 3 status',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_aux3',
+    'unique_id': 'TEST123456789_relay_aux3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_3_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Pool Device Auxiliary relay 3 status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_3_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/pooldose/snapshots/test_binary_sensor.ambr
+++ b/tests/components/pooldose/snapshots/test_binary_sensor.ambr
@@ -48,54 +48,6 @@
     'state': 'on',
   })
 # ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_1-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_1',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Auxiliary relay 1',
-    'platform': 'pooldose',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'relay_aux1',
-    'unique_id': 'TEST123456789_relay_aux1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Pool Device Auxiliary relay 1',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_1_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -145,54 +97,6 @@
     'state': 'off',
   })
 # ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Auxiliary relay 2',
-    'platform': 'pooldose',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'relay_aux2',
-    'unique_id': 'TEST123456789_relay_aux2',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Pool Device Auxiliary relay 2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_2_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -236,54 +140,6 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.pool_device_auxiliary_relay_2_status',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_3-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_3',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Auxiliary relay 3',
-    'platform': 'pooldose',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'relay_aux3',
-    'unique_id': 'TEST123456789_relay_aux3',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_binary_sensors[binary_sensor.pool_device_auxiliary_relay_3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Pool Device Auxiliary relay 3',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.pool_device_auxiliary_relay_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/pooldose/test_binary_sensor.py
+++ b/tests/components/pooldose/test_binary_sensor.py
@@ -1,0 +1,199 @@
+"""Test the PoolDose binary sensor platform."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pooldose.request_status import RequestStatus
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_binary_sensors(
+    hass: HomeAssistant,
+    mock_pooldose_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the Pooldose binary sensors."""
+    with patch("homeassistant.components.pooldose.PLATFORMS", [Platform.BINARY_SENSOR]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize("exception", [TimeoutError, ConnectionError, OSError])
+async def test_exception_raising(
+    hass: HomeAssistant,
+    mock_pooldose_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the Pooldose binary sensors."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("binary_sensor.pool_device_recirculation_pump").state
+        == STATE_ON
+    )
+
+    mock_pooldose_client.instant_values_structured.side_effect = exception
+
+    freezer.tick(timedelta(minutes=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("binary_sensor.pool_device_recirculation_pump").state
+        == STATE_UNAVAILABLE
+    )
+
+
+async def test_no_data(
+    hass: HomeAssistant,
+    mock_pooldose_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the Pooldose binary sensors."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("binary_sensor.pool_device_recirculation_pump").state
+        == STATE_ON
+    )
+
+    mock_pooldose_client.instant_values_structured.return_value = (
+        RequestStatus.SUCCESS,
+        None,
+    )
+
+    freezer.tick(timedelta(minutes=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("binary_sensor.pool_device_recirculation_pump").state
+        == STATE_UNAVAILABLE
+    )
+
+
+async def test_binary_sensor_entity_unavailable_no_coordinator_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pooldose_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test binary sensor entity becomes unavailable when coordinator has no data."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify initial working state
+    pump_state = hass.states.get("binary_sensor.pool_device_recirculation_pump")
+    assert pump_state.state == STATE_ON
+
+    # Set coordinator data to None by making API return empty
+    mock_pooldose_client.instant_values_structured.return_value = (
+        RequestStatus.HOST_UNREACHABLE,
+        None,
+    )
+
+    freezer.tick(timedelta(minutes=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Check binary sensor becomes unavailable
+    pump_state = hass.states.get("binary_sensor.pool_device_recirculation_pump")
+    assert pump_state.state == STATE_UNAVAILABLE
+
+
+async def test_binary_sensor_state_changes(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pooldose_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test binary sensor state changes."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify initial states
+    pump_state = hass.states.get("binary_sensor.pool_device_recirculation_pump")
+    assert pump_state.state == STATE_ON
+
+    ph_level_state = hass.states.get("binary_sensor.pool_device_ph_tank_level")
+    assert ph_level_state.state == STATE_OFF
+
+    # Update data with changed values
+    current_data = mock_pooldose_client.instant_values_structured.return_value[1]
+    updated_data = current_data.copy()
+    updated_data["binary_sensor"]["pump_alarm"]["value"] = False
+    updated_data["binary_sensor"]["ph_level_alarm"]["value"] = True
+
+    mock_pooldose_client.instant_values_structured.return_value = (
+        RequestStatus.SUCCESS,
+        updated_data,
+    )
+
+    freezer.tick(timedelta(minutes=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Check states have changed
+    pump_state = hass.states.get("binary_sensor.pool_device_recirculation_pump")
+    assert pump_state.state == STATE_OFF
+
+    ph_level_state = hass.states.get("binary_sensor.pool_device_ph_tank_level")
+    assert ph_level_state.state == STATE_ON
+
+
+async def test_binary_sensor_missing_from_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pooldose_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test binary sensor becomes unavailable when missing from coordinator data."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify initial working state
+    flow_alarm_state = hass.states.get("binary_sensor.pool_device_flow_rate")
+    assert flow_alarm_state.state == STATE_OFF
+
+    # Update data with missing sensor
+    current_data = mock_pooldose_client.instant_values_structured.return_value[1]
+    updated_data = current_data.copy()
+    del updated_data["binary_sensor"]["flow_rate_alarm"]
+
+    mock_pooldose_client.instant_values_structured.return_value = (
+        RequestStatus.SUCCESS,
+        updated_data,
+    )
+
+    freezer.tick(timedelta(minutes=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Check sensor becomes unknown when not in coordinator data
+    flow_alarm_state = hass.states.get("binary_sensor.pool_device_flow_rate")
+    assert flow_alarm_state.state == "unknown"

--- a/tests/components/pooldose/test_binary_sensor.py
+++ b/tests/components/pooldose/test_binary_sensor.py
@@ -188,6 +188,6 @@ async def test_binary_sensor_missing_from_data(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    # Check sensor becomes unknown when not in coordinator data
+    # Check sensor becomes unavailable when not in coordinator data
     flow_alarm_state = hass.states.get("binary_sensor.pool_device_flow_rate")
-    assert flow_alarm_state.state == "unknown"
+    assert flow_alarm_state.state == STATE_UNAVAILABLE

--- a/tests/components/pooldose/test_binary_sensor.py
+++ b/tests/components/pooldose/test_binary_sensor.py
@@ -45,10 +45,7 @@ async def test_exception_raising(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("binary_sensor.pool_device_recirculation_pump").state
-        == STATE_ON
-    )
+    assert hass.states.get("binary_sensor.pool_device_recirculation").state == STATE_ON
 
     mock_pooldose_client.instant_values_structured.side_effect = exception
 
@@ -57,7 +54,7 @@ async def test_exception_raising(
     await hass.async_block_till_done()
 
     assert (
-        hass.states.get("binary_sensor.pool_device_recirculation_pump").state
+        hass.states.get("binary_sensor.pool_device_recirculation").state
         == STATE_UNAVAILABLE
     )
 
@@ -73,10 +70,7 @@ async def test_no_data(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("binary_sensor.pool_device_recirculation_pump").state
-        == STATE_ON
-    )
+    assert hass.states.get("binary_sensor.pool_device_recirculation").state == STATE_ON
 
     mock_pooldose_client.instant_values_structured.return_value = (
         RequestStatus.SUCCESS,
@@ -88,7 +82,7 @@ async def test_no_data(
     await hass.async_block_till_done()
 
     assert (
-        hass.states.get("binary_sensor.pool_device_recirculation_pump").state
+        hass.states.get("binary_sensor.pool_device_recirculation").state
         == STATE_UNAVAILABLE
     )
 
@@ -106,7 +100,7 @@ async def test_binary_sensor_entity_unavailable_no_coordinator_data(
     await hass.async_block_till_done()
 
     # Verify initial working state
-    pump_state = hass.states.get("binary_sensor.pool_device_recirculation_pump")
+    pump_state = hass.states.get("binary_sensor.pool_device_recirculation")
     assert pump_state.state == STATE_ON
 
     # Set coordinator data to None by making API return empty
@@ -120,7 +114,7 @@ async def test_binary_sensor_entity_unavailable_no_coordinator_data(
     await hass.async_block_till_done()
 
     # Check binary sensor becomes unavailable
-    pump_state = hass.states.get("binary_sensor.pool_device_recirculation_pump")
+    pump_state = hass.states.get("binary_sensor.pool_device_recirculation")
     assert pump_state.state == STATE_UNAVAILABLE
 
 
@@ -136,7 +130,7 @@ async def test_binary_sensor_state_changes(
     await hass.async_block_till_done()
 
     # Verify initial states
-    pump_state = hass.states.get("binary_sensor.pool_device_recirculation_pump")
+    pump_state = hass.states.get("binary_sensor.pool_device_recirculation")
     assert pump_state.state == STATE_ON
 
     ph_level_state = hass.states.get("binary_sensor.pool_device_ph_tank_level")
@@ -158,7 +152,7 @@ async def test_binary_sensor_state_changes(
     await hass.async_block_till_done()
 
     # Check states have changed
-    pump_state = hass.states.get("binary_sensor.pool_device_recirculation_pump")
+    pump_state = hass.states.get("binary_sensor.pool_device_recirculation")
     assert pump_state.state == STATE_OFF
 
     ph_level_state = hass.states.get("binary_sensor.pool_device_ph_tank_level")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds binary sensor support to the pooldose integration, exposing the following sensors:

### Alarm Sensors (device_class: PROBLEM)
- **Recirculation pump alarm** - Indicates pump operation issues
- **pH tank level** - Low pH dosing solution level
- **ORP tank level** - Low ORP dosing solution level  
- **Chlorine tank level** - Low chlorine dosing solution level
- **Flow rate alarm** - Water flow issues
- **pH overfeed** - Excessive pH dosing detected
- **ORP overfeed** - Excessive ORP dosing detected

### Relay Status Sensors
- **Alarm relay** - Main alarm relay state
- **Auxiliary relays 1-3** - Additional relay outputs

### Status Monitoring
- **Pump monitoring** (device_class: RUNNING) - Pump operation status
- **Flow rate reed sensor** (device_class: OPENING) - Flow detection


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41873
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
