### PR TITLE
Update fitbit to use new asyncio client library for device list

### DIFF
--- a/homeassistant/components/fitbit/api.py
+++ b/homeassistant/components/fitbit/api.py
@@ -7,7 +7,8 @@ from typing import Any, cast
 
 from fitbit import Fitbit
 from fitbit.exceptions import HTTPException, HTTPUnauthorized
-from fitbit_web_api import ApiClient, Configuration, Device, DevicesApi
+from fitbit_web_api import ApiClient, Configuration, DevicesApi
+from fitbit_web_api.models.device import Device
 from fitbit_web_api.exceptions import (
     ApiException,
     OpenApiException,
@@ -158,7 +159,7 @@ class FitbitApi(ABC):
             _LOGGER.debug("Error from fitbit API: %s", err)
             raise FitbitApiException("Error from fitbit API") from err
         except OpenApiException as err:
-            _LOGGER.debug("Connection communicating with fitbit API: %s", err)
+            _LOGGER.debug("Error communicating with fitbit API: %s", err)
             raise FitbitApiException("Communication error from fitbit API") from err
 
 

--- a/homeassistant/components/fitbit/api.py
+++ b/homeassistant/components/fitbit/api.py
@@ -1,22 +1,29 @@
 """API for fitbit bound to Home Assistant OAuth."""
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 import logging
 from typing import Any, cast
 
 from fitbit import Fitbit
 from fitbit.exceptions import HTTPException, HTTPUnauthorized
+from fitbit_web_api import ApiClient, Configuration, Device, DevicesApi
+from fitbit_web_api.exceptions import (
+    ApiException,
+    OpenApiException,
+    UnauthorizedException,
+)
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .const import FitbitUnitSystem
 from .exceptions import FitbitApiException, FitbitAuthException
-from .model import FitbitDevice, FitbitProfile
+from .model import FitbitProfile
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,6 +65,14 @@ class FitbitApi(ABC):
             expires_at=float(token[CONF_EXPIRES_AT]),
         )
 
+    async def _async_get_fitbit_web_api(self) -> ApiClient:
+        """Create and return an ApiClient configured with the current access token."""
+        token = await self.async_get_access_token()
+        configuration = Configuration()
+        configuration.pool_manager = async_get_clientsession(self._hass)
+        configuration.access_token = token[CONF_ACCESS_TOKEN]
+        return ApiClient(configuration)
+
     async def async_get_user_profile(self) -> FitbitProfile:
         """Return the user profile from the API."""
         if self._profile is None:
@@ -94,21 +109,13 @@ class FitbitApi(ABC):
             return FitbitUnitSystem.METRIC
         return FitbitUnitSystem.EN_US
 
-    async def async_get_devices(self) -> list[FitbitDevice]:
-        """Return available devices."""
-        client = await self._async_get_client()
-        devices: list[dict[str, str]] = await self._run(client.get_devices)
+    async def async_get_devices(self) -> list[Device]:
+        """Return available devices using fitbit-web-api."""
+        client = await self._async_get_fitbit_web_api()
+        devices_api = DevicesApi(client)
+        devices: list[Device] = await self._run_async(devices_api.get_devices)
         _LOGGER.debug("get_devices=%s", devices)
-        return [
-            FitbitDevice(
-                id=device["id"],
-                device_version=device["deviceVersion"],
-                battery_level=int(device["batteryLevel"]),
-                battery=device["battery"],
-                type=device["type"],
-            )
-            for device in devices
-        ]
+        return devices
 
     async def async_get_latest_time_series(self, resource_type: str) -> dict[str, Any]:
         """Return the most recent value from the time series for the specified resource type."""
@@ -139,6 +146,20 @@ class FitbitApi(ABC):
         except HTTPException as err:
             _LOGGER.debug("Error from fitbit API: %s", err)
             raise FitbitApiException("Error from fitbit API") from err
+
+    async def _run_async[_T](self, func: Callable[[], Awaitable[_T]]) -> _T:
+        """Run client command."""
+        try:
+            return await func()
+        except UnauthorizedException as err:
+            _LOGGER.debug("Unauthorized error from fitbit API: %s", err)
+            raise FitbitAuthException("Authentication error from fitbit API") from err
+        except ApiException as err:
+            _LOGGER.debug("Error from fitbit API: %s", err)
+            raise FitbitApiException("Error from fitbit API") from err
+        except OpenApiException as err:
+            _LOGGER.debug("Connection communicating with fitbit API: %s", err)
+            raise FitbitApiException("Communication error from fitbit API") from err
 
 
 class OAuthFitbitApi(FitbitApi):

--- a/homeassistant/components/fitbit/api.py
+++ b/homeassistant/components/fitbit/api.py
@@ -8,12 +8,12 @@ from typing import Any, cast
 from fitbit import Fitbit
 from fitbit.exceptions import HTTPException, HTTPUnauthorized
 from fitbit_web_api import ApiClient, Configuration, DevicesApi
-from fitbit_web_api.models.device import Device
 from fitbit_web_api.exceptions import (
     ApiException,
     OpenApiException,
     UnauthorizedException,
 )
+from fitbit_web_api.models.device import Device
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from homeassistant.const import CONF_ACCESS_TOKEN

--- a/homeassistant/components/fitbit/coordinator.py
+++ b/homeassistant/components/fitbit/coordinator.py
@@ -6,6 +6,8 @@ import datetime
 import logging
 from typing import Final
 
+from fitbit_web_api.models.device import Device
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -13,7 +15,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .api import FitbitApi
 from .exceptions import FitbitApiException, FitbitAuthException
-from .model import FitbitDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ TIMEOUT = 10
 type FitbitConfigEntry = ConfigEntry[FitbitData]
 
 
-class FitbitDeviceCoordinator(DataUpdateCoordinator[dict[str, FitbitDevice]]):
+class FitbitDeviceCoordinator(DataUpdateCoordinator[dict[str, Device]]):
     """Coordinator for fetching fitbit devices from the API."""
 
     config_entry: FitbitConfigEntry
@@ -41,7 +42,7 @@ class FitbitDeviceCoordinator(DataUpdateCoordinator[dict[str, FitbitDevice]]):
         )
         self._api = api
 
-    async def _async_update_data(self) -> dict[str, FitbitDevice]:
+    async def _async_update_data(self) -> dict[str, Device]:
         """Fetch data from API endpoint."""
         async with asyncio.timeout(TIMEOUT):
             try:
@@ -50,7 +51,7 @@ class FitbitDeviceCoordinator(DataUpdateCoordinator[dict[str, FitbitDevice]]):
                 raise ConfigEntryAuthFailed(err) from err
             except FitbitApiException as err:
                 raise UpdateFailed(err) from err
-        return {device.id: device for device in devices}
+        return {device.id: device for device in devices if device.id is not None}
 
 
 @dataclass

--- a/homeassistant/components/fitbit/manifest.json
+++ b/homeassistant/components/fitbit/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/fitbit",
   "iot_class": "cloud_polling",
   "loggers": ["fitbit", "fitbit_web_api"],
-  "requirements": ["fitbit==0.3.1", "fitbit-web-api==2.13.3"]
+  "requirements": ["fitbit==0.3.1", "fitbit-web-api==2.13.5"]
 }

--- a/homeassistant/components/fitbit/manifest.json
+++ b/homeassistant/components/fitbit/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": ["application_credentials", "http"],
   "documentation": "https://www.home-assistant.io/integrations/fitbit",
   "iot_class": "cloud_polling",
-  "loggers": ["fitbit"],
-  "requirements": ["fitbit==0.3.1"]
+  "loggers": ["fitbit", "fitbit_web_api"],
+  "requirements": ["fitbit==0.3.1", "fitbit-web-api==2.13.3"]
 }

--- a/homeassistant/components/fitbit/model.py
+++ b/homeassistant/components/fitbit/model.py
@@ -22,26 +22,6 @@ class FitbitProfile:
 
 
 @dataclass
-class FitbitDevice:
-    """Device from the Fitbit API response."""
-
-    id: str
-    """The device ID."""
-
-    device_version: str
-    """The product name of the device."""
-
-    battery_level: int
-    """The battery level as a percentage."""
-
-    battery: str
-    """Returns the battery level of the device."""
-
-    type: str
-    """The type of the device such as TRACKER or SCALE."""
-
-
-@dataclass
 class FitbitConfig:
     """Information from the fitbit ConfigEntry data."""
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -956,7 +956,7 @@ fing_agent_api==1.0.3
 fints==3.1.0
 
 # homeassistant.components.fitbit
-fitbit-web-api==2.13.3
+fitbit-web-api==2.13.5
 
 # homeassistant.components.fitbit
 fitbit==0.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -956,6 +956,9 @@ fing_agent_api==1.0.3
 fints==3.1.0
 
 # homeassistant.components.fitbit
+fitbit-web-api==2.13.3
+
+# homeassistant.components.fitbit
 fitbit==0.3.1
 
 # homeassistant.components.fivem

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -844,7 +844,7 @@ fing_agent_api==1.0.3
 fints==3.1.0
 
 # homeassistant.components.fitbit
-fitbit-web-api==2.13.3
+fitbit-web-api==2.13.5
 
 # homeassistant.components.fitbit
 fitbit==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -844,6 +844,9 @@ fing_agent_api==1.0.3
 fints==3.1.0
 
 # homeassistant.components.fitbit
+fitbit-web-api==2.13.3
+
+# homeassistant.components.fitbit
 fitbit==0.3.1
 
 # homeassistant.components.fivem

--- a/tests/components/fitbit/conftest.py
+++ b/tests/components/fitbit/conftest.py
@@ -20,6 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
@@ -206,12 +207,13 @@ def mock_device_response() -> list[dict[str, Any]]:
 
 
 @pytest.fixture(autouse=True)
-def mock_devices(requests_mock: Mocker, devices_response: dict[str, Any]) -> None:
+def mock_devices(
+    aioclient_mock: AiohttpClientMocker, devices_response: dict[str, Any]
+) -> None:
     """Fixture to setup fake device responses."""
-    requests_mock.register_uri(
-        "GET",
+    aioclient_mock.get(
         DEVICES_API_URL,
-        status_code=HTTPStatus.OK,
+        status=HTTPStatus.OK,
         json=devices_response,
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a first step in a larger migration to a new API that is pure asyncio, and follows modern package practices. The old API does not meet homeassistant standards. Future changes will move additional sensors/platforms to the new API. When all calls are moved to the new API then the old API will be dropped.

Releases: https://github.com/allenporter/fitbit-web-api/releases
Change log: https://github.com/allenporter/fitbit-web-api/compare/v0.0.0...v2.13.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
