### PR TITLE
Use "medium" instead of "med" for the medium fan mode in Coolmaster

### DIFF
--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -8,6 +8,10 @@ from typing import Any
 from pycoolmasternet_async import SWING_MODES
 
 from homeassistant.components.climate import (
+    FAN_AUTO,
+    FAN_HIGH,
+    FAN_LOW,
+    FAN_MEDIUM,
     ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
@@ -31,7 +35,16 @@ CM_TO_HA_STATE = {
 
 HA_STATE_TO_CM = {value: key for key, value in CM_TO_HA_STATE.items()}
 
-FAN_MODES = ["low", "med", "high", "auto"]
+CM_TO_HA_FAN = {
+    "low": FAN_LOW,
+    "med": FAN_MEDIUM,
+    "high": FAN_HIGH,
+    "auto": FAN_AUTO,
+}
+
+HA_FAN_TO_CM = {value: key for key, value in CM_TO_HA_FAN.items()}
+
+FAN_MODES = list(CM_TO_HA_FAN.values())
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,7 +124,7 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
     @property
     def fan_mode(self):
         """Return the fan setting."""
-        return self._unit.fan_speed
+        return CM_TO_HA_FAN[self._unit.fan_speed]
 
     @property
     def fan_modes(self):
@@ -138,7 +151,7 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
         _LOGGER.debug("Setting fan mode of %s to %s", self.unique_id, fan_mode)
-        self._unit = await self._unit.set_fan_speed(fan_mode)
+        self._unit = await self._unit.set_fan_speed(HA_FAN_TO_CM[fan_mode])
         self.async_write_ha_state()
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -16,7 +16,6 @@ from homeassistant.components.climate import (
     DOMAIN as CLIMATE_DOMAIN,
     FAN_HIGH,
     FAN_LOW,
-    FAN_MEDIUM,
     SERVICE_SET_FAN_MODE,
     SERVICE_SET_HVAC_MODE,
     SERVICE_SET_SWING_MODE,
@@ -175,8 +174,8 @@ async def test_set_fan_mode(
     """Test the Coolmaster climate set fan mode."""
     assert hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODE] == FAN_LOW
 
-    # Set the fan to HIGH, MEDIUM, and LOW and verify the changes
-    for target_fan in (FAN_HIGH, FAN_MEDIUM, FAN_LOW):
+    # Set the fan to all supported modes and verify the changes
+    for target_fan in FAN_MODES:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_FAN_MODE,

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -16,6 +16,7 @@ from homeassistant.components.climate import (
     DOMAIN as CLIMATE_DOMAIN,
     FAN_HIGH,
     FAN_LOW,
+    FAN_MEDIUM,
     SERVICE_SET_FAN_MODE,
     SERVICE_SET_HVAC_MODE,
     SERVICE_SET_SWING_MODE,
@@ -173,17 +174,20 @@ async def test_set_fan_mode(
 ) -> None:
     """Test the Coolmaster climate set fan mode."""
     assert hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODE] == FAN_LOW
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_FAN_MODE,
-        {
-            ATTR_ENTITY_ID: "climate.l1_100",
-            ATTR_FAN_MODE: FAN_HIGH,
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-    assert hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODE] == FAN_HIGH
+
+    # Set the fan to HIGH, MEDIUM, and LOW and verify the changes
+    for target_fan in (FAN_HIGH, FAN_MEDIUM, FAN_LOW):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {
+                ATTR_ENTITY_ID: "climate.l1_100",
+                ATTR_FAN_MODE: target_fan,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODE] == target_fan
 
 
 async def test_set_swing_mode(

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -167,26 +167,28 @@ async def test_set_temperature(
     assert hass.states.get("climate.l1_100").attributes[ATTR_TEMPERATURE] == 30
 
 
+@pytest.mark.parametrize("target_fan_mode", FAN_MODES)
 async def test_set_fan_mode(
     hass: HomeAssistant,
     load_int: ConfigEntry,
+    target_fan_mode: str,
 ) -> None:
     """Test the Coolmaster climate set fan mode."""
     assert hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODE] == FAN_LOW
 
-    # Set the fan to all supported modes and verify the changes
-    for target_fan in FAN_MODES:
-        await hass.services.async_call(
-            CLIMATE_DOMAIN,
-            SERVICE_SET_FAN_MODE,
-            {
-                ATTR_ENTITY_ID: "climate.l1_100",
-                ATTR_FAN_MODE: target_fan,
-            },
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-        assert hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODE] == target_fan
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_FAN_MODE,
+        {
+            ATTR_ENTITY_ID: "climate.l1_100",
+            ATTR_FAN_MODE: target_fan_mode,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert (
+        hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODE] == target_fan_mode
+    )
 
 
 async def test_set_swing_mode(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The climate entities provided by the coolmaster integration now uses `medium` (matching the `FAN_MEDIUM` constant) for the medium fan mode; before this change, it was `med`. If your automations are using `med` when setting or querying the fan speed, you'll have to change it to `medium`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prior to this change, the climate entities created by the Coolmaster integration would use `med` for fan mode representing the medium speed. This causes issues as no other component in home assistant recognizes that as the medium speed. For instance, the entity card doesn't pick up the right icon for the medium fan speed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- This PR fixes or closes issue: fixes #133068
- This PR is me re-attempting PR133254.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
