### PR TITLE
Avoid custom  template platform deprecations

### DIFF
--- a/homeassistant/components/template/helpers.py
+++ b/homeassistant/components/template/helpers.py
@@ -46,6 +46,7 @@ from .const import (
     CONF_DEFAULT_ENTITY_ID,
     CONF_PICTURE,
     DOMAIN,
+    PLATFORMS,
 )
 from .entity import AbstractTemplateEntity
 from .template_entity import TemplateEntity
@@ -234,6 +235,8 @@ def create_legacy_template_issue(
     hass: HomeAssistant, config: ConfigType, domain: str
 ) -> None:
     """Create a repair for legacy template entities."""
+    if domain not in PLATFORMS:
+        return
 
     breadcrumb = "Template Entity"
     # Default entity id should be in most legacy configuration because

--- a/tests/components/template/test_helpers.py
+++ b/tests/components/template/test_helpers.py
@@ -13,6 +13,7 @@ from homeassistant.components.template.cover import LEGACY_FIELDS as COVER_LEGAC
 from homeassistant.components.template.fan import LEGACY_FIELDS as FAN_LEGACY_FIELDS
 from homeassistant.components.template.helpers import (
     async_setup_template_platform,
+    create_legacy_template_issue,
     format_migration_config,
     rewrite_legacy_to_modern_config,
     rewrite_legacy_to_modern_configs,
@@ -637,3 +638,40 @@ async def test_yaml_config_recursion_depth(hass: HomeAssistant) -> None:
 
     with pytest.raises(RecursionError):
         format_migration_config({1: {2: {3: {4: {5: {6: [{7: {8: {9: {10: {}}}}}]}}}}}})
+
+
+@pytest.mark.parametrize(
+    ("domain", "config"),
+    [
+        (
+            "media_player",
+            {
+                "media_player": {
+                    "platform": "template",
+                    "name": "My Media Player",
+                    "unique_id": "Foobar",
+                },
+            },
+        ),
+        (
+            "climate",
+            {
+                "climate": {
+                    "platform": "template",
+                    "name": "My Climate",
+                    "unique_id": "Foobar",
+                },
+            },
+        ),
+    ],
+)
+async def test_custom_integration_deprecation(
+    hass: HomeAssistant,
+    domain: str,
+    config: dict,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test that custom integrations do not create deprecations."""
+
+    create_legacy_template_issue(hass, config, domain)
+    assert len(issue_registry.issues) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

There are a few custom template integratiosn that use the `platform: template` key and they create an issue.  These should not create an issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
