### PR TITLE
Add coverage to Shelly utils

### DIFF
--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -31,7 +31,6 @@ from .utils import (
     async_remove_orphaned_entities,
     async_remove_shelly_entity,
     get_block_channel,
-    get_block_channel_name,
     get_block_custom_name,
     get_block_number_of_channels,
     get_device_entry_gen,
@@ -211,7 +210,7 @@ class ShellyBlockEvent(ShellyBlockEntity, EventEntity):
                 else ""
             }
         else:
-            self._attr_name = get_block_channel_name(coordinator.device, block)
+            self._attr_name = get_block_custom_name(coordinator.device, block)
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -647,7 +647,7 @@ def async_remove_shelly_rpc_entities(
 
 def get_virtual_component_ids(config: dict[str, Any], platform: str) -> list[str]:
     """Return a list of virtual component IDs for a platform."""
-    component = VIRTUAL_COMPONENTS_MAP[(platform)]
+    component = VIRTUAL_COMPONENTS_MAP[platform]
 
     ids: list[str] = []
 

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -110,8 +110,6 @@ def get_block_number_of_channels(device: BlockDevice, block: Block) -> int:
         channels = device.shelly.get("num_emeters")
     elif block.type in ["relay", "light"]:
         channels = device.shelly.get("num_outputs")
-    elif block.type in ["roller", "device"]:
-        channels = 1
 
     return channels or 1
 
@@ -132,21 +130,6 @@ def get_block_channel(block: Block | None, base: str = "1") -> str:
     assert block and block.channel
 
     return chr(int(block.channel) + ord(base))
-
-
-def get_block_channel_name(device: BlockDevice, block: Block | None) -> str | None:
-    """Get name based on device and channel name."""
-    if (
-        not block
-        or block.type in ("device", "light", "relay", "emeter")
-        or get_block_number_of_channels(device, block) == 1
-    ):
-        return None
-
-    if custom_name := get_block_custom_name(device, block):
-        return custom_name
-
-    return f"Channel {get_block_channel(block)}"
 
 
 def get_block_sub_device_name(device: BlockDevice, block: Block) -> str:
@@ -664,10 +647,7 @@ def async_remove_shelly_rpc_entities(
 
 def get_virtual_component_ids(config: dict[str, Any], platform: str) -> list[str]:
     """Return a list of virtual component IDs for a platform."""
-    component = VIRTUAL_COMPONENTS_MAP.get(platform)
-
-    if not component:
-        return []
+    component = VIRTUAL_COMPONENTS_MAP[(platform)]
 
     ids: list[str] = []
 
@@ -975,10 +955,10 @@ def async_migrate_rpc_virtual_components_unique_ids(
     The new unique_id format is: {mac}-{key}-{component}_{role}
     """
     for component in VIRTUAL_COMPONENTS:
-        if entity_entry.unique_id.endswith(f"-{component!s}"):
-            key = entity_entry.unique_id.split("-")[-2]
-            if key not in config:
-                continue
+        if (
+            entity_entry.unique_id.endswith(f"-{component!s}")
+            and (key := entity_entry.unique_id.split("-")[-2]) in config
+        ):
             role = get_rpc_role_by_key(config, key)
             new_unique_id = f"{entity_entry.unique_id}_{role}"
             LOGGER.debug(

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -9,7 +9,6 @@ from aioshelly.const import (
     MODEL_BUTTON1,
     MODEL_BUTTON1_V2,
     MODEL_DIMMER_2,
-    MODEL_EM3,
     MODEL_I3,
     MODEL_MOTION,
     MODEL_PLUS_2PM_V2,
@@ -24,7 +23,6 @@ from homeassistant.components.shelly.const import (
     UPTIME_DEVIATION,
 )
 from homeassistant.components.shelly.utils import (
-    get_block_channel_name,
     get_block_device_sleep_period,
     get_block_input_triggers,
     get_block_number_of_channels,
@@ -74,44 +72,6 @@ async def test_block_get_block_number_of_channels(
         )
         == 2
     )
-
-
-async def test_block_get_block_channel_name(
-    mock_block_device: Mock, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Test block get block channel name."""
-    result = get_block_channel_name(
-        mock_block_device,
-        mock_block_device.blocks[DEVICE_BLOCK_ID],
-    )
-    # when has_entity_name is True the result should be None
-    assert result is None
-
-    monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "type", "relay")
-    result = get_block_channel_name(
-        mock_block_device,
-        mock_block_device.blocks[DEVICE_BLOCK_ID],
-    )
-    # when has_entity_name is True the result should be None
-    assert result is None
-
-    monkeypatch.setitem(mock_block_device.settings["device"], "type", MODEL_EM3)
-    result = get_block_channel_name(
-        mock_block_device,
-        mock_block_device.blocks[DEVICE_BLOCK_ID],
-    )
-    # when has_entity_name is True the result should be None
-    assert result is None
-
-    monkeypatch.setitem(
-        mock_block_device.settings, "relays", [{"name": "test-channel"}]
-    )
-    result = get_block_channel_name(
-        mock_block_device,
-        mock_block_device.blocks[DEVICE_BLOCK_ID],
-    )
-    # when has_entity_name is True the result should be None
-    assert result is None
 
 
 async def test_is_block_momentary_input(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add coverage to Shelly `utils.py`, left with 2 uncovered lines which will be added in follow-up PR
`get_block_channel_name` is only used in the `event` platform and actually fallback to `get_block_custom_name`, it was showing some coverage only because we have a test for it `test_block_get_block_channel_name`.
Tested the event change on Shelly I3 & Shelly 2.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
