### PR TITLE
Fix regression in roborock image entity naming

### DIFF
--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -32,7 +32,6 @@ async def async_setup_entry(
         (
             RoborockMap(
                 config_entry,
-                f"{coord.duid_slug}_map_{map_info.name}",
                 coord,
                 coord.properties_api.home,
                 map_info.map_flag,
@@ -55,13 +54,17 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
     def __init__(
         self,
         config_entry: ConfigEntry,
-        unique_id: str,
         coordinator: RoborockDataUpdateCoordinator,
         home_trait: HomeTrait,
         map_flag: int,
         map_name: str,
     ) -> None:
         """Initialize a Roborock map."""
+        map_name = map_name or f"Map {map_flag}"
+        # Note: Map names are not a valid unique id since they can be changed
+        # in the roborock app. This should be migrated to use map flag for
+        # the unique id.
+        unique_id = f"{coordinator.duid_slug}_map_{map_name}"
         RoborockCoordinatedEntityV1.__init__(self, unique_id, coordinator)
         ImageEntity.__init__(self, coordinator.hass)
         self.config_entry = config_entry

--- a/tests/components/roborock/mock_data.py
+++ b/tests/components/roborock/mock_data.py
@@ -1153,6 +1153,29 @@ MULTI_MAP_LIST = MultiMapsList.from_dict(
         ],
     }
 )
+MULTI_MAP_LIST_NO_MAP_NAMES = MultiMapsList.from_dict(
+    {
+        "maxMultiMap": 4,
+        "maxBakMap": 1,
+        "multiMapCount": 2,
+        "mapInfo": [
+            {
+                "mapFlag": 0,
+                "addTime": 1686235489,
+                "length": 0,
+                "name": "",
+                "bakMaps": [{"addTime": 1673304288}],
+            },
+            {
+                "mapFlag": 1,
+                "addTime": 1697579901,
+                "length": 0,
+                "name": "",
+                "bakMaps": [{"addTime": 1695521431}],
+            },
+        ],
+    }
+)
 
 MAP_DATA = MapData(0, 0)
 MAP_DATA.image = ImageData(

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 from roborock import RoborockException
-from roborock.data import MultiMapsListMapInfo, RoborockStateCode
+from roborock.data import RoborockStateCode
 from roborock.devices.traits.v1.map_content import MapContent
 
 from homeassistant.components.roborock.const import V1_LOCAL_NOT_CLEANING_INTERVAL
@@ -17,7 +17,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from .conftest import FakeDevice, make_home_trait
-from .mock_data import HOME_DATA, MAP_DATA, ROOM_MAPPING, STATUS
+from .mock_data import (
+    HOME_DATA,
+    MAP_DATA,
+    MULTI_MAP_LIST_NO_MAP_NAMES,
+    ROOM_MAPPING,
+    STATUS,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.typing import ClientSessionGenerator
@@ -175,28 +181,9 @@ async def test_empty_room_name(
     fake_vacuum: FakeDevice,
 ) -> None:
     """Test entity naming when no map name is set."""
-    multi_map_list_map_infos = [
-        MultiMapsListMapInfo.from_dict(
-            {
-                "mapFlag": 0,
-                "addTime": 1686235489,
-                "length": 0,
-                "name": "",
-            },
-        ),
-        MultiMapsListMapInfo.from_dict(
-            {
-                "mapFlag": 1,
-                "addTime": 1697579901,
-                "length": 0,
-                "name": "",
-                "bakMaps": [{"addTime": 1695521431}],
-            },
-        ),
-    ]
     assert fake_vacuum.v1_properties
     fake_vacuum.v1_properties.home = make_home_trait(
-        map_info=multi_map_list_map_infos,
+        map_info=MULTI_MAP_LIST_NO_MAP_NAMES.map_info,
         current_map=STATUS.current_map,
         room_mapping=ROOM_MAPPING,
         rooms=HOME_DATA.rooms,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix regression in roborock image entity naming. This restores the previous behavior of adding a placeholder map name e.g. "Map 0" based on the map id (map flag).

This adds a parameterized test that exercises entity naming with both named and unnamed maps.  The test home trait setup is factored out to a function that can be called during the test.

Note: The unique id used for image entities is incorrect since it can changed, so added a placeholder comment that will be addressed in a future PR.  This needs to be tagged for a beta patch.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #157378
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
