### PR TITLE
Return early when setting cloud ai_task and conversation and not logged in to cloud

### DIFF
--- a/homeassistant/components/cloud/ai_task.py
+++ b/homeassistant/components/cloud/ai_task.py
@@ -94,8 +94,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Home Assistant Cloud AI Task entity."""
-    cloud = hass.data[DATA_CLOUD]
-    if not cloud.is_logged_in:
+    if not (cloud := hass.data[DATA_CLOUD]).is_logged_in:
         return
     try:
         await cloud.llm.async_ensure_token()

--- a/homeassistant/components/cloud/ai_task.py
+++ b/homeassistant/components/cloud/ai_task.py
@@ -6,6 +6,7 @@ import io
 from json import JSONDecodeError
 import logging
 
+from hass_nabucasa import NabuCasaBaseError
 from hass_nabucasa.llm import (
     LLMAuthenticationError,
     LLMError,
@@ -94,9 +95,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up Home Assistant Cloud AI Task entity."""
     cloud = hass.data[DATA_CLOUD]
+    if not cloud.is_logged_in:
+        return
     try:
         await cloud.llm.async_ensure_token()
-    except LLMError:
+    except (LLMError, NabuCasaBaseError):
         return
 
     async_add_entities([CloudLLMTaskEntity(cloud, config_entry)])

--- a/homeassistant/components/cloud/conversation.py
+++ b/homeassistant/components/cloud/conversation.py
@@ -24,8 +24,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Home Assistant Cloud conversation entity."""
-    cloud = hass.data[DATA_CLOUD]
-    if not cloud.is_logged_in:
+    if not (cloud := hass.data[DATA_CLOUD]).is_logged_in:
         return
     try:
         await cloud.llm.async_ensure_token()

--- a/homeassistant/components/cloud/conversation.py
+++ b/homeassistant/components/cloud/conversation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
+from hass_nabucasa import NabuCasaBaseError
 from hass_nabucasa.llm import LLMError
 
 from homeassistant.components import conversation
@@ -24,9 +25,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Home Assistant Cloud conversation entity."""
     cloud = hass.data[DATA_CLOUD]
+    if not cloud.is_logged_in:
+        return
     try:
         await cloud.llm.async_ensure_token()
-    except LLMError:
+    except (LLMError, NabuCasaBaseError):
         return
 
     async_add_entities([CloudConversationEntity(cloud, config_entry)])

--- a/tests/components/cloud/test_ai_task.py
+++ b/tests/components/cloud/test_ai_task.py
@@ -21,7 +21,9 @@ from homeassistant.components import ai_task, conversation
 from homeassistant.components.cloud.ai_task import (
     CloudLLMTaskEntity,
     async_prepare_image_generation_attachments,
+    async_setup_entry,
 )
+from homeassistant.components.cloud.const import DATA_CLOUD
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 
@@ -44,6 +46,21 @@ def mock_cloud_ai_task_entity(hass: HomeAssistant) -> CloudLLMTaskEntity:
     entity.entity_id = "ai_task.cloud_ai_task"
     entity.hass = hass
     return entity
+
+
+async def test_setup_entry_skips_when_not_logged_in(
+    hass: HomeAssistant,
+) -> None:
+    """Test setup_entry exits early when not logged in."""
+    cloud = MagicMock()
+    cloud.is_logged_in = False
+    entry = MockConfigEntry(domain="cloud")
+    entry.add_to_hass(hass)
+    hass.data[DATA_CLOUD] = cloud
+
+    async_add_entities = AsyncMock()
+    await async_setup_entry(hass, entry, async_add_entities)
+    async_add_entities.assert_not_called()
 
 
 @pytest.fixture(name="mock_handle_chat_log")

--- a/tests/components/cloud/test_conversation.py
+++ b/tests/components/cloud/test_conversation.py
@@ -34,6 +34,21 @@ def cloud_conversation_entity(hass: HomeAssistant) -> CloudConversationEntity:
     return entity
 
 
+async def test_setup_entry_skips_when_not_logged_in(
+    hass: HomeAssistant,
+) -> None:
+    """Test setup_entry exits early when not logged in."""
+    cloud = MagicMock()
+    cloud.is_logged_in = False
+    entry = MockConfigEntry(domain="cloud")
+    entry.add_to_hass(hass)
+    hass.data[DATA_CLOUD] = cloud
+
+    async_add_entities = AsyncMock()
+    await async_setup_entry(hass, entry, async_add_entities)
+    async_add_entities.assert_not_called()
+
+
 def test_entity_availability(
     cloud_conversation_entity: CloudConversationEntity,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes a bug where the cloud integration was throwing an error when setting up `ai_task` and `conversation`, and users were not logged in to HomeAssistant Cloud.
It guards against not logged in users and handles `NabuCasaBaseError`s


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/157371
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
