### PR TITLE
Add switch platform to PoolDose integration

### DIFF
--- a/homeassistant/components/pooldose/__init__.py
+++ b/homeassistant/components/pooldose/__init__.py
@@ -17,7 +17,7 @@ from .coordinator import PooldoseConfigEntry, PooldoseCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: PooldoseConfigEntry) -> bool:

--- a/homeassistant/components/pooldose/icons.json
+++ b/homeassistant/components/pooldose/icons.json
@@ -120,6 +120,29 @@
       "ph_type_dosing": {
         "default": "mdi:beaker"
       }
+    },
+    "switch": {
+      "frequency_input": {
+        "default": "mdi:sine-wave",
+        "state": {
+          "off": "mdi:pulse",
+          "on": "mdi:sine-wave"
+        }
+      },
+      "pause_dosing": {
+        "default": "mdi:pause",
+        "state": {
+          "off": "mdi:play",
+          "on": "mdi:pause"
+        }
+      },
+      "pump_monitoring": {
+        "default": "mdi:pump",
+        "state": {
+          "off": "mdi:pump-off",
+          "on": "mdi:pump"
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/pooldose/strings.json
+++ b/homeassistant/components/pooldose/strings.json
@@ -161,6 +161,17 @@
           "alcalyne": "pH+"
         }
       }
+    },
+    "switch": {
+      "frequency_input": {
+        "name": "Frequency input"
+      },
+      "pause_dosing": {
+        "name": "Pause dosing"
+      },
+      "pump_monitoring": {
+        "name": "Pump monitoring"
+      }
     }
   }
 }

--- a/homeassistant/components/pooldose/switch.py
+++ b/homeassistant/components/pooldose/switch.py
@@ -1,0 +1,95 @@
+"""Switches for the Seko PoolDose integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import PooldoseConfigEntry
+from .entity import PooldoseEntity
+
+if TYPE_CHECKING:
+    from .coordinator import PooldoseCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+SWITCH_DESCRIPTIONS: tuple[SwitchEntityDescription, ...] = (
+    SwitchEntityDescription(
+        key="pause_dosing",
+        translation_key="pause_dosing",
+        entity_category=EntityCategory.CONFIG,
+    ),
+    SwitchEntityDescription(
+        key="pump_monitoring",
+        translation_key="pump_monitoring",
+        entity_category=EntityCategory.CONFIG,
+    ),
+    SwitchEntityDescription(
+        key="frequency_input",
+        translation_key="frequency_input",
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: PooldoseConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up PoolDose switch entities from a config entry."""
+    if TYPE_CHECKING:
+        assert config_entry.unique_id is not None
+
+    coordinator = config_entry.runtime_data
+    switch_data = coordinator.data["switch"]
+    serial_number = config_entry.unique_id
+
+    async_add_entities(
+        PooldoseSwitch(coordinator, serial_number, coordinator.device_info, description)
+        for description in SWITCH_DESCRIPTIONS
+        if description.key in switch_data
+    )
+
+
+class PooldoseSwitch(PooldoseEntity, SwitchEntity):
+    """Switch entity for the Seko PoolDose Python API."""
+
+    def __init__(
+        self,
+        coordinator: PooldoseCoordinator,
+        serial_number: str,
+        device_info: Any,
+        description: SwitchEntityDescription,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, serial_number, device_info, description, "switch")
+        self._async_update_attrs()
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()
+
+    def _async_update_attrs(self) -> None:
+        """Update switch attributes."""
+        data = cast(dict, self.get_data())
+        self._attr_is_on = cast(bool, data["value"])
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        await self.coordinator.client.set_switch(self.entity_description.key, True)
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        await self.coordinator.client.set_switch(self.entity_description.key, False)
+        self._attr_is_on = False
+        self.async_write_ha_state()

--- a/tests/components/pooldose/conftest.py
+++ b/tests/components/pooldose/conftest.py
@@ -8,7 +8,7 @@ from pooldose.request_status import RequestStatus
 import pytest
 
 from homeassistant.components.pooldose.const import DOMAIN
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 
 from tests.common import (
@@ -59,6 +59,7 @@ def mock_pooldose_client(device_info: dict[str, Any]) -> Generator[MagicMock]:
             instant_values_data,
         )
 
+        client.set_switch = AsyncMock(return_value=RequestStatus.SUCCESS)
         client.is_connected = True
         yield client
 
@@ -88,11 +89,23 @@ def mock_config_entry_v1_1(device_info: dict[str, Any]) -> MockConfigEntry:
     )
 
 
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return []
+
+
+@pytest.fixture
 async def init_integration(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    platforms: list[Platform],
 ) -> MockConfigEntry:
     """Set up the integration for testing."""
     mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+
+    with patch("homeassistant.components.pooldose.PLATFORMS", platforms):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
     return mock_config_entry

--- a/tests/components/pooldose/snapshots/test_switch.ambr
+++ b/tests/components/pooldose/snapshots/test_switch.ambr
@@ -1,0 +1,145 @@
+# serializer version: 1
+# name: test_all_switches[switch.pool_device_frequency_input-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.pool_device_frequency_input',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Frequency input',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'frequency_input',
+    'unique_id': 'TEST123456789_frequency_input',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_switches[switch.pool_device_frequency_input-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pool Device Frequency input',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.pool_device_frequency_input',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_switches[switch.pool_device_pause_dosing-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.pool_device_pause_dosing',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Pause dosing',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pause_dosing',
+    'unique_id': 'TEST123456789_pause_dosing',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_switches[switch.pool_device_pause_dosing-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pool Device Pause dosing',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.pool_device_pause_dosing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_switches[switch.pool_device_pump_monitoring-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.pool_device_pump_monitoring',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Pump monitoring',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pump_monitoring',
+    'unique_id': 'TEST123456789_pump_monitoring',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_switches[switch.pool_device_pump_monitoring-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pool Device Pump monitoring',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.pool_device_pump_monitoring',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/pooldose/test_switch.py
+++ b/tests/components/pooldose/test_switch.py
@@ -1,0 +1,146 @@
+"""Tests for the Seko PoolDose switch platform."""
+
+from unittest.mock import AsyncMock
+
+from pooldose.request_status import RequestStatus
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return [Platform.SWITCH]
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_all_switches(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the Pooldose switches."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_switches_created(
+    hass: HomeAssistant,
+) -> None:
+    """Test that switch entities are created."""
+    # Verify all three switches exist
+    assert hass.states.get("switch.pool_device_pause_dosing") is not None
+    assert hass.states.get("switch.pool_device_pump_monitoring") is not None
+    assert hass.states.get("switch.pool_device_frequency_input") is not None
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_switch_entity_unavailable_no_coordinator_data(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_pooldose_client: AsyncMock,
+) -> None:
+    """Test switch entity becomes unavailable when coordinator has no data."""
+    # Verify entity has a state initially
+    pause_dosing_state = hass.states.get("switch.pool_device_pause_dosing")
+    assert pause_dosing_state.state == STATE_OFF
+
+    # Update coordinator data to None
+    mock_pooldose_client.instant_values_structured.return_value = (None, None)
+    coordinator = init_integration.runtime_data
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # Check entity becomes unavailable
+    pause_dosing_state = hass.states.get("switch.pool_device_pause_dosing")
+    assert pause_dosing_state.state == "unavailable"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_switch_state_changes(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_pooldose_client: AsyncMock,
+) -> None:
+    """Test switch state changes when coordinator updates."""
+    # Initial state
+    pause_dosing_state = hass.states.get("switch.pool_device_pause_dosing")
+    assert pause_dosing_state.state == STATE_OFF
+
+    # Update coordinator data with switch value changed
+    current_data = mock_pooldose_client.instant_values_structured.return_value[1]
+    updated_data = current_data.copy()
+    updated_data["switch"]["pause_dosing"]["value"] = True
+
+    mock_pooldose_client.instant_values_structured.return_value = (
+        RequestStatus.SUCCESS,
+        updated_data,
+    )
+
+    coordinator = init_integration.runtime_data
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # Check state changed
+    pause_dosing_state = hass.states.get("switch.pool_device_pause_dosing")
+    assert pause_dosing_state.state == STATE_ON
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_turn_on_switch(
+    hass: HomeAssistant,
+    mock_pooldose_client: AsyncMock,
+) -> None:
+    """Test turning on a switch."""
+    # Verify initial state is off
+    pause_dosing_state = hass.states.get("switch.pool_device_pause_dosing")
+    assert pause_dosing_state.state == STATE_OFF
+
+    # Turn on the switch
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: "switch.pool_device_pause_dosing"},
+        blocking=True,
+    )
+
+    # Verify API was called
+    mock_pooldose_client.set_switch.assert_called_once_with("pause_dosing", True)
+
+    # Verify state updated immediately
+    pause_dosing_state = hass.states.get("switch.pool_device_pause_dosing")
+    assert pause_dosing_state.state == STATE_ON
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_turn_off_switch(
+    hass: HomeAssistant,
+    mock_pooldose_client: AsyncMock,
+) -> None:
+    """Test turning off a switch."""
+    # pump_monitoring starts as on in fixture data
+    pump_monitoring_state = hass.states.get("switch.pool_device_pump_monitoring")
+    assert pump_monitoring_state.state == STATE_ON
+
+    # Turn off the switch
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_off",
+        {ATTR_ENTITY_ID: "switch.pool_device_pump_monitoring"},
+        blocking=True,
+    )
+
+    # Verify API was called
+    mock_pooldose_client.set_switch.assert_called_once_with("pump_monitoring", False)
+
+    # Verify state updated immediately
+    pump_monitoring_state = hass.states.get("switch.pool_device_pump_monitoring")
+    assert pump_monitoring_state.state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds three configuration switches to control device settings:

- Pause dosing - Temporarily stop automatic chemical dosing
- Pump monitoring - Enable/disable pump monitoring
- Frequency input - Toggle frequency-based input mode

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41974
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
