### PR TITLE
Feature: Native Service to Enable/Disable Integrations

### DIFF
--- a/homeassistant/components/homeassistant/icons.json
+++ b/homeassistant/components/homeassistant/icons.json
@@ -3,6 +3,12 @@
     "check_config": {
       "service": "mdi:receipt-text-check"
     },
+    "disable_config_entry": {
+      "service": "mdi:close"
+    },
+    "enable_config_entry": {
+      "service": "mdi:check"
+    },
     "reload_all": {
       "service": "mdi:reload"
     },

--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -58,6 +58,22 @@ reload_config_entry:
       selector:
         config_entry:
 
+enable_config_entry:
+  fields:
+    entry_id:
+      required: true
+      example: 8955375327824e14ba89e4b29cc3ec9a
+      selector:
+        config_entry:
+
+disable_config_entry:
+  fields:
+    entry_id:
+      required: true
+      example: 8955375327824e14ba89e4b29cc3ec9a
+      selector:
+        config_entry:
+
 save_persistent_states:
 
 reload_all:

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -178,6 +178,26 @@
       "description": "Checks the Home Assistant YAML-configuration files for errors. Errors will be shown in the Home Assistant logs.",
       "name": "Check configuration"
     },
+    "disable_config_entry": {
+      "description": "Disables the specified config entry.",
+      "fields": {
+        "entry_id": {
+          "description": "The configuration entry ID of the entry to be disabled.",
+          "name": "Config entry ID"
+        }
+      },
+      "name": "Disable config entry"
+    },
+    "enable_config_entry": {
+      "description": "Enables the specified config entry.",
+      "fields": {
+        "entry_id": {
+          "description": "The configuration entry ID of the entry to be enabled.",
+          "name": "Config entry ID"
+        }
+      },
+      "name": "Enable config entry"
+    },
     "reload_all": {
       "description": "Reloads all YAML configuration that can be reloaded without restarting Home Assistant.",
       "name": "Reload all"

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -6,12 +6,14 @@ import pytest
 import voluptuous as vol
 import yaml
 
-from homeassistant import config, core as ha
+from homeassistant import config, config_entries, core as ha
 from homeassistant.components.homeassistant import (
     ATTR_ENTRY_ID,
     ATTR_SAFE_MODE,
     DOMAIN,
     SERVICE_CHECK_CONFIG,
+    SERVICE_DISABLE_CONFIG_ENTRY,
+    SERVICE_ENABLE_CONFIG_ENTRY,
     SERVICE_HOMEASSISTANT_RESTART,
     SERVICE_HOMEASSISTANT_STOP,
     SERVICE_RELOAD_ALL,
@@ -403,6 +405,46 @@ async def test_reload_config_entry_by_entry_id(hass: HomeAssistant) -> None:
 
     assert len(mock_reload.mock_calls) == 1
     assert mock_reload.mock_calls[0][1][0] == "8955375327824e14ba89e4b29cc3ec9a"
+
+
+async def test_disable_config_entry_by_entry_id(hass: HomeAssistant) -> None:
+    """Test being able to disable a config entry by config entry id."""
+    await async_setup_component(hass, "homeassistant", {})
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_set_disabled_by",
+        return_value=True,
+    ) as mock_disable:
+        await hass.services.async_call(
+            "homeassistant",
+            SERVICE_DISABLE_CONFIG_ENTRY,
+            {ATTR_ENTRY_ID: "8955375327824e14ba89e4b29cc3ec9a"},
+            blocking=True,
+        )
+
+    assert len(mock_disable.mock_calls) == 1
+    assert mock_disable.mock_calls[0][1][0] == "8955375327824e14ba89e4b29cc3ec9a"
+    assert mock_disable.mock_calls[0][1][1] == config_entries.ConfigEntryDisabler.USER
+
+
+async def test_enable_config_entry_by_entry_id(hass: HomeAssistant) -> None:
+    """Test being able to enable a config entry by config entry id."""
+    await async_setup_component(hass, "homeassistant", {})
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_set_disabled_by",
+        return_value=True,
+    ) as mock_enable:
+        await hass.services.async_call(
+            "homeassistant",
+            SERVICE_ENABLE_CONFIG_ENTRY,
+            {ATTR_ENTRY_ID: "8955375327824e14ba89e4b29cc3ec9a"},
+            blocking=True,
+        )
+
+    assert len(mock_enable.mock_calls) == 1
+    assert mock_enable.mock_calls[0][1][0] == "8955375327824e14ba89e4b29cc3ec9a"
+    assert mock_enable.mock_calls[0][1][1] is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, if you want to disable an integration (e.g., turn off the "Cloud" integration to save data, or disable "Christmas Lights" integration in July), you have to go to Settings → Devices → Click "Disable." You cannot do this via Automation. A famous custom component called Spook implements this as a custom service (homeassistant.enable_config_entry).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
See Spook's similar feature: https://spook.boo/integrations/

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
