### PR TITLE
Add repair issue for Shelly devices with open WiFi access point

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -60,6 +60,7 @@ from .coordinator import (
 from .repairs import (
     async_manage_ble_scanner_firmware_unsupported_issue,
     async_manage_deprecated_firmware_issue,
+    async_manage_open_wifi_ap_issue,
     async_manage_outbound_websocket_incorrectly_enabled_issue,
 )
 from .utils import (
@@ -347,6 +348,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
             hass,
             entry,
         )
+        async_manage_open_wifi_ap_issue(hass, entry)
         remove_empty_sub_devices(hass, entry)
     elif (
         sleep_period is None

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -254,6 +254,7 @@ OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID = (
     "outbound_websocket_incorrectly_enabled_{unique}"
 )
 DEPRECATED_FIRMWARE_ISSUE_ID = "deprecated_firmware_{unique}"
+OPEN_WIFI_AP_ISSUE_ID = "open_wifi_ap_{unique}"
 
 
 class DeprecatedFirmwareInfo(TypedDict):

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -22,6 +22,7 @@ from .const import (
     DEPRECATED_FIRMWARE_ISSUE_ID,
     DEPRECATED_FIRMWARES,
     DOMAIN,
+    OPEN_WIFI_AP_ISSUE_ID,
     OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID,
     BLEScannerMode,
 )
@@ -149,6 +150,45 @@ def async_manage_outbound_websocket_incorrectly_enabled_issue(
     ir.async_delete_issue(hass, DOMAIN, issue_id)
 
 
+@callback
+def async_manage_open_wifi_ap_issue(
+    hass: HomeAssistant,
+    entry: ShellyConfigEntry,
+) -> None:
+    """Manage the open WiFi AP issue."""
+    issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=entry.unique_id)
+
+    if TYPE_CHECKING:
+        assert entry.runtime_data.rpc is not None
+
+    device = entry.runtime_data.rpc.device
+
+    # Check if WiFi AP is enabled and has no password (open/unsecured)
+    if (
+        (wifi_config := device.config.get("wifi"))
+        and (ap_config := wifi_config.get("ap"))
+        and ap_config.get("enable")
+        and not ap_config.get("pass")
+    ):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=True,
+            is_persistent=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="open_wifi_ap",
+            translation_placeholders={
+                "device_name": device.name,
+                "ip_address": device.ip_address,
+            },
+            data={"entry_id": entry.entry_id},
+        )
+        return
+
+    ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+
 class ShellyRpcRepairsFlow(RepairsFlow):
     """Handler for an issue fixing flow."""
 
@@ -229,6 +269,27 @@ class DisableOutboundWebSocketFlow(ShellyRpcRepairsFlow):
         return self.async_create_entry(title="", data={})
 
 
+class DisableOpenWiFiApFlow(ShellyRpcRepairsFlow):
+    """Handler for Disable Open WiFi AP flow."""
+
+    async def _async_step_confirm(self) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        return await self.async_step_disable_wifi_ap()
+
+    async def async_step_disable_wifi_ap(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Disable the open WiFi AP."""
+        try:
+            result = await self._device.wifi_setconfig(ap_enable=False)
+            if result.get("restart_required"):
+                await self._device.trigger_reboot()
+        except (DeviceConnectionError, RpcCallError):
+            return self.async_abort(reason="cannot_connect")
+
+        return self.async_create_entry(title="", data={})
+
+
 async def async_create_fix_flow(
     hass: HomeAssistant, issue_id: str, data: dict[str, str] | None
 ) -> RepairsFlow:
@@ -252,5 +313,8 @@ async def async_create_fix_flow(
 
     if "outbound_websocket_incorrectly_enabled" in issue_id:
         return DisableOutboundWebSocketFlow(device)
+
+    if "open_wifi_ap" in issue_id:
+        return DisableOpenWiFiApFlow(device)
 
     return ConfirmRepairFlow()

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -163,12 +163,12 @@ def async_manage_open_wifi_ap_issue(
 
     device = entry.runtime_data.rpc.device
 
-    # Check if WiFi AP is enabled and has no password (open/unsecured)
+    # Check if WiFi AP is enabled and is open (no password)
     if (
         (wifi_config := device.config.get("wifi"))
         and (ap_config := wifi_config.get("ap"))
         and ap_config.get("enable")
-        and not ap_config.get("pass")
+        and ap_config.get("is_open")
     ):
         ir.async_create_issue(
             hass,

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -175,7 +175,7 @@ def async_manage_open_wifi_ap_issue(
             DOMAIN,
             issue_id,
             is_fixable=True,
-            is_persistent=True,
+            is_persistent=False,
             severity=ir.IssueSeverity.WARNING,
             translation_key="open_wifi_ap",
             translation_placeholders={

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -671,12 +671,12 @@
         },
         "step": {
           "confirm": {
-            "description": "Your Shelly device {device_name} with IP address {ip_address} has an open WiFi access point enabled without a password. This is a security risk as anyone nearby can connect to the device.\n\nTo fix this issue:\n\n1. Select **Submit** to automatically disable the WiFi access point, OR\n2. Select **Ignore** if you want to keep the access point enabled (not recommended)\n\nNote: If you disable the access point, the device may need to restart.",
+            "description": "Your Shelly device {device_name} with IP address {ip_address} has an open WiFi access point enabled without a password. This is a security risk as anyone nearby can connect to the device.\n\nTo fix this issue:\n\n1. Select **Submit** to automatically disable the WiFi access point, OR\n2. Select **Ignore** to dismiss this warning if you want to keep the access point enabled (not recommended)\n\nNote: If you disable the access point, the device may need to restart.",
             "title": "[%key:component::shelly::issues::open_wifi_ap::title%]"
           }
         }
       },
-      "title": "{device_name} has an open WiFi access point"
+      "title": "Open WiFi access point on {device_name}"
     },
     "outbound_websocket_incorrectly_enabled": {
       "fix_flow": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -667,11 +667,16 @@
     "open_wifi_ap": {
       "fix_flow": {
         "abort": {
-          "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+          "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+          "issue_ignored": "Issue ignored"
         },
         "step": {
-          "confirm": {
-            "description": "Your Shelly device {device_name} with IP address {ip_address} has an open WiFi access point enabled without a password. This is a security risk as anyone nearby can connect to the device.\n\nTo fix this issue:\n\n1. Select **Submit** to automatically disable the WiFi access point, OR\n2. Select **Ignore** to dismiss this warning if you want to keep the access point enabled (not recommended)\n\nNote: If you disable the access point, the device may need to restart.",
+          "init": {
+            "description": "Your Shelly device {device_name} with IP address {ip_address} has an open WiFi access point enabled without a password. This is a security risk as anyone nearby can connect to the device.\n\nNote: If you disable the access point, the device may need to restart.",
+            "menu_options": {
+              "confirm": "Disable WiFi access point",
+              "ignore": "Ignore"
+            },
             "title": "[%key:component::shelly::issues::open_wifi_ap::title%]"
           }
         }

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -664,6 +664,20 @@
       "description": "Shelly device {device_name} with IP address {ip_address} requires calibration. To calibrate the device, it must be rebooted after proper installation on the valve. You can reboot the device in its web panel, go to 'Settings' > 'Device Reboot'.",
       "title": "Shelly device {device_name} is not calibrated"
     },
+    "open_wifi_ap": {
+      "fix_flow": {
+        "abort": {
+          "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+        },
+        "step": {
+          "confirm": {
+            "description": "Your Shelly device {device_name} with IP address {ip_address} has an open WiFi access point enabled without a password. This is a security risk as anyone nearby can connect to the device.\n\nTo fix this issue:\n\n1. Select **Submit** to automatically disable the WiFi access point, OR\n2. Select **Ignore** if you want to keep the access point enabled (not recommended)\n\nNote: If you disable the access point, the device may need to restart.",
+            "title": "[%key:component::shelly::issues::open_wifi_ap::title%]"
+          }
+        }
+      },
+      "title": "{device_name} has an open WiFi access point"
+    },
     "outbound_websocket_incorrectly_enabled": {
       "fix_flow": {
         "abort": {

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -576,7 +576,7 @@ def _mock_rpc_device(version: str | None = None):
         zigbee_enabled=False,
         zigbee_firmware=False,
         ip_address="10.10.10.10",
-        wifi_setconfig=AsyncMock(return_value={}),
+        wifi_setconfig=AsyncMock(return_value={"restart_required": True}),
         ble_setconfig=AsyncMock(return_value={"restart_required": False}),
         shutdown=AsyncMock(),
     )

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -268,7 +268,7 @@ async def test_open_wifi_ap_issue(
     monkeypatch.setitem(
         mock_rpc_device.config,
         "wifi",
-        {"ap": {"enable": True, "pass": ""}},
+        {"ap": {"enable": True, "is_open": True}},
     )
 
     issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)
@@ -308,7 +308,7 @@ async def test_open_wifi_ap_issue_no_restart(
     monkeypatch.setitem(
         mock_rpc_device.config,
         "wifi",
-        {"ap": {"enable": True, "pass": ""}},
+        {"ap": {"enable": True, "is_open": True}},
     )
 
     issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)
@@ -354,7 +354,7 @@ async def test_open_wifi_ap_issue_exc(
     monkeypatch.setitem(
         mock_rpc_device.config,
         "wifi",
-        {"ap": {"enable": True, "pass": ""}},
+        {"ap": {"enable": True, "is_open": True}},
     )
 
     issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)
@@ -393,7 +393,7 @@ async def test_no_open_wifi_ap_issue_with_password(
     monkeypatch.setitem(
         mock_rpc_device.config,
         "wifi",
-        {"ap": {"enable": True, "pass": "secure_password"}},
+        {"ap": {"enable": True, "is_open": False}},
     )
 
     issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)
@@ -413,7 +413,7 @@ async def test_no_open_wifi_ap_issue_when_disabled(
     monkeypatch.setitem(
         mock_rpc_device.config,
         "wifi",
-        {"ap": {"enable": False, "pass": ""}},
+        {"ap": {"enable": False, "is_open": True}},
     )
 
     issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)
@@ -434,7 +434,7 @@ async def test_open_wifi_ap_issue_ignore(
     monkeypatch.setitem(
         mock_rpc_device.config,
         "wifi",
-        {"ap": {"enable": True, "pass": ""}},
+        {"ap": {"enable": True, "is_open": True}},
     )
 
     issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -284,9 +284,10 @@ async def test_open_wifi_ap_issue(
     result = await start_repair_fix_flow(client, DOMAIN, issue_id)
 
     flow_id = result["flow_id"]
-    assert result["step_id"] == "confirm"
+    assert result["step_id"] == "init"
+    assert result["type"] == "menu"
 
-    result = await process_repair_fix_flow(client, flow_id)
+    result = await process_repair_fix_flow(client, flow_id, {"next_step_id": "confirm"})
     assert result["type"] == "create_entry"
     assert mock_rpc_device.wifi_setconfig.call_count == 1
     assert mock_rpc_device.wifi_setconfig.call_args[1] == {"ap_enable": False}
@@ -323,11 +324,12 @@ async def test_open_wifi_ap_issue_no_restart(
     result = await start_repair_fix_flow(client, DOMAIN, issue_id)
 
     flow_id = result["flow_id"]
-    assert result["step_id"] == "confirm"
+    assert result["step_id"] == "init"
+    assert result["type"] == "menu"
 
     mock_rpc_device.wifi_setconfig.return_value = {"restart_required": False}
 
-    result = await process_repair_fix_flow(client, flow_id)
+    result = await process_repair_fix_flow(client, flow_id, {"next_step_id": "confirm"})
     assert result["type"] == "create_entry"
     assert mock_rpc_device.wifi_setconfig.call_count == 1
     assert mock_rpc_device.wifi_setconfig.call_args[1] == {"ap_enable": False}
@@ -368,10 +370,11 @@ async def test_open_wifi_ap_issue_exc(
     result = await start_repair_fix_flow(client, DOMAIN, issue_id)
 
     flow_id = result["flow_id"]
-    assert result["step_id"] == "confirm"
+    assert result["step_id"] == "init"
+    assert result["type"] == "menu"
 
     mock_rpc_device.wifi_setconfig.side_effect = exception
-    result = await process_repair_fix_flow(client, flow_id)
+    result = await process_repair_fix_flow(client, flow_id, {"next_step_id": "confirm"})
     assert result["type"] == "abort"
     assert result["reason"] == "cannot_connect"
     assert mock_rpc_device.wifi_setconfig.call_count == 1
@@ -418,3 +421,41 @@ async def test_no_open_wifi_ap_issue_when_disabled(
 
     assert not issue_registry.async_get_issue(DOMAIN, issue_id)
     assert len(issue_registry.issues) == 0
+
+
+async def test_open_wifi_ap_issue_ignore(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_rpc_device: Mock,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test ignoring the open WiFi AP issue."""
+    monkeypatch.setitem(
+        mock_rpc_device.config,
+        "wifi",
+        {"ap": {"enable": True, "pass": ""}},
+    )
+
+    issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)
+    assert await async_setup_component(hass, "repairs", {})
+    await hass.async_block_till_done()
+    await init_integration(hass, 2)
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1
+
+    await async_process_repairs_platforms(hass)
+    client = await hass_client()
+    result = await start_repair_fix_flow(client, DOMAIN, issue_id)
+
+    flow_id = result["flow_id"]
+    assert result["step_id"] == "init"
+    assert result["type"] == "menu"
+
+    result = await process_repair_fix_flow(client, flow_id, {"next_step_id": "ignore"})
+    assert result["type"] == "abort"
+    assert result["reason"] == "issue_ignored"
+    assert mock_rpc_device.wifi_setconfig.call_count == 0
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id).dismissed_version

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -11,6 +11,7 @@ from homeassistant.components.shelly.const import (
     CONF_BLE_SCANNER_MODE,
     DEPRECATED_FIRMWARE_ISSUE_ID,
     DOMAIN,
+    OPEN_WIFI_AP_ISSUE_ID,
     OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID,
     BLEScannerMode,
     DeprecatedFirmwareInfo,
@@ -252,5 +253,168 @@ async def test_deprecated_firmware_issue(
     assert mock_rpc_device.trigger_ota_update.call_count == 1
 
     # Assert the issue is no longer present
+    assert not issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 0
+
+
+async def test_open_wifi_ap_issue(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_rpc_device: Mock,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test repair issues handling for open WiFi AP."""
+    monkeypatch.setitem(
+        mock_rpc_device.config,
+        "wifi",
+        {"ap": {"enable": True, "pass": ""}},
+    )
+
+    issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)
+    assert await async_setup_component(hass, "repairs", {})
+    await hass.async_block_till_done()
+    await init_integration(hass, 2)
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1
+
+    await async_process_repairs_platforms(hass)
+    client = await hass_client()
+    result = await start_repair_fix_flow(client, DOMAIN, issue_id)
+
+    flow_id = result["flow_id"]
+    assert result["step_id"] == "confirm"
+
+    result = await process_repair_fix_flow(client, flow_id)
+    assert result["type"] == "create_entry"
+    assert mock_rpc_device.wifi_setconfig.call_count == 1
+    assert mock_rpc_device.wifi_setconfig.call_args[1] == {"ap_enable": False}
+    assert mock_rpc_device.trigger_reboot.call_count == 1
+
+    assert not issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 0
+
+
+async def test_open_wifi_ap_issue_no_restart(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_rpc_device: Mock,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test repair issues handling for open WiFi AP when restart not required."""
+    monkeypatch.setitem(
+        mock_rpc_device.config,
+        "wifi",
+        {"ap": {"enable": True, "pass": ""}},
+    )
+
+    issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)
+    assert await async_setup_component(hass, "repairs", {})
+    await hass.async_block_till_done()
+    await init_integration(hass, 2)
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1
+
+    await async_process_repairs_platforms(hass)
+    client = await hass_client()
+    result = await start_repair_fix_flow(client, DOMAIN, issue_id)
+
+    flow_id = result["flow_id"]
+    assert result["step_id"] == "confirm"
+
+    mock_rpc_device.wifi_setconfig.return_value = {"restart_required": False}
+
+    result = await process_repair_fix_flow(client, flow_id)
+    assert result["type"] == "create_entry"
+    assert mock_rpc_device.wifi_setconfig.call_count == 1
+    assert mock_rpc_device.wifi_setconfig.call_args[1] == {"ap_enable": False}
+    assert mock_rpc_device.trigger_reboot.call_count == 0
+
+    assert not issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 0
+
+
+@pytest.mark.parametrize(
+    "exception", [DeviceConnectionError, RpcCallError(999, "Unknown error")]
+)
+async def test_open_wifi_ap_issue_exc(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_rpc_device: Mock,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    exception: Exception,
+) -> None:
+    """Test repair issues handling when wifi_setconfig ends with an exception."""
+    monkeypatch.setitem(
+        mock_rpc_device.config,
+        "wifi",
+        {"ap": {"enable": True, "pass": ""}},
+    )
+
+    issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)
+    assert await async_setup_component(hass, "repairs", {})
+    await hass.async_block_till_done()
+    await init_integration(hass, 2)
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1
+
+    await async_process_repairs_platforms(hass)
+    client = await hass_client()
+    result = await start_repair_fix_flow(client, DOMAIN, issue_id)
+
+    flow_id = result["flow_id"]
+    assert result["step_id"] == "confirm"
+
+    mock_rpc_device.wifi_setconfig.side_effect = exception
+    result = await process_repair_fix_flow(client, flow_id)
+    assert result["type"] == "abort"
+    assert result["reason"] == "cannot_connect"
+    assert mock_rpc_device.wifi_setconfig.call_count == 1
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1
+
+
+async def test_no_open_wifi_ap_issue_with_password(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test no repair issue is created when WiFi AP has a password."""
+    monkeypatch.setitem(
+        mock_rpc_device.config,
+        "wifi",
+        {"ap": {"enable": True, "pass": "secure_password"}},
+    )
+
+    issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)
+    await init_integration(hass, 2)
+
+    assert not issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 0
+
+
+async def test_no_open_wifi_ap_issue_when_disabled(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test no repair issue is created when WiFi AP is disabled."""
+    monkeypatch.setitem(
+        mock_rpc_device.config,
+        "wifi",
+        {"ap": {"enable": False, "pass": ""}},
+    )
+
+    issue_id = OPEN_WIFI_AP_ISSUE_ID.format(unique=MOCK_MAC)
+    await init_integration(hass, 2)
+
     assert not issue_registry.async_get_issue(DOMAIN, issue_id)
     assert len(issue_registry.issues) == 0


### PR DESCRIPTION
## Proposed change

Add a repair issue for Shelly devices that warns users when a WiFi access point is enabled without a password. This addresses a security vulnerability where devices may be left with an open WiFi AP after provisioning, allowing unauthorized access.

The repair issue:
- Detects all Shelly RPC devices with an enabled WiFi AP that has no password configured
- Provides a menu-based repair flow with two options:
  - **Disable WiFi access point**: Automatically disables the AP via the device API
  - **Ignore**: Allows users to dismiss the warning if they intentionally want to keep the AP enabled
- Triggers when the device connection is first established during setup
- Displays clear, actionable instructions explaining the security risk

This complements the existing Bluetooth provisioning flow which already attempts to disable the AP after setup, but handles cases where:
- The AP was not disabled during Bluetooth provisioning (user choice or failure)
- The device was provisioned through other methods (zeroconf, manual)
- The AP was re-enabled after initial setup

**Implementation Details:**
- Uses menu-based repair flow pattern (like synology_dsm and zwave_js)
- Issue is checked on each setup and automatically dismissed if the AP is secured or disabled by other means
- Not persistent (`is_persistent=False`) - the issue is re-evaluated at each device setup
- Supports both device restart scenarios (required and not required)

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
