### PR TITLE
Add cover entity triggers xxx_opened

### DIFF
--- a/homeassistant/components/cover/icons.json
+++ b/homeassistant/components/cover/icons.json
@@ -110,8 +110,32 @@
     }
   },
   "triggers": {
+    "awning_opened": {
+      "trigger": "mdi:awning-outline"
+    },
+    "blind_opened": {
+      "trigger": "mdi:blinds-horizontal"
+    },
+    "curtain_opened": {
+      "trigger": "mdi:curtains"
+    },
+    "door_opened": {
+      "trigger": "mdi:door-open"
+    },
     "garage_opened": {
       "trigger": "mdi:garage-open"
+    },
+    "gate_opened": {
+      "trigger": "mdi:gate-open"
+    },
+    "shade_opened": {
+      "trigger": "mdi:roller-shade"
+    },
+    "shutter_opened": {
+      "trigger": "mdi:window-shutter-open"
+    },
+    "window_opened": {
+      "trigger": "mdi:window-open"
     }
   }
 }

--- a/homeassistant/components/cover/strings.json
+++ b/homeassistant/components/cover/strings.json
@@ -147,6 +147,66 @@
   },
   "title": "Cover",
   "triggers": {
+    "awning_opened": {
+      "description": "Triggers when an awning opens.",
+      "description_configured": "[%key:component::cover::triggers::awning_opened::description%]",
+      "fields": {
+        "behavior": {
+          "description": "The behavior of the targeted awnings to trigger on.",
+          "name": "Behavior"
+        },
+        "fully_opened": {
+          "description": "Require the awnings to be fully opened before triggering.",
+          "name": "Fully opened"
+        }
+      },
+      "name": "When an awning opens"
+    },
+    "blind_opened": {
+      "description": "Triggers when a blind opens.",
+      "description_configured": "[%key:component::cover::triggers::blind_opened::description%]",
+      "fields": {
+        "behavior": {
+          "description": "The behavior of the targeted blinds to trigger on.",
+          "name": "Behavior"
+        },
+        "fully_opened": {
+          "description": "Require the blinds to be fully opened before triggering.",
+          "name": "Fully opened"
+        }
+      },
+      "name": "When a blind opens"
+    },
+    "curtain_opened": {
+      "description": "Triggers when a curtain opens.",
+      "description_configured": "[%key:component::cover::triggers::curtain_opened::description%]",
+      "fields": {
+        "behavior": {
+          "description": "The behavior of the targeted curtains to trigger on.",
+          "name": "Behavior"
+        },
+        "fully_opened": {
+          "description": "Require the curtains to be fully opened before triggering.",
+          "name": "Fully opened"
+        }
+      },
+      "name": "When a curtain opens"
+    },
+    "door_opened": {
+      "description": "Triggers when a door opens.",
+      "description_configured": "[%key:component::cover::triggers::door_opened::description%]",
+      "fields": {
+        "behavior": {
+          "description": "The behavior of the targeted doors to trigger on.",
+          "name": "Behavior"
+        },
+        "fully_opened": {
+          "description": "Require the doors to be fully opened before triggering.",
+          "name": "Fully opened"
+        }
+      },
+      "name": "When a door opens"
+    },
     "garage_opened": {
       "description": "Triggers when a garage door opens.",
       "description_configured": "[%key:component::cover::triggers::garage_opened::description%]",
@@ -161,6 +221,66 @@
         }
       },
       "name": "When a garage door opens"
+    },
+    "gate_opened": {
+      "description": "Triggers when a gate opens.",
+      "description_configured": "[%key:component::cover::triggers::gate_opened::description%]",
+      "fields": {
+        "behavior": {
+          "description": "The behavior of the targeted gates to trigger on.",
+          "name": "Behavior"
+        },
+        "fully_opened": {
+          "description": "Require the gates to be fully opened before triggering.",
+          "name": "Fully opened"
+        }
+      },
+      "name": "When a gate opens"
+    },
+    "shade_opened": {
+      "description": "Triggers when a shade opens.",
+      "description_configured": "[%key:component::cover::triggers::shade_opened::description%]",
+      "fields": {
+        "behavior": {
+          "description": "The behavior of the targeted shades to trigger on.",
+          "name": "Behavior"
+        },
+        "fully_opened": {
+          "description": "Require the shades to be fully opened before triggering.",
+          "name": "Fully opened"
+        }
+      },
+      "name": "When a shade opens"
+    },
+    "shutter_opened": {
+      "description": "Triggers when a shutter opens.",
+      "description_configured": "[%key:component::cover::triggers::shutter_opened::description%]",
+      "fields": {
+        "behavior": {
+          "description": "The behavior of the targeted shutters to trigger on.",
+          "name": "Behavior"
+        },
+        "fully_opened": {
+          "description": "Require the shutters to be fully opened before triggering.",
+          "name": "Fully opened"
+        }
+      },
+      "name": "When a shutter opens"
+    },
+    "window_opened": {
+      "description": "Triggers when a window opens.",
+      "description_configured": "[%key:component::cover::triggers::window_opened::description%]",
+      "fields": {
+        "behavior": {
+          "description": "The behavior of the targeted windows to trigger on.",
+          "name": "Behavior"
+        },
+        "fully_opened": {
+          "description": "Require the windows to be fully opened before triggering.",
+          "name": "Fully opened"
+        }
+      },
+      "name": "When a window opens"
     }
   }
 }

--- a/homeassistant/components/cover/trigger.py
+++ b/homeassistant/components/cover/trigger.py
@@ -99,7 +99,15 @@ def make_cover_opened_trigger(
 
 
 TRIGGERS: dict[str, type[Trigger]] = {
+    "awning_opened": make_cover_opened_trigger(CoverDeviceClass.AWNING),
+    "blind_opened": make_cover_opened_trigger(CoverDeviceClass.BLIND),
+    "curtain_opened": make_cover_opened_trigger(CoverDeviceClass.CURTAIN),
+    "door_opened": make_cover_opened_trigger(CoverDeviceClass.DOOR),
     "garage_opened": make_cover_opened_trigger(CoverDeviceClass.GARAGE),
+    "gate_opened": make_cover_opened_trigger(CoverDeviceClass.GATE),
+    "shade_opened": make_cover_opened_trigger(CoverDeviceClass.SHADE),
+    "shutter_opened": make_cover_opened_trigger(CoverDeviceClass.SHUTTER),
+    "window_opened": make_cover_opened_trigger(CoverDeviceClass.WINDOW),
 }
 
 

--- a/homeassistant/components/cover/triggers.yaml
+++ b/homeassistant/components/cover/triggers.yaml
@@ -1,21 +1,79 @@
+.trigger_common_fields: &trigger_common_fields
+  behavior:
+    required: true
+    default: any
+    selector:
+      select:
+        translation_key: trigger_behavior
+        options:
+          - first
+          - last
+          - any
+  fully_opened:
+    required: true
+    default: false
+    selector:
+      boolean:
+
+awning_opened:
+  fields: *trigger_common_fields
+  target:
+    entity:
+      domain: cover
+      device_class: awning
+
+blind_opened:
+  fields: *trigger_common_fields
+  target:
+    entity:
+      domain: cover
+      device_class: blind
+
+curtain_opened:
+  fields: *trigger_common_fields
+  target:
+    entity:
+      domain: cover
+      device_class: curtain
+
+door_opened:
+  fields: *trigger_common_fields
+  target:
+    entity:
+      domain: cover
+      device_class: door
+
 garage_opened:
+  fields: *trigger_common_fields
   target:
     entity:
       domain: cover
       device_class: garage
-  fields:
-    behavior:
-      required: true
-      default: any
-      selector:
-        select:
-          translation_key: trigger_behavior
-          options:
-            - first
-            - last
-            - any
-    fully_opened:
-      required: true
-      default: false
-      selector:
-        boolean:
+
+gate_opened:
+  fields: *trigger_common_fields
+  target:
+    entity:
+      domain: cover
+      device_class: gate
+
+shade_opened:
+  fields: *trigger_common_fields
+  target:
+    entity:
+      domain: cover
+      device_class: shade
+
+shutter_opened:
+  fields: *trigger_common_fields
+  target:
+    entity:
+      domain: cover
+      device_class: shutter
+
+window_opened:
+  fields: *trigger_common_fields
+  target:
+    entity:
+      domain: cover
+      device_class: window

--- a/tests/components/cover/test_trigger.py
+++ b/tests/components/cover/test_trigger.py
@@ -86,7 +86,15 @@ def parametrize_opened_trigger_states(
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
     [
+        *parametrize_opened_trigger_states("cover.awning_opened", "awning"),
+        *parametrize_opened_trigger_states("cover.blind_opened", "blind"),
+        *parametrize_opened_trigger_states("cover.curtain_opened", "curtain"),
+        *parametrize_opened_trigger_states("cover.door_opened", "door"),
         *parametrize_opened_trigger_states("cover.garage_opened", "garage"),
+        *parametrize_opened_trigger_states("cover.gate_opened", "gate"),
+        *parametrize_opened_trigger_states("cover.shade_opened", "shade"),
+        *parametrize_opened_trigger_states("cover.shutter_opened", "shutter"),
+        *parametrize_opened_trigger_states("cover.window_opened", "window"),
     ],
 )
 async def test_cover_state_attribute_trigger_behavior_any(
@@ -135,7 +143,15 @@ async def test_cover_state_attribute_trigger_behavior_any(
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
     [
+        *parametrize_opened_trigger_states("cover.awning_opened", "awning"),
+        *parametrize_opened_trigger_states("cover.blind_opened", "blind"),
+        *parametrize_opened_trigger_states("cover.curtain_opened", "curtain"),
+        *parametrize_opened_trigger_states("cover.door_opened", "door"),
         *parametrize_opened_trigger_states("cover.garage_opened", "garage"),
+        *parametrize_opened_trigger_states("cover.gate_opened", "gate"),
+        *parametrize_opened_trigger_states("cover.shade_opened", "shade"),
+        *parametrize_opened_trigger_states("cover.shutter_opened", "shutter"),
+        *parametrize_opened_trigger_states("cover.window_opened", "window"),
     ],
 )
 async def test_cover_state_attribute_trigger_behavior_first(
@@ -188,7 +204,15 @@ async def test_cover_state_attribute_trigger_behavior_first(
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
     [
+        *parametrize_opened_trigger_states("cover.awning_opened", "awning"),
+        *parametrize_opened_trigger_states("cover.blind_opened", "blind"),
+        *parametrize_opened_trigger_states("cover.curtain_opened", "curtain"),
+        *parametrize_opened_trigger_states("cover.door_opened", "door"),
         *parametrize_opened_trigger_states("cover.garage_opened", "garage"),
+        *parametrize_opened_trigger_states("cover.gate_opened", "gate"),
+        *parametrize_opened_trigger_states("cover.shade_opened", "shade"),
+        *parametrize_opened_trigger_states("cover.shutter_opened", "shutter"),
+        *parametrize_opened_trigger_states("cover.window_opened", "window"),
     ],
 )
 async def test_cover_state_attribute_trigger_behavior_last(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add cover entity triggers xxx_opened:
- `cover.awning_opened`
- `cover.blind_opened`
- `cover.curtain_opened`
- `cover.door_opened`
- `cover.gate_opened`
- `cover.shade_opened`
- `cover.shutter_opened`
- `cover.window_opened`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
