### PR TITLE
Assign icons for more Octoprint sensors

### DIFF
--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the available OctoPrint binary sensors."""
+    """Set up the available OctoPrint sensors."""
     coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]["coordinator"]
@@ -111,7 +111,7 @@ class OctoPrintSensorBase(
 
 
 class OctoPrintStatusSensor(OctoPrintSensorBase):
-    """Representation of an OctoPrint sensor."""
+    """Representation of an OctoPrint status sensor."""
 
     _attr_icon = "mdi:printer-3d"
 
@@ -137,7 +137,7 @@ class OctoPrintStatusSensor(OctoPrintSensorBase):
 
 
 class OctoPrintJobPercentageSensor(OctoPrintSensorBase):
-    """Representation of an OctoPrint sensor."""
+    """Representation of an OctoPrint job percentage sensor."""
 
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_icon = "mdi:file-percent"
@@ -162,9 +162,10 @@ class OctoPrintJobPercentageSensor(OctoPrintSensorBase):
 
 
 class OctoPrintEstimatedFinishTimeSensor(OctoPrintSensorBase):
-    """Representation of an OctoPrint sensor."""
+    """Representation of an OctoPrint estimated finish time sensor."""
 
     _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:clock-end"
 
     def __init__(
         self, coordinator: OctoprintDataUpdateCoordinator, device_id: str
@@ -191,9 +192,10 @@ class OctoPrintEstimatedFinishTimeSensor(OctoPrintSensorBase):
 
 
 class OctoPrintStartTimeSensor(OctoPrintSensorBase):
-    """Representation of an OctoPrint sensor."""
+    """Representation of an OctoPrint start time sensor."""
 
     _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:clock-start"
 
     def __init__(
         self, coordinator: OctoprintDataUpdateCoordinator, device_id: str
@@ -221,11 +223,12 @@ class OctoPrintStartTimeSensor(OctoPrintSensorBase):
 
 
 class OctoPrintTemperatureSensor(OctoPrintSensorBase):
-    """Representation of an OctoPrint sensor."""
+    """Representation of an OctoPrint temperature sensor."""
 
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:printer-3d-nozzle-heat"
 
     def __init__(
         self,
@@ -267,7 +270,9 @@ class OctoPrintTemperatureSensor(OctoPrintSensorBase):
 
 
 class OctoPrintFileNameSensor(OctoPrintSensorBase):
-    """Representation of an OctoPrint sensor."""
+    """Representation of an OctoPrint file name sensor."""
+
+    _attr_icon = "mdi:printer-3d-nozzle"
 
     def __init__(
         self,
@@ -294,7 +299,7 @@ class OctoPrintFileNameSensor(OctoPrintSensorBase):
 
 
 class OctoPrintFileSizeSensor(OctoPrintSensorBase):
-    """Representation of an OctoPrint sensor."""
+    """Representation of an OctoPrint file size sensor."""
 
     _attr_device_class = SensorDeviceClass.DATA_SIZE
     _attr_native_unit_of_measurement = UnitOfInformation.BYTES


### PR DESCRIPTION
## Proposed change

Assign custom default icons to several of the [Octoprint](https://www.home-assistant.io/integrations/octoprint/) sensors, to provide better visual indication of what they measure.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] ~~Tests have been added to verify that the new code works.~~ (N/A)
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] ~~Documentation added/updated for [www.home-assistant.io][docs-repository]~~ (N/A)

If the code communicates with devices, web services, or third-party tools:

- [ ] ~~The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.~~ (N/A
- [ ] ~~New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.~~ (N/A
- [ ] ~~For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.~~ (N/A

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure