### PR TITLE
Bump reolink-aio to 0.16.6

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.16.5"]
+  "requirements": ["reolink-aio==0.16.6"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2720,7 +2720,7 @@ renault-api==0.5.0
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.16.5
+reolink-aio==0.16.6
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2274,7 +2274,7 @@ renault-api==0.5.0
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.16.5
+reolink-aio==0.16.6
 
 # homeassistant.components.rflink
 rflink==0.0.67


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.16.6:
**Additions:**
- [Baichuan fallback for GetMdAlarm](https://github.com/starkillerOG/reolink_aio/commit/0bfcca63e3b957f27d573bfdf8557aa328b0ab1f)
- [Baichuan fallback for SetMdAlarm](https://github.com/starkillerOG/reolink_aio/commit/58a6167867dae87b14bdbb4758c97002a3701724)
- [Baichuan fallback for GetAiAlarm](https://github.com/starkillerOG/reolink_aio/commit/f0705586f93ed6970a27b6cffb58e401907eacdc)
- [Baichuan fallback for SetAiAlarm](https://github.com/starkillerOG/reolink_aio/commit/503684e90bba4779794f3c259f903a99846dd43a)
- [Baichuan fallback for GetEnc](https://github.com/starkillerOG/reolink_aio/commit/72b8eca173518f63e575b120027b5c07cad3e3a1)
- [Use Baichuan to get Encoding range](https://github.com/starkillerOG/reolink_aio/commit/859f3cc99c001eba32aecebab2b45afb41b54b5f)
- [Baichuan fallback for SetEnc](https://github.com/starkillerOG/reolink_aio/commit/765c5c8b3a67c284f7aed55a35d1a1292142d687)
- [Detect IR light support using Baichuan](https://github.com/starkillerOG/reolink_aio/commit/3ad32b1d0c644101a84135dc3cb6cee4a42096fa)

**Bug fixes:**
- [Fix KeyError when name not present in chime DingDongOpt](https://github.com/starkillerOG/reolink_aio/commit/2688d31f345dbe1df7f7411fad94d5c719f7213d)
- [Always check for GetMdAlarm support](https://github.com/starkillerOG/reolink_aio/commit/7fe1b19bc50fd2d827664caa94d6e68d0626f306)

**Optimizations:**
- [Add RTSP and ONVIF flags for baichuan only cam](https://github.com/starkillerOG/reolink_aio/commit/71b5c7c04efd17ed8d71c41900b61f51037870a6)
- [Remove "MdAlarm"/"Alarm" from internal chache](https://github.com/starkillerOG/reolink_aio/commit/555a16585f5a9d9708f255dafc2308b3cf3b7c41)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.16.5...0.16.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/155388 fixes https://github.com/home-assistant/core/issues/156630
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
