### PR TITLE
Fix Anglian Water sensor setup

### DIFF
--- a/homeassistant/components/anglian_water/entity.py
+++ b/homeassistant/components/anglian_water/entity.py
@@ -18,17 +18,21 @@ _LOGGER = logging.getLogger(__name__)
 class AnglianWaterEntity(CoordinatorEntity[AnglianWaterUpdateCoordinator]):
     """Defines a Anglian Water entity."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: AnglianWaterUpdateCoordinator,
         smart_meter: SmartMeter,
+        key: str,
     ) -> None:
         """Initialize Anglian Water entity."""
         super().__init__(coordinator)
         self.smart_meter = smart_meter
+        self._attr_unique_id = f"{smart_meter.serial_number}_{key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, smart_meter.serial_number)},
-            name="Smart Water Meter",
+            name=smart_meter.serial_number,
             manufacturer="Anglian Water",
             serial_number=smart_meter.serial_number,
         )

--- a/homeassistant/components/anglian_water/sensor.py
+++ b/homeassistant/components/anglian_water/sensor.py
@@ -108,9 +108,8 @@ class AnglianWaterSensorEntity(AnglianWaterEntity, SensorEntity):
         description: AnglianWaterSensorEntityDescription,
     ) -> None:
         """Initialize Anglian Water sensor."""
-        super().__init__(coordinator, smart_meter)
+        super().__init__(coordinator, smart_meter, description.key)
         self.entity_description = description
-        self._attr_unique_id = f"{smart_meter.serial_number}_{description.key}"
 
     @property
     def native_value(self) -> float | None:

--- a/tests/components/anglian_water/snapshots/test_sensor.ambr
+++ b/tests/components/anglian_water/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sensor[sensor.anglian_water_testsn_latest_reading-entry]
+# name: test_sensor[sensor.testsn_latest_reading-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -14,8 +14,8 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.anglian_water_testsn_latest_reading',
-    'has_entity_name': False,
+    'entity_id': 'sensor.testsn_latest_reading',
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -29,7 +29,7 @@
     }),
     'original_device_class': <SensorDeviceClass.WATER: 'water'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Latest reading',
     'platform': 'anglian_water',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -39,22 +39,73 @@
     'unit_of_measurement': <UnitOfVolume.CUBIC_METERS: 'm³'>,
   })
 # ---
-# name: test_sensor[sensor.anglian_water_testsn_latest_reading-state]
+# name: test_sensor[sensor.testsn_latest_reading-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'water',
+      'friendly_name': 'TESTSN Latest reading',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfVolume.CUBIC_METERS: 'm³'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.anglian_water_testsn_latest_reading',
+    'entity_id': 'sensor.testsn_latest_reading',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '50',
   })
 # ---
-# name: test_sensor[sensor.anglian_water_testsn_yesterday_consumption-entry]
+# name: test_sensor[sensor.testsn_yesterday_s_sewerage_cost-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.testsn_yesterday_s_sewerage_cost',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
+    'original_icon': None,
+    'original_name': "Yesterday's sewerage cost",
+    'platform': 'anglian_water',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <AnglianWaterSensor.YESTERDAY_SEWERAGE_COST: 'yesterday_sewerage_cost'>,
+    'unique_id': 'TESTSN_yesterday_sewerage_cost',
+    'unit_of_measurement': 'GBP',
+  })
+# ---
+# name: test_sensor[sensor.testsn_yesterday_s_sewerage_cost-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'monetary',
+      'friendly_name': "TESTSN Yesterday's sewerage cost",
+      'unit_of_measurement': 'GBP',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testsn_yesterday_s_sewerage_cost',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.5',
+  })
+# ---
+# name: test_sensor[sensor.testsn_yesterday_s_usage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -69,8 +120,8 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.anglian_water_testsn_yesterday_consumption',
-    'has_entity_name': False,
+    'entity_id': 'sensor.testsn_yesterday_s_usage',
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -84,7 +135,7 @@
     }),
     'original_device_class': <SensorDeviceClass.WATER: 'water'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': "Yesterday's usage",
     'platform': 'anglian_water',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -94,22 +145,23 @@
     'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
   })
 # ---
-# name: test_sensor[sensor.anglian_water_testsn_yesterday_consumption-state]
+# name: test_sensor[sensor.testsn_yesterday_s_usage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'water',
+      'friendly_name': "TESTSN Yesterday's usage",
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.anglian_water_testsn_yesterday_consumption',
+    'entity_id': 'sensor.testsn_yesterday_s_usage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '50',
   })
 # ---
-# name: test_sensor[sensor.anglian_water_testsn_yesterday_sewerage_cost-entry]
+# name: test_sensor[sensor.testsn_yesterday_s_water_cost-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -122,8 +174,8 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.anglian_water_testsn_yesterday_sewerage_cost',
-    'has_entity_name': False,
+    'entity_id': 'sensor.testsn_yesterday_s_water_cost',
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -134,56 +186,7 @@
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
-    'platform': 'anglian_water',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': <AnglianWaterSensor.YESTERDAY_SEWERAGE_COST: 'yesterday_sewerage_cost'>,
-    'unique_id': 'TESTSN_yesterday_sewerage_cost',
-    'unit_of_measurement': 'GBP',
-  })
-# ---
-# name: test_sensor[sensor.anglian_water_testsn_yesterday_sewerage_cost-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'monetary',
-      'unit_of_measurement': 'GBP',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.anglian_water_testsn_yesterday_sewerage_cost',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.5',
-  })
-# ---
-# name: test_sensor[sensor.anglian_water_testsn_yesterday_water_cost-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.anglian_water_testsn_yesterday_water_cost',
-    'has_entity_name': False,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
-    'original_icon': None,
-    'original_name': None,
+    'original_name': "Yesterday's water cost",
     'platform': 'anglian_water',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -193,14 +196,15 @@
     'unit_of_measurement': 'GBP',
   })
 # ---
-# name: test_sensor[sensor.anglian_water_testsn_yesterday_water_cost-state]
+# name: test_sensor[sensor.testsn_yesterday_s_water_cost-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'monetary',
+      'friendly_name': "TESTSN Yesterday's water cost",
       'unit_of_measurement': 'GBP',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.anglian_water_testsn_yesterday_water_cost',
+    'entity_id': 'sensor.testsn_yesterday_s_water_cost',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR moves the unique_id setter for the Anglian Water integration to the base `AnglianWaterEntity` class (inline with other integrations), sets `_attr_has_entity_name` to True to correctly pull in translations and updates the name of the device to match the water meter's serial number (which allows for identification between different water meters at the same property. I'm told that a single billing account can have multiple meters)

Please can we tag this for the 2025.12 beta?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
