### PR TITLE
Address Home Assistant Labs review comments

### DIFF
--- a/homeassistant/components/kitchen_sink/__init__.py
+++ b/homeassistant/components/kitchen_sink/__init__.py
@@ -11,11 +11,7 @@ from random import random
 
 import voluptuous as vol
 
-from homeassistant.components.labs import (
-    EVENT_LABS_UPDATED,
-    EventLabsUpdatedData,
-    async_is_preview_feature_enabled,
-)
+from homeassistant.components.labs import async_is_preview_feature_enabled, async_listen
 from homeassistant.components.recorder import DOMAIN as RECORDER_DOMAIN, get_instance
 from homeassistant.components.recorder.models import (
     StatisticData,
@@ -35,7 +31,7 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfVolume,
 )
-from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.issue_registry import (
@@ -120,17 +116,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.async_create_task(_notify_backup_listeners(hass), eager_start=False)
 
     # Subscribe to labs feature updates for kitchen_sink preview repair
-    @callback
-    def _async_labs_updated(event: Event[EventLabsUpdatedData]) -> None:
-        """Handle labs feature update event."""
-        if (
-            event.data["domain"] == "kitchen_sink"
-            and event.data["preview_feature"] == "special_repair"
-        ):
-            _async_update_special_repair(hass)
-
     entry.async_on_unload(
-        hass.bus.async_listen(EVENT_LABS_UPDATED, _async_labs_updated)
+        async_listen(
+            hass,
+            domain=DOMAIN,
+            preview_feature="special_repair",
+            listener=lambda: _async_update_special_repair(hass),
+        )
     )
 
     # Check if lab feature is currently enabled and create repair if so

--- a/tests/components/labs/test_init.py
+++ b/tests/components/labs/test_init.py
@@ -11,17 +11,17 @@ from homeassistant.components.labs import (
     EVENT_LABS_UPDATED,
     LabsStorage,
     async_is_preview_feature_enabled,
-    async_setup,
 )
-from homeassistant.components.labs.const import LABS_DATA, LabPreviewFeature
+from homeassistant.components.labs.const import DOMAIN, LABS_DATA, LabPreviewFeature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 from homeassistant.loader import Integration
+from homeassistant.setup import async_setup_component
 
 
 async def test_async_setup(hass: HomeAssistant) -> None:
     """Test the Labs integration setup."""
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     # Verify WebSocket commands are registered
@@ -40,7 +40,7 @@ async def test_async_is_preview_feature_enabled_nonexistent(
     hass: HomeAssistant,
 ) -> None:
     """Test checking if non-existent preview feature is enabled."""
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     result = async_is_preview_feature_enabled(
@@ -68,7 +68,7 @@ async def test_async_is_preview_feature_enabled_when_enabled(
         },
     }
 
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     result = async_is_preview_feature_enabled(hass, "kitchen_sink", "special_repair")
@@ -82,7 +82,7 @@ async def test_async_is_preview_feature_enabled_when_disabled(
     # Load kitchen_sink integration so preview feature exists
     hass.config.components.add("kitchen_sink")
 
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     result = async_is_preview_feature_enabled(hass, "kitchen_sink", "special_repair")
@@ -143,7 +143,7 @@ async def test_storage_cleanup_stale_features(
         "data": {"preview_feature_status": features_to_store},
     }
 
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     # Verify expected features are preserved
@@ -160,7 +160,7 @@ async def test_event_fired_on_preview_feature_update(hass: HomeAssistant) -> Non
     # Load kitchen_sink integration
     hass.config.components.add("kitchen_sink")
 
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     events = []
@@ -215,7 +215,7 @@ async def test_async_is_preview_feature_enabled(
         },
     }
 
-    await async_setup(hass, {})
+    await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     result = async_is_preview_feature_enabled(hass, domain, preview_feature)
@@ -224,10 +224,10 @@ async def test_async_is_preview_feature_enabled(
 
 async def test_multiple_setups_idempotent(hass: HomeAssistant) -> None:
     """Test that calling async_setup multiple times is safe."""
-    result1 = await async_setup(hass, {})
+    result1 = await async_setup_component(hass, DOMAIN, {})
     assert result1 is True
 
-    result2 = await async_setup(hass, {})
+    result2 = await async_setup_component(hass, DOMAIN, {})
     assert result2 is True
 
     # Verify store is still accessible
@@ -246,7 +246,7 @@ async def test_storage_load_missing_preview_feature_status_key(
         "data": {},  # Missing preview_feature_status
     }
 
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     # Should initialize correctly - verify no feature is enabled
@@ -343,7 +343,7 @@ async def test_custom_integration_with_preview_features(
         "homeassistant.components.labs.async_get_custom_components",
         return_value={"custom_test": mock_integration},
     ):
-        assert await async_setup(hass, {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     # Verify the custom integration's preview feature can be checked
@@ -375,13 +375,13 @@ async def test_preview_feature_is_built_in_flag(
             "homeassistant.components.labs.async_get_custom_components",
             return_value={"custom_test": mock_integration},
         ):
-            assert await async_setup(hass, {})
+            assert await async_setup_component(hass, DOMAIN, {})
             await hass.async_block_till_done()
         feature_key = "custom_test.custom_feature"
     else:
         # Load built-in kitchen_sink integration
         hass.config.components.add("kitchen_sink")
-        assert await async_setup(hass, {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         feature_key = "kitchen_sink.special_repair"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR addresses unresolved review comments from #156840 (Home Assistant Labs introduction):

1. **Code quality improvement**: Changed `.items()` to `.values()` in labs integration where only values are used
2. **API enhancement**: Added `async_listen()` helper function to simplify preview feature event listening for integrations
3. **Fixed hardcoded string**: Changed hardcoded `"kitchen_sink"` to use `DOMAIN` constant
4. **Test improvements**:
   - Updated labs tests to use proper `async_setup_component()` pattern instead of direct `async_setup()` calls
   - Split parametrized test into two separate tests with shared fixture for better clarity

The `async_listen()` helper provides a cleaner API for integrations to listen for specific preview feature changes, abstracting away the event bus details:

**Before:**
```python
@callback
def _async_labs_updated(event: Event[EventLabsUpdatedData]) -> None:
    if (
        event.data["domain"] == "kitchen_sink"
        and event.data["preview_feature"] == "special_repair"
    ):
        _async_update_special_repair(hass)

entry.async_on_unload(
    hass.bus.async_listen(EVENT_LABS_UPDATED, _async_labs_updated)
)
```

**After:**
```python
entry.async_on_unload(
    async_listen(
        hass,
        domain=DOMAIN,
        preview_feature="special_repair",
        listener=lambda: _async_update_special_repair(hass),
    )
)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #156840
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
