### PR TITLE
Pooldose bump api 0.8.0 (new)

### DIFF
--- a/homeassistant/components/pooldose/manifest.json
+++ b/homeassistant/components/pooldose/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/pooldose",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["python-pooldose==0.7.8"]
+  "requirements": ["python-pooldose==0.7.9"]
 }

--- a/homeassistant/components/pooldose/manifest.json
+++ b/homeassistant/components/pooldose/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/pooldose",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["python-pooldose==0.7.9"]
+  "requirements": ["python-pooldose==0.8.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2548,7 +2548,7 @@ python-overseerr==0.7.1
 python-picnic-api2==1.3.1
 
 # homeassistant.components.pooldose
-python-pooldose==0.7.9
+python-pooldose==0.8.0
 
 # homeassistant.components.rabbitair
 python-rabbitair==0.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2548,7 +2548,7 @@ python-overseerr==0.7.1
 python-picnic-api2==1.3.1
 
 # homeassistant.components.pooldose
-python-pooldose==0.7.8
+python-pooldose==0.7.9
 
 # homeassistant.components.rabbitair
 python-rabbitair==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2129,7 +2129,7 @@ python-overseerr==0.7.1
 python-picnic-api2==1.3.1
 
 # homeassistant.components.pooldose
-python-pooldose==0.7.8
+python-pooldose==0.7.9
 
 # homeassistant.components.rabbitair
 python-rabbitair==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2129,7 +2129,7 @@ python-overseerr==0.7.1
 python-picnic-api2==1.3.1
 
 # homeassistant.components.pooldose
-python-pooldose==0.7.9
+python-pooldose==0.8.0
 
 # homeassistant.components.rabbitair
 python-rabbitair==0.0.8


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump to python-pooldose 0.8.0

### Changes in 0.7.9 + 0.8.0

- **Simplified Entity Types**: Reduced complexity by moving read-only numeric values to sensor type
  - `water_meter_total_permanent` moved from number to sensor
  - `water_meter_total_resettable` moved from number to sensor
  - `flow_rate_value` moved from number to sensor
- **Streamlined Configuration**: Reduced select entities to essential configuration options only
  - Removed redundant read-only select types
  - Focused on user-configurable settings for better clarity
  - Improved entity organization and usability

### Enhanced

- **Entity Type Refinement**: `flow_rate_value` renamed to `flow_rate`
- **Entity Organization**: Better alignment between entity types and their actual usage patterns
- **API Clarity**: More intuitive distinction between read-only sensors and configurable numbers

**Full Changelog**: https://github.com/lmaertin/python-pooldose/compare/0.7.8...0.8.0

Note: No breaking change as number platform has not been configured yet. The three new sensors will be added in a future PR. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
