### PR TITLE
Handle invalid IP addresses in ip_bans.yaml gracefully

### DIFF
--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -233,6 +233,9 @@ class IpBanManager:
             except vol.Invalid as err:
                 _LOGGER.error("Failed to load IP ban %s: %s", ip_info, err)
                 continue
+            except ValueError:
+                _LOGGER.error("Failed to load IP ban: invalid IP address %s", ip_ban)
+                continue
 
         self.ip_bans_lookup = ip_bans_lookup
 

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -159,9 +159,12 @@ async def test_access_from_banned_ip_with_invalid_ip_entry(
     assert resp.status == HTTPStatus.NOT_FOUND
 
     # Check that both invalid IP entries were logged
-    assert "Failed to load IP ban" in caplog.text
-    assert "Eo128.199.160.243" in caplog.text
-    assert "invalidip" in caplog.text
+    for ip in ("Eo128.199.160.243", "invalidip"):
+        assert (
+            "homeassistant.components.http.ban",
+            logging.ERROR,
+            f"Failed to load IP ban: invalid IP address {ip}",
+        ) in caplog.record_tuples
 
 
 async def test_no_ip_bans_file(

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -2,6 +2,7 @@
 
 from http import HTTPStatus
 from ipaddress import ip_address
+import logging
 import os
 from unittest.mock import AsyncMock, Mock, mock_open, patch
 

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -113,6 +113,57 @@ async def test_access_from_banned_ip_with_partially_broken_yaml_file(
     assert "Failed to load IP ban" in caplog.text
 
 
+async def test_access_from_banned_ip_with_invalid_ip_entry(
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that invalid IP addresses in ban file are skipped gracefully.
+
+    An invalid IP entry (e.g., with typo like "Eo128.199.160.243") should
+    be logged as an error and skipped, allowing valid bans to still load.
+    The test ensures that valid IPs after invalid ones are still processed.
+    """
+    app = web.Application()
+    app[KEY_HASS] = hass
+    setup_bans(hass, app, 5)
+    set_real_ip = mock_real_ip(app)
+
+    # Invalid IPs interspersed between valid ones to ensure continue works
+    data = {
+        "Eo128.199.160.243": {"banned_at": "2024-07-06T14:07:46"},
+        BANNED_IPS[0]: {"banned_at": "2016-11-16T19:20:03"},
+        "invalidip": {"banned_at": "2024-07-06T14:07:46"},
+        BANNED_IPS[1]: {"banned_at": "2016-11-16T19:20:03"},
+    }
+
+    with patch(
+        "homeassistant.components.http.ban.load_yaml_config_file",
+        return_value=data,
+    ):
+        client = await aiohttp_client(app)
+
+    # Verify exactly 2 valid IPs were loaded (invalid ones skipped)
+    manager = app[KEY_BAN_MANAGER]
+    assert len(manager.ip_bans_lookup) == len(BANNED_IPS)
+
+    # Valid banned IPs should still be blocked (even though they came after invalid ones)
+    for remote_addr in BANNED_IPS:
+        set_real_ip(remote_addr)
+        resp = await client.get("/")
+        assert resp.status == HTTPStatus.FORBIDDEN
+
+    # Non-banned IP should have access
+    set_real_ip("192.168.1.1")
+    resp = await client.get("/")
+    assert resp.status == HTTPStatus.NOT_FOUND
+
+    # Check that both invalid IP entries were logged
+    assert "Failed to load IP ban" in caplog.text
+    assert "Eo128.199.160.243" in caplog.text
+    assert "invalidip" in caplog.text
+
+
 async def test_no_ip_bans_file(
     hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
 ) -> None:


### PR DESCRIPTION
## Proposed change

When an invalid IP address entry exists in `ip_bans.yaml` (e.g., a typo like `"Eo128.199.160.243"`), Home Assistant crashes with a `ValueError` during startup, making the web UI completely unreachable.

This change catches `ValueError` exceptions when parsing IP addresses from the ban file and logs an error message while skipping the invalid entry. Valid IP bans continue to be loaded and enforced normally.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #157180
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr