### PR TITLE
Default conversation agent to store tool calls in chat log

### DIFF
--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -17,6 +17,11 @@ from homeassistant.components.conversation import (
     default_agent,
     get_agent_manager,
 )
+from homeassistant.components.conversation.chat_log import (
+    AssistantContent,
+    ToolResultContent,
+    async_get_chat_log,
+)
 from homeassistant.components.conversation.default_agent import METADATA_CUSTOM_SENTENCE
 from homeassistant.components.conversation.models import ConversationInput
 from homeassistant.components.conversation.trigger import TriggerDetails
@@ -52,6 +57,7 @@ from homeassistant.core import (
 )
 from homeassistant.helpers import (
     area_registry as ar,
+    chat_session,
     device_registry as dr,
     entity_registry as er,
     floor_registry as fr,
@@ -3424,3 +3430,149 @@ async def test_fuzzy_matching(
         if slot_name != "preferred_area_id"  # context area
     }
     assert actual_slots == slots
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_intent_tool_call_in_chat_log(hass: HomeAssistant) -> None:
+    """Test that intent tool calls are stored in the chat log."""
+    hass.states.async_set(
+        "light.test_light", "off", attributes={ATTR_FRIENDLY_NAME: "Test Light"}
+    )
+    async_mock_service(hass, "light", "turn_on")
+
+    result = await conversation.async_converse(
+        hass, "turn on test light", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+
+    with (
+        chat_session.async_get_chat_session(hass, result.conversation_id) as session,
+        async_get_chat_log(hass, session) as chat_log,
+    ):
+        pass
+
+    # Find the tool call in the chat log
+    tool_call_content: AssistantContent | None = None
+    tool_result_content: ToolResultContent | None = None
+    assistant_content: AssistantContent | None = None
+
+    for content in chat_log.content:
+        if content.role == "assistant" and content.tool_calls:
+            tool_call_content = content
+        if content.role == "tool_result":
+            tool_result_content = content
+        if content.role == "assistant" and not content.tool_calls:
+            assistant_content = content
+
+    # Verify tool call was stored
+    assert tool_call_content is not None and tool_call_content.tool_calls is not None
+    assert len(tool_call_content.tool_calls) == 1
+    assert tool_call_content.tool_calls[0].tool_name == "HassTurnOn"
+    assert tool_call_content.tool_calls[0].external is True
+    assert tool_call_content.tool_calls[0].tool_args.get("name") == "Test Light"
+
+    # Verify tool result was stored
+    assert tool_result_content is not None
+    assert tool_result_content.tool_name == "HassTurnOn"
+    assert tool_result_content.tool_result["response_type"] == "action_done"
+
+    # Verify final assistant content with speech
+    assert assistant_content is not None
+    assert assistant_content.content is not None
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_trigger_tool_call_in_chat_log(hass: HomeAssistant) -> None:
+    """Test that trigger tool calls are stored in the chat log."""
+    trigger_sentence = "test automation trigger"
+    trigger_response = "Trigger activated!"
+
+    manager = get_agent_manager(hass)
+    callback = AsyncMock(return_value=trigger_response)
+    manager.register_trigger(TriggerDetails([trigger_sentence], callback))
+
+    result = await conversation.async_converse(
+        hass, trigger_sentence, None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+
+    with (
+        chat_session.async_get_chat_session(hass, result.conversation_id) as session,
+        async_get_chat_log(hass, session) as chat_log,
+    ):
+        pass
+
+    # Find the tool call in the chat log
+    tool_call_content: AssistantContent | None = None
+    tool_result_content: ToolResultContent | None = None
+
+    for content in chat_log.content:
+        if content.role == "assistant" and content.tool_calls:
+            tool_call_content = content
+        if content.role == "tool_result":
+            tool_result_content = content
+
+    # Verify tool call was stored
+    assert tool_call_content is not None and tool_call_content.tool_calls is not None
+    assert len(tool_call_content.tool_calls) == 1
+    assert tool_call_content.tool_calls[0].tool_name == "trigger_sentence"
+    assert tool_call_content.tool_calls[0].external is True
+    assert tool_call_content.tool_calls[0].tool_args == {}
+
+    # Verify tool result was stored
+    assert tool_result_content is not None
+    assert tool_result_content.tool_name == "trigger_sentence"
+    assert tool_result_content.tool_result["response"] == trigger_response
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_no_tool_call_on_no_intent_match(hass: HomeAssistant) -> None:
+    """Test that no tool call is stored when no intent is matched."""
+    result = await conversation.async_converse(
+        hass, "this is a random sentence that should not match", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+
+    with (
+        chat_session.async_get_chat_session(hass, result.conversation_id) as session,
+        async_get_chat_log(hass, session) as chat_log,
+    ):
+        pass
+
+    # Verify no tool call was stored
+    for content in chat_log.content:
+        if content.role == "assistant":
+            assert content.tool_calls is None or len(content.tool_calls) == 0
+            break
+    else:
+        pytest.fail("No assistant content found in chat log")
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_intent_tool_call_with_error_response(hass: HomeAssistant) -> None:
+    """Test that intent tool calls store error information correctly."""
+    # Request to turn on a non-existent device
+    result = await conversation.async_converse(
+        hass, "turn on the non existent device", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+
+    with (
+        chat_session.async_get_chat_session(hass, result.conversation_id) as session,
+        async_get_chat_log(hass, session) as chat_log,
+    ):
+        pass
+
+    # Verify no tool call was stored for unmatched entities
+    tool_call_found = False
+    for content in chat_log.content:
+        if content.role == "assistant" and content.tool_calls:
+            tool_call_found = True
+
+    # No tool call should be stored since the entity could not be matched
+    assert not tool_call_found


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This makes the default conversation agent store tool calls in the chat log to better represent the full picture of what happened during a conversation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
