### PR TITLE
Implement shelly autotimer

### DIFF
--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -328,6 +328,18 @@
       "apparent_power_with_channel_name": {
         "name": "{channel_name} apparent power"
       },
+      "auto_off": {
+        "name": "Auto-off"
+      },
+      "auto_off_with_channel_name": {
+        "name": "{channel_name} auto-off"
+      },
+      "auto_on": {
+        "name": "Auto-on"
+      },
+      "auto_on_with_channel_name": {
+        "name": "{channel_name} auto-on"
+      },
       "average_temperature": {
         "name": "Average temperature"
       },
@@ -507,6 +519,18 @@
       },
       "tilt": {
         "name": "Tilt"
+      },
+      "timer_duration": {
+        "name": "Timer duration"
+      },
+      "timer_duration_with_channel_name": {
+        "name": "{channel_name} timer duration"
+      },
+      "timer_remaining": {
+        "name": "Timer remaining"
+      },
+      "timer_remaining_with_channel_name": {
+        "name": "{channel_name} timer remaining"
       },
       "valve_position": {
         "name": "Valve position"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add support to **show** the auto-timer state of Shellys.
I think this only works for gen2+
<img width="375" height="292" alt="Bildschirmfoto_20251122_140722" src="https://github.com/user-attachments/assets/eb5f268f-4d28-4bc1-a811-63d1ec3e7e75" />
<img width="375" height="292" alt="Bildschirmfoto_20251122_140709" src="https://github.com/user-attachments/assets/73270460-d9cb-486e-9192-140d78eb5aff" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Please check this view of the history. Is this ok to have this as is?
<img width="598" height="484" alt="Bildschirmfoto_20251122_140736" src="https://github.com/user-attachments/assets/ac032ed5-1763-4c40-a511-ff2f356d85c8" />

I had to reorder `BlockSleepingNumber` (unchanged) as the new entity is initialized statically and references it.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
