### PR TITLE
Mark entity unavailable if data can't be fetched

### DIFF
--- a/homeassistant/components/lcn/binary_sensor.py
+++ b/homeassistant/components/lcn/binary_sensor.py
@@ -73,14 +73,17 @@ class LcnBinarySensor(LcnEntity, BinarySensorEntity):
 
     async def async_update(self) -> None:
         """Update the state of the entity."""
-        await self.device_connection.request_status_binary_sensors(
-            SCAN_INTERVAL.seconds
+        self._attr_available = (
+            await self.device_connection.request_status_binary_sensors(
+                SCAN_INTERVAL.seconds
+            )
+            is not None
         )
 
     def input_received(self, input_obj: InputType) -> None:
         """Set sensor value when LCN input object (command) is received."""
         if not isinstance(input_obj, pypck.inputs.ModStatusBinSensors):
             return
-
+        self._attr_available = True
         self._attr_is_on = input_obj.get_state(self.bin_sensor_port.value)
         self.async_write_ha_state()

--- a/homeassistant/components/lcn/climate.py
+++ b/homeassistant/components/lcn/climate.py
@@ -171,20 +171,22 @@ class LcnClimate(LcnEntity, ClimateEntity):
 
     async def async_update(self) -> None:
         """Update the state of the entity."""
-        await asyncio.gather(
-            self.device_connection.request_status_variable(
-                self.variable, SCAN_INTERVAL.seconds
-            ),
-            self.device_connection.request_status_variable(
-                self.setpoint, SCAN_INTERVAL.seconds
-            ),
+        self._attr_available = any(
+            await asyncio.gather(
+                self.device_connection.request_status_variable(
+                    self.variable, SCAN_INTERVAL.seconds
+                ),
+                self.device_connection.request_status_variable(
+                    self.setpoint, SCAN_INTERVAL.seconds
+                ),
+            )
         )
 
     def input_received(self, input_obj: InputType) -> None:
         """Set temperature value when LCN input object is received."""
         if not isinstance(input_obj, pypck.inputs.ModStatusVar):
             return
-
+        self._attr_available = True
         if input_obj.get_var() == self.variable:
             self._attr_current_temperature = float(
                 input_obj.get_value().to_var_unit(self.unit)

--- a/homeassistant/components/lcn/cover.py
+++ b/homeassistant/components/lcn/cover.py
@@ -133,13 +133,15 @@ class LcnOutputsCover(LcnEntity, CoverEntity):
     async def async_update(self) -> None:
         """Update the state of the entity."""
         if not self.device_connection.is_group:
-            await asyncio.gather(
-                self.device_connection.request_status_output(
-                    pypck.lcn_defs.OutputPort["OUTPUTUP"], SCAN_INTERVAL.seconds
-                ),
-                self.device_connection.request_status_output(
-                    pypck.lcn_defs.OutputPort["OUTPUTDOWN"], SCAN_INTERVAL.seconds
-                ),
+            self._attr_available = any(
+                await asyncio.gather(
+                    self.device_connection.request_status_output(
+                        pypck.lcn_defs.OutputPort["OUTPUTUP"], SCAN_INTERVAL.seconds
+                    ),
+                    self.device_connection.request_status_output(
+                        pypck.lcn_defs.OutputPort["OUTPUTDOWN"], SCAN_INTERVAL.seconds
+                    ),
+                )
             )
 
     def input_received(self, input_obj: InputType) -> None:
@@ -149,7 +151,7 @@ class LcnOutputsCover(LcnEntity, CoverEntity):
             or input_obj.get_output_id() not in self.output_ids
         ):
             return
-
+        self._attr_available = True
         if input_obj.get_percent() > 0:  # motor is on
             if input_obj.get_output_id() == self.output_ids[0]:
                 self._attr_is_opening = True
@@ -272,11 +274,12 @@ class LcnRelayCover(LcnEntity, CoverEntity):
                     self.motor, self.positioning_mode, SCAN_INTERVAL.seconds
                 )
             )
-        await asyncio.gather(*coros)
+        self._attr_available = any(await asyncio.gather(*coros))
 
     def input_received(self, input_obj: InputType) -> None:
         """Set cover states when LCN input object (command) is received."""
         if isinstance(input_obj, pypck.inputs.ModStatusRelays):
+            self._attr_available = True
             self._attr_is_opening = input_obj.is_opening(self.motor.value)
             self._attr_is_closing = input_obj.is_closing(self.motor.value)
 
@@ -293,6 +296,7 @@ class LcnRelayCover(LcnEntity, CoverEntity):
             )
             and input_obj.motor == self.motor.value
         ):
+            self._attr_available = True
             self._attr_current_cover_position = int(input_obj.position)
             if self._attr_current_cover_position in [0, 100]:
                 self._attr_is_opening = False

--- a/homeassistant/components/lcn/light.py
+++ b/homeassistant/components/lcn/light.py
@@ -149,8 +149,11 @@ class LcnOutputLight(LcnEntity, LightEntity):
 
     async def async_update(self) -> None:
         """Update the state of the entity."""
-        await self.device_connection.request_status_output(
-            self.output, SCAN_INTERVAL.seconds
+        self._attr_available = (
+            await self.device_connection.request_status_output(
+                self.output, SCAN_INTERVAL.seconds
+            )
+            is not None
         )
 
     def input_received(self, input_obj: InputType) -> None:
@@ -200,12 +203,15 @@ class LcnRelayLight(LcnEntity, LightEntity):
 
     async def async_update(self) -> None:
         """Update the state of the entity."""
-        await self.device_connection.request_status_relays(SCAN_INTERVAL.seconds)
+        self._attr_available = (
+            await self.device_connection.request_status_relays(SCAN_INTERVAL.seconds)
+            is not None
+        )
 
     def input_received(self, input_obj: InputType) -> None:
         """Set light state when LCN input object (command) is received."""
         if not isinstance(input_obj, pypck.inputs.ModStatusRelays):
             return
-
+        self._attr_available = True
         self._attr_is_on = input_obj.get_state(self.output.value)
         self.async_write_ha_state()

--- a/homeassistant/components/lcn/quality_scale.yaml
+++ b/homeassistant/components/lcn/quality_scale.yaml
@@ -25,7 +25,7 @@ rules:
     status: exempt
     comment: Integration has no configuration parameters
   docs-installation-parameters: done
-  entity-unavailable: todo
+  entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done

--- a/homeassistant/components/lcn/sensor.py
+++ b/homeassistant/components/lcn/sensor.py
@@ -133,8 +133,11 @@ class LcnVariableSensor(LcnEntity, SensorEntity):
 
     async def async_update(self) -> None:
         """Update the state of the entity."""
-        await self.device_connection.request_status_variable(
-            self.variable, SCAN_INTERVAL.seconds
+        self._attr_available = (
+            await self.device_connection.request_status_variable(
+                self.variable, SCAN_INTERVAL.seconds
+            )
+            is not None
         )
 
     def input_received(self, input_obj: InputType) -> None:
@@ -144,7 +147,7 @@ class LcnVariableSensor(LcnEntity, SensorEntity):
             or input_obj.get_var() != self.variable
         ):
             return
-
+        self._attr_available = True
         is_regulator = self.variable.name in SETPOINTS
         self._attr_native_value = input_obj.get_value().to_var_unit(
             self.unit, is_regulator
@@ -171,15 +174,18 @@ class LcnLedLogicSensor(LcnEntity, SensorEntity):
 
     async def async_update(self) -> None:
         """Update the state of the entity."""
-        await self.device_connection.request_status_led_and_logic_ops(
-            SCAN_INTERVAL.seconds
+        self._attr_available = (
+            await self.device_connection.request_status_led_and_logic_ops(
+                SCAN_INTERVAL.seconds
+            )
+            is not None
         )
 
     def input_received(self, input_obj: InputType) -> None:
         """Set sensor value when LCN input object (command) is received."""
         if not isinstance(input_obj, pypck.inputs.ModStatusLedsAndLogicOps):
             return
-
+        self._attr_available = True
         if self.source in pypck.lcn_defs.LedPort:
             self._attr_native_value = input_obj.get_led_state(
                 self.source.value

--- a/homeassistant/components/lcn/switch.py
+++ b/homeassistant/components/lcn/switch.py
@@ -95,8 +95,11 @@ class LcnOutputSwitch(LcnEntity, SwitchEntity):
 
     async def async_update(self) -> None:
         """Update the state of the entity."""
-        await self.device_connection.request_status_output(
-            self.output, SCAN_INTERVAL.seconds
+        self._attr_available = (
+            await self.device_connection.request_status_output(
+                self.output, SCAN_INTERVAL.seconds
+            )
+            is not None
         )
 
     def input_received(self, input_obj: InputType) -> None:
@@ -106,7 +109,7 @@ class LcnOutputSwitch(LcnEntity, SwitchEntity):
             or input_obj.get_output_id() != self.output.value
         ):
             return
-
+        self._attr_available = True
         self._attr_is_on = input_obj.get_percent() > 0
         self.async_write_ha_state()
 
@@ -142,13 +145,16 @@ class LcnRelaySwitch(LcnEntity, SwitchEntity):
 
     async def async_update(self) -> None:
         """Update the state of the entity."""
-        await self.device_connection.request_status_relays(SCAN_INTERVAL.seconds)
+        self._attr_available = (
+            await self.device_connection.request_status_relays(SCAN_INTERVAL.seconds)
+            is not None
+        )
 
     def input_received(self, input_obj: InputType) -> None:
         """Set switch state when LCN input object (command) is received."""
         if not isinstance(input_obj, pypck.inputs.ModStatusRelays):
             return
-
+        self._attr_available = True
         self._attr_is_on = input_obj.get_state(self.output.value)
         self.async_write_ha_state()
 
@@ -183,8 +189,11 @@ class LcnRegulatorLockSwitch(LcnEntity, SwitchEntity):
 
     async def async_update(self) -> None:
         """Update the state of the entity."""
-        await self.device_connection.request_status_variable(
-            self.setpoint_variable, SCAN_INTERVAL.seconds
+        self._attr_available = (
+            await self.device_connection.request_status_variable(
+                self.setpoint_variable, SCAN_INTERVAL.seconds
+            )
+            is not None
         )
 
     def input_received(self, input_obj: InputType) -> None:
@@ -194,7 +203,7 @@ class LcnRegulatorLockSwitch(LcnEntity, SwitchEntity):
             or input_obj.get_var() != self.setpoint_variable
         ):
             return
-
+        self._attr_available = True
         self._attr_is_on = input_obj.get_value().is_locked_regulator()
         self.async_write_ha_state()
 
@@ -236,7 +245,12 @@ class LcnKeyLockSwitch(LcnEntity, SwitchEntity):
 
     async def async_update(self) -> None:
         """Update the state of the entity."""
-        await self.device_connection.request_status_locked_keys(SCAN_INTERVAL.seconds)
+        self._attr_available = (
+            await self.device_connection.request_status_locked_keys(
+                SCAN_INTERVAL.seconds
+            )
+            is not None
+        )
 
     def input_received(self, input_obj: InputType) -> None:
         """Set switch state when LCN input object (command) is received."""
@@ -245,6 +259,6 @@ class LcnKeyLockSwitch(LcnEntity, SwitchEntity):
             or self.key not in pypck.lcn_defs.Key
         ):
             return
-
+        self._attr_available = True
         self._attr_is_on = input_obj.get_state(self.table_id, self.key_id)
         self.async_write_ha_state()

--- a/tests/components/lcn/test_binary_sensor.py
+++ b/tests/components/lcn/test_binary_sensor.py
@@ -2,18 +2,20 @@
 
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 from pypck.inputs import ModStatusBinSensors
 from pypck.lcn_addr import LcnAddr
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.lcn.binary_sensor import SCAN_INTERVAL
 from homeassistant.components.lcn.helpers import get_device_connection
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MockConfigEntry, init_integration
+from .conftest import MockConfigEntry, MockDeviceConnection, init_integration
 
-from tests.common import snapshot_platform
+from tests.common import async_fire_time_changed, snapshot_platform
 
 BINARY_SENSOR_SENSOR1 = "binary_sensor.testmodule_binary_sensor1"
 
@@ -59,6 +61,43 @@ async def test_pushed_binsensor_status_change(
     state = hass.states.get(BINARY_SENSOR_SENSOR1)
     assert state is not None
     assert state.state == STATE_ON
+
+
+async def test_availability(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, entry: MockConfigEntry
+) -> None:
+    """Test the availability of binary_sensor entity."""
+    await init_integration(hass, entry)
+
+    state = hass.states.get(BINARY_SENSOR_SENSOR1)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+    # no response from device -> unavailable
+    with patch.object(
+        MockDeviceConnection, "request_status_binary_sensors", return_value=None
+    ):
+        freezer.tick(SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(BINARY_SENSOR_SENSOR1)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    # response from device -> available
+    with patch.object(
+        MockDeviceConnection,
+        "request_status_binary_sensors",
+        return_value=ModStatusBinSensors(LcnAddr(0, 7, False), [False] * 8),
+    ):
+        freezer.tick(SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(BINARY_SENSOR_SENSOR1)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
 
 
 async def test_unload_config_entry(hass: HomeAssistant, entry: MockConfigEntry) -> None:

--- a/tests/components/lcn/test_climate.py
+++ b/tests/components/lcn/test_climate.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 from pypck.inputs import ModStatusVar, Unknown
 from pypck.lcn_addr import LcnAddr
 from pypck.lcn_defs import Var, VarUnit, VarValue
@@ -18,6 +19,7 @@ from homeassistant.components.climate import (
     SERVICE_SET_TEMPERATURE,
     HVACMode,
 )
+from homeassistant.components.lcn.climate import SCAN_INTERVAL
 from homeassistant.components.lcn.helpers import get_device_connection
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -31,7 +33,9 @@ from homeassistant.helpers import entity_registry as er
 
 from .conftest import MockConfigEntry, MockDeviceConnection, init_integration
 
-from tests.common import snapshot_platform
+from tests.common import async_fire_time_changed, snapshot_platform
+
+CLIMATE_CLIMATE1 = "climate.testmodule_climate1"
 
 
 async def test_setup_lcn_climate(
@@ -56,7 +60,7 @@ async def test_set_hvac_mode_heat(hass: HomeAssistant, entry: MockConfigEntry) -
             DOMAIN_CLIMATE,
             SERVICE_SET_HVAC_MODE,
             {
-                ATTR_ENTITY_ID: "climate.testmodule_climate1",
+                ATTR_ENTITY_ID: CLIMATE_CLIMATE1,
                 ATTR_HVAC_MODE: HVACMode.OFF,
             },
             blocking=True,
@@ -69,7 +73,7 @@ async def test_set_hvac_mode_heat(hass: HomeAssistant, entry: MockConfigEntry) -
             DOMAIN_CLIMATE,
             SERVICE_SET_HVAC_MODE,
             {
-                ATTR_ENTITY_ID: "climate.testmodule_climate1",
+                ATTR_ENTITY_ID: CLIMATE_CLIMATE1,
                 ATTR_HVAC_MODE: HVACMode.HEAT,
             },
             blocking=True,
@@ -77,7 +81,7 @@ async def test_set_hvac_mode_heat(hass: HomeAssistant, entry: MockConfigEntry) -
 
         lock_regulator.assert_awaited_with(0, False)
 
-        state = hass.states.get("climate.testmodule_climate1")
+        state = hass.states.get(CLIMATE_CLIMATE1)
         assert state is not None
         assert state.state != HVACMode.HEAT
 
@@ -89,7 +93,7 @@ async def test_set_hvac_mode_heat(hass: HomeAssistant, entry: MockConfigEntry) -
             DOMAIN_CLIMATE,
             SERVICE_SET_HVAC_MODE,
             {
-                ATTR_ENTITY_ID: "climate.testmodule_climate1",
+                ATTR_ENTITY_ID: CLIMATE_CLIMATE1,
                 ATTR_HVAC_MODE: HVACMode.HEAT,
             },
             blocking=True,
@@ -97,7 +101,7 @@ async def test_set_hvac_mode_heat(hass: HomeAssistant, entry: MockConfigEntry) -
 
         lock_regulator.assert_awaited_with(0, False)
 
-        state = hass.states.get("climate.testmodule_climate1")
+        state = hass.states.get(CLIMATE_CLIMATE1)
         assert state is not None
         assert state.state == HVACMode.HEAT
 
@@ -107,7 +111,7 @@ async def test_set_hvac_mode_off(hass: HomeAssistant, entry: MockConfigEntry) ->
     await init_integration(hass, entry)
 
     with patch.object(MockDeviceConnection, "lock_regulator") as lock_regulator:
-        state = hass.states.get("climate.testmodule_climate1")
+        state = hass.states.get(CLIMATE_CLIMATE1)
         state.state = HVACMode.HEAT
 
         # command failed
@@ -117,7 +121,7 @@ async def test_set_hvac_mode_off(hass: HomeAssistant, entry: MockConfigEntry) ->
             DOMAIN_CLIMATE,
             SERVICE_SET_HVAC_MODE,
             {
-                ATTR_ENTITY_ID: "climate.testmodule_climate1",
+                ATTR_ENTITY_ID: CLIMATE_CLIMATE1,
                 ATTR_HVAC_MODE: HVACMode.OFF,
             },
             blocking=True,
@@ -125,7 +129,7 @@ async def test_set_hvac_mode_off(hass: HomeAssistant, entry: MockConfigEntry) ->
 
         lock_regulator.assert_awaited_with(0, True, -1)
 
-        state = hass.states.get("climate.testmodule_climate1")
+        state = hass.states.get(CLIMATE_CLIMATE1)
         assert state is not None
         assert state.state != HVACMode.OFF
 
@@ -137,7 +141,7 @@ async def test_set_hvac_mode_off(hass: HomeAssistant, entry: MockConfigEntry) ->
             DOMAIN_CLIMATE,
             SERVICE_SET_HVAC_MODE,
             {
-                ATTR_ENTITY_ID: "climate.testmodule_climate1",
+                ATTR_ENTITY_ID: CLIMATE_CLIMATE1,
                 ATTR_HVAC_MODE: HVACMode.OFF,
             },
             blocking=True,
@@ -145,7 +149,7 @@ async def test_set_hvac_mode_off(hass: HomeAssistant, entry: MockConfigEntry) ->
 
         lock_regulator.assert_awaited_with(0, True, -1)
 
-        state = hass.states.get("climate.testmodule_climate1")
+        state = hass.states.get(CLIMATE_CLIMATE1)
         assert state is not None
         assert state.state == HVACMode.OFF
 
@@ -155,7 +159,7 @@ async def test_set_temperature(hass: HomeAssistant, entry: MockConfigEntry) -> N
     await init_integration(hass, entry)
 
     with patch.object(MockDeviceConnection, "var_abs") as var_abs:
-        state = hass.states.get("climate.testmodule_climate1")
+        state = hass.states.get(CLIMATE_CLIMATE1)
         state.state = HVACMode.HEAT
 
         # wrong temperature set via service call with high/low attributes
@@ -166,7 +170,7 @@ async def test_set_temperature(hass: HomeAssistant, entry: MockConfigEntry) -> N
                 DOMAIN_CLIMATE,
                 SERVICE_SET_TEMPERATURE,
                 {
-                    ATTR_ENTITY_ID: "climate.testmodule_climate1",
+                    ATTR_ENTITY_ID: CLIMATE_CLIMATE1,
                     ATTR_TARGET_TEMP_LOW: 24.5,
                     ATTR_TARGET_TEMP_HIGH: 25.5,
                 },
@@ -182,13 +186,13 @@ async def test_set_temperature(hass: HomeAssistant, entry: MockConfigEntry) -> N
         await hass.services.async_call(
             DOMAIN_CLIMATE,
             SERVICE_SET_TEMPERATURE,
-            {ATTR_ENTITY_ID: "climate.testmodule_climate1", ATTR_TEMPERATURE: 25.5},
+            {ATTR_ENTITY_ID: CLIMATE_CLIMATE1, ATTR_TEMPERATURE: 25.5},
             blocking=True,
         )
 
         var_abs.assert_awaited_with(Var.R1VARSETPOINT, 25.5, VarUnit.CELSIUS)
 
-        state = hass.states.get("climate.testmodule_climate1")
+        state = hass.states.get(CLIMATE_CLIMATE1)
         assert state is not None
         assert state.attributes[ATTR_TEMPERATURE] != 25.5
 
@@ -199,13 +203,13 @@ async def test_set_temperature(hass: HomeAssistant, entry: MockConfigEntry) -> N
         await hass.services.async_call(
             DOMAIN_CLIMATE,
             SERVICE_SET_TEMPERATURE,
-            {ATTR_ENTITY_ID: "climate.testmodule_climate1", ATTR_TEMPERATURE: 25.5},
+            {ATTR_ENTITY_ID: CLIMATE_CLIMATE1, ATTR_TEMPERATURE: 25.5},
             blocking=True,
         )
 
         var_abs.assert_awaited_with(Var.R1VARSETPOINT, 25.5, VarUnit.CELSIUS)
 
-        state = hass.states.get("climate.testmodule_climate1")
+        state = hass.states.get(CLIMATE_CLIMATE1)
         assert state is not None
         assert state.attributes[ATTR_TEMPERATURE] == 25.5
 
@@ -226,7 +230,7 @@ async def test_pushed_current_temperature_status_change(
     await device_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
-    state = hass.states.get("climate.testmodule_climate1")
+    state = hass.states.get(CLIMATE_CLIMATE1)
     assert state is not None
     assert state.state == HVACMode.HEAT
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 25.5
@@ -249,7 +253,7 @@ async def test_pushed_setpoint_status_change(
     await device_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
-    state = hass.states.get("climate.testmodule_climate1")
+    state = hass.states.get(CLIMATE_CLIMATE1)
     assert state is not None
     assert state.state == HVACMode.HEAT
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] is None
@@ -272,7 +276,7 @@ async def test_pushed_lock_status_change(
     await device_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
-    state = hass.states.get("climate.testmodule_climate1")
+    state = hass.states.get(CLIMATE_CLIMATE1)
     assert state is not None
     assert state.state == HVACMode.OFF
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] is None
@@ -291,9 +295,48 @@ async def test_pushed_wrong_input(
     await device_connection.async_process_input(Unknown("input"))
     await hass.async_block_till_done()
 
-    state = hass.states.get("climate.testmodule_climate1")
+    state = hass.states.get(CLIMATE_CLIMATE1)
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] is None
     assert state.attributes[ATTR_TEMPERATURE] is None
+
+
+async def test_availability(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, entry: MockConfigEntry
+) -> None:
+    """Test the availability of climate entity."""
+    await init_integration(hass, entry)
+
+    state = hass.states.get(CLIMATE_CLIMATE1)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+    # no response from device -> unavailable
+    with patch.object(
+        MockDeviceConnection, "request_status_variable", return_value=None
+    ):
+        freezer.tick(SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(CLIMATE_CLIMATE1)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    # response from device -> available
+    with patch.object(
+        MockDeviceConnection,
+        "request_status_variable",
+        return_value=ModStatusVar(
+            LcnAddr(0, 7, False), Var.R1VARSETPOINT, VarValue.from_celsius(25.5)
+        ),
+    ):
+        freezer.tick(SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(CLIMATE_CLIMATE1)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
 
 
 async def test_unload_config_entry(
@@ -304,5 +347,5 @@ async def test_unload_config_entry(
     await init_integration(hass, entry)
 
     await hass.config_entries.async_unload(entry.entry_id)
-    state = hass.states.get("climate.testmodule_climate1")
+    state = hass.states.get(CLIMATE_CLIMATE1)
     assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
LCN entity states are updated using `async_update`. If no data can be fetched, we can assume that the entity is not available and the `_attr_available` property is set accordingly.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
