### PR TITLE
Add support for authentication to the Music Assistant integration

### DIFF
--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -67,7 +67,6 @@ class MusicAssistantEntryData:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Music Assistant component."""
-    # Register services
     register_actions(hass)
 
     return True

--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -8,16 +8,25 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from music_assistant_client import MusicAssistantClient
-from music_assistant_client.exceptions import CannotConnect, InvalidServerVersion
+from music_assistant_client.exceptions import (
+    CannotConnect,
+    InvalidServerVersion,
+    MusicAssistantClientException,
+)
 from music_assistant_models.config_entries import PlayerConfig
 from music_assistant_models.enums import EventType
-from music_assistant_models.errors import ActionUnavailable, MusicAssistantError
+from music_assistant_models.errors import (
+    ActionUnavailable,
+    AuthenticationFailed,
+    InvalidToken,
+    MusicAssistantError,
+)
 from music_assistant_models.player import Player
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.issue_registry import (
@@ -26,7 +35,7 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 
-from .const import ATTR_CONF_EXPOSE_PLAYER_TO_HA, DOMAIN, LOGGER
+from .const import ATTR_CONF_EXPOSE_PLAYER_TO_HA, CONF_TOKEN, DOMAIN, LOGGER
 from .helpers import get_music_assistant_client
 from .services import register_actions
 
@@ -58,7 +67,9 @@ class MusicAssistantEntryData:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Music Assistant component."""
+    # Register services
     register_actions(hass)
+
     return True
 
 
@@ -68,7 +79,9 @@ async def async_setup_entry(  # noqa: C901
     """Set up Music Assistant from a config entry."""
     http_session = async_get_clientsession(hass, verify_ssl=False)
     mass_url = entry.data[CONF_URL]
-    mass = MusicAssistantClient(mass_url, http_session)
+    # Get token from config entry (for schema >= AUTH_SCHEMA_VERSION)
+    token = entry.data.get(CONF_TOKEN)
+    mass = MusicAssistantClient(mass_url, http_session, token=token)
 
     try:
         async with asyncio.timeout(CONNECT_TIMEOUT):
@@ -87,6 +100,14 @@ async def async_setup_entry(  # noqa: C901
             translation_key="invalid_server_version",
         )
         raise ConfigEntryNotReady(f"Invalid server version: {err}") from err
+    except (AuthenticationFailed, InvalidToken) as err:
+        raise ConfigEntryAuthFailed(
+            f"Authentication failed for {mass_url}: {err}"
+        ) from err
+    except MusicAssistantClientException as err:
+        raise ConfigEntryNotReady(
+            f"Failed to connect to music assistant server {mass_url}: {err}"
+        ) from err
     except MusicAssistantError as err:
         LOGGER.exception("Failed to connect to music assistant server", exc_info=err)
         raise ConfigEntryNotReady(

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -189,10 +189,7 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         self._set_confirm_only()
-        return self.async_show_form(
-            step_id="hassio_confirm",
-            description_placeholders={"url": self.url},
-        )
+        return self.async_show_form(step_id="hassio_confirm")
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -193,7 +193,7 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="server_not_ready")
 
         # We trust the token from hassio discovery and validate it during setup
-        self.token = discovery_info.config["token"]
+        self.token = discovery_info.config["auth_token"]
 
         self.server_info = server_info
         await self.async_set_unique_id(server_info.server_id)

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -405,9 +405,15 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             except (AuthenticationFailed, InvalidToken):
                 errors["base"] = "auth_failed"
             except MusicAssistantClientException:
-                LOGGER.exception("Unexpected exception during reauth")
+                LOGGER.exception("Unexpected exception during manual auth")
                 return self.async_abort(reason="unknown")
             else:
+                if self.source == SOURCE_REAUTH:
+                    return self.async_update_reload_and_abort(
+                        self._get_reauth_entry(),
+                        data={CONF_URL: self.url, CONF_TOKEN: self.token},
+                    )
+
                 return self.async_create_entry(
                     title=DEFAULT_TITLE,
                     data={CONF_URL: self.url, CONF_TOKEN: self.token},

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -111,7 +111,6 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
         self.url: str | None = None
         self.token: str | None = None
         self.server_info: ServerInfoMessage | None = None
-        self._external_auth_available: bool = False
 
     def _ensure_callback_view_registered(self) -> None:
         """Ensure the auth callback view is registered."""

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -289,9 +289,7 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             state = _encode_jwt(
                 self.hass, {"flow_id": self.flow_id, "redirect_uri": redirect_uri}
             )
-
             # Music Assistant server will redirect to: {redirect_uri}?state={state}&code={token}
-            # (we use "code" parameter to match OAuth2 callback expectations)
             params = urlencode(
                 {
                     "return_url": f"{redirect_uri}?state={state}",

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -196,7 +196,6 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             LOGGER.exception("Unexpected exception during add-on discovery")
             return self.async_abort(reason="unknown")
 
-        # Check if server has completed onboarding
         if not server_info.onboard_done:
             return self.async_abort(reason="server_not_ready")
 

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -252,16 +252,6 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={"url": self.url},
         )
 
-    def _check_external_auth_available(self) -> bool:
-        """Check if external auth (redirect) is available."""
-        try:
-            async_get_redirect_uri(self.hass)
-        except RuntimeError:
-            # No current request context or missing required headers
-            return False
-        else:
-            return True
-
     async def async_step_auth(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -278,7 +278,6 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="auth_error")
             # OAuth2 callback sends token as "code" parameter
             if "code" in user_input:
-                # Token was received from OAuth2 callback, store it and complete external step
                 self.token = user_input["code"]
                 return self.async_external_step_done(next_step_id="finish_auth")
 
@@ -335,7 +334,6 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             LOGGER.exception("Unexpected exception during connection test")
             return self.async_abort(reason="unknown")
 
-        # Check if this is a reauth flow
         if self.source == SOURCE_REAUTH:
             reauth_entry = self._get_reauth_entry()
             return self.async_update_reload_and_abort(
@@ -384,7 +382,6 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
                     data={CONF_URL: self.url, CONF_TOKEN: self.token},
                 )
 
-        # Show form for manual token entry
         return self.async_show_form(
             step_id="auth_manual",
             data_schema=vol.Schema({vol.Required(CONF_TOKEN): str}),

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -272,8 +272,8 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             assert self.url is not None
             assert self.token is not None
 
-        # Exchange short-lived token for long-lived token
-        # The OAuth flow gives us a short-lived session token (30 day expiration)
+        # Exchange session token for long-lived token
+        # The OAuth flow gives us a session token (30 day expiration)
         session = aiohttp_client.async_get_clientsession(self.hass)
 
         try:

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -2,41 +2,103 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlencode
 
-from music_assistant_client import MusicAssistantClient
+from music_assistant_client.auth_helpers import create_long_lived_token, get_server_info
 from music_assistant_client.exceptions import (
     CannotConnect,
     InvalidServerVersion,
     MusicAssistantClientException,
 )
 from music_assistant_models.api import ServerInfoMessage
+from music_assistant_models.errors import AuthenticationFailed, InvalidToken
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.components import http
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from .const import AUTH_SCHEMA_VERSION, DOMAIN, LOGGER
+from .const import AUTH_SCHEMA_VERSION, CONF_TOKEN, DOMAIN, LOGGER
+
+AUTH_CALLBACK_PATH = "/auth/music_assistant/callback"
 
 DEFAULT_TITLE = "Music Assistant"
 DEFAULT_URL = "http://mass.local:8095"
 
 
+class MusicAssistantAuthCallbackView(http.HomeAssistantView):
+    """Music Assistant authorization callback view."""
+
+    requires_auth = False
+    url = AUTH_CALLBACK_PATH
+    name = "auth:music_assistant:callback"
+
+    async def get(self, request: http.web.Request) -> http.web.Response:
+        """Receive authorization token from Music Assistant."""
+        if "flow_id" not in request.query:
+            return http.web.Response(text="Missing flow_id parameter", status=400)
+
+        if "token" not in request.query:
+            return http.web.Response(text="Missing token parameter", status=400)
+
+        hass = request.app[http.KEY_HASS]
+        flow_id = request.query["flow_id"]
+        token = request.query["token"]
+
+        # Pass token directly to the config flow via user_input
+        await hass.config_entries.flow.async_configure(
+            flow_id=flow_id, user_input={CONF_TOKEN: token}
+        )
+
+        # Return script to close the popup window
+        return http.web.Response(
+            headers={"content-type": "text/html"},
+            text="<script>window.close()</script>Success! You can close this window.",
+        )
+
+
 STEP_USER_SCHEMA = vol.Schema({vol.Required(CONF_URL): str})
+STEP_AUTH_TOKEN_SCHEMA = vol.Schema({vol.Required(CONF_TOKEN): str})
+
+
+def _parse_zeroconf_server_info(properties: dict[str, str]) -> ServerInfoMessage:
+    """Parse zeroconf properties to ServerInfoMessage."""
+
+    def _parse_bool(value: str | bool) -> bool:
+        """Parse string boolean."""
+        if isinstance(value, bool):
+            return value
+        return value.lower() in ("true", "1", "yes")
+
+    def _parse_int(value: str | int) -> int:
+        """Parse string integer."""
+        if isinstance(value, int):
+            return value
+        return int(value)
+
+    return ServerInfoMessage(
+        server_id=properties["server_id"],
+        server_version=properties["server_version"],
+        schema_version=_parse_int(properties["schema_version"]),
+        min_supported_schema_version=_parse_int(
+            properties["min_supported_schema_version"]
+        ),
+        base_url=properties["base_url"],
+        homeassistant_addon=_parse_bool(properties["homeassistant_addon"]),
+        onboard_done=_parse_bool(properties["onboard_done"]),
+    )
 
 
 async def _get_server_info(hass: HomeAssistant, url: str) -> ServerInfoMessage:
-    """Validate the user input allows us to connect."""
-    async with MusicAssistantClient(
-        url, aiohttp_client.async_get_clientsession(hass)
-    ) as client:
-        if TYPE_CHECKING:
-            assert client.server_info is not None
-        return client.server_info
+    """Get MA server info for the given URL."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    return await get_server_info(server_url=url, aiohttp_session=session)
 
 
 class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -47,16 +109,25 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Set up flow instance."""
         self.url: str | None = None
+        self.token: str | None = None
+        self.server_info: ServerInfoMessage | None = None
+        self._external_auth_available: bool = False
+
+    def _ensure_callback_view_registered(self) -> None:
+        """Ensure the auth callback view is registered."""
+        if self.hass.http is not None:
+            # register_view is idempotent - safe to call multiple times
+            self.hass.http.register_view(MusicAssistantAuthCallbackView())
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a manual configuration."""
         errors: dict[str, str] = {}
-
         if user_input is not None:
+            self.url = user_input[CONF_URL]
             try:
-                server_info = await _get_server_info(self.hass, user_input[CONF_URL])
+                server_info = await _get_server_info(self.hass, self.url)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidServerVersion:
@@ -65,16 +136,21 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
                 LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
+                self.server_info = server_info
                 await self.async_set_unique_id(
                     server_info.server_id, raise_on_progress=False
                 )
-                self._abort_if_unique_id_configured(
-                    updates={CONF_URL: user_input[CONF_URL]}
-                )
+                self._abort_if_unique_id_configured(updates={CONF_URL: self.url})
 
+                # Check if authentication is required
+                if server_info.schema_version >= AUTH_SCHEMA_VERSION:
+                    # Redirect to browser-based authentication
+                    return await self.async_step_auth()
+
+                # Old server, no auth needed
                 return self.async_create_entry(
                     title=DEFAULT_TITLE,
-                    data={CONF_URL: user_input[CONF_URL]},
+                    data={CONF_URL: self.url},
                 )
 
         suggested_values = user_input
@@ -99,11 +175,9 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
         # Build URL from add-on discovery info
         # The add-on exposes the API on port 8095, but also has an internal-only
         # port 8094 for the Home Assistant integration to connect to
-        # If the add-on provides host info, use it; otherwise use the add-on slug
         host = discovery_info.config["host"]
         port = discovery_info.config["port"]
         self.url = f"http://{host}:{port}"
-
         try:
             server_info = await _get_server_info(self.hass, self.url)
         except CannotConnect:
@@ -118,8 +192,14 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
         if not server_info.onboard_done:
             return self.async_abort(reason="server_not_ready")
 
+        # We trust the token from hassio discovery and validate it during setup
+        self.token = discovery_info.config["token"]
+
+        self.server_info = server_info
         await self.async_set_unique_id(server_info.server_id)
-        self._abort_if_unique_id_configured(updates={CONF_URL: self.url})
+        self._abort_if_unique_id_configured(
+            updates={CONF_URL: self.url, CONF_TOKEN: self.token}
+        )
 
         return await self.async_step_hassio_confirm()
 
@@ -131,9 +211,12 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             assert self.url is not None
 
         if user_input is not None:
+            data = {CONF_URL: self.url}
+            if self.token:
+                data[CONF_TOKEN] = self.token
             return self.async_create_entry(
                 title=DEFAULT_TITLE,
-                data={CONF_URL: self.url},
+                data=data,
             )
 
         self._set_confirm_only()
@@ -142,28 +225,151 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={"url": self.url},
         )
 
+    def _check_external_auth_available(self) -> bool:
+        """Check if external auth (redirect) is available."""
+        if (req := http.current_request.get()) is None:
+            return False
+        if req.headers.get("HA-Frontend-Base") is None:
+            return False
+        return True
+
+    async def async_step_auth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle authentication via redirect to MA login."""
+        if TYPE_CHECKING:
+            assert self.url is not None
+
+        # Check if we're returning from the external auth step with a token
+        if user_input is not None and CONF_TOKEN in user_input:
+            # Token was received from callback, store it and complete external step
+            self.token = user_input[CONF_TOKEN]
+            return self.async_external_step_done(next_step_id="finish_auth")
+
+        # Check if we can use external auth (redirect flow)
+        if self._check_external_auth_available():
+            # Ensure callback view is registered before redirecting
+            self._ensure_callback_view_registered()
+
+            # Build MA login URL with callback
+            req = http.current_request.get()
+            ha_host = req.headers.get("HA-Frontend-Base")  # type: ignore[union-attr]
+            callback_url = f"{ha_host}{AUTH_CALLBACK_PATH}?flow_id={self.flow_id}"
+            params = urlencode(
+                {"return_url": callback_url, "device_name": "Home Assistant"}
+            )
+            login_url = f"{self.url}/login?{params}"
+            return self.async_external_step(step_id="auth", url=login_url)
+
+        # Fallback to manual token entry if no request context
+        return await self.async_step_auth_manual()
+
+    async def async_step_finish_auth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Finish authentication after receiving token."""
+        if TYPE_CHECKING:
+            assert self.url is not None
+            assert self.token is not None
+
+        # Exchange short-lived token for long-lived token
+        # The OAuth flow gives us a short-lived session token (30 day expiration)
+        session = aiohttp_client.async_get_clientsession(self.hass)
+
+        try:
+            LOGGER.debug("Creating long-lived token")
+            long_lived_token = await create_long_lived_token(
+                self.url,
+                self.token,
+                "Home Assistant",
+                aiohttp_session=session,
+            )
+            LOGGER.debug("Successfully created long-lived token")
+        except (TimeoutError, CannotConnect):
+            return self.async_abort(reason="cannot_connect")
+        except (AuthenticationFailed, InvalidToken) as err:
+            LOGGER.error("Authentication failed: %s", err)
+            return self.async_abort(reason="auth_failed")
+        except InvalidServerVersion as err:
+            LOGGER.error("Invalid server version: %s", err)
+            return self.async_abort(reason="invalid_server_version")
+        except MusicAssistantClientException:
+            LOGGER.exception("Unexpected exception during connection test")
+            return self.async_abort(reason="unknown")
+
+        # Check if this is a reauth flow
+        if self.source == SOURCE_REAUTH:
+            reauth_entry = self._get_reauth_entry()
+            # Update existing entry with new token
+            return self.async_update_reload_and_abort(
+                reauth_entry,
+                data={CONF_URL: self.url, CONF_TOKEN: long_lived_token},
+            )
+
+        # Token has been validated through the connection test
+        return self.async_create_entry(
+            title=DEFAULT_TITLE,
+            data={CONF_URL: self.url, CONF_TOKEN: long_lived_token},
+        )
+
+    async def async_step_auth_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle manual token entry as fallback."""
+        if TYPE_CHECKING:
+            assert self.url is not None
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self.token = user_input[CONF_TOKEN]
+            # Token will be validated during setup
+            # If invalid, setup will raise ConfigEntryAuthFailed
+            return self.async_create_entry(
+                title=DEFAULT_TITLE,
+                data={CONF_URL: self.url, CONF_TOKEN: self.token},
+            )
+
+        # Show form for manual token entry
+        return self.async_show_form(
+            step_id="auth_manual",
+            data_schema=vol.Schema({vol.Required(CONF_TOKEN): str}),
+            description_placeholders={"url": self.url},
+            errors=errors,
+        )
+
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
         """Handle a zeroconf discovery for a Music Assistant server."""
         try:
-            server_info = ServerInfoMessage.from_dict(discovery_info.properties)
-        except LookupError:
+            # Parse zeroconf properties (strings) to ServerInfoMessage
+            server_info = _parse_zeroconf_server_info(discovery_info.properties)
+        except (LookupError, KeyError, ValueError):
             return self.async_abort(reason="invalid_discovery_info")
 
-        # Ignore servers running as Home Assistant add-on (only for schema >= AUTH_SCHEMA_VERSION)
-        # (they should be discovered through hassio discovery instead)
-        if (
-            server_info.schema_version >= AUTH_SCHEMA_VERSION
-            and server_info.homeassistant_addon
-        ):
-            return self.async_abort(reason="already_discovered_addon")
+        LOGGER.debug(
+            "Zeroconf discovery: schema=%s, addon=%s, onboard_done=%s",
+            server_info.schema_version,
+            server_info.homeassistant_addon,
+            server_info.onboard_done,
+        )
 
-        # Ignore servers that have not completed onboarding yet
-        if not server_info.onboard_done:
-            return self.async_abort(reason="server_not_ready")
+        # For servers with schema >= 28, apply additional filtering
+        if server_info.schema_version >= AUTH_SCHEMA_VERSION:
+            # Ignore servers running as Home Assistant add-on
+            # (they should be discovered through hassio discovery instead)
+            if server_info.homeassistant_addon:
+                LOGGER.debug("Ignoring add-on server in zeroconf discovery")
+                return self.async_abort(reason="already_discovered_addon")
+
+            # Ignore servers that have not completed onboarding yet
+            if not server_info.onboard_done:
+                LOGGER.debug("Ignoring server that hasn't completed onboarding")
+                return self.async_abort(reason="server_not_ready")
 
         self.url = server_info.base_url
+        self.server_info = server_info
 
         await self.async_set_unique_id(server_info.server_id)
         self._abort_if_unique_id_configured(updates={CONF_URL: self.url})
@@ -181,8 +387,15 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle user-confirmation of discovered server."""
         if TYPE_CHECKING:
             assert self.url is not None
+            assert self.server_info is not None
 
         if user_input is not None:
+            # Check if authentication is required
+            if self.server_info.schema_version >= AUTH_SCHEMA_VERSION:
+                # Redirect to browser-based authentication
+                return await self.async_step_auth()
+
+            # Old server, no auth needed
             return self.async_create_entry(
                 title=DEFAULT_TITLE,
                 data={CONF_URL: self.url},
@@ -191,5 +404,41 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
         self._set_confirm_only()
         return self.async_show_form(
             step_id="discovery_confirm",
+            description_placeholders={"url": self.url},
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauth when token is invalid or expired."""
+        # Store the URL from the existing entry
+        self.url = entry_data[CONF_URL]
+        # Get server info to determine auth method
+        try:
+            self.server_info = await _get_server_info(self.hass, self.url)
+        except CannotConnect:
+            return self.async_abort(reason="cannot_connect")
+        except InvalidServerVersion:
+            return self.async_abort(reason="invalid_server_version")
+        except MusicAssistantClientException:
+            LOGGER.exception("Unexpected exception during reauth")
+            return self.async_abort(reason="unknown")
+
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm reauth dialog."""
+        if TYPE_CHECKING:
+            assert self.url is not None
+            assert self.server_info is not None
+
+        if user_input is not None:
+            # Redirect to auth flow
+            return await self.async_step_auth()
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
             description_placeholders={"url": self.url},
         )

--- a/homeassistant/components/music_assistant/const.py
+++ b/homeassistant/components/music_assistant/const.py
@@ -11,7 +11,6 @@ DEFAULT_NAME = "Music Assistant"
 # This version also introduces hassio discovery support
 AUTH_SCHEMA_VERSION = 28
 
-# Configuration constants
 CONF_TOKEN = "token"
 
 ATTR_IS_GROUP = "is_group"

--- a/homeassistant/components/music_assistant/const.py
+++ b/homeassistant/components/music_assistant/const.py
@@ -8,8 +8,9 @@ DOMAIN_EVENT = f"{DOMAIN}_event"
 DEFAULT_NAME = "Music Assistant"
 
 # Schema version where mandatory authentication was added to the MA webserver
-# This version also introduces hassio discovery support
 AUTH_SCHEMA_VERSION = 28
+# Schema version where hassio discovery support was added
+HASSIO_DISCOVERY_SCHEMA_VERSION = 28
 
 CONF_TOKEN = "token"
 

--- a/homeassistant/components/music_assistant/const.py
+++ b/homeassistant/components/music_assistant/const.py
@@ -11,6 +11,9 @@ DEFAULT_NAME = "Music Assistant"
 # This version also introduces hassio discovery support
 AUTH_SCHEMA_VERSION = 28
 
+# Configuration constants
+CONF_TOKEN = "token"
+
 ATTR_IS_GROUP = "is_group"
 ATTR_GROUP_MEMBERS = "group_members"
 ATTR_GROUP_PARENTS = "group_parents"

--- a/homeassistant/components/music_assistant/const.py
+++ b/homeassistant/components/music_assistant/const.py
@@ -7,6 +7,10 @@ DOMAIN_EVENT = f"{DOMAIN}_event"
 
 DEFAULT_NAME = "Music Assistant"
 
+# Schema version where mandatory authentication was added to the MA webserver
+# This version also introduces hassio discovery support
+AUTH_SCHEMA_VERSION = 28
+
 ATTR_IS_GROUP = "is_group"
 ATTR_GROUP_MEMBERS = "group_members"
 ATTR_GROUP_PARENTS = "group_parents"

--- a/homeassistant/components/music_assistant/manifest.json
+++ b/homeassistant/components/music_assistant/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "music_assistant",
   "name": "Music Assistant",
-  "after_dependencies": ["hassio", "media_source", "media_player"],
+  "after_dependencies": ["hassio", "http", "media_source", "media_player"],
   "codeowners": ["@music-assistant", "@arturpragacz"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/music_assistant",

--- a/homeassistant/components/music_assistant/manifest.json
+++ b/homeassistant/components/music_assistant/manifest.json
@@ -1,9 +1,10 @@
 {
   "domain": "music_assistant",
   "name": "Music Assistant",
-  "after_dependencies": ["http", "media_source", "media_player"],
+  "after_dependencies": ["media_source", "media_player"],
   "codeowners": ["@music-assistant", "@arturpragacz"],
   "config_flow": true,
+  "dependencies": ["auth"],
   "documentation": "https://www.home-assistant.io/integrations/music_assistant",
   "iot_class": "local_push",
   "loggers": ["music_assistant"],

--- a/homeassistant/components/music_assistant/manifest.json
+++ b/homeassistant/components/music_assistant/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "music_assistant",
   "name": "Music Assistant",
-  "after_dependencies": ["hassio", "http", "media_source", "media_player"],
+  "after_dependencies": ["http", "media_source", "media_player"],
   "codeowners": ["@music-assistant", "@arturpragacz"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/music_assistant",

--- a/homeassistant/components/music_assistant/manifest.json
+++ b/homeassistant/components/music_assistant/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "music_assistant",
   "name": "Music Assistant",
-  "after_dependencies": ["media_source", "media_player"],
+  "after_dependencies": ["hassio", "media_source", "media_player"],
   "codeowners": ["@music-assistant", "@arturpragacz"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/music_assistant",

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -2,21 +2,18 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "already_discovered_addon": "Music Assistant server is running as a Home Assistant add-on and should be discovered automatically",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_server_version": "[%key:component::music_assistant::config::error::invalid_server_version%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "reconfiguration_successful": "Successfully reconfigured the Music Assistant integration.",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "server_not_ready": "Music Assistant server has not completed initial setup yet",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "error": {
+      "auth_error": "Authentication error, please try again",
       "auth_failed": "Authentication failed, please try again",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_server_version": "The Music Assistant server is not the correct version",
-      "no_token": "No authentication token received",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "error": {
+      "auth_failed": "[%key:component::music_assistant::config::abort::auth_failed%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_server_version": "[%key:component::music_assistant::config::abort::invalid_server_version%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -2,10 +2,14 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_discovered_addon": "Music Assistant server is running as a Home Assistant add-on and should be discovered automatically",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_server_version": "[%key:component::music_assistant::config::error::invalid_server_version%]",
       "reconfiguration_successful": "Successfully reconfigured the Music Assistant integration.",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "server_not_ready": "Music Assistant server has not completed initial setup yet",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -16,6 +20,10 @@
       "discovery_confirm": {
         "description": "Do you want to add the Music Assistant server `{url}` to Home Assistant?",
         "title": "Discovered Music Assistant server"
+      },
+      "hassio_confirm": {
+        "description": "Do you want to set up the Music Assistant add-on?",
+        "title": "Discovered Music Assistant add-on"
       },
       "user": {
         "data": {

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -6,17 +6,27 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_server_version": "[%key:component::music_assistant::config::error::invalid_server_version%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfiguration_successful": "Successfully reconfigured the Music Assistant integration.",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "server_not_ready": "Music Assistant server has not completed initial setup yet",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "error": {
+      "auth_failed": "Authentication failed, please try again",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_server_version": "The Music Assistant server is not the correct version",
+      "no_token": "No authentication token received",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "auth_manual": {
+        "data": {
+          "token": "Long-lived access token"
+        },
+        "description": "Create a long-lived access token in your Music Assistant server settings and paste it here.",
+        "title": "Enter long-lived access token"
+      },
       "discovery_confirm": {
         "description": "Do you want to add the Music Assistant server `{url}` to Home Assistant?",
         "title": "Discovered Music Assistant server"
@@ -24,6 +34,10 @@
       "hassio_confirm": {
         "description": "Do you want to set up the Music Assistant add-on?",
         "title": "Discovered Music Assistant add-on"
+      },
+      "reauth_confirm": {
+        "description": "The authentication token for Music Assistant server `{url}` is no longer valid. Please re-authenticate to continue using the integration.",
+        "title": "Reauthentication required"
       },
       "user": {
         "data": {

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -32,7 +32,7 @@
         "title": "Discovered Music Assistant server"
       },
       "hassio_confirm": {
-        "description": "Do you want to set up the Music Assistant add-on?",
+        "description": "Do you want to add the Music Assistant server to Home Assistant?",
         "title": "Discovered Music Assistant add-on"
       },
       "reauth_confirm": {

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -21,7 +21,9 @@
         "data": {
           "token": "Long-lived access token"
         },
-        "description": "Create a long-lived access token in your Music Assistant server settings and paste it here.",
+        "data_description": {
+          "token": "Create a long-lived access token in your Music Assistant server settings and paste it here"
+        },
         "title": "Enter long-lived access token"
       },
       "discovery_confirm": {

--- a/tests/components/music_assistant/fixtures/server_info_message.json
+++ b/tests/components/music_assistant/fixtures/server_info_message.json
@@ -1,9 +1,9 @@
 {
   "server_id": "1234",
   "server_version": "0.0.0",
-  "schema_version": 23,
-  "min_supported_schema_version": 23,
+  "schema_version": 28,
+  "min_supported_schema_version": 28,
   "base_url": "http://localhost:8095",
   "homeassistant_addon": false,
-  "onboard_done": false
+  "onboard_done": true
 }

--- a/tests/components/music_assistant/test_config_flow.py
+++ b/tests/components/music_assistant/test_config_flow.py
@@ -68,7 +68,7 @@ ZEROCONF_DATA = ZeroconfServiceInfo(
 )
 
 HASSIO_DATA = HassioServiceInfo(
-    config={"host": "addon-music-assistant", "port": 8094, "token": "test_token"},
+    config={"host": "addon-music-assistant", "port": 8094, "auth_token": "test_token"},
     name="Music Assistant",
     slug="music_assistant",
     uuid="1234",
@@ -660,7 +660,7 @@ async def test_hassio_flow_with_token(
         config={
             "host": "addon-music-assistant",
             "port": 8094,
-            CONF_TOKEN: "test_token",
+            "auth_token": "test_token",
         },
         name="Music Assistant",
         slug="music_assistant",

--- a/tests/components/music_assistant/test_config_flow.py
+++ b/tests/components/music_assistant/test_config_flow.py
@@ -955,3 +955,36 @@ async def test_finish_auth_errors(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == abort_reason
+
+
+async def test_auth_step_with_oauth2_callback(
+    hass: HomeAssistant,
+    mock_get_server_info: AsyncMock,
+) -> None:
+    """Test auth step receiving OAuth2 callback with code parameter."""
+    flow = MusicAssistantConfigFlow()
+    flow.hass = hass
+    flow.url = "http://localhost:8095"
+    flow.server_info = mock_get_server_info.return_value
+
+    result = await flow.async_step_auth(user_input={"code": "test_session_token"})
+
+    assert result["type"] is FlowResultType.EXTERNAL_STEP_DONE
+    assert result["step_id"] == "finish_auth"
+    assert flow.token == "test_session_token"
+
+
+async def test_auth_step_with_error(
+    hass: HomeAssistant,
+    mock_get_server_info: AsyncMock,
+) -> None:
+    """Test auth step receiving error from OAuth2 callback."""
+    flow = MusicAssistantConfigFlow()
+    flow.hass = hass
+    flow.url = "http://localhost:8095"
+    flow.server_info = mock_get_server_info.return_value
+
+    result = await flow.async_step_auth(user_input={"error": "access_denied"})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "auth_error"


### PR DESCRIPTION
## Proposed change

Music Assistant will soon (from schema 28 and onwards) require authentication on the webserver/API to mitigate the security risk of an unauthenticated webserver. This PR adds support in the Home Assistant integration for this (upcoming) mandatory authentication requirement. To provide the best possible user experience we make a difference between Music Assistant running as add-on within Home Assistant and externally running Music Assistant servers:
In case of the Music Assistant add-on, the music assistant server hosts a dedicated tcp site in the webserver (on the internal docker network) for HA to connect to. It's used to host the Ingress panel and can also be leveraged by the HA integration to connect directly and we don't have to ask the user for credentials.

- Depends on the bump of the client lib here: https://github.com/home-assistant/core/pull/157261
- Add support for hassio discovery to handle the add-on running the ingress webserver
- Add support for doing a oAuth login flow to MA to get a access token and then create a long lived token
- Backwards compatible, it can still connect to servers running an older schema version (so have no auth)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
