### PR TITLE
Add target_humidity_step attribute to humidifier

### DIFF
--- a/homeassistant/components/demo/humidifier.py
+++ b/homeassistant/components/demo/humidifier.py
@@ -28,10 +28,11 @@ async def async_setup_entry(
             DemoHumidifier(
                 name="Humidifier",
                 mode=None,
-                target_humidity=68,
+                target_humidity=65,
                 current_humidity=45,
                 action=HumidifierAction.HUMIDIFYING,
                 device_class=HumidifierDeviceClass.HUMIDIFIER,
+                target_humidity_step=5,
             ),
             DemoHumidifier(
                 name="Dehumidifier",
@@ -66,6 +67,7 @@ class DemoHumidifier(HumidifierEntity):
         is_on: bool = True,
         action: HumidifierAction | None = None,
         device_class: HumidifierDeviceClass | None = None,
+        target_humidity_step: float | None = None,
     ) -> None:
         """Initialize the humidifier device."""
         self._attr_name = name
@@ -79,6 +81,7 @@ class DemoHumidifier(HumidifierEntity):
         self._attr_mode = mode
         self._attr_available_modes = available_modes
         self._attr_device_class = device_class
+        self._attr_target_humidity_step = target_humidity_step
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""

--- a/homeassistant/components/humidifier/__init__.py
+++ b/homeassistant/components/humidifier/__init__.py
@@ -177,8 +177,8 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
             ATTR_MIN_HUMIDITY: self.min_humidity,
             ATTR_MAX_HUMIDITY: self.max_humidity,
         }
-        if target_humidity_step := self.target_humidity_step:
-            data[ATTR_TARGET_HUMIDITY_STEP] = target_humidity_step
+        if self.target_humidity_step is not None:
+            data[ATTR_TARGET_HUMIDITY_STEP] = self.target_humidity_step
 
         if HumidifierEntityFeature.MODES in self.supported_features:
             data[ATTR_AVAILABLE_MODES] = self.available_modes

--- a/homeassistant/components/humidifier/__init__.py
+++ b/homeassistant/components/humidifier/__init__.py
@@ -34,6 +34,7 @@ from .const import (  # noqa: F401
     ATTR_HUMIDITY,
     ATTR_MAX_HUMIDITY,
     ATTR_MIN_HUMIDITY,
+    ATTR_TARGET_HUMIDITY_STEP,
     DEFAULT_MAX_HUMIDITY,
     DEFAULT_MIN_HUMIDITY,
     DOMAIN,
@@ -141,6 +142,7 @@ CACHED_PROPERTIES_WITH_ATTR_ = {
     "min_humidity",
     "max_humidity",
     "supported_features",
+    "target_humidity_step",
 }
 
 
@@ -148,7 +150,12 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
     """Base class for humidifier entities."""
 
     _entity_component_unrecorded_attributes = frozenset(
-        {ATTR_MIN_HUMIDITY, ATTR_MAX_HUMIDITY, ATTR_AVAILABLE_MODES}
+        {
+            ATTR_MIN_HUMIDITY,
+            ATTR_MAX_HUMIDITY,
+            ATTR_AVAILABLE_MODES,
+            ATTR_TARGET_HUMIDITY_STEP,
+        }
     )
 
     entity_description: HumidifierEntityDescription
@@ -161,6 +168,7 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
     _attr_mode: str | None
     _attr_supported_features: HumidifierEntityFeature = HumidifierEntityFeature(0)
     _attr_target_humidity: float | None = None
+    _attr_target_humidity_step: float | None = None
 
     @property
     def capability_attributes(self) -> dict[str, Any]:
@@ -169,6 +177,8 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
             ATTR_MIN_HUMIDITY: self.min_humidity,
             ATTR_MAX_HUMIDITY: self.max_humidity,
         }
+        if target_humidity_step := self.target_humidity_step:
+            data[ATTR_TARGET_HUMIDITY_STEP] = target_humidity_step
 
         if HumidifierEntityFeature.MODES in self.supported_features:
             data[ATTR_AVAILABLE_MODES] = self.available_modes
@@ -250,6 +260,11 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
     async def async_set_mode(self, mode: str) -> None:
         """Set new mode."""
         await self.hass.async_add_executor_job(self.set_mode, mode)
+
+    @cached_property
+    def target_humidity_step(self) -> float | None:
+        """Return the supported step of humidity."""
+        return self._attr_target_humidity_step
 
     @cached_property
     def min_humidity(self) -> float:

--- a/homeassistant/components/humidifier/const.py
+++ b/homeassistant/components/humidifier/const.py
@@ -28,6 +28,7 @@ ATTR_CURRENT_HUMIDITY = "current_humidity"
 ATTR_HUMIDITY = "humidity"
 ATTR_MAX_HUMIDITY = "max_humidity"
 ATTR_MIN_HUMIDITY = "min_humidity"
+ATTR_TARGET_HUMIDITY_STEP = "target_humidity_step"
 
 DEFAULT_MIN_HUMIDITY = 0
 DEFAULT_MAX_HUMIDITY = 100

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -354,7 +354,7 @@ async def test_query_humidifier_request(
     assert devices["humidifier.humidifier"] == {
         "on": True,
         "online": True,
-        "humiditySetpointPercent": 68,
+        "humiditySetpointPercent": 65,
         "humidityAmbientPercent": 45,
     }
     assert devices["humidifier.dehumidifier"] == {

--- a/tests/components/humidifier/test_recorder.py
+++ b/tests/components/humidifier/test_recorder.py
@@ -9,6 +9,7 @@ from homeassistant.components.humidifier import (
     ATTR_AVAILABLE_MODES,
     ATTR_MAX_HUMIDITY,
     ATTR_MIN_HUMIDITY,
+    ATTR_TARGET_HUMIDITY_STEP,
 )
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states
@@ -46,3 +47,4 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
         assert ATTR_MAX_HUMIDITY not in state.attributes
         assert ATTR_AVAILABLE_MODES not in state.attributes
         assert ATTR_FRIENDLY_NAME in state.attributes
+        assert ATTR_TARGET_HUMIDITY_STEP not in state.attributes


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add attribute "target_humidity_step" to humidifier for customize step in frontend.
It was discussed that this attribute is necessary to apply LG-based humidifiers. https://github.com/home-assistant/core/pull/152593#discussion_r2523708072

- core: Add attr_target_humidity_step to humidifier entity.
- frontend: Additionally, attribute is required to the step function of the humidifier control.
> `
>   private get _step() {
>     return this.stateObj.attributes.target_humidity_step ?? 1;
>   }
> `

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/152593
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2865
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/28005

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
