### PR TITLE
Add device info and parallel_updates to Transmission

### DIFF
--- a/homeassistant/components/transmission/entity.py
+++ b/homeassistant/components/transmission/entity.py
@@ -1,5 +1,8 @@
 """Base class for Transmission entities."""
 
+from typing import Final
+
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -24,7 +27,12 @@ class TransmissionEntity(CoordinatorEntity[TransmissionDataUpdateCoordinator]):
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}-{entity_description.key}"
         )
+        protocol: Final = "https" if coordinator.config_entry.data[CONF_SSL] else "http"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
             manufacturer="Transmission",
+            sw_version=coordinator.api.server_version,
+            configuration_url=(
+                f"{protocol}://{coordinator.config_entry.data[CONF_HOST]}:{coordinator.config_entry.data[CONF_PORT]}"
+            ),
         )

--- a/homeassistant/components/transmission/entity.py
+++ b/homeassistant/components/transmission/entity.py
@@ -1,8 +1,5 @@
 """Base class for Transmission entities."""
 
-from typing import Final
-
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -27,12 +24,6 @@ class TransmissionEntity(CoordinatorEntity[TransmissionDataUpdateCoordinator]):
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}-{entity_description.key}"
         )
-        protocol: Final = "https" if coordinator.config_entry.data[CONF_SSL] else "http"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
-            manufacturer="Transmission",
-            sw_version=coordinator.api.server_version,
-            configuration_url=(
-                f"{protocol}://{coordinator.config_entry.data[CONF_HOST]}:{coordinator.config_entry.data[CONF_PORT]}"
-            ),
         )

--- a/homeassistant/components/transmission/quality_scale.yaml
+++ b/homeassistant/components/transmission/quality_scale.yaml
@@ -25,10 +25,7 @@ rules:
   # Silver
   action-exceptions: done
   config-entry-unloading: done
-  docs-configuration-parameters:
-    status: todo
-    comment: |
-      Remove the torrent attributes/configuration and change to a get_torrents service.
+  docs-configuration-parameters: todo
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done

--- a/homeassistant/components/transmission/quality_scale.yaml
+++ b/homeassistant/components/transmission/quality_scale.yaml
@@ -25,20 +25,20 @@ rules:
   # Silver
   action-exceptions: done
   config-entry-unloading: done
-  docs-configuration-parameters: todo
+  docs-configuration-parameters:
+    status: todo
+    comment: |
+      Remove the torrent attributes/configuration and change to a get_torrents service.
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: done
   test-coverage: done
 
   # Gold
-  devices:
-    status: todo
-    comment: |
-      Add additional device detail including link to ui.
+  devices: done
   diagnostics: todo
   discovery-update-info: todo
   discovery: todo

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -29,6 +29,8 @@ from .const import (
 from .coordinator import TransmissionConfigEntry, TransmissionDataUpdateCoordinator
 from .entity import TransmissionEntity
 
+PARALLEL_UPDATES = 0
+
 MODES: dict[str, list[str] | None] = {
     "started_torrents": ["downloading"],
     "completed_torrents": ["seeding"],

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -11,6 +11,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .coordinator import TransmissionConfigEntry, TransmissionDataUpdateCoordinator
 from .entity import TransmissionEntity
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class TransmissionSwitchEntityDescription(SwitchEntityDescription):

--- a/tests/components/transmission/conftest.py
+++ b/tests/components/transmission/conftest.py
@@ -47,6 +47,8 @@ def mock_transmission_client() -> Generator[AsyncMock]:
     ):
         client = mock_client_class.return_value
 
+        client.server_version = "4.0.5 (a6fe2a64aa)"
+
         session_stats_data = {
             "uploadSpeed": 1,
             "downloadSpeed": 1,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds version and a configuration url to device info, moving into init to avoid duplication.
Also added parallel_updates which was missing, this is a one liner in switch/sensor and we are using standard coordinator polling.
Update QS, also with a comment about why docs-configuration-parameters requires more work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
