### PR TITLE
Nanoleaf integration that supports Nanoleaf Essentials and Screen Mirroring.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1041,8 +1041,8 @@ build.json @home-assistant/supervisor
 /tests/components/myuplink/ @pajzo @astrandb
 /homeassistant/components/nam/ @bieniu
 /tests/components/nam/ @bieniu
-/homeassistant/components/nanoleaf/ @milanmeu @joostlek
-/tests/components/nanoleaf/ @milanmeu @joostlek
+/homeassistant/components/nanoleaf/ @loebi-ch @milanmeu @joostlek
+/tests/components/nanoleaf/ @loebi-ch @milanmeu @joostlek
 /homeassistant/components/nasweb/ @nasWebio
 /tests/components/nasweb/ @nasWebio
 /homeassistant/components/nederlandse_spoorwegen/ @YarmoM @heindrichpaul

--- a/homeassistant/components/nanoleaf/__init__.py
+++ b/homeassistant/components/nanoleaf/__init__.py
@@ -6,7 +6,7 @@ import asyncio
 from contextlib import suppress
 import logging
 
-from aionanoleaf import EffectsEvent, Nanoleaf, StateEvent, TouchEvent
+from aionanoleaf2 import EffectsEvent, Nanoleaf, StateEvent, TouchEvent
 
 from homeassistant.const import (
     CONF_DEVICE_ID,

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -7,7 +7,7 @@ import logging
 import os
 from typing import Any, Final, cast
 
-from aionanoleaf import InvalidToken, Nanoleaf, Unauthorized, Unavailable
+from aionanoleaf2 import InvalidToken, Nanoleaf, Unauthorized, Unavailable
 import voluptuous as vol
 
 from homeassistant.config_entries import (

--- a/homeassistant/components/nanoleaf/const.py
+++ b/homeassistant/components/nanoleaf/const.py
@@ -6,6 +6,10 @@ NANOLEAF_EVENT = f"{DOMAIN}_event"
 
 TOUCH_MODELS = {"NL29", "NL42", "NL52"}
 
+EMERSION_MODELS = {"NL69"}
+
+EMERSION_MODES = ["1D", "2D", "3D", "4D"]
+
 TOUCH_GESTURE_TRIGGER_MAP = {
     2: "swipe_up",
     3: "swipe_down",

--- a/homeassistant/components/nanoleaf/coordinator.py
+++ b/homeassistant/components/nanoleaf/coordinator.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 import logging
 
-from aionanoleaf import InvalidToken, Nanoleaf, Unavailable
+from aionanoleaf2 import InvalidToken, Nanoleaf, Unavailable
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -58,7 +58,7 @@ class NanoleafLight(NanoleafEntity, LightEntity):
             return "mdi:led-strip-variant"
         else:
             return "mdi:triangle-outline"
-    
+
     @property
     def brightness(self) -> int:
         """Return the brightness of the light."""

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -1,8 +1,9 @@
 """Support for Nanoleaf Lights."""
 
 from __future__ import annotations
-
+from collections import OrderedDict
 from typing import Any
+from aionanoleaf2 import Nanoleaf
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -14,11 +15,13 @@ from homeassistant.components.light import (
     LightEntity,
     LightEntityFeature,
 )
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-
 from .coordinator import NanoleafConfigEntry, NanoleafCoordinator
 from .entity import NanoleafEntity
+from .const import EMERSION_MODELS, EMERSION_MODES
+
 
 RESERVED_EFFECTS = ("*Solid*", "*Static*", "*Dynamic*")
 DEFAULT_NAME = "Nanoleaf"
@@ -49,13 +52,21 @@ class NanoleafLight(NanoleafEntity, LightEntity):
         self._attr_min_color_temp_kelvin = self._nanoleaf.color_temperature_min
 
     @property
+    def icon(self) -> str | None:
+        """Icon of the entity, based on model."""
+        if self._nanoleaf.model in EMERSION_MODELS:
+            return "mdi:led-strip-variant"
+        else:
+            return "mdi:triangle-outline"
+    
+    @property
     def brightness(self) -> int:
         """Return the brightness of the light."""
         return int(self._nanoleaf.brightness * 2.55)
 
     @property
-    def color_temp_kelvin(self) -> int | None:
-        """Return the color temperature value in Kelvin."""
+    def color_temp_kelvin(self) -> int:
+        """Return the current color temperature."""
         return self._nanoleaf.color_temperature
 
     @property
@@ -65,14 +76,24 @@ class NanoleafLight(NanoleafEntity, LightEntity):
         # The effects *Static* and *Dynamic* are not supported by Home Assistant.
         # These reserved effects are implicitly set and are not in the effect_list.
         # https://forum.nanoleaf.me/docs/openapi#_byoot0bams8f
-        return (
-            None if self._nanoleaf.effect in RESERVED_EFFECTS else self._nanoleaf.effect
-        )
+        active_effect = ""
+        if self._nanoleaf.effect in RESERVED_EFFECTS:
+            return None
+        if self._nanoleaf.effect == "*Emersion*":
+            active_effect = self._nanoleaf.emersion
+        else:
+            active_effect = self._nanoleaf.effect
+        return active_effect
 
     @property
     def effect_list(self) -> list[str]:
         """Return the list of supported effects."""
-        return self._nanoleaf.effects_list
+        effect_dict = OrderedDict.fromkeys(self._nanoleaf.effects_list)
+        if self._nanoleaf.model in EMERSION_MODELS:
+            for mode in EMERSION_MODES:
+                effect_dict[mode] = None
+        effect_list = list(effect_dict.keys())
+        return effect_list
 
     @property
     def is_on(self) -> bool:
@@ -107,13 +128,20 @@ class NanoleafLight(NanoleafEntity, LightEntity):
                 raise ValueError(
                     f"Attempting to apply effect not in the effect list: '{effect}'"
                 )
-            await self._nanoleaf.set_effect(effect)
+
+            if effect not in EMERSION_MODES:
+                await self._nanoleaf.set_effect(effect)
+            else:
+                await self._nanoleaf.set_emersion(effect)
+
         elif hs_color:
             hue, saturation = hs_color
             await self._nanoleaf.set_hue(int(hue))
             await self._nanoleaf.set_saturation(int(saturation))
+
         elif color_temp_kelvin:
             await self._nanoleaf.set_color_temperature(color_temp_kelvin)
+
         if transition:
             if brightness:  # tune to the required brightness in n seconds
                 await self._nanoleaf.set_brightness(

--- a/homeassistant/components/nanoleaf/manifest.json
+++ b/homeassistant/components/nanoleaf/manifest.json
@@ -1,15 +1,15 @@
 {
   "domain": "nanoleaf",
   "name": "Nanoleaf",
-  "codeowners": ["@milanmeu", "@joostlek"],
+  "codeowners": ["@loebi-ch", "@JaspervRijbroek", "@jonathanrobichaud4", "@milanmeu", "@joostlek"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/nanoleaf",
   "homekit": {
     "models": ["NL29", "NL42", "NL47", "NL48", "NL52", "NL59", "NL69", "NL81"]
   },
   "iot_class": "local_push",
-  "loggers": ["aionanoleaf"],
-  "requirements": ["aionanoleaf==0.2.1"],
+  "loggers": ["aionanoleaf2"],
+  "requirements": ["aionanoleaf2>=1.0.0"],
   "ssdp": [
     {
       "st": "Nanoleaf_aurora:light"

--- a/homeassistant/components/nanoleaf/manifest.json
+++ b/homeassistant/components/nanoleaf/manifest.json
@@ -2,12 +2,13 @@
   "domain": "nanoleaf",
   "name": "Nanoleaf",
   "version": "2.0.0",
-  "codeowners": ["@loebi-ch", "@JaspervRijbroek", "@jonathanrobichaud4", "@milanmeu", "@joostlek"],
+  "codeowners": ["@loebi-ch", "@JaspervRijbroek", "@jonathanrobichaud4"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/nanoleaf",
   "homekit": {
     "models": ["NL29", "NL42", "NL47", "NL48", "NL52", "NL59", "NL69", "NL81"]
   },
+  "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["aionanoleaf2"],
   "requirements": ["aionanoleaf2>=1.0.0"],

--- a/homeassistant/components/nanoleaf/manifest.json
+++ b/homeassistant/components/nanoleaf/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "nanoleaf",
   "name": "Nanoleaf",
+  "version": "2.0.0",
   "codeowners": ["@loebi-ch", "@JaspervRijbroek", "@jonathanrobichaud4", "@milanmeu", "@joostlek"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/nanoleaf",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -328,7 +328,7 @@ aiomodernforms==0.1.8
 aiomusiccast==0.15.0
 
 # homeassistant.components.nanoleaf
-aionanoleaf==0.2.1
+aionanoleaf2==1.0.0
 
 # homeassistant.components.notion
 aionotion==2024.03.0

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from aionanoleaf import InvalidToken, Unauthorized, Unavailable
+from aionanoleaf2 import InvalidToken, Unauthorized, Unavailable
 import pytest
 
 from homeassistant import config_entries


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current Nanoleaf integration depends on the abandoned and not maintained PyPi package `aionanoleaf` that doesn't work for the newer **Nanoleaf Essentials** devices (that changed their API slightly) and is also missing the emersion modes for the Nanoleaf **4D Screen Mirroring** kit. All pull requests and contact trials failed. Therefore I created the new PyPi package `aionanoleaf2` which fixes the above two problems/features while keeping the backwards compatibility.

This pull request replaces the dependency from `aionanoleaf` with `aionanoleaf2` and allows to select the emersion modes (1D, 2D, 3D and 4D) from the effects list for Nanoleaf Screen Mirroring devices.

A diff between `aionanoleaf` and `aionanoleaf2` can be found here: https://github.com/milanmeu/aionanoleaf/pull/18/files

I have changed the codeowners to @loebi-ch (me), @JaspervRijbroek (contributor of Essentials fix) and @jonathanrobichaud4 (contributor of Screen Mirroring feature) because the other two guys haven't responded to pull requests for years.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issues: fixes https://github.com/home-assistant/core/issues/132084, https://github.com/home-assistant/core/issues/152849, https://github.com/home-assistant/core/issues/152713
- This PR is related to issue: https://github.com/home-assistant/core/issues/142960, https://github.com/home-assistant/core/issues/141964 (This two issues will be probably solved by the pull request and the update of the device firmware)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
