### PR TITLE
Add support for HLS and WebRTC Octoprint cameras

### DIFF
--- a/homeassistant/components/octoprint/camera.py
+++ b/homeassistant/components/octoprint/camera.py
@@ -2,17 +2,41 @@
 
 from __future__ import annotations
 
-from pyoctoprintapi import OctoprintClient, WebcamSettings
+import asyncio
+from collections.abc import Callable
+from datetime import datetime, timedelta
+from json import JSONDecodeError
+import logging
 
+import httpx
+from propcache.api import cached_property
+from pyoctoprintapi import OctoprintClient, WebcamSettings
+from webrtc_models import RTCIceCandidateInit
+
+from homeassistant.components.camera import (
+    Camera,
+    CameraEntityFeature,
+    WebRTCAnswer,
+    WebRTCSendMessage,
+)
 from homeassistant.components.mjpeg import MjpegCamera
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import OctoprintDataUpdateCoordinator
-from .const import DOMAIN
+from .const import DOMAIN, GET_IMAGE_TIMEOUT
+
+_LOGGER = logging.getLogger(__name__)
+
+#: Type alias for a callable that creates a camera from Octoprint camera information.
+_OctoprintCameraConstructor = Callable[
+    [WebcamSettings, OctoprintDataUpdateCoordinator, str, bool], Camera
+]
 
 
 async def async_setup_entry(
@@ -35,9 +59,18 @@ async def async_setup_entry(
     if not camera_info or not camera_info.enabled:
         return
 
+    # Choose correct implementation based on the stream type, using the same logic the Octoprint front-end does
+    camera_ctor: _OctoprintCameraConstructor
+    if camera_info.stream_url.endswith(".m3u8"):
+        camera_ctor = OctoprintHlsCamera
+    elif camera_info.stream_url.startswith(("webrtc://", "webrtcs://")):
+        camera_ctor = OctoprintWebrtcCamera
+    else:
+        camera_ctor = OctoprintMjpegCamera
+
     async_add_entities(
         [
-            OctoprintCamera(
+            camera_ctor(
                 camera_info,
                 coordinator,
                 device_id,
@@ -47,8 +80,12 @@ async def async_setup_entry(
     )
 
 
-class OctoprintCamera(CoordinatorEntity[OctoprintDataUpdateCoordinator], MjpegCamera):
-    """Representation of an OctoPrint Camera Stream."""
+class OctoprintMjpegCamera(
+    CoordinatorEntity[OctoprintDataUpdateCoordinator], MjpegCamera
+):
+    """Representation of an OctoPrint MJPEG Camera Stream."""
+
+    _attr_is_streaming = True
 
     def __init__(
         self,
@@ -58,7 +95,8 @@ class OctoprintCamera(CoordinatorEntity[OctoprintDataUpdateCoordinator], MjpegCa
         verify_ssl: bool,
     ) -> None:
         """Initialize as a subclass of MjpegCamera."""
-        super().__init__(
+        CoordinatorEntity.__init__(
+            self,
             coordinator=coordinator,
         )
         MjpegCamera.__init__(
@@ -70,3 +108,152 @@ class OctoprintCamera(CoordinatorEntity[OctoprintDataUpdateCoordinator], MjpegCa
             unique_id=device_id,
             verify_ssl=verify_ssl,
         )
+
+
+class _OctoprintCamera(CoordinatorEntity[OctoprintDataUpdateCoordinator], Camera):
+    """Representation of an OctoPrint Camera Stream."""
+
+    _attr_name = "OctoPrint Camera"
+    _attr_supported_features = CameraEntityFeature.STREAM
+    _attr_is_streaming = True
+
+    def __init__(
+        self,
+        camera_settings: WebcamSettings,
+        coordinator: OctoprintDataUpdateCoordinator,
+        device_id: str,
+        verify_ssl: bool,
+    ) -> None:
+        CoordinatorEntity.__init__(
+            self,
+            coordinator=coordinator,
+        )
+        Camera.__init__(self)
+
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = device_id
+
+        self._camera_settings = camera_settings
+        self._verify_ssl = verify_ssl
+
+        self._last_image: bytes | None = None
+        self._last_update = datetime.min
+        self._update_lock = asyncio.Lock()
+
+    @cached_property
+    def use_stream_for_stills(self) -> bool:
+        """Use stream for stills if no snapshot URL is available."""
+        return not self._camera_settings.internal_snapshot_url
+
+    async def async_camera_image(
+        self, width: int | None = None, height: int | None = None
+    ) -> bytes | None:
+        "Fetch the camera image from the Octoprint URL."
+
+        if not (url := self._camera_settings.internal_snapshot_url):
+            return None
+
+        async with self._update_lock:
+            if (
+                self._last_image is not None
+                and self._last_update + timedelta(0, self._attr_frame_interval)
+                > datetime.now()
+            ):
+                return self._last_image
+
+            try:
+                update_time = datetime.now()
+                async_client = get_async_client(
+                    self.hass,
+                    verify_ssl=self._verify_ssl
+                    and self._camera_settings.snapshot_ssl_validation_enabled,
+                )
+                response = await async_client.get(
+                    url,
+                    follow_redirects=True,
+                    timeout=GET_IMAGE_TIMEOUT,
+                )
+                response.raise_for_status()
+                self._last_image = response.content
+                self._last_update = update_time
+
+            except httpx.TimeoutException:
+                _LOGGER.error("Timeout getting camera image from %s", self.name)
+            except (httpx.RequestError, httpx.HTTPStatusError) as err:
+                _LOGGER.error(
+                    "Error getting new camera image from %s: %s", self.name, err
+                )
+
+            return self._last_image
+
+
+class OctoprintHlsCamera(_OctoprintCamera):
+    """Representation of an HLS OctoPrint Camera Stream."""
+
+    async def stream_source(self) -> str:
+        "Use the Octoprint HLS URL as the stream source."
+
+        return self._camera_settings.stream_url
+
+
+class OctoprintWebrtcCamera(_OctoprintCamera):
+    """Representation of an OctoPrint WebRTC Camera Stream."""
+
+    @cached_property
+    def _offer_url(self) -> str:
+        "The offer/answer signaling URL."
+
+        url = self._camera_settings.stream_url
+
+        # Transform "webrtc(s)://" to "http(s)://", like Octoprint does
+        if url.startswith(("webrtc://", "webrtcs://")):
+            url = f"http{url[6:]}"
+
+        return url
+
+    async def async_handle_async_webrtc_offer(
+        self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
+    ) -> None:
+        """Handle an SDP offer via HTTP POST, like Octoprint does."""
+
+        # POST the offer and get the answer in response. This is the signaling protocol the Octoprint front-end uses,
+        # so if it works there it should work here too. (Like WHEP, but JSONified.)
+
+        try:
+            async_client = get_async_client(self.hass, verify_ssl=self._verify_ssl)
+            response = await async_client.post(
+                self._offer_url,
+                follow_redirects=True,
+                json={
+                    "type": "offer",
+                    "sdp": offer_sdp,
+                },
+            )
+            response.raise_for_status()
+        except (httpx.RequestError, httpx.HTTPStatusError) as err:
+            raise HomeAssistantError(
+                f"Error during WebRTC signaling HTTP POST for {self.name}: {err}"
+            ) from err
+
+        try:
+            response_json = response.json()
+        except (UnicodeDecodeError, JSONDecodeError) as err:
+            raise HomeAssistantError(
+                f"Invalid answer response for {self.name}: {err}"
+            ) from err
+
+        if (
+            response_json.get("type") != "answer"
+            or (response_sdp := response_json.get("sdp")) is None
+        ):
+            raise HomeAssistantError(f"Invalid answer response for {self.name}")
+
+        send_message(WebRTCAnswer(response_sdp))
+
+    async def async_on_webrtc_candidate(
+        self, session_id: str, candidate: RTCIceCandidateInit
+    ) -> None:
+        "Ignore additional WebRTC candidates."
+        # No mechanism to send additional candidates. Octoprint waits for all local candidates to be generated before
+        # sending the offer, so that they are included there. That does not seem possible here. Just do the best we can.
+        _LOGGER.debug("Ignoring WebRTC candidate for %s: %s", session_id, candidate)

--- a/homeassistant/components/octoprint/camera.py
+++ b/homeassistant/components/octoprint/camera.py
@@ -153,6 +153,9 @@ class _OctoprintCamera(CoordinatorEntity[OctoprintDataUpdateCoordinator], Camera
         if not (url := self._camera_settings.internal_snapshot_url):
             return None
 
+        # Lock to prevent concurrent calls to async_camera_image() from making concurrent requests to the snapshot URL,
+        # and thus violating our _attr_frame_interval limit. When the first call releases the lock, other waiting calls
+        # will (usually) just immediately return the cached _last_image from the first.
         async with self._update_lock:
             if (
                 self._last_image is not None

--- a/homeassistant/components/octoprint/const.py
+++ b/homeassistant/components/octoprint/const.py
@@ -6,3 +6,5 @@ DEFAULT_NAME = "OctoPrint"
 
 SERVICE_CONNECT = "printer_connect"
 CONF_BAUDRATE = "baudrate"
+
+GET_IMAGE_TIMEOUT = 10

--- a/homeassistant/components/octoprint/manifest.json
+++ b/homeassistant/components/octoprint/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "octoprint",
   "name": "OctoPrint",
+  "after_dependencies": ["mjpeg"],
   "codeowners": ["@rfleming71"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/octoprint",

--- a/tests/components/octoprint/test_camera.py
+++ b/tests/components/octoprint/test_camera.py
@@ -1,10 +1,22 @@
 """The tests for Octoptint camera module."""
 
-import pytest
+from http import HTTPStatus
+import json
+from typing import Any
 
+import httpx
+import pytest
+import respx
+
+from homeassistant.components import camera
+from homeassistant.components.websocket_api import TYPE_RESULT
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+
+from tests.typing import MockHAClientWebSocket, WebSocketGenerator
+
+pytestmark = pytest.mark.usefixtures("init_integration")
 
 
 @pytest.fixture
@@ -13,41 +25,67 @@ def platform() -> Platform:
     return Platform.CAMERA
 
 
+@pytest.fixture
+def stream_url() -> str:
+    """Fixture for stream URL of the Octoprint camera."""
+
+    return "/webcam/?action=stream"
+
+
+@pytest.fixture
+def snapshot_url() -> str:
+    """Fixture for the snapshot URL of the Octoprint camera."""
+
+    return "http://127.0.0.1:8080/?action=snapshot"
+
+
+@pytest.fixture
+def webcam_enabled() -> bool:
+    """Fixture for the enablement state of the Octoprint camera."""
+
+    return True
+
+
+@pytest.fixture
+def webcam(stream_url: str, snapshot_url: str, webcam_enabled: bool) -> dict[str, Any]:
+    """Fixture for the webcam settings for an Octoprint camera."""
+
+    return {
+        "base_url": "http://fake-octoprint/",
+        "raw": {
+            "streamUrl": stream_url,
+            "snapshotUrl": snapshot_url,
+            "webcamEnabled": webcam_enabled,
+            "snapshotSslValidation": False,
+        },
+    }
+
+
 @pytest.mark.parametrize(
-    "webcam",
+    ("stream_url", "expected_stream_types"),
     [
-        {
-            "base_url": "http://fake-octoprint/",
-            "raw": {
-                "streamUrl": "/webcam/?action=stream",
-                "snapshotUrl": "http://127.0.0.1:8080/?action=snapshot",
-                "webcamEnabled": True,
-            },
-        }
+        ("/webcam/?action=stream", set()),
+        ("/webcam/stream.m3u8", {camera.StreamType.HLS}),
+        ("webrtc://fake-webcam/stream", {camera.StreamType.WEB_RTC}),
+        ("webrtcs://fake-webcam/stream", {camera.StreamType.WEB_RTC}),
     ],
 )
-@pytest.mark.usefixtures("init_integration")
-async def test_camera(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
-    """Test the underlying camera."""
+async def test_camera(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    expected_stream_types: set[camera.StreamType],
+) -> None:
+    """Test the underlying camera is created and of the correct type."""
+
     entry = entity_registry.async_get("camera.octoprint_camera")
     assert entry is not None
     assert entry.unique_id == "uuid"
 
+    entity = hass.data.get(camera.DOMAIN).get_entity("camera.octoprint_camera")
+    assert entity.camera_capabilities.frontend_stream_types == expected_stream_types
 
-@pytest.mark.parametrize(
-    "webcam",
-    [
-        {
-            "base_url": "http://fake-octoprint/",
-            "raw": {
-                "streamUrl": "/webcam/?action=stream",
-                "snapshotUrl": "http://127.0.0.1:8080/?action=snapshot",
-                "webcamEnabled": False,
-            },
-        }
-    ],
-)
-@pytest.mark.usefixtures("init_integration")
+
+@pytest.mark.parametrize("webcam_enabled", [False])
 async def test_camera_disabled(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
@@ -56,10 +94,179 @@ async def test_camera_disabled(
     assert entry is None
 
 
-@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize("webcam", [None])
 async def test_no_supported_camera(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test that the camera does not load if there is not one configured."""
     entry = entity_registry.async_get("camera.octoprint_camera")
     assert entry is None
+
+
+@pytest.mark.parametrize(
+    "stream_url", ["/webcam/stream.m3u8", "webrtc://fake-webcam/stream"]
+)
+@pytest.mark.parametrize(
+    "snapshot_url", ["http://127.0.0.1:8080/?action=snapshot", None]
+)
+async def test_use_stream_for_stills(
+    hass: HomeAssistant, snapshot_url: str | None
+) -> None:
+    """Test that the stream is used for stills only when there is not snapshot URL."""
+
+    entity = hass.data.get(camera.DOMAIN).get_entity("camera.octoprint_camera")
+    assert entity.use_stream_for_stills == (not snapshot_url)
+
+
+FAKE_IMAGE = b"fake image"
+
+
+@respx.mock
+@pytest.mark.parametrize("stream_url", ["webrtc://fake-webcam/stream"])
+async def test_camera_image(hass: HomeAssistant, snapshot_url: str) -> None:
+    """Test getting the camera image from the snapshot URL."""
+
+    entity = hass.data.get(camera.DOMAIN).get_entity("camera.octoprint_camera")
+    entity._attr_frame_interval = 3600  # Increase frame interval from the default to make the test timing-resistant
+
+    respx.get(snapshot_url).respond(content=FAKE_IMAGE)
+    assert await entity.async_camera_image() == FAKE_IMAGE
+
+    # A second request within the frame interval reuses the cached image, without contacting the server again
+    respx.get(snapshot_url).respond(content=b"different image")
+    assert await entity.async_camera_image() == FAKE_IMAGE
+
+
+@respx.mock
+@pytest.mark.parametrize("stream_url", ["webrtc://fake-webcam/stream"])
+async def test_camera_image_error(hass: HomeAssistant, snapshot_url: str) -> None:
+    """Test errors while getting the camera image from the snapshot URL."""
+
+    entity = hass.data.get(camera.DOMAIN).get_entity("camera.octoprint_camera")
+    entity._last_image = FAKE_IMAGE  # Errors should return the cached image
+
+    respx.get(snapshot_url).respond(status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
+    assert await entity.async_camera_image() == FAKE_IMAGE
+
+
+@respx.mock
+@pytest.mark.parametrize("stream_url", ["webrtc://fake-webcam/stream"])
+async def test_camera_image_timeout(hass: HomeAssistant, snapshot_url: str) -> None:
+    "Test a timeout while getting the camera image from the snapshot URL."
+
+    entity = hass.data.get(camera.DOMAIN).get_entity("camera.octoprint_camera")
+    entity._last_image = FAKE_IMAGE  # Timeouts should return the cached image
+
+    respx.get(snapshot_url).mock(side_effect=httpx.TimeoutException)
+    assert await entity.async_camera_image() == FAKE_IMAGE
+
+
+async def send_offer_for_mock_response(
+    *, stream_url: str, client: MockHAClientWebSocket, **kwargs: Any
+):
+    """Send an SDP offer via web-socket, with mocking of the response, and validate that it was sent successfully."""
+
+    OFFER_SDP = "v=0\r\n"
+
+    respx.post(f"http{stream_url[6:]}").respond(**kwargs)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "camera/webrtc/offer",
+            "entity_id": "camera.octoprint_camera",
+            "offer": OFFER_SDP,
+        }
+    )
+
+    response = await client.receive_json()
+    assert response["id"] == 1
+    assert response["type"] == TYPE_RESULT
+    assert response["success"]
+    assert response["result"] is None
+
+    response = await client.receive_json()
+    assert response["id"] == 1
+    assert response["type"] == "event"
+    assert response["event"]["type"] == "session"
+    assert response["event"]["session_id"]
+
+    request = json.loads(respx.calls.last.request.content)
+    assert request["type"] == "offer"
+    assert request["sdp"] == OFFER_SDP
+
+
+@respx.mock
+@pytest.mark.parametrize("stream_url", ["webrtc://fake-webcam/stream"])
+async def test_webrtc_offer(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    stream_url: str,
+) -> None:
+    """Test that WebRTC offers are sent as HTTP POSTs and the answer reported."""
+
+    ANSWER_SDP = "v=1\r\n"
+
+    client = await hass_ws_client(hass)
+    await send_offer_for_mock_response(
+        stream_url=stream_url,
+        client=client,
+        status_code=HTTPStatus.OK,
+        json={"type": "answer", "sdp": ANSWER_SDP},
+    )
+
+    response = await client.receive_json()
+    assert response["id"] == 1
+    assert response["type"] == "event"
+    assert response["event"]["type"] == "answer"
+    assert response["event"]["answer"] == ANSWER_SDP
+
+
+@respx.mock
+@pytest.mark.parametrize("stream_url", ["webrtc://fake-webcam/stream"])
+async def test_webrtc_offer_error(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    stream_url: str,
+) -> None:
+    """Test that WebRTC offer HTTP failures are reported via websocket."""
+
+    client = await hass_ws_client(hass)
+    await send_offer_for_mock_response(
+        stream_url=stream_url,
+        client=client,
+        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+    )
+
+    response = await client.receive_json()
+    assert response["id"] == 1
+    assert response["type"] == "event"
+    assert response["event"]["type"] == "error"
+    assert response["event"]["code"] == "webrtc_offer_failed"
+    assert "500" in response["event"]["message"]
+
+
+@respx.mock
+@pytest.mark.parametrize("stream_url", ["webrtc://fake-webcam/stream"])
+@pytest.mark.parametrize("invalid_response", [b"not json", b"{}"])
+async def test_webrtc_offer_invalid(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    stream_url: str,
+    invalid_response: bytes,
+) -> None:
+    """Test that WebRTC offers with invalid responses are reported via websocket."""
+
+    client = await hass_ws_client(hass)
+    await send_offer_for_mock_response(
+        stream_url=stream_url,
+        client=client,
+        status_code=HTTPStatus.OK,
+        content=invalid_response,
+    )
+
+    response = await client.receive_json()
+    assert response["id"] == 1
+    assert response["type"] == "event"
+    assert response["event"]["type"] == "error"
+    assert response["event"]["code"] == "webrtc_offer_failed"
+    assert "Invalid answer" in response["event"]["message"]


### PR DESCRIPTION
## Proposed change

[Octoprint](https://www.home-assistant.io/integrations/octoprint/) has for a couple years now supported HLS and WebRTC camera streams, in addition to the original MJPEG. The current Home Assistant integration, however, still assumes that all streams are MJPEG. This PR adds support for HLS and WebRTC streams.

A previous version of this PR (#107044) attempted to build on top of `GenericCamera`. Intervening changes to how WebRTC is handled, however, made that less helpful, so now both the HLS and WebRTC implementations derive directly from `Camera`. The `async_camera_image()` implementation is still based on that of `GenericCamera`, but with all the templating parts removed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] ~~Documentation added/updated for [www.home-assistant.io][docs-repository]~~ (N/A)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] ~~New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.~~ (N/A)
- [ ] ~~For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.~~ (N/A)

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
