### PR TITLE
Abort Z-Wave JS discovery from ESPHome if add-on umanaged

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -28,6 +28,7 @@ from homeassistant.components.hassio import (
 from homeassistant.config_entries import (
     SOURCE_ESPHOME,
     SOURCE_USB,
+    ConfigEntry,
     ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
@@ -1516,6 +1517,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="not_hassio")
 
         if discovery_info.zwave_home_id:
+            existing_entry: ConfigEntry | None = None
             if (
                 (
                     current_config_entries := self._async_current_entries(
@@ -1535,23 +1537,25 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
                 # Only update existing entries that are configured via sockets
                 and existing_entry.data.get(CONF_SOCKET_PATH)
-                # And use the add-on
-                and existing_entry.data.get(CONF_USE_ADDON)
             ):
-                manager = get_addon_manager(self.hass)
-                await self._async_set_addon_config(
-                    {CONF_ADDON_SOCKET: discovery_info.socket_path}
-                )
-                if self.restart_addon:
-                    await manager.async_stop_addon()
-                self.hass.config_entries.async_update_entry(
-                    existing_entry,
-                    data={
-                        **existing_entry.data,
-                        CONF_SOCKET_PATH: discovery_info.socket_path,
-                    },
-                )
-                self.hass.config_entries.async_schedule_reload(existing_entry.entry_id)
+                # Only update config if we're using the add-on
+                if existing_entry.data.get(CONF_USE_ADDON):
+                    manager = get_addon_manager(self.hass)
+                    await self._async_set_addon_config(
+                        {CONF_ADDON_SOCKET: discovery_info.socket_path}
+                    )
+                    if self.restart_addon:
+                        await manager.async_stop_addon()
+                    self.hass.config_entries.async_update_entry(
+                        existing_entry,
+                        data={
+                            **existing_entry.data,
+                            CONF_SOCKET_PATH: discovery_info.socket_path,
+                        },
+                    )
+                    self.hass.config_entries.async_schedule_reload(
+                        existing_entry.entry_id
+                    )
                 return self.async_abort(reason="already_configured")
 
             # We are not aborting if home ID configured here, we just want to make sure that it's set

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1421,6 +1421,47 @@ async def test_esphome_discovery_already_configured(
     assert stop_addon.call_args == call("core_zwave_js")
 
 
+@pytest.mark.usefixtures("supervisor", "addon_running", "addon_info")
+async def test_esphome_discovery_already_configured_unmanaged_addon(
+    hass: HomeAssistant,
+    set_addon_options: AsyncMock,
+    addon_options: dict[str, Any],
+    stop_addon: AsyncMock,
+) -> None:
+    """Test ESPHome discovery success path."""
+    addon_options[CONF_ADDON_SOCKET] = "esphome://existing-device:6053"
+    addon_options["another_key"] = "should_not_be_touched"
+
+    entry = MockConfigEntry(
+        entry_id="mock-entry-id",
+        domain=DOMAIN,
+        data={
+            CONF_SOCKET_PATH: "esphome://existing-device:6053",
+            "use_addon": False,
+            "integration_created_addon": False,
+        },
+        title=TITLE,
+        unique_id="1234",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ESPHOME},
+        data=ESPHOME_DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+    # Data did not get updated. Since we don't use the addon, we don't update the data
+    assert entry.data == {
+        CONF_SOCKET_PATH: "esphome://existing-device:6053",
+        "use_addon": False,
+        "integration_created_addon": False,
+    }
+
+
 @pytest.mark.usefixtures("supervisor", "addon_not_installed", "addon_info")
 async def test_esphome_discovery_usb_same_home_id(
     hass: HomeAssistant,

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1428,7 +1428,7 @@ async def test_esphome_discovery_already_configured_unmanaged_addon(
     addon_options: dict[str, Any],
     stop_addon: AsyncMock,
 ) -> None:
-    """Test ESPHome discovery success path."""
+    """Test ESPHome discovery aborts when home ID already configured with unmanaged add-on."""
     addon_options[CONF_ADDON_SOCKET] = "esphome://existing-device:6053"
     addon_options["another_key"] = "should_not_be_touched"
 

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1373,7 +1373,7 @@ async def test_esphome_discovery_already_configured(
     addon_options: dict[str, Any],
     stop_addon: AsyncMock,
 ) -> None:
-    """Test ESPHome discovery success path."""
+    """Test ESPHome discovery when already configured."""
     addon_options[CONF_ADDON_SOCKET] = "esphome://existing-device:6053"
     addon_options["another_key"] = "should_not_be_touched"
 
@@ -1436,7 +1436,6 @@ async def test_esphome_discovery_already_configured_unmanaged_addon(
         entry_id="mock-entry-id",
         domain=DOMAIN,
         data={
-            CONF_SOCKET_PATH: "esphome://existing-device:6053",
             "use_addon": False,
             "integration_created_addon": False,
         },
@@ -1456,7 +1455,6 @@ async def test_esphome_discovery_already_configured_unmanaged_addon(
 
     # Data did not get updated. Since we don't use the addon, we don't update the data
     assert entry.data == {
-        CONF_SOCKET_PATH: "esphome://existing-device:6053",
         "use_addon": False,
         "integration_created_addon": False,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Z-Wave JS discovery from ESPHome are now automatically aborted if a config entry for the home ID already exists, and it's connected to Z-Wave JS instance not managed by Home Assistant.

Fixes #154655

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
