### PR TITLE
Add Tuya climate tests for US unit_system

### DIFF
--- a/tests/components/tuya/fixtures/kt_wxqdp6ecfkd78zzz.json
+++ b/tests/components/tuya/fixtures/kt_wxqdp6ecfkd78zzz.json
@@ -1,0 +1,152 @@
+{
+  "endpoint": "https://apigw.tuyaus.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Mini-Split",
+  "category": "kt",
+  "product_id": "wxqdp6ecfkd78zzz",
+  "product_name": "Air Conditioner",
+  "online": true,
+  "sub": false,
+  "time_zone": "-07:00",
+  "active_time": "2024-07-06T03:42:10+00:00",
+  "create_time": "2024-07-06T03:42:10+00:00",
+  "update_time": "2024-07-06T03:42:10+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "\u2103/F",
+        "min": 160,
+        "max": 900,
+        "scale": 1,
+        "step": 10
+      }
+    },
+    "mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["cold", "hot", "wet", "wind", "auto"]
+      }
+    },
+    "mode_eco": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "heat": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "light": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "lock": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "switch_horizontal": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "sleep": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "health": {
+      "type": "Boolean",
+      "value": {}
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "\u2103/F",
+        "min": 160,
+        "max": 900,
+        "scale": 1,
+        "step": 10
+      }
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": {
+        "unit": "\u2103/F",
+        "min": -300,
+        "max": 1760,
+        "scale": 1,
+        "step": 10
+      }
+    },
+    "mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["cold", "hot", "wet", "wind", "auto"]
+      }
+    },
+    "mode_eco": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "heat": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "light": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "lock": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "power_consumption": {
+      "type": "Integer",
+      "value": {
+        "unit": "kW\u00b7h",
+        "min": 0,
+        "max": 255,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "switch_horizontal": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "sleep": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "health": {
+      "type": "Boolean",
+      "value": {}
+    }
+  },
+  "status": {
+    "switch": false,
+    "temp_set": 660,
+    "temp_current": 690,
+    "mode": "cold",
+    "mode_eco": false,
+    "heat": false,
+    "light": false,
+    "lock": false,
+    "power_consumption": 0,
+    "switch_horizontal": false,
+    "sleep": false,
+    "health": false
+  },
+  "set_up": true,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_climate.ambr
+++ b/tests/components/tuya/snapshots/test_climate.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_platform_setup_and_discovery[climate.air_conditioner-entry]
+# name: test_platform_setup_and_discovery[metric][climate.air_conditioner-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -46,7 +46,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.air_conditioner-state]
+# name: test_platform_setup_and_discovery[metric][climate.air_conditioner-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 22.0,
@@ -74,7 +74,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.anbau-entry]
+# name: test_platform_setup_and_discovery[metric][climate.anbau-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -122,7 +122,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.anbau-state]
+# name: test_platform_setup_and_discovery[metric][climate.anbau-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Anbau',
@@ -148,7 +148,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.bathroom_radiator-entry]
+# name: test_platform_setup_and_discovery[metric][climate.bathroom_radiator-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -197,7 +197,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.bathroom_radiator-state]
+# name: test_platform_setup_and_discovery[metric][climate.bathroom_radiator-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 19.5,
@@ -227,7 +227,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.boiler_temperature_controller-entry]
+# name: test_platform_setup_and_discovery[metric][climate.boiler_temperature_controller-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -270,7 +270,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.boiler_temperature_controller-state]
+# name: test_platform_setup_and_discovery[metric][climate.boiler_temperature_controller-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 57.5,
@@ -292,7 +292,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.clima_cucina-entry]
+# name: test_platform_setup_and_discovery[metric][climate.clima_cucina-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -342,7 +342,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.clima_cucina-state]
+# name: test_platform_setup_and_discovery[metric][climate.clima_cucina-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 27.0,
@@ -373,7 +373,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.el_termostato_de_la_cocina-entry]
+# name: test_platform_setup_and_discovery[metric][climate.el_termostato_de_la_cocina-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -416,7 +416,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.el_termostato_de_la_cocina-state]
+# name: test_platform_setup_and_discovery[metric][climate.el_termostato_de_la_cocina-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 45.0,
@@ -439,7 +439,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.empore-entry]
+# name: test_platform_setup_and_discovery[metric][climate.empore-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -487,7 +487,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.empore-state]
+# name: test_platform_setup_and_discovery[metric][climate.empore-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 19.0,
@@ -516,7 +516,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.floor_thermostat_kitchen-entry]
+# name: test_platform_setup_and_discovery[metric][climate.floor_thermostat_kitchen-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -564,7 +564,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.floor_thermostat_kitchen-state]
+# name: test_platform_setup_and_discovery[metric][climate.floor_thermostat_kitchen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 20.0,
@@ -593,7 +593,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.geti_solar_pv_water_heater-entry]
+# name: test_platform_setup_and_discovery[metric][climate.geti_solar_pv_water_heater-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -634,7 +634,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.geti_solar_pv_water_heater-state]
+# name: test_platform_setup_and_discovery[metric][climate.geti_solar_pv_water_heater-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 60.0,
@@ -654,7 +654,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.kabinet-entry]
+# name: test_platform_setup_and_discovery[metric][climate.kabinet-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -701,7 +701,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.kabinet-state]
+# name: test_platform_setup_and_discovery[metric][climate.kabinet-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 19.5,
@@ -729,7 +729,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.master_bedroom_ac-entry]
+# name: test_platform_setup_and_discovery[metric][climate.master_bedroom_ac-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -776,7 +776,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.master_bedroom_ac-state]
+# name: test_platform_setup_and_discovery[metric][climate.master_bedroom_ac-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_humidity': 0,
@@ -804,7 +804,90 @@
     'state': 'cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.mr_pure-entry]
+# name: test_platform_setup_and_discovery[metric][climate.mini_split-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.DRY: 'dry'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 90.0,
+      'min_temp': 16.0,
+      'swing_modes': list([
+        'off',
+        'horizontal',
+      ]),
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.mini_split',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 417>,
+    'translation_key': None,
+    'unique_id': 'tuya.zzz87dkfce6pdqxwtk',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[metric][climate.mini_split-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 69.0,
+      'friendly_name': 'Mini-Split',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.DRY: 'dry'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 90.0,
+      'min_temp': 16.0,
+      'supported_features': <ClimateEntityFeature: 417>,
+      'swing_mode': 'off',
+      'swing_modes': list([
+        'off',
+        'horizontal',
+      ]),
+      'target_temp_step': 1.0,
+      'temperature': 66.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.mini_split',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[metric][climate.mr_pure-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -845,7 +928,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.mr_pure-state]
+# name: test_platform_setup_and_discovery[metric][climate.mr_pure-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': None,
@@ -865,7 +948,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.polotentsosushitel-entry]
+# name: test_platform_setup_and_discovery[metric][climate.polotentsosushitel-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -911,7 +994,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.polotentsosushitel-state]
+# name: test_platform_setup_and_discovery[metric][climate.polotentsosushitel-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 25.3,
@@ -938,7 +1021,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.salon-entry]
+# name: test_platform_setup_and_discovery[metric][climate.salon-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -986,7 +1069,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.salon-state]
+# name: test_platform_setup_and_discovery[metric][climate.salon-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 20.3,
@@ -1015,7 +1098,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.smart_thermostats-entry]
+# name: test_platform_setup_and_discovery[metric][climate.smart_thermostats-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1059,7 +1142,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.smart_thermostats-state]
+# name: test_platform_setup_and_discovery[metric][climate.smart_thermostats-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 21.5,
@@ -1083,7 +1166,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.sove-entry]
+# name: test_platform_setup_and_discovery[metric][climate.sove-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1130,7 +1213,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.sove-state]
+# name: test_platform_setup_and_discovery[metric][climate.sove-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 24.0,
@@ -1158,7 +1241,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.term_prizemi-entry]
+# name: test_platform_setup_and_discovery[metric][climate.term_prizemi-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1201,7 +1284,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.term_prizemi-state]
+# name: test_platform_setup_and_discovery[metric][climate.term_prizemi-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 23.0,
@@ -1224,7 +1307,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.wifi_smart_gas_boiler_thermostat-entry]
+# name: test_platform_setup_and_discovery[metric][climate.wifi_smart_gas_boiler_thermostat-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1267,7 +1350,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[climate.wifi_smart_gas_boiler_thermostat-state]
+# name: test_platform_setup_and_discovery[metric][climate.wifi_smart_gas_boiler_thermostat-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 24.9,
@@ -1281,6 +1364,1380 @@
       'supported_features': <ClimateEntityFeature: 385>,
       'target_temp_step': 0.5,
       'temperature': 22.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.wifi_smart_gas_boiler_thermostat',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.air_conditioner-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'fan_modes': list([
+        '1',
+        '2',
+      ]),
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 187,
+      'min_temp': 61,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.air_conditioner',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 393>,
+    'translation_key': None,
+    'unique_id': 'tuya.mvsdcwtskkezlnw5tk',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.air_conditioner-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 72,
+      'fan_mode': None,
+      'fan_modes': list([
+        '1',
+        '2',
+      ]),
+      'friendly_name': 'Air Conditioner',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 187,
+      'min_temp': 61,
+      'supported_features': <ClimateEntityFeature: 393>,
+      'target_temp_step': 1.0,
+      'temperature': 73,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.air_conditioner',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.anbau-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 41,
+      'preset_modes': list([
+        'off',
+      ]),
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.anbau',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 17>,
+    'translation_key': None,
+    'unique_id': 'tuya.sq6fbd3pfkw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.anbau-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Anbau',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 41,
+      'preset_modes': list([
+        'off',
+      ]),
+      'supported_features': <ClimateEntityFeature: 17>,
+      'target_temp_step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.anbau',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.bathroom_radiator-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 158,
+      'min_temp': 34,
+      'preset_modes': list([
+        'holiday',
+        'eco',
+      ]),
+      'target_temp_step': 0.5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.bathroom_radiator',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 17>,
+    'translation_key': None,
+    'unique_id': 'tuya.fc2ngmpckw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.bathroom_radiator-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 67,
+      'friendly_name': 'Bathroom radiator',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 158,
+      'min_temp': 34,
+      'preset_mode': None,
+      'preset_modes': list([
+        'holiday',
+        'eco',
+      ]),
+      'supported_features': <ClimateEntityFeature: 17>,
+      'target_temp_step': 0.5,
+      'temperature': 54,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.bathroom_radiator',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.boiler_temperature_controller-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 45,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.boiler_temperature_controller',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 384>,
+    'translation_key': None,
+    'unique_id': 'tuya.zgiyrxflahjowpcckw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.boiler_temperature_controller-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 136,
+      'friendly_name': 'Boiler Temperature Controller',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 45,
+      'supported_features': <ClimateEntityFeature: 384>,
+      'target_temp_step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.boiler_temperature_controller',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.clima_cucina-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'fan_modes': list([
+        'low',
+        'middle',
+        'high',
+        'auto',
+      ]),
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 41,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.clima_cucina',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 393>,
+    'translation_key': None,
+    'unique_id': 'tuya.x7quooqakw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.clima_cucina-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 81,
+      'fan_mode': 'auto',
+      'fan_modes': list([
+        'low',
+        'middle',
+        'high',
+        'auto',
+      ]),
+      'friendly_name': 'Clima cucina',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 41,
+      'supported_features': <ClimateEntityFeature: 393>,
+      'target_temp_step': 1.0,
+      'temperature': 77,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.clima_cucina',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.el_termostato_de_la_cocina-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 45,
+      'min_temp': 34,
+      'target_temp_step': 0.5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.el_termostato_de_la_cocina',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 385>,
+    'translation_key': None,
+    'unique_id': 'tuya.LmLMc0ht1KW2zYAIkw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.el_termostato_de_la_cocina-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 113,
+      'friendly_name': 'El termostato de la cocina',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 45,
+      'min_temp': 34,
+      'supported_features': <ClimateEntityFeature: 385>,
+      'target_temp_step': 0.5,
+      'temperature': 40,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.el_termostato_de_la_cocina',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.empore-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 41,
+      'preset_modes': list([
+        'off',
+      ]),
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.empore',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 17>,
+    'translation_key': None,
+    'unique_id': 'tuya.paxijfx9fkw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.empore-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 66,
+      'friendly_name': 'Empore',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 41,
+      'preset_mode': None,
+      'preset_modes': list([
+        'off',
+      ]),
+      'supported_features': <ClimateEntityFeature: 17>,
+      'target_temp_step': 1.0,
+      'temperature': 95,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.empore',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.floor_thermostat_kitchen-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 41,
+      'preset_modes': list([
+        'off',
+      ]),
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.floor_thermostat_kitchen',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 401>,
+    'translation_key': None,
+    'unique_id': 'tuya.oq9ksabjz6tip49tkw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.floor_thermostat_kitchen-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 68,
+      'friendly_name': 'Floor Thermostat Kitchen',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 41,
+      'preset_mode': None,
+      'preset_modes': list([
+        'off',
+      ]),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'target_temp_step': 1.0,
+      'temperature': 36,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.floor_thermostat_kitchen',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.geti_solar_pv_water_heater-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+      ]),
+      'max_temp': 95,
+      'min_temp': 45,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.geti_solar_pv_water_heater',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.fcacn8iqbocuow7dsr',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.geti_solar_pv_water_heater-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 140,
+      'friendly_name': 'Geti Solar PV Water Heater',
+      'hvac_modes': list([
+      ]),
+      'max_temp': 95,
+      'min_temp': 45,
+      'supported_features': <ClimateEntityFeature: 0>,
+      'target_temp_step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.geti_solar_pv_water_heater',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.kabinet-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 203,
+      'min_temp': 41,
+      'preset_modes': list([
+        'program',
+      ]),
+      'target_temp_step': 0.5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.kabinet',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 401>,
+    'translation_key': None,
+    'unique_id': 'tuya.dn7cjik6kw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.kabinet-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 67,
+      'friendly_name': 'Кабінет',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 203,
+      'min_temp': 41,
+      'preset_mode': None,
+      'preset_modes': list([
+        'program',
+      ]),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'target_temp_step': 0.5,
+      'temperature': 71,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.kabinet',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.master_bedroom_ac-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.DRY: 'dry'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 190,
+      'min_temp': 61,
+      'target_temp_step': 0.5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.master_bedroom_ac',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 385>,
+    'translation_key': None,
+    'unique_id': 'tuya.g1fmm26qhhrimmbitk',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.master_bedroom_ac-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_humidity': 0,
+      'current_temperature': 79,
+      'friendly_name': 'Master Bedroom AC',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.DRY: 'dry'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 190,
+      'min_temp': 61,
+      'supported_features': <ClimateEntityFeature: 385>,
+      'target_temp_step': 0.5,
+      'temperature': 167,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.master_bedroom_ac',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.mini_split-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.DRY: 'dry'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 194,
+      'min_temp': 61,
+      'swing_modes': list([
+        'off',
+        'horizontal',
+      ]),
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.mini_split',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 417>,
+    'translation_key': None,
+    'unique_id': 'tuya.zzz87dkfce6pdqxwtk',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.mini_split-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 156,
+      'friendly_name': 'Mini-Split',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.DRY: 'dry'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 194,
+      'min_temp': 61,
+      'supported_features': <ClimateEntityFeature: 417>,
+      'swing_mode': 'off',
+      'swing_modes': list([
+        'off',
+        'horizontal',
+      ]),
+      'target_temp_step': 1.0,
+      'temperature': 151,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.mini_split',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.mr_pure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+      ]),
+      'max_temp': 95,
+      'min_temp': 45,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.mr_pure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.gnqwzcph94wj2sl5nq',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.mr_pure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': None,
+      'friendly_name': 'Mr. Pure',
+      'hvac_modes': list([
+      ]),
+      'max_temp': 95,
+      'min_temp': 45,
+      'supported_features': <ClimateEntityFeature: 0>,
+      'target_temp_step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.mr_pure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.polotentsosushitel-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 104,
+      'min_temp': 41,
+      'preset_modes': list([
+        'holiday',
+      ]),
+      'target_temp_step': 0.5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.polotentsosushitel',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 401>,
+    'translation_key': None,
+    'unique_id': 'tuya.53apxfah2qoxb1cgkw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.polotentsosushitel-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 78,
+      'friendly_name': 'Полотенцосушитель',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 104,
+      'min_temp': 41,
+      'preset_mode': None,
+      'preset_modes': list([
+        'holiday',
+      ]),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'target_temp_step': 0.5,
+      'temperature': 41,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.polotentsosushitel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.salon-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 43,
+      'min_temp': 32,
+      'preset_modes': list([
+        'holiday',
+      ]),
+      'target_temp_step': 0.5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.salon',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 17>,
+    'translation_key': None,
+    'unique_id': 'tuya.gm0whbftkw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.salon-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 69,
+      'friendly_name': 'Salon',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 43,
+      'min_temp': 32,
+      'preset_mode': None,
+      'preset_modes': list([
+        'holiday',
+      ]),
+      'supported_features': <ClimateEntityFeature: 17>,
+      'target_temp_step': 0.5,
+      'temperature': 43,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.salon',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.smart_thermostats-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 194,
+      'min_temp': 41,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.smart_thermostats',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 385>,
+    'translation_key': None,
+    'unique_id': 'tuya.sb3zdertrw50bgogkw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.smart_thermostats-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 71,
+      'friendly_name': 'smart thermostats',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 194,
+      'min_temp': 41,
+      'supported_features': <ClimateEntityFeature: 385>,
+      'target_temp_step': 1.0,
+      'temperature': 54,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.smart_thermostats',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.sove-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'fan_modes': list([
+        '1',
+        '2',
+      ]),
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 187,
+      'min_temp': 61,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.sove',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 393>,
+    'translation_key': None,
+    'unique_id': 'tuya.dt4whlrosmnldadvtk',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.sove-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 75,
+      'fan_mode': None,
+      'fan_modes': list([
+        '1',
+        '2',
+      ]),
+      'friendly_name': 'Sove',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 187,
+      'min_temp': 61,
+      'supported_features': <ClimateEntityFeature: 393>,
+      'target_temp_step': 1.0,
+      'temperature': 61,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.sove',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.term_prizemi-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 158,
+      'min_temp': 33,
+      'target_temp_step': 0.1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.term_prizemi',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 385>,
+    'translation_key': None,
+    'unique_id': 'tuya.jm2fsqtzuhqtbo5ykw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.term_prizemi-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 73,
+      'friendly_name': 'Term - Prizemi',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 158,
+      'min_temp': 33,
+      'supported_features': <ClimateEntityFeature: 385>,
+      'target_temp_step': 0.1,
+      'temperature': 73,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.term_prizemi',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.wifi_smart_gas_boiler_thermostat-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 41,
+      'target_temp_step': 0.5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.wifi_smart_gas_boiler_thermostat',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 385>,
+    'translation_key': None,
+    'unique_id': 'tuya.j6mn1t4ut5end6ifkw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[us_customary][climate.wifi_smart_gas_boiler_thermostat-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 77,
+      'friendly_name': 'WiFi Smart Gas Boiler Thermostat ',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 95,
+      'min_temp': 41,
+      'supported_features': <ClimateEntityFeature: 385>,
+      'target_temp_step': 0.5,
+      'temperature': 72,
     }),
     'context': <ANY>,
     'entity_id': 'climate.wifi_smart_gas_boiler_thermostat',

--- a/tests/components/tuya/snapshots/test_climate.ambr
+++ b/tests/components/tuya/snapshots/test_climate.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_platform_setup_and_discovery[metric][climate.air_conditioner-entry]
+# name: test_platform_setup_and_discovery[climate.air_conditioner-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -46,7 +46,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.air_conditioner-state]
+# name: test_platform_setup_and_discovery[climate.air_conditioner-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 22.0,
@@ -74,7 +74,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.anbau-entry]
+# name: test_platform_setup_and_discovery[climate.anbau-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -122,7 +122,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.anbau-state]
+# name: test_platform_setup_and_discovery[climate.anbau-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Anbau',
@@ -148,7 +148,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.bathroom_radiator-entry]
+# name: test_platform_setup_and_discovery[climate.bathroom_radiator-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -197,7 +197,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.bathroom_radiator-state]
+# name: test_platform_setup_and_discovery[climate.bathroom_radiator-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 19.5,
@@ -227,7 +227,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.boiler_temperature_controller-entry]
+# name: test_platform_setup_and_discovery[climate.boiler_temperature_controller-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -270,7 +270,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.boiler_temperature_controller-state]
+# name: test_platform_setup_and_discovery[climate.boiler_temperature_controller-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 57.5,
@@ -292,7 +292,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.clima_cucina-entry]
+# name: test_platform_setup_and_discovery[climate.clima_cucina-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -342,7 +342,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.clima_cucina-state]
+# name: test_platform_setup_and_discovery[climate.clima_cucina-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 27.0,
@@ -373,7 +373,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.el_termostato_de_la_cocina-entry]
+# name: test_platform_setup_and_discovery[climate.el_termostato_de_la_cocina-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -416,7 +416,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.el_termostato_de_la_cocina-state]
+# name: test_platform_setup_and_discovery[climate.el_termostato_de_la_cocina-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 45.0,
@@ -439,7 +439,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.empore-entry]
+# name: test_platform_setup_and_discovery[climate.empore-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -487,7 +487,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.empore-state]
+# name: test_platform_setup_and_discovery[climate.empore-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 19.0,
@@ -516,7 +516,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.floor_thermostat_kitchen-entry]
+# name: test_platform_setup_and_discovery[climate.floor_thermostat_kitchen-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -564,7 +564,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.floor_thermostat_kitchen-state]
+# name: test_platform_setup_and_discovery[climate.floor_thermostat_kitchen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 20.0,
@@ -593,7 +593,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.geti_solar_pv_water_heater-entry]
+# name: test_platform_setup_and_discovery[climate.geti_solar_pv_water_heater-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -634,7 +634,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.geti_solar_pv_water_heater-state]
+# name: test_platform_setup_and_discovery[climate.geti_solar_pv_water_heater-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 60.0,
@@ -654,7 +654,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.kabinet-entry]
+# name: test_platform_setup_and_discovery[climate.kabinet-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -701,7 +701,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.kabinet-state]
+# name: test_platform_setup_and_discovery[climate.kabinet-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 19.5,
@@ -729,7 +729,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.master_bedroom_ac-entry]
+# name: test_platform_setup_and_discovery[climate.master_bedroom_ac-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -776,7 +776,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.master_bedroom_ac-state]
+# name: test_platform_setup_and_discovery[climate.master_bedroom_ac-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_humidity': 0,
@@ -804,7 +804,7 @@
     'state': 'cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.mini_split-entry]
+# name: test_platform_setup_and_discovery[climate.mini_split-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -855,7 +855,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.mini_split-state]
+# name: test_platform_setup_and_discovery[climate.mini_split-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 69.0,
@@ -887,7 +887,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.mr_pure-entry]
+# name: test_platform_setup_and_discovery[climate.mr_pure-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -928,7 +928,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.mr_pure-state]
+# name: test_platform_setup_and_discovery[climate.mr_pure-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': None,
@@ -948,7 +948,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.polotentsosushitel-entry]
+# name: test_platform_setup_and_discovery[climate.polotentsosushitel-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -994,7 +994,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.polotentsosushitel-state]
+# name: test_platform_setup_and_discovery[climate.polotentsosushitel-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 25.3,
@@ -1021,7 +1021,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.salon-entry]
+# name: test_platform_setup_and_discovery[climate.salon-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1069,7 +1069,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.salon-state]
+# name: test_platform_setup_and_discovery[climate.salon-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 20.3,
@@ -1098,7 +1098,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.smart_thermostats-entry]
+# name: test_platform_setup_and_discovery[climate.smart_thermostats-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1142,7 +1142,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.smart_thermostats-state]
+# name: test_platform_setup_and_discovery[climate.smart_thermostats-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 21.5,
@@ -1166,7 +1166,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.sove-entry]
+# name: test_platform_setup_and_discovery[climate.sove-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1213,7 +1213,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.sove-state]
+# name: test_platform_setup_and_discovery[climate.sove-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 24.0,
@@ -1241,7 +1241,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.term_prizemi-entry]
+# name: test_platform_setup_and_discovery[climate.term_prizemi-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1284,7 +1284,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.term_prizemi-state]
+# name: test_platform_setup_and_discovery[climate.term_prizemi-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 23.0,
@@ -1307,7 +1307,7 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.wifi_smart_gas_boiler_thermostat-entry]
+# name: test_platform_setup_and_discovery[climate.wifi_smart_gas_boiler_thermostat-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1350,7 +1350,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[metric][climate.wifi_smart_gas_boiler_thermostat-state]
+# name: test_platform_setup_and_discovery[climate.wifi_smart_gas_boiler_thermostat-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 24.9,
@@ -1373,1377 +1373,169 @@
     'state': 'heat_cool',
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.air_conditioner-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'fan_modes': list([
-        '1',
-        '2',
-      ]),
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-      ]),
-      'max_temp': 187,
-      'min_temp': 61,
-      'target_temp_step': 1.0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.air_conditioner',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 393>,
-    'translation_key': None,
-    'unique_id': 'tuya.mvsdcwtskkezlnw5tk',
-    'unit_of_measurement': None,
+# name: test_us_customary_system[climate.air_conditioner]
+  ReadOnlyDict({
+    'current_temperature': 72,
+    'max_temp': 187,
+    'min_temp': 61,
+    'target_temp_step': 1.0,
+    'temperature': 73,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.air_conditioner-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 72,
-      'fan_mode': None,
-      'fan_modes': list([
-        '1',
-        '2',
-      ]),
-      'friendly_name': 'Air Conditioner',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-      ]),
-      'max_temp': 187,
-      'min_temp': 61,
-      'supported_features': <ClimateEntityFeature: 393>,
-      'target_temp_step': 1.0,
-      'temperature': 73,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.air_conditioner',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
+# name: test_us_customary_system[climate.anbau]
+  ReadOnlyDict({
+    'max_temp': 95,
+    'min_temp': 41,
+    'target_temp_step': 1.0,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.anbau-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT: 'heat'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 41,
-      'preset_modes': list([
-        'off',
-      ]),
-      'target_temp_step': 1.0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.anbau',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 17>,
-    'translation_key': None,
-    'unique_id': 'tuya.sq6fbd3pfkw',
-    'unit_of_measurement': None,
+# name: test_us_customary_system[climate.bathroom_radiator]
+  ReadOnlyDict({
+    'current_temperature': 67,
+    'max_temp': 158,
+    'min_temp': 34,
+    'target_temp_step': 0.5,
+    'temperature': 54,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.anbau-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Anbau',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT: 'heat'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 41,
-      'preset_modes': list([
-        'off',
-      ]),
-      'supported_features': <ClimateEntityFeature: 17>,
-      'target_temp_step': 1.0,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.anbau',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
+# name: test_us_customary_system[climate.boiler_temperature_controller]
+  ReadOnlyDict({
+    'current_temperature': 136,
+    'max_temp': 95,
+    'min_temp': 45,
+    'target_temp_step': 1.0,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.bathroom_radiator-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 158,
-      'min_temp': 34,
-      'preset_modes': list([
-        'holiday',
-        'eco',
-      ]),
-      'target_temp_step': 0.5,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.bathroom_radiator',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 17>,
-    'translation_key': None,
-    'unique_id': 'tuya.fc2ngmpckw',
-    'unit_of_measurement': None,
+# name: test_us_customary_system[climate.clima_cucina]
+  ReadOnlyDict({
+    'current_temperature': 81,
+    'max_temp': 95,
+    'min_temp': 41,
+    'target_temp_step': 1.0,
+    'temperature': 77,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.bathroom_radiator-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 67,
-      'friendly_name': 'Bathroom radiator',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 158,
-      'min_temp': 34,
-      'preset_mode': None,
-      'preset_modes': list([
-        'holiday',
-        'eco',
-      ]),
-      'supported_features': <ClimateEntityFeature: 17>,
-      'target_temp_step': 0.5,
-      'temperature': 54,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.bathroom_radiator',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'heat_cool',
+# name: test_us_customary_system[climate.el_termostato_de_la_cocina]
+  ReadOnlyDict({
+    'current_temperature': 113,
+    'max_temp': 45,
+    'min_temp': 34,
+    'target_temp_step': 0.5,
+    'temperature': 40,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.boiler_temperature_controller-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 45,
-      'target_temp_step': 1.0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.boiler_temperature_controller',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 384>,
-    'translation_key': None,
-    'unique_id': 'tuya.zgiyrxflahjowpcckw',
-    'unit_of_measurement': None,
+# name: test_us_customary_system[climate.empore]
+  ReadOnlyDict({
+    'current_temperature': 66,
+    'max_temp': 95,
+    'min_temp': 41,
+    'target_temp_step': 1.0,
+    'temperature': 95,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.boiler_temperature_controller-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 136,
-      'friendly_name': 'Boiler Temperature Controller',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 45,
-      'supported_features': <ClimateEntityFeature: 384>,
-      'target_temp_step': 1.0,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.boiler_temperature_controller',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'heat_cool',
+# name: test_us_customary_system[climate.floor_thermostat_kitchen]
+  ReadOnlyDict({
+    'current_temperature': 68,
+    'max_temp': 95,
+    'min_temp': 41,
+    'target_temp_step': 1.0,
+    'temperature': 36,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.clima_cucina-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'fan_modes': list([
-        'low',
-        'middle',
-        'high',
-        'auto',
-      ]),
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-        <HVACMode.HEAT: 'heat'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 41,
-      'target_temp_step': 1.0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.clima_cucina',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 393>,
-    'translation_key': None,
-    'unique_id': 'tuya.x7quooqakw',
-    'unit_of_measurement': None,
+# name: test_us_customary_system[climate.geti_solar_pv_water_heater]
+  ReadOnlyDict({
+    'current_temperature': 140,
+    'max_temp': 95,
+    'min_temp': 45,
+    'target_temp_step': 1.0,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.clima_cucina-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 81,
-      'fan_mode': 'auto',
-      'fan_modes': list([
-        'low',
-        'middle',
-        'high',
-        'auto',
-      ]),
-      'friendly_name': 'Clima cucina',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-        <HVACMode.HEAT: 'heat'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 41,
-      'supported_features': <ClimateEntityFeature: 393>,
-      'target_temp_step': 1.0,
-      'temperature': 77,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.clima_cucina',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
+# name: test_us_customary_system[climate.kabinet]
+  ReadOnlyDict({
+    'current_temperature': 67,
+    'max_temp': 203,
+    'min_temp': 41,
+    'target_temp_step': 0.5,
+    'temperature': 71,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.el_termostato_de_la_cocina-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 45,
-      'min_temp': 34,
-      'target_temp_step': 0.5,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.el_termostato_de_la_cocina',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 385>,
-    'translation_key': None,
-    'unique_id': 'tuya.LmLMc0ht1KW2zYAIkw',
-    'unit_of_measurement': None,
+# name: test_us_customary_system[climate.master_bedroom_ac]
+  ReadOnlyDict({
+    'current_temperature': 79,
+    'max_temp': 190,
+    'min_temp': 61,
+    'target_temp_step': 0.5,
+    'temperature': 167,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.el_termostato_de_la_cocina-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 113,
-      'friendly_name': 'El termostato de la cocina',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 45,
-      'min_temp': 34,
-      'supported_features': <ClimateEntityFeature: 385>,
-      'target_temp_step': 0.5,
-      'temperature': 40,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.el_termostato_de_la_cocina',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'heat_cool',
+# name: test_us_customary_system[climate.mini_split]
+  ReadOnlyDict({
+    'current_temperature': 156,
+    'max_temp': 194,
+    'min_temp': 61,
+    'target_temp_step': 1.0,
+    'temperature': 151,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.empore-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT: 'heat'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 41,
-      'preset_modes': list([
-        'off',
-      ]),
-      'target_temp_step': 1.0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.empore',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 17>,
-    'translation_key': None,
-    'unique_id': 'tuya.paxijfx9fkw',
-    'unit_of_measurement': None,
+# name: test_us_customary_system[climate.mr_pure]
+  ReadOnlyDict({
+    'current_temperature': None,
+    'max_temp': 95,
+    'min_temp': 45,
+    'target_temp_step': 1.0,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.empore-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 66,
-      'friendly_name': 'Empore',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT: 'heat'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 41,
-      'preset_mode': None,
-      'preset_modes': list([
-        'off',
-      ]),
-      'supported_features': <ClimateEntityFeature: 17>,
-      'target_temp_step': 1.0,
-      'temperature': 95,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.empore',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'heat_cool',
+# name: test_us_customary_system[climate.polotentsosushitel]
+  ReadOnlyDict({
+    'current_temperature': 78,
+    'max_temp': 104,
+    'min_temp': 41,
+    'target_temp_step': 0.5,
+    'temperature': 41,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.floor_thermostat_kitchen-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 41,
-      'preset_modes': list([
-        'off',
-      ]),
-      'target_temp_step': 1.0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.floor_thermostat_kitchen',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 401>,
-    'translation_key': None,
-    'unique_id': 'tuya.oq9ksabjz6tip49tkw',
-    'unit_of_measurement': None,
+# name: test_us_customary_system[climate.salon]
+  ReadOnlyDict({
+    'current_temperature': 69,
+    'max_temp': 43,
+    'min_temp': 32,
+    'target_temp_step': 0.5,
+    'temperature': 43,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.floor_thermostat_kitchen-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 68,
-      'friendly_name': 'Floor Thermostat Kitchen',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 41,
-      'preset_mode': None,
-      'preset_modes': list([
-        'off',
-      ]),
-      'supported_features': <ClimateEntityFeature: 401>,
-      'target_temp_step': 1.0,
-      'temperature': 36,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.floor_thermostat_kitchen',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'heat_cool',
+# name: test_us_customary_system[climate.smart_thermostats]
+  ReadOnlyDict({
+    'current_temperature': 71,
+    'max_temp': 194,
+    'min_temp': 41,
+    'target_temp_step': 1.0,
+    'temperature': 54,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.geti_solar_pv_water_heater-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-      ]),
-      'max_temp': 95,
-      'min_temp': 45,
-      'target_temp_step': 1.0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.geti_solar_pv_water_heater',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.fcacn8iqbocuow7dsr',
-    'unit_of_measurement': None,
+# name: test_us_customary_system[climate.sove]
+  ReadOnlyDict({
+    'current_temperature': 75,
+    'max_temp': 187,
+    'min_temp': 61,
+    'target_temp_step': 1.0,
+    'temperature': 61,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.geti_solar_pv_water_heater-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 140,
-      'friendly_name': 'Geti Solar PV Water Heater',
-      'hvac_modes': list([
-      ]),
-      'max_temp': 95,
-      'min_temp': 45,
-      'supported_features': <ClimateEntityFeature: 0>,
-      'target_temp_step': 1.0,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.geti_solar_pv_water_heater',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
+# name: test_us_customary_system[climate.term_prizemi]
+  ReadOnlyDict({
+    'current_temperature': 73,
+    'max_temp': 158,
+    'min_temp': 33,
+    'target_temp_step': 0.1,
+    'temperature': 73,
   })
 # ---
-# name: test_platform_setup_and_discovery[us_customary][climate.kabinet-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 203,
-      'min_temp': 41,
-      'preset_modes': list([
-        'program',
-      ]),
-      'target_temp_step': 0.5,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.kabinet',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 401>,
-    'translation_key': None,
-    'unique_id': 'tuya.dn7cjik6kw',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.kabinet-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 67,
-      'friendly_name': 'Кабінет',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 203,
-      'min_temp': 41,
-      'preset_mode': None,
-      'preset_modes': list([
-        'program',
-      ]),
-      'supported_features': <ClimateEntityFeature: 401>,
-      'target_temp_step': 0.5,
-      'temperature': 71,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.kabinet',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'heat_cool',
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.master_bedroom_ac-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-        <HVACMode.HEAT: 'heat'>,
-        <HVACMode.DRY: 'dry'>,
-        <HVACMode.FAN_ONLY: 'fan_only'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 190,
-      'min_temp': 61,
-      'target_temp_step': 0.5,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.master_bedroom_ac',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 385>,
-    'translation_key': None,
-    'unique_id': 'tuya.g1fmm26qhhrimmbitk',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.master_bedroom_ac-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_humidity': 0,
-      'current_temperature': 79,
-      'friendly_name': 'Master Bedroom AC',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-        <HVACMode.HEAT: 'heat'>,
-        <HVACMode.DRY: 'dry'>,
-        <HVACMode.FAN_ONLY: 'fan_only'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 190,
-      'min_temp': 61,
-      'supported_features': <ClimateEntityFeature: 385>,
-      'target_temp_step': 0.5,
-      'temperature': 167,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.master_bedroom_ac',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'cool',
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.mini_split-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-        <HVACMode.HEAT: 'heat'>,
-        <HVACMode.DRY: 'dry'>,
-        <HVACMode.FAN_ONLY: 'fan_only'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 194,
-      'min_temp': 61,
-      'swing_modes': list([
-        'off',
-        'horizontal',
-      ]),
-      'target_temp_step': 1.0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.mini_split',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 417>,
-    'translation_key': None,
-    'unique_id': 'tuya.zzz87dkfce6pdqxwtk',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.mini_split-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 156,
-      'friendly_name': 'Mini-Split',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-        <HVACMode.HEAT: 'heat'>,
-        <HVACMode.DRY: 'dry'>,
-        <HVACMode.FAN_ONLY: 'fan_only'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 194,
-      'min_temp': 61,
-      'supported_features': <ClimateEntityFeature: 417>,
-      'swing_mode': 'off',
-      'swing_modes': list([
-        'off',
-        'horizontal',
-      ]),
-      'target_temp_step': 1.0,
-      'temperature': 151,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.mini_split',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.mr_pure-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-      ]),
-      'max_temp': 95,
-      'min_temp': 45,
-      'target_temp_step': 1.0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.mr_pure',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.gnqwzcph94wj2sl5nq',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.mr_pure-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': None,
-      'friendly_name': 'Mr. Pure',
-      'hvac_modes': list([
-      ]),
-      'max_temp': 95,
-      'min_temp': 45,
-      'supported_features': <ClimateEntityFeature: 0>,
-      'target_temp_step': 1.0,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.mr_pure',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.polotentsosushitel-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 104,
-      'min_temp': 41,
-      'preset_modes': list([
-        'holiday',
-      ]),
-      'target_temp_step': 0.5,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.polotentsosushitel',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 401>,
-    'translation_key': None,
-    'unique_id': 'tuya.53apxfah2qoxb1cgkw',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.polotentsosushitel-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 78,
-      'friendly_name': 'Полотенцосушитель',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 104,
-      'min_temp': 41,
-      'preset_mode': None,
-      'preset_modes': list([
-        'holiday',
-      ]),
-      'supported_features': <ClimateEntityFeature: 401>,
-      'target_temp_step': 0.5,
-      'temperature': 41,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.polotentsosushitel',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.salon-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 43,
-      'min_temp': 32,
-      'preset_modes': list([
-        'holiday',
-      ]),
-      'target_temp_step': 0.5,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.salon',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 17>,
-    'translation_key': None,
-    'unique_id': 'tuya.gm0whbftkw',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.salon-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 69,
-      'friendly_name': 'Salon',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 43,
-      'min_temp': 32,
-      'preset_mode': None,
-      'preset_modes': list([
-        'holiday',
-      ]),
-      'supported_features': <ClimateEntityFeature: 17>,
-      'target_temp_step': 0.5,
-      'temperature': 43,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.salon',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'heat_cool',
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.smart_thermostats-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 194,
-      'min_temp': 41,
-      'target_temp_step': 1.0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.smart_thermostats',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 385>,
-    'translation_key': None,
-    'unique_id': 'tuya.sb3zdertrw50bgogkw',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.smart_thermostats-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 71,
-      'friendly_name': 'smart thermostats',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 194,
-      'min_temp': 41,
-      'supported_features': <ClimateEntityFeature: 385>,
-      'target_temp_step': 1.0,
-      'temperature': 54,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.smart_thermostats',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.sove-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'fan_modes': list([
-        '1',
-        '2',
-      ]),
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-      ]),
-      'max_temp': 187,
-      'min_temp': 61,
-      'target_temp_step': 1.0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.sove',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 393>,
-    'translation_key': None,
-    'unique_id': 'tuya.dt4whlrosmnldadvtk',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.sove-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 75,
-      'fan_mode': None,
-      'fan_modes': list([
-        '1',
-        '2',
-      ]),
-      'friendly_name': 'Sove',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-      ]),
-      'max_temp': 187,
-      'min_temp': 61,
-      'supported_features': <ClimateEntityFeature: 393>,
-      'target_temp_step': 1.0,
-      'temperature': 61,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.sove',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.term_prizemi-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 158,
-      'min_temp': 33,
-      'target_temp_step': 0.1,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.term_prizemi',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 385>,
-    'translation_key': None,
-    'unique_id': 'tuya.jm2fsqtzuhqtbo5ykw',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.term_prizemi-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 73,
-      'friendly_name': 'Term - Prizemi',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 158,
-      'min_temp': 33,
-      'supported_features': <ClimateEntityFeature: 385>,
-      'target_temp_step': 0.1,
-      'temperature': 73,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.term_prizemi',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'heat_cool',
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.wifi_smart_gas_boiler_thermostat-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 41,
-      'target_temp_step': 0.5,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'climate',
-    'entity_category': None,
-    'entity_id': 'climate.wifi_smart_gas_boiler_thermostat',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 385>,
-    'translation_key': None,
-    'unique_id': 'tuya.j6mn1t4ut5end6ifkw',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[us_customary][climate.wifi_smart_gas_boiler_thermostat-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'current_temperature': 77,
-      'friendly_name': 'WiFi Smart Gas Boiler Thermostat ',
-      'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.HEAT_COOL: 'heat_cool'>,
-      ]),
-      'max_temp': 95,
-      'min_temp': 41,
-      'supported_features': <ClimateEntityFeature: 385>,
-      'target_temp_step': 0.5,
-      'temperature': 72,
-    }),
-    'context': <ANY>,
-    'entity_id': 'climate.wifi_smart_gas_boiler_thermostat',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'heat_cool',
+# name: test_us_customary_system[climate.wifi_smart_gas_boiler_thermostat]
+  ReadOnlyDict({
+    'current_temperature': 77,
+    'max_temp': 95,
+    'min_temp': 41,
+    'target_temp_step': 0.5,
+    'temperature': 72,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -8462,3 +8462,34 @@
     'via_device_id': None,
   })
 # ---
+# name: test_device_registry[zzz87dkfce6pdqxwtk]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tuya',
+        'zzz87dkfce6pdqxwtk',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Tuya',
+    'model': 'Air Conditioner',
+    'model_id': 'wxqdp6ecfkd78zzz',
+    'name': 'Mini-Split',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/tuya/snapshots/test_light.ambr
+++ b/tests/components/tuya/snapshots/test_light.ambr
@@ -2399,6 +2399,63 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[light.mini_split_backlight-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'light.mini_split_backlight',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Backlight',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'backlight',
+    'unique_id': 'tuya.zzz87dkfce6pdqxwtklight',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[light.mini_split_backlight-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'color_mode': None,
+      'friendly_name': 'Mini-Split Backlight',
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.mini_split_backlight',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[light.parker_ceiling_fan_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -6627,6 +6627,54 @@
     'state': 'off',
   })
 # ---
+# name: test_platform_setup_and_discovery[switch.mini_split_child_lock-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mini_split_child_lock',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Child lock',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'child_lock',
+    'unique_id': 'tuya.zzz87dkfce6pdqxwtklock',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.mini_split_child_lock-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mini-Split Child lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mini_split_child_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[switch.mirilla_puerta_flip-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -29,6 +29,11 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceNotSupported
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util.unit_system import (
+    METRIC_SYSTEM,
+    US_CUSTOMARY_SYSTEM,
+    UnitSystem,
+)
 
 from . import initialize_entry
 
@@ -36,15 +41,22 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.CLIMATE])
+@pytest.mark.parametrize(
+    "unit_system",
+    [METRIC_SYSTEM, US_CUSTOMARY_SYSTEM],
+    ids=["metric", "us_customary"],
+)
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,
+    unit_system: UnitSystem,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test platform setup and discovery."""
+    hass.config.units = unit_system
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_devices)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -11,10 +11,14 @@ from syrupy.filters import props
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.climate import (
+    ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
     ATTR_HUMIDITY,
     ATTR_HVAC_MODE,
+    ATTR_MAX_TEMP,
+    ATTR_MIN_TEMP,
     ATTR_PRESET_MODE,
+    ATTR_TARGET_TEMP_STEP,
     ATTR_TEMPERATURE,
     DOMAIN as CLIMATE_DOMAIN,
     SERVICE_SET_FAN_MODE,
@@ -71,11 +75,11 @@ async def test_us_customary_system(
         assert state.attributes == snapshot(
             name=entity.entity_id,
             include=props(
-                "current_temperature",
-                "max_temp",
-                "min_temp",
-                "target_temp_step",
-                "temperature",
+                ATTR_CURRENT_TEMPERATURE,
+                ATTR_MAX_TEMP,
+                ATTR_MIN_TEMP,
+                ATTR_TARGET_TEMP_STEP,
+                ATTR_TEMPERATURE,
             ),
         )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Preliminary work for #156999

The unit_system is sometimes used in Tuya to get the preferred unit, and we have no coverage for this.

https://github.com/home-assistant/core/blob/b76e9ad1c04e181c5caa40d805ff69c4fa7d87e3/homeassistant/components/tuya/climate.py#L184-L186

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
