### PR TITLE
Adding AlarmControlPanelEntityFeature to concord232

### DIFF
--- a/homeassistant/components/concord232/binary_sensor.py
+++ b/homeassistant/components/concord232/binary_sensor.py
@@ -104,6 +104,12 @@ def get_opening_type(zone):
         return BinarySensorDeviceClass.SMOKE
     if "WATER" in zone["name"]:
         return "water"
+    if "DOOR" in zone["name"]:
+        return BinarySensorDeviceClass.DOOR
+    if "WINDOW" in zone["name"]:
+        return BinarySensorDeviceClass.WINDOW
+    if "SOUND" in zone["name"]:
+        return BinarySensorDeviceClass.SOUND
     return BinarySensorDeviceClass.OPENING
 
 
@@ -117,6 +123,11 @@ class Concord232ZoneSensor(BinarySensorEntity):
         self._zone = zone
         self._number = zone["number"]
         self._zone_type = zone_type
+
+    @property
+    def unique_id(self):
+        """Return a unique id for this sensor."""
+        return f"{self._number}"
 
     @property
     def device_class(self):

--- a/tests/components/concord232/test_binary_sensor.py
+++ b/tests/components/concord232/test_binary_sensor.py
@@ -219,7 +219,7 @@ async def test_device_class(
 )
 async def test_unique_id(
     hass: HomeAssistant,
-    mock_concord232_client: MagicMock,  # noqa: ARG001
+    mock_concord232_client: MagicMock,
     entity_registry: er.EntityRegistry,
     entity_id: str,
     expected_unique_id: str,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enhances the Concord232 integration with alarm trigger detection, device class improvements, and entity registry support.

Changes: 
* Alarm trigger detection: Detects triggered alarms when zones report "Unknown" state and adds a triggered_by attribute indicating which zone triggered the alarm
* Binary sensor improvements: Adds unique_id property for entity registry tracking and expands device class detection to include DOOR, WINDOW, and SOUND sensor types
* Test coverage: Adds tests for alarm trigger detection, device class detection, and unique_id property (all 15 tests passing)

With these changes, users can be notified if their alarm is tripped. An example automation trigger that I use with the above changes is as follows

```
alias: "Security: On alarm, send notification"
description: ""
mode: single
triggers:
  - entity_id:
      - alarm_control_panel.concord232
    to: triggered
    trigger: state
conditions: []
actions:
  - data:
      title: Home Alarm Alert
      message: >-
        {% if trigger is defined and trigger.to_state is defined |
        default(false) -%} Triggered by {{
        trigger.to_state.attributes.triggered_by }} {%- else -%} This is a test
        alert message.{%- endif %}
      data:
        color: "#FFBF00"
        channel: Alarm
        importance: high
        push:
          interruption-level: critical
          sound:
            name: default
            critical: 1
            volume: 0
    action: notify.mobile_app_neals_iphone
```

Then, if my house is armed and I open the front door, I receive this push notification:  
<img width="1254" height="223" alt="image" src="https://github.com/user-attachments/assets/73e2b8d6-ddb7-47f9-8739-ada048d41916" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
