### PR TITLE
Fix: remove deprecated http prefix from ecovacs strings

### DIFF
--- a/homeassistant/components/ecovacs/strings.json
+++ b/homeassistant/components/ecovacs/strings.json
@@ -8,7 +8,8 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_url": "Invalid URL",
       "invalid_url_schema_override_mqtt_url": "Invalid MQTT URL scheme.\nThe URL should start with `mqtt://` or `mqtts://`.",
-      "invalid_url_schema_override_rest_url": "Invalid REST URL scheme.\nThe URL should start with `http://` or `https://`.",
+      "invalid_url_schema_override_rest_url":"Invalid REST URL scheme. Please provide a valid HTTP or HTTPS URL."
+
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {


### PR DESCRIPTION
This PR removes a deprecated hardcoded `http://` reference from ecovacs/strings.json.
Replaced it with neutral wording per project guidelines.
