### PR TITLE
Remove the restriction that Bluetooth login to the Switchbot account is only possible in active mode

### DIFF
--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -17,9 +17,7 @@ from switchbot import (
 import voluptuous as vol
 
 from homeassistant.components.bluetooth import (
-    BluetoothScanningMode,
     BluetoothServiceInfoBleak,
-    async_current_scanners,
     async_discovered_service_info,
 )
 from homeassistant.config_entries import (
@@ -325,15 +323,6 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the user step to choose cloud login or direct discovery."""
-        # Check if all scanners are in active mode
-        # If so, skip the menu and go directly to device selection
-        scanners = async_current_scanners(self.hass)
-        if scanners and all(
-            scanner.current_mode == BluetoothScanningMode.ACTIVE for scanner in scanners
-        ):
-            # All scanners are active, skip the menu
-            return await self.async_step_select_device()
-
         return self.async_show_menu(
             step_id="user",
             menu_options=["cloud_login", "select_device"],

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -45,18 +45,6 @@ DOMAIN = "switchbot"
 
 
 @pytest.fixture
-def mock_scanners_all_active() -> Generator[None]:
-    """Mock all scanners as active mode."""
-    mock_scanner = Mock()
-    mock_scanner.current_mode = BluetoothScanningMode.ACTIVE
-    with patch(
-        "homeassistant.components.bluetooth.async_current_scanners",
-        return_value=[mock_scanner],
-    ):
-        yield
-
-
-@pytest.fixture
 def mock_scanners_all_passive() -> Generator[None]:
     """Mock all scanners as passive mode."""
     mock_scanner = Mock()

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -1461,38 +1461,6 @@ async def test_user_setup_worelay_switch_1pm_auth_switchbot_api_down(
     assert result["description_placeholders"] == {"error_detail": "Switchbot API down"}
 
 
-@pytest.mark.usefixtures("mock_scanners_all_active")
-async def test_user_skip_menu_when_all_scanners_active(hass: HomeAssistant) -> None:
-    """Test that menu is skipped when all scanners are in active mode."""
-    with (
-        patch(
-            "homeassistant.components.switchbot.config_flow.async_discovered_service_info",
-            return_value=[WOHAND_SERVICE_INFO],
-        ),
-        patch_async_setup_entry() as mock_setup_entry,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}
-        )
-
-        # Should skip menu and go directly to select_device -> confirm
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "confirm"
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Bot EEFF"
-    assert result["data"] == {
-        CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
-        CONF_SENSOR_TYPE: "bot",
-    }
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
 async def test_user_show_menu_when_passive_scanner_present(hass: HomeAssistant) -> None:
     """Test that menu is shown when any scanner is in passive mode."""
     mock_scanner_active = Mock()

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -50,7 +50,7 @@ def mock_scanners_all_active() -> Generator[None]:
     mock_scanner = Mock()
     mock_scanner.current_mode = BluetoothScanningMode.ACTIVE
     with patch(
-        "homeassistant.components.switchbot.config_flow.async_current_scanners",
+        "homeassistant.components.bluetooth.async_current_scanners",
         return_value=[mock_scanner],
     ):
         yield
@@ -62,7 +62,7 @@ def mock_scanners_all_passive() -> Generator[None]:
     mock_scanner = Mock()
     mock_scanner.current_mode = BluetoothScanningMode.PASSIVE
     with patch(
-        "homeassistant.components.switchbot.config_flow.async_current_scanners",
+        "homeassistant.components.bluetooth.async_current_scanners",
         return_value=[mock_scanner],
     ):
         yield
@@ -1470,7 +1470,7 @@ async def test_user_show_menu_when_passive_scanner_present(hass: HomeAssistant) 
 
     with (
         patch(
-            "homeassistant.components.switchbot.config_flow.async_current_scanners",
+            "homeassistant.components.bluetooth.async_current_scanners",
             return_value=[mock_scanner_active, mock_scanner_passive],
         ),
         patch(
@@ -1514,7 +1514,7 @@ async def test_user_show_menu_when_no_scanners(hass: HomeAssistant) -> None:
     """Test that menu is shown when no scanners are available."""
     with (
         patch(
-            "homeassistant.components.switchbot.config_flow.async_current_scanners",
+            "homeassistant.components.bluetooth.async_current_scanners",
             return_value=[],
         ),
         patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Even when Bluetooth is in passive mode, it allows users to sync device types by logging in with their account, which should be helpful when adding sensor categories.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:https://github.com/home-assistant/home-assistant.io/pull/41938
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
