### PR TITLE
Reload templates when labs flag automation.new_triggers_conditions is set

### DIFF
--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -8,7 +8,10 @@ import logging
 from typing import Any
 
 from homeassistant import config as conf_util
-from homeassistant.components.automation import NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG
+from homeassistant.components.automation import (
+    DOMAIN as AUTOMATION_DOMAIN,
+    NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG,
+)
 from homeassistant.components.labs import async_listen as async_labs_listen
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -95,11 +98,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     @callback
     def new_triggers_conditions_listener() -> None:
         """Handle new_triggers_conditions flag change."""
-        hass.services.call(DOMAIN, SERVICE_RELOAD)
+        hass.async_create_task(
+            _reload_config(ServiceCall(hass, DOMAIN, SERVICE_RELOAD))
+        )
 
     async_labs_listen(
         hass,
-        DOMAIN,
+        AUTOMATION_DOMAIN,
         NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG,
         new_triggers_conditions_listener,
     )

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -8,6 +8,8 @@ import logging
 from typing import Any
 
 from homeassistant import config as conf_util
+from homeassistant.components.automation import NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG
+from homeassistant.components.labs import async_listen as async_labs_listen
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -16,7 +18,7 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
     SERVICE_RELOAD,
 )
-from homeassistant.core import Event, HomeAssistant, ServiceCall
+from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryError, HomeAssistantError
 from homeassistant.helpers import discovery, issue_registry as ir
 from homeassistant.helpers.device import (
@@ -89,6 +91,18 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass.bus.async_fire(f"event_{DOMAIN}_reloaded", context=call.context)
 
     async_register_admin_service(hass, DOMAIN, SERVICE_RELOAD, _reload_config)
+
+    @callback
+    def new_triggers_conditions_listener() -> None:
+        """Handle new_triggers_conditions flag change."""
+        hass.services.call(DOMAIN, SERVICE_RELOAD)
+
+    async_labs_listen(
+        hass,
+        DOMAIN,
+        NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG,
+        new_triggers_conditions_listener,
+    )
 
     return True
 

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -6,9 +6,10 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config
+from homeassistant.components import labs
 from homeassistant.components.template import DOMAIN
 from homeassistant.const import SERVICE_RELOAD
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
@@ -17,7 +18,14 @@ from homeassistant.helpers import (
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed, get_fixture_path
+from tests.common import (
+    MockConfigEntry,
+    MockUser,
+    async_capture_events,
+    async_fire_time_changed,
+    get_fixture_path,
+)
+from tests.typing import WebSocketGenerator
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, "sensor")])
@@ -586,3 +594,97 @@ async def test_fail_non_numerical_number_settings(
         "The 'My template' number template needs to be reconfigured, "
         "max must be a number, got '{{ 100 }}'" in caplog.text
     )
+
+
+async def test_reload_when_labs_flag_changes(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    calls: list[ServiceCall],
+    hass_admin_user: MockUser,
+    hass_read_only_user: MockUser,
+) -> None:
+    """Test automations are reloaded when labs flag changes."""
+    ws_client = await hass_ws_client(hass)
+
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                "triggers": {
+                    "trigger": "event",
+                    "event_type": "test_event",
+                },
+                "sensor": {
+                    "name": "hello",
+                    "state": "{{ trigger.event.event_type }}",
+                },
+            }
+        },
+    )
+    assert await async_setup_component(hass, labs.DOMAIN, {})
+    assert hass.states.get("sensor.hello") is not None
+    assert hass.states.get("sensor.bye") is None
+    listeners = hass.bus.async_listeners()
+    assert listeners.get("test_event") == 1
+    assert listeners.get("test_event2") is None
+
+    context = Context()
+    hass.bus.async_fire("test_event", context=context)
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].data.get("event") == "test_event"
+
+    test_reload_event = async_capture_events(hass, "event_template_reloaded")
+
+    # Check we reload whenever the labs flag is set, even if it's already enabled
+    for enabled in (True, True, False, False):
+        test_reload_event.clear()
+        calls.clear()
+
+        with patch(
+            "homeassistant.config.load_yaml_config_file",
+            autospec=True,
+            return_value={
+                DOMAIN: {
+                    "triggers": {
+                        "trigger": "event",
+                        "event_type": "test_event",
+                    },
+                    "sensor": {
+                        "name": "bye",
+                        "state": "{{ trigger.event.event_type }}",
+                    },
+                }
+            },
+        ):
+            await ws_client.send_json_auto_id(
+                {
+                    "type": "labs/update",
+                    "domain": "template",
+                    "preview_feature": "new_triggers_conditions",
+                    "enabled": enabled,
+                }
+            )
+
+            msg = await ws_client.receive_json()
+            assert msg["success"]
+            await hass.async_block_till_done()
+
+        assert len(test_reload_event) == 1
+
+        assert hass.states.get("sensor.hello") is None
+        assert hass.states.get("sensor.bye") is not None
+        listeners = hass.bus.async_listeners()
+        assert listeners.get("test_event") is None
+        assert listeners.get("test_event2") == 1
+
+        hass.bus.async_fire("test_event")
+        await hass.async_block_till_done()
+        assert len(calls) == 0
+
+        hass.bus.async_fire("test_event2")
+        await hass.async_block_till_done()
+        assert len(calls) == 1
+        assert calls[-1].data.get("event") == "test_event2"

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -602,7 +602,7 @@ async def test_reload_when_labs_flag_changes(
     hass_admin_user: MockUser,
     hass_read_only_user: MockUser,
 ) -> None:
-    """Test automations are reloaded when labs flag changes."""
+    """Test templates are reloaded when labs flag changes."""
     ws_client = await hass_ws_client(hass)
 
     assert await async_setup_component(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reload automations when labs flag automation.new_triggers_conditions is set or unset

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
