### PR TITLE
Add lock reduced guard button to Volvo integration

### DIFF
--- a/homeassistant/components/volvo/button.py
+++ b/homeassistant/components/volvo/button.py
@@ -64,6 +64,11 @@ _DESCRIPTIONS: tuple[VolvoButtonDescription, ...] = (
         api_command="honk-flash",
         required_command_key="HONK_AND_FLASH",
     ),
+    VolvoButtonDescription(
+        key="lock_reduced_guard",
+        api_command="lock-reduced-guard",
+        required_command_key="LOCK_REDUCED_GUARD",
+    ),
 )
 
 

--- a/homeassistant/components/volvo/icons.json
+++ b/homeassistant/components/volvo/icons.json
@@ -281,6 +281,9 @@
       },
       "honk_flash": {
         "default": "mdi:alarm-light"
+      },
+      "lock_reduced_guard": {
+        "default": "mdi:lock-minus"
       }
     },
     "device_tracker": {

--- a/homeassistant/components/volvo/strings.json
+++ b/homeassistant/components/volvo/strings.json
@@ -208,6 +208,9 @@
       },
       "honk_flash": {
         "name": "Honk & flash"
+      },
+      "lock_reduced_guard": {
+        "name": "Lock reduced guard"
       }
     },
     "device_tracker": {

--- a/tests/components/volvo/snapshots/test_button.ambr
+++ b/tests/components/volvo/snapshots/test_button.ambr
@@ -143,6 +143,54 @@
     'state': 'unknown',
   })
 # ---
+# name: test_button[ex30_2024][button.volvo_ex30_lock_reduced_guard-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.volvo_ex30_lock_reduced_guard',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Lock reduced guard',
+    'platform': 'volvo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lock_reduced_guard',
+    'unique_id': 'yv1abcdefg1234567_lock_reduced_guard',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[ex30_2024][button.volvo_ex30_lock_reduced_guard-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Volvo EX30 Lock reduced guard',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.volvo_ex30_lock_reduced_guard',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_button[ex30_2024][button.volvo_ex30_start_climatization-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -377,6 +425,54 @@
     }),
     'context': <ANY>,
     'entity_id': 'button.volvo_s90_honk_flash',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[s90_diesel_2018][button.volvo_s90_lock_reduced_guard-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.volvo_s90_lock_reduced_guard',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Lock reduced guard',
+    'platform': 'volvo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lock_reduced_guard',
+    'unique_id': 'yv1abcdefg1234567_lock_reduced_guard',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[s90_diesel_2018][button.volvo_s90_lock_reduced_guard-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Volvo S90 Lock reduced guard',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.volvo_s90_lock_reduced_guard',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -623,6 +719,54 @@
     'state': 'unknown',
   })
 # ---
+# name: test_button[xc40_electric_2024][button.volvo_xc40_lock_reduced_guard-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.volvo_xc40_lock_reduced_guard',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Lock reduced guard',
+    'platform': 'volvo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lock_reduced_guard',
+    'unique_id': 'yv1abcdefg1234567_lock_reduced_guard',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[xc40_electric_2024][button.volvo_xc40_lock_reduced_guard-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Volvo XC40 Lock reduced guard',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.volvo_xc40_lock_reduced_guard',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_button[xc40_electric_2024][button.volvo_xc40_start_climatization-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -857,6 +1001,54 @@
     }),
     'context': <ANY>,
     'entity_id': 'button.volvo_xc90_honk_flash',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[xc90_petrol_2019][button.volvo_xc90_lock_reduced_guard-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.volvo_xc90_lock_reduced_guard',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Lock reduced guard',
+    'platform': 'volvo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lock_reduced_guard',
+    'unique_id': 'yv1abcdefg1234567_lock_reduced_guard',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[xc90_petrol_2019][button.volvo_xc90_lock_reduced_guard-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Volvo XC90 Lock reduced guard',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.volvo_xc90_lock_reduced_guard',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/volvo/test_button.py
+++ b/tests/components/volvo/test_button.py
@@ -43,7 +43,14 @@ async def test_button(
 @pytest.mark.usefixtures("full_model")
 @pytest.mark.parametrize(
     "command",
-    ["start_climatization", "stop_climatization", "flash", "honk", "honk_flash"],
+    [
+        "start_climatization",
+        "stop_climatization",
+        "flash",
+        "honk",
+        "honk_flash",
+        "lock_reduced_guard",
+    ],
 )
 async def test_button_press(
     hass: HomeAssistant,
@@ -72,7 +79,14 @@ async def test_button_press(
 @pytest.mark.usefixtures("full_model")
 @pytest.mark.parametrize(
     "command",
-    ["start_climatization", "stop_climatization", "flash", "honk", "honk_flash"],
+    [
+        "start_climatization",
+        "stop_climatization",
+        "flash",
+        "honk",
+        "honk_flash",
+        "lock_reduced_guard",
+    ],
 )
 async def test_button_press_error(
     hass: HomeAssistant,
@@ -99,7 +113,14 @@ async def test_button_press_error(
 @pytest.mark.usefixtures("full_model")
 @pytest.mark.parametrize(
     "command",
-    ["start_climatization", "stop_climatization", "flash", "honk", "honk_flash"],
+    [
+        "start_climatization",
+        "stop_climatization",
+        "flash",
+        "honk",
+        "honk_flash",
+        "lock_reduced_guard",
+    ],
 )
 async def test_button_press_failure(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a button to let users lock the vehicle with reduced guard. A regular lock entity is already available. This button just gives the user an additional option. It was kind of [discussed here](https://github.com/home-assistant/core/pull/154168#issuecomment-3467113553).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41915
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
