### PR TITLE
Normalize input for Droplet pairing code

### DIFF
--- a/tests/components/droplet/test_config_flow.py
+++ b/tests/components/droplet/test_config_flow.py
@@ -23,8 +23,22 @@ from .conftest import MOCK_CODE, MOCK_DEVICE_ID, MOCK_HOST, MOCK_PORT
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.parametrize(
+    ("pre_normalized_code", "normalized_code"),
+    [
+        (
+            "abc 123",
+            "ABC123",
+        ),
+        (" 123456 ", "123456"),
+        ("123ABC", "123ABC"),
+    ],
+    ids=["alphanumeric_lower_space", "numeric_space", "alphanumeric_no_space"],
+)
 async def test_user_setup(
     hass: HomeAssistant,
+    pre_normalized_code: str,
+    normalized_code: str,
     mock_droplet_discovery: AsyncMock,
     mock_droplet_connection: AsyncMock,
     mock_droplet: AsyncMock,
@@ -39,12 +53,12 @@ async def test_user_setup(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_CODE: MOCK_CODE, CONF_IP_ADDRESS: "192.168.1.2"},
+        user_input={CONF_CODE: pre_normalized_code, CONF_IP_ADDRESS: "192.168.1.2"},
     )
     assert result is not None
     assert result.get("type") is FlowResultType.CREATE_ENTRY
     assert result.get("data") == {
-        CONF_CODE: MOCK_CODE,
+        CONF_CODE: normalized_code,
         CONF_DEVICE_ID: MOCK_DEVICE_ID,
         CONF_IP_ADDRESS: MOCK_HOST,
         CONF_PORT: MOCK_PORT,
@@ -133,8 +147,22 @@ async def test_user_setup_already_configured(
     assert result.get("reason") == "already_configured"
 
 
+@pytest.mark.parametrize(
+    ("pre_normalized_code", "normalized_code"),
+    [
+        (
+            "abc 123",
+            "ABC123",
+        ),
+        (" 123456 ", "123456"),
+        ("123ABC", "123ABC"),
+    ],
+    ids=["alphanumeric_lower_space", "numeric_space", "alphanumeric_no_space"],
+)
 async def test_zeroconf_setup(
     hass: HomeAssistant,
+    pre_normalized_code: str,
+    normalized_code: str,
     mock_droplet_discovery: AsyncMock,
     mock_droplet: AsyncMock,
     mock_droplet_connection: AsyncMock,
@@ -159,7 +187,7 @@ async def test_zeroconf_setup(
     assert result.get("step_id") == "confirm"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_CODE: MOCK_CODE}
+        result["flow_id"], user_input={CONF_CODE: pre_normalized_code}
     )
     assert result is not None
     assert result.get("type") is FlowResultType.CREATE_ENTRY
@@ -167,7 +195,7 @@ async def test_zeroconf_setup(
         CONF_DEVICE_ID: MOCK_DEVICE_ID,
         CONF_IP_ADDRESS: MOCK_HOST,
         CONF_PORT: MOCK_PORT,
-        CONF_CODE: MOCK_CODE,
+        CONF_CODE: normalized_code,
     }
     assert result.get("context") is not None
     assert result.get("context", {}).get("unique_id") == MOCK_DEVICE_ID


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Droplet app shows the pairing code with a space in the middle for easier readability, e.g. `ABC 123`. However, it must be entered with no spaces (and in all caps) to be accepted by the Droplet device. This is noted in the documentation, but it's easy to miss, so we should just normalize it in the config flow.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/157300
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
