### PR TITLE
Fix parsing of Tuya electricity RAW values

### DIFF
--- a/homeassistant/components/tuya/raw_data_models.py
+++ b/homeassistant/components/tuya/raw_data_models.py
@@ -1,0 +1,60 @@
+"""Parsers for RAW (base64-encoded bytes) values."""
+
+from dataclasses import dataclass
+import struct
+from typing import Self
+
+
+@dataclass(kw_only=True)
+class ElectricityData:
+    """Electricity RAW value."""
+
+    current: float
+    power: float
+    voltage: float
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self | None:
+        """Parse bytes and return an ElectricityValue object."""
+        # Format:
+        # - legacy: 8 bytes
+        # - v01: [ver=0x01][len=0x0F][data(15 bytes)]
+        # - v02: [ver=0x02][len=0x0F][data(15 bytes)][sign_bitmap(1 byte)]
+        # Data layout (big-endian):
+        # - voltage: 2B, unit 0.1 V
+        # - current: 3B, unit 0.001 A (i.e., mA)
+        # - active power: 3B, unit 0.001 kW (i.e., W)
+        # - reactive power: 3B, unit 0.001 kVar
+        # - apparent power: 3B, unit 0.001 kVA
+        # - power factor: 1B, unit 0.01
+        # Sign bitmap (v02 only, 1 bit means negative):
+        # - bit0 current
+        # - bit1 active power
+        # - bit2 reactive
+        # - bit3 power factor
+
+        is_v1 = len(raw) == 17 and raw[0:2] == b"\x01\x0f"
+        is_v2 = len(raw) == 18 and raw[0:2] == b"\x02\x0f"
+        if is_v1 or is_v2:
+            data = raw[2:17]
+
+            voltage = struct.unpack(">H", data[0:2])[0] / 10.0
+            current = struct.unpack(">L", b"\x00" + data[2:5])[0]
+            power = struct.unpack(">L", b"\x00" + data[5:8])[0]
+
+            if is_v2:
+                sign_bitmap = raw[17]
+                if sign_bitmap & 0x01:
+                    current = -current
+                if sign_bitmap & 0x02:
+                    power = -power
+
+            return cls(current=current, power=power, voltage=voltage)
+
+        if len(raw) >= 8:
+            voltage = struct.unpack(">H", raw[0:2])[0] / 10.0
+            current = struct.unpack(">L", b"\x00" + raw[2:5])[0]
+            power = struct.unpack(">L", b"\x00" + raw[5:8])[0]
+            return cls(current=current, power=power, voltage=voltage)
+
+        return None

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import struct
 
 from tuya_sharing import CustomerDevice, Manager
 
@@ -49,6 +48,7 @@ from .models import (
     DPCodeWrapper,
     EnumTypeData,
 )
+from .raw_data_models import ElectricityData
 
 
 class _WindDirectionWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
@@ -120,153 +120,52 @@ class _JsonElectricityVoltageWrapper(DPCodeJsonWrapper):
         return raw_value.get("voltage")
 
 
-def _u24_be(value: bytes) -> int:
-    """Parse 3-byte big-endian unsigned integer.
+class _RawElectricityDataWrapper(DPCodeBase64Wrapper):
+    """Custom DPCode Wrapper for extracting ElectricityData from base64."""
 
-    Returns the integer value. Caller ensures the length is 3.
-    """
-    # struct doesn't support 3-byte directly; prepend 0x00 and unpack as uint32
-    return struct.unpack(">L", b"\x00" + value)[0]
+    def _convert(self, value: ElectricityData) -> float:
+        """Extract specific value from T."""
+        raise NotImplementedError
 
-
-def _parse_phase_payload_v00(raw_value: bytes) -> tuple[float, float, float] | None:
-    """Parse legacy v00 8-byte payload: V(2B,0.1V) + I(3B,0.001A) + P(3B,0.001kW).
-
-    Returns (voltage_V, current_mA, power_W).
-    """
-    if len(raw_value) < 8:
-        return None
-    voltage_v = struct.unpack(">H", raw_value[0:2])[0] / 10.0
-    current_ma = float(_u24_be(raw_value[2:5]))  # 0.001A == 1 mA
-    power_w = float(_u24_be(raw_value[5:8]))  # 0.001 kW == 1 W
-    return voltage_v, current_ma, power_w
+    def read_device_status(self, device: CustomerDevice) -> float | None:
+        """Read the device value for the dpcode."""
+        if (raw_value := super().read_bytes(device)) is None or (
+            value := ElectricityData.from_bytes(raw_value)
+        ) is None:
+            return None
+        return self._convert(value)
 
 
-def _parse_phase_payload_v01_v02(raw_value: bytes) -> tuple[float, float, float] | None:
-    """Parse v01/v02 framed payloads.
-
-    Format:
-    - v01: [ver=0x01][len=0x0F][data(15 bytes)]
-    - v02: [ver=0x02][len=0x0F][data(15 bytes)][sign_bitmap(1 byte)]
-
-    Data layout (big-endian):
-    - voltage: 2B, unit 0.1 V
-    - current: 3B, unit 0.001 A (i.e., mA)
-    - active power: 3B, unit 0.001 kW (i.e., W)
-    - reactive power: 3B, unit 0.001 kVar (ignored here)
-    - apparent power: 3B, unit 0.001 kVA (ignored here)
-    - power factor: 1B, unit 0.01 (ignored here)
-
-    Sign bitmap (v02 only, 1 bit means negative):
-    bit0 current, bit1 active power, bit2 reactive, bit3 power factor.
-
-    Returns (voltage_V, current_mA, power_W) if parsed; otherwise None.
-    """
-    if len(raw_value) < 2:
-        return None
-    ver = raw_value[0]
-    if ver not in (0x01, 0x02):
-        return None
-    data_len = raw_value[1]
-    # Expect 15-byte data area for v01/v02
-    if data_len != 0x0F:
-        return None
-    expect_len = 2 + data_len + (1 if ver == 0x02 else 0)
-    if len(raw_value) < expect_len:
-        return None
-    data = raw_value[2 : 2 + data_len]
-    sign_bitmap = 0
-    if ver == 0x02:
-        sign_bitmap = raw_value[2 + data_len]
-
-    try:
-        voltage_v = struct.unpack(">H", data[0:2])[0] / 10.0
-        current_ma_val = _u24_be(data[2:5])  # mA
-        power_w_val = _u24_be(data[5:8])  # W
-
-        if ver == 0x02:
-            # bit0: current negative; bit1: active power negative
-            if sign_bitmap & 0x01:
-                current_ma_val = -current_ma_val
-            if sign_bitmap & 0x02:
-                power_w_val = -power_w_val
-
-        return voltage_v, float(current_ma_val), float(power_w_val)
-    except (struct.error, ValueError, IndexError):
-        # Defensive: return None if payload is malformed despite prior length checks
-        return None
-
-
-def _parse_phase_payload_auto(raw_value: bytes) -> tuple[float, float, float] | None:
-    """Dispatch parser for phase payload across v00/v01/v02.
-
-    Returns (voltage_V, current_mA, power_W) or None if cannot be parsed.
-    """
-    # Try framed formats first (v01/v02)
-    parsed = _parse_phase_payload_v01_v02(raw_value)
-    if parsed is not None:
-        return parsed
-    # Then try legacy 8-byte v00
-    return _parse_phase_payload_v00(raw_value)
-
-
-class _RawElectricityCurrentWrapper(DPCodeBase64Wrapper):
+class _RawElectricityCurrentWrapper(_RawElectricityDataWrapper):
     """Custom DPCode Wrapper for extracting electricity current from base64."""
 
     native_unit = UnitOfElectricCurrent.MILLIAMPERE
     suggested_unit = UnitOfElectricCurrent.AMPERE
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:
-        """Read the device value for the dpcode."""
-        if (raw_value := super().read_bytes(device)) is None:
-            return None
-        parsed = _parse_phase_payload_auto(raw_value)
-        if parsed is None:
-            # Fallback to legacy slicing if the payload is unexpected
-            if len(raw_value) >= 5:
-                return struct.unpack(">L", b"\x00" + raw_value[2:5])[0]
-            return None
-        _voltage_v, current_ma, _power_w = parsed
-        return current_ma
+    def _convert(self, value: ElectricityData) -> float:
+        """Extract specific value from ElectricityData."""
+        return value.current
 
 
-class _RawElectricityPowerWrapper(DPCodeBase64Wrapper):
+class _RawElectricityPowerWrapper(_RawElectricityDataWrapper):
     """Custom DPCode Wrapper for extracting electricity power from base64."""
 
     native_unit = UnitOfPower.WATT
     suggested_unit = UnitOfPower.KILO_WATT
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:
-        """Read the device value for the dpcode."""
-        if (raw_value := super().read_bytes(device)) is None:
-            return None
-        parsed = _parse_phase_payload_auto(raw_value)
-        if parsed is None:
-            # Fallback to legacy slicing if the payload is unexpected
-            if len(raw_value) >= 8:
-                return struct.unpack(">L", b"\x00" + raw_value[5:8])[0]
-            return None
-        _voltage_v, _current_ma, power_w = parsed
-        return power_w
+    def _convert(self, value: ElectricityData) -> float:
+        """Extract specific value from ElectricityData."""
+        return value.power
 
 
-class _RawElectricityVoltageWrapper(DPCodeBase64Wrapper):
+class _RawElectricityVoltageWrapper(_RawElectricityDataWrapper):
     """Custom DPCode Wrapper for extracting electricity voltage from base64."""
 
     native_unit = UnitOfElectricPotential.VOLT
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:
-        """Read the device value for the dpcode."""
-        if (raw_value := super().read_bytes(device)) is None:
-            return None
-        parsed = _parse_phase_payload_auto(raw_value)
-        if parsed is None:
-            # Fallback to legacy slicing if the payload is unexpected
-            if len(raw_value) >= 2:
-                return struct.unpack(">H", raw_value[0:2])[0] / 10.0
-            return None
-        voltage_v, _current_ma, _power_w = parsed
-        return voltage_v
+    def _convert(self, value: ElectricityData) -> float:
+        """Extract specific value from ElectricityData."""
+        return value.voltage
 
 
 CURRENT_WRAPPER = (_RawElectricityCurrentWrapper, _JsonElectricityCurrentWrapper)

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -5630,7 +5630,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '599.296',
+    'state': '0.072',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.duan_lu_qi_ha_phase_a_power-entry]
@@ -5689,7 +5689,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '18.432',
+    'state': '0.008',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.duan_lu_qi_ha_phase_a_voltage-entry]
@@ -5745,7 +5745,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '52.7',
+    'state': '234.1',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.duan_lu_qi_ha_supply_frequency-entry]


### PR DESCRIPTION
### Proposed change
- Add a unified parser for Tuya `phase_a` RAW payloads, supporting three protocol versions:
  - v00 (legacy 8 bytes): Voltage 2B (0.1V), Current 3B (0.001A → mA), Active Power 3B (0.001kW → W).
  - v01 (framed): `[0x01][0x0F] + 15 bytes data`.
  - v02 (framed with sign): `[0x02][0x0F] + 15 bytes data + 1 byte sign bitmap` (bit0: current negative; bit1: active power negative; bit2: reactive negative; bit3: PF negative).
- Correct unit scaling and sign handling:
  - Voltage in V (0.1V scaling as per spec).
  - Current parsed in mA (entity can suggest/display A).
  - Active power parsed in W.
- Keep backward compatibility: if a framed payload is not detected or parsing fails, fall back to the legacy fixed-offset logic (existing behavior).
- Result: realistic values for devices (e.g., category `dlq`, product `cnpkf4xdmd9v49iq`) that report `phase_a` in v01/v02 formats. For example, a fixture previously showing `599.296 A` (due to mis-parsing) now shows `0.072 A` for the same payload, which matches the vendor protocol.

### Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

### Additional information
- Affected integration: `tuya` (category `dlq`, product example `cnpkf4xdmd9v49iq`).
- Protocol references used in this change:
  - v00 (8B): `V(2B, 0.1V)`, `I(3B, 0.001A)`, `P(3B, 0.001kW)`; big-endian.
  - v01: `[01][0F] + 15B data` (Voltage, Current, Active/Reactive/Apparent Power, PF).
  - v02: `[02][0F] + 15B data + 1B sign bitmap` (bit0 current, bit1 active power, bit2 reactive, bit3 PF).
- Example frames used for verification:
  - v00: `08800003E8002710` → 217.6 V, 1.000 A, 10.000 kW (10,000 W).
  - v01: `010F08800003E8002710000DAC0030D450` → 217.6 V, 1.000 A, 10,000 W.
  - v02: `020F08800003E8002710000DAC0030D4500F` → 217.6 V, -1.000 A, -10,000 W (sign bitmap applied).
- Fixture illustrating the bug fix (used in tests):
  - `tests/components/tuya/fixtures/dlq_cnpkf4xdmd9v49iq.json` has `status["phase_a"] = "Ag8JJQAASAAACAAAAAAACGME"` (v02). New parsing yields `0.072 A` instead of the old `599.296 A`.

This PR fixes or closes issue: (none)

This PR is related to issue: (none)

Link to documentation pull request: (none required; behavior is a correctness fix)

### Checklist
- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. Your PR cannot be merged unless tests pass.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the development checklist.
- [ ] I have followed the perfect PR recommendations.
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`).
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for www.home-assistant.io

If the code communicates with devices, web services, or third-party tools:
- [x] The manifest file has all fields filled out correctly.  (No manifest changes required in this PR.)
- [ ] New or updated dependencies have been added to `requirements_all.txt`. (Not applicable)
- [ ] For updated dependencies – a link to changelog or diff is added. (Not applicable)

I have reviewed two other open pull requests in this repository: (optional)

### Notes for reviewers
- Parsing changes are limited to `homeassistant/components/tuya/sensor.py` and only affect RAW `phase_a` fields.
- When a framed payload (v01/v02) is detected, the parser uses precise offsets, endianness, and scaling as per spec; otherwise it falls back to legacy offsets used for v00.
- Snapshot updates (if any) reflect corrected values for affected fixtures. Focused unit tests can be added in a follow-up commit if desired (e.g., a new `tests/components/tuya/test_sensor_phase_parsing.py` to assert v00/v01/v02 parsing and v02 sign handling).

### How I tested locally
- `script/run-in-env.sh pytest tests/components/tuya/test_sensor.py -k test_platform_setup_and_discovery -vv`
- Verified diffs for `dlq_cnpkf4xdmd9v49iq.json` are consistent with the vendor protocol.
- Then updated the snapshot for that test only: `--snapshot-update`.
- Ran all Tuya tests: `script/run-in-env.sh pytest tests/components/tuya -q`.
- Ran hassfest and lints:
  - `script/run-in-env.sh python -m script.hassfest`
  - `script/run-in-env.sh pylint homeassistant/components/tuya -j 2`