### PR TITLE
Fix elkm1 connection cleanup on setup failure

### DIFF
--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -338,7 +338,7 @@ class ElkSyncWaiter:
         self._loop = asyncio.get_running_loop()
         self._sync_future: asyncio.Future[None] = self._loop.create_future()
         self._login_future: asyncio.Future[None] = self._loop.create_future()
-        self._login_succeeded = True
+        self._login_succeeded = False
 
     def _set_future_if_not_done(self, future: asyncio.Future[None]) -> None:
         """Set the future result if not already done."""

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -90,7 +90,7 @@ async def validate_input(data: dict[str, str], mac: str | None) -> dict[str, str
 
     try:
         await ElkSyncWaiter(elk, LOGIN_TIMEOUT, VALIDATE_TIMEOUT).async_wait()
-    except (TimeoutError, LoginFailed) as exc:
+    except LoginFailed as exc:
         raise InvalidAuth from exc
     finally:
         elk.disconnect()

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.typing import DiscoveryInfoType, VolDictType
 from homeassistant.util import slugify
 from homeassistant.util.network import is_ip_address
 
-from . import ElkSyncWaiter, hostname_from_url
+from . import ElkSyncWaiter, LoginFailed, hostname_from_url
 from .const import CONF_AUTO_CONFIGURE, DISCOVER_SCAN_TIMEOUT, DOMAIN, LOGIN_TIMEOUT
 from .discovery import (
     _short_mac,
@@ -89,8 +89,9 @@ async def validate_input(data: dict[str, str], mac: str | None) -> dict[str, str
     elk.connect()
 
     try:
-        if not await ElkSyncWaiter(elk, LOGIN_TIMEOUT, VALIDATE_TIMEOUT).async_wait():
-            raise InvalidAuth
+        await ElkSyncWaiter(elk, LOGIN_TIMEOUT, VALIDATE_TIMEOUT).async_wait()
+    except (TimeoutError, LoginFailed) as exc:
+        raise InvalidAuth from exc
     finally:
         elk.disconnect()
 

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.typing import DiscoveryInfoType, VolDictType
 from homeassistant.util import slugify
 from homeassistant.util.network import is_ip_address
 
-from . import async_wait_for_elk_to_sync, hostname_from_url
+from . import ElkSyncWaiter, hostname_from_url
 from .const import CONF_AUTO_CONFIGURE, DISCOVER_SCAN_TIMEOUT, DOMAIN, LOGIN_TIMEOUT
 from .discovery import (
     _short_mac,
@@ -89,7 +89,7 @@ async def validate_input(data: dict[str, str], mac: str | None) -> dict[str, str
     elk.connect()
 
     try:
-        if not await async_wait_for_elk_to_sync(elk, LOGIN_TIMEOUT, VALIDATE_TIMEOUT):
+        if not await ElkSyncWaiter(elk, LOGIN_TIMEOUT, VALIDATE_TIMEOUT).async_wait():
             raise InvalidAuth
     finally:
         elk.disconnect()


### PR DESCRIPTION
## Proposed change

Fix elkm1 integration failing to clean up connection when setup is cancelled or times out, which caused multiple competing Elk instances and connection instability.

Changes:
- Refactor sync waiting logic into `ElkSyncWaiter` class to avoid nonlocal variables
- Add `LoginFailed` exception for explicit login failure handling
- Use futures with `call_later` for timeout handling instead of `asyncio.timeout` to avoid `CancelledError` propagation issues from elkm1-lib's internal task cancellation
- Ensure `elk.disconnect()` is called when any step fails (timeout, login failure, cancellation)
- Clean up handlers with `remove_handler` in finally block to prevent leaks

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #156892
- This PR is related to issue:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
