### PR TITLE
Fix usage_prediction incorrectly accessing target fields

### DIFF
--- a/homeassistant/components/usage_prediction/common_control.py
+++ b/homeassistant/components/usage_prediction/common_control.py
@@ -145,8 +145,10 @@ async def async_predict_common_control(
             continue
 
         entity_ids: str | list[str] | None
-        if (target := service_data.get("target")) and (
-            target_entity_ids := target.get("entity_id")
+        if (
+            (target := service_data.get("target"))
+            and isinstance(target, dict)
+            and (target_entity_ids := target.get("entity_id"))
         ):
             entity_ids = target_entity_ids
         else:

--- a/homeassistant/components/usage_prediction/common_control.py
+++ b/homeassistant/components/usage_prediction/common_control.py
@@ -144,15 +144,7 @@ async def async_predict_common_control(
         if not service_data:
             continue
 
-        entity_ids: str | list[str] | None
-        if (
-            (target := service_data.get("target"))
-            and isinstance(target, dict)
-            and (target_entity_ids := target.get("entity_id"))
-        ):
-            entity_ids = target_entity_ids
-        else:
-            entity_ids = service_data.get("entity_id")
+        entity_ids: str | list[str] | None = service_data.get("entity_id")
 
         # No entity IDs found, skip this event
         if entity_ids is None:

--- a/tests/components/usage_prediction/test_common_control.py
+++ b/tests/components/usage_prediction/test_common_control.py
@@ -89,7 +89,19 @@ async def test_with_service_calls(hass: HomeAssistant) -> None:
             {
                 "domain": "climate",
                 "service": "set_temperature",
-                "service_data": {"entity_id": "climate.thermostat"},
+                "service_data": {
+                    "target": {"entity_id": "climate.thermostat"},
+                },
+            },
+            context=Context(user_id=user_id),
+        )
+        # Check events with non-dict targets do not cause issues.
+        hass.bus.async_fire(
+            EVENT_CALL_SERVICE,
+            {
+                "domain": "script",
+                "service": "some_user_script",
+                "service_data": {"target": "42"},
             },
             context=Context(user_id=user_id),
         )

--- a/tests/components/usage_prediction/test_common_control.py
+++ b/tests/components/usage_prediction/test_common_control.py
@@ -89,9 +89,7 @@ async def test_with_service_calls(hass: HomeAssistant) -> None:
             {
                 "domain": "climate",
                 "service": "set_temperature",
-                "service_data": {
-                    "target": {"entity_id": "climate.thermostat"},
-                },
+                "service_data": {"entity_id": "climate.thermostat"},
             },
             context=Context(user_id=user_id),
         )

--- a/tests/components/usage_prediction/test_common_control.py
+++ b/tests/components/usage_prediction/test_common_control.py
@@ -93,16 +93,6 @@ async def test_with_service_calls(hass: HomeAssistant) -> None:
             },
             context=Context(user_id=user_id),
         )
-        # Check events with non-dict targets do not cause issues.
-        hass.bus.async_fire(
-            EVENT_CALL_SERVICE,
-            {
-                "domain": "script",
-                "service": "some_user_script",
-                "service_data": {"target": "42"},
-            },
-            context=Context(user_id=user_id),
-        )
         await hass.async_block_till_done()
 
     # Evening events


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

`usage_prediction` incorrectly looks into service call data for a `target` field, but by that point entity service fields are already folded into top-level service data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/153515
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
