### PR TITLE
Fix Shelly BLE rediscovery after factory reset

### DIFF
--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -2082,7 +2082,7 @@ async def test_bluetooth_provisioning_clears_match_history(
     mock_setup_entry: AsyncMock,
     mock_setup: AsyncMock,
 ) -> None:
-    """Test bluetooth provisioning clears match history after successful provisioning."""
+    """Test bluetooth provisioning clears match history at discovery start and after successful provisioning."""
     # Inject BLE device so it's available in the bluetooth scanner
     inject_bluetooth_service_info_bleak(hass, BLE_DISCOVERY_INFO)
 

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -2115,6 +2115,9 @@ async def test_bluetooth_provisioning_clears_match_history(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "bluetooth_confirm"
 
+        # Reset mock to only count calls during provisioning
+        mock_clear.reset_mock()
+
         # Confirm
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
@@ -2141,11 +2144,8 @@ async def test_bluetooth_provisioning_clears_match_history(
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["result"].unique_id == "C049EF8873E8"
 
-        # Verify match history was cleared at least twice:
-        # - Once at the start of the bluetooth discovery flow
-        # - Once after successful WiFi provisioning
-        # (May be called additional times by automatic discovery flows)
-        assert mock_clear.call_count >= 2
+        # Verify match history was cleared once during provisioning
+        assert mock_clear.call_count == 1
         mock_clear.assert_called_with(hass, BLE_DISCOVERY_INFO.address)
 
 


### PR DESCRIPTION
## Proposed change

Fix Shelly BLE devices not being rediscovered after factory reset.

When a Shelly device was factory reset, it would re-enable RPC-over-BLE provisioning, but the Bluetooth discovery system would not trigger a new config flow because the device's address remained in the match history. This prevented users from re-provisioning factory reset devices via BLE.

The fix clears the Bluetooth match history:
- At the start of the discovery flow (allows rediscovery if flow is abandoned or device is factory reset later)
- After successful WiFi provisioning (allows rediscovery if device is factory reset in the future)

This matches the proven pattern used by the improv_ble integration.

**Known limitation: Some shelly devices never update the adv to show RPC over BLE is disabled after we turn it off so even with this fix they can't be rediscovered until HA is restarted because the ADV doesn't change.  This is likely a race where the device only broadcast for a short period before the reset finishes and sometimes we don't see it. This means we still need to add support for BLE discovery in the user flow in a future PR.**  I have reported this to Shelly.

After provisioning — before factory reset
```
{"name":"7C:2C:67:68:98:FA","address":"7C:2C:67:68:98:FA","rssi":-31,"manufacturer_data":{"2985":"0105000b31100af89868672c7c"},"service_data":{"0000fff6-0000-1000-8000-00805f9b34fb":"00f8009014311001"},"service_uuids":[],"source":"10:51:DB:A7:A8:62","connectable":true,"time":1763909798.0074828,"tx_power":null,"raw":"0201060b16f6ff00f8009014311001"}
```

After factory reset (this should have switched to 0101 but it didn't)
```
{"name":"7C:2C:67:68:98:FA","address":"7C:2C:67:68:98:FA","rssi":-31,"manufacturer_data":{"2985":"0105000b31100af89868672c7c"},"service_data":{"0000fff6-0000-1000-8000-00805f9b34fb":"00f8009014311001"},"service_uuids":[],"source":"10:51:DB:A7:A8:62","connectable":true,"time":1763909798.0074828,"tx_power":null,"raw":"0201060b16f6ff00f8009014311001"}
```

After factory reset 2
```
{"name":"7C:2C:67:68:98:FA","address":"7C:2C:67:68:98:FA","rssi":-37,"manufacturer_data":{"2985":"0101000b31100af89868672c7c"},"service_data":{"0000fff6-0000-1000-8000-00805f9b34fb":"00f8009014311001"},"service_uuids":[],"source":"B8:F8:62:F8:D9:52","connectable":true,"time":1763910287.5946715,"tx_power":null,"raw":"0201060b16f6ff00f8009014311001"}
```

0105 <— has BLE RPC
0101 <— no BLE RPC

**Note: For testing, you must delete the config entry as well to enable the ble discovery to appear since we suppress the ble discovery when there is a valid config entry to avoid discoveries for already configured devices.**

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr