### PR TITLE
Improve Nest error message wording in test before setup

### DIFF
--- a/homeassistant/components/nest/quality_scale.yaml
+++ b/homeassistant/components/nest/quality_scale.yaml
@@ -23,12 +23,7 @@ rules:
   entity-unique-id: done
   docs-installation-instructions: done
   docs-removal-instructions: todo
-  test-before-setup:
-    status: todo
-    comment: |
-      The integration does tests on setup, however the most common issues
-      observed are related to ipv6 misconfigurations and the error messages
-      are not self explanatory and can be improved.
+  test-before-setup: done
   docs-high-level-description: done
   config-flow-test-coverage: done
   docs-actions: done

--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -131,6 +131,26 @@
       }
     }
   },
+  "exceptions": {
+    "auth_client_error": {
+      "message": "Client error during authentication, please check your network connection."
+    },
+    "auth_server_error": {
+      "message": "Error response from authentication server, please see logs for details."
+    },
+    "device_api_error": {
+      "message": "Error communicating with the Device Access API, please see logs for details."
+    },
+    "reauth_required": {
+      "message": "Reauthentication is required, please follow the instructions in the UI to reauthenticate your account."
+    },
+    "subscriber_error": {
+      "message": "Subscriber failed to connect to Google, please see logs for details."
+    },
+    "subscriber_timeout": {
+      "message": "Subscriber timed out while attempting to connect to Google. Please check your network connection and ipv6 configuration if applicable."
+    }
+  },
   "selector": {
     "subscription_name": {
       "options": {

--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -148,7 +148,7 @@
       "message": "Subscriber failed to connect to Google, please see logs for details."
     },
     "subscriber_timeout": {
-      "message": "Subscriber timed out while attempting to connect to Google. Please check your network connection and ipv6 configuration if applicable."
+      "message": "Subscriber timed out while attempting to connect to Google. Please check your network connection and IPv6 configuration if applicable."
     }
   },
   "selector": {

--- a/tests/components/nest/test_init.py
+++ b/tests/components/nest/test_init.py
@@ -20,6 +20,7 @@ from google_nest_sdm.exceptions import (
     AuthException,
     ConfigurationException,
     SubscriberException,
+    SubscriberTimeoutException,
 )
 import pytest
 
@@ -110,19 +111,27 @@ async def test_setup_configuration_failure(
     assert "Subscription misconfigured. Expected subscriber_id" in caplog.text
 
 
-@pytest.mark.parametrize("subscriber_side_effect", [SubscriberException()])
+@pytest.mark.parametrize(
+    ("subscriber_side_effect", "expected_log_message"),
+    [
+        (SubscriberException(), "Subscriber error:"),
+        (SubscriberTimeoutException(), "Subscriber timed out"),
+    ],
+)
 async def test_setup_subscriber_failure(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     setup_base_platform,
+    expected_log_message: str,
 ) -> None:
     """Test configuration error."""
     await setup_base_platform()
-    assert "Subscriber error:" in caplog.text
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].state is ConfigEntryState.SETUP_RETRY
+
+    assert expected_log_message in caplog.text
 
 
 async def test_setup_device_manager_failure(
@@ -137,7 +146,7 @@ async def test_setup_device_manager_failure(
     ):
         await setup_base_platform()
 
-    assert "Device manager error:" in caplog.text
+    assert "Error communicating with the Device Access API" in caplog.text
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -211,7 +220,7 @@ async def test_subscriber_auth_failure(
     assert flows[0]["step_id"] == "reauth_confirm"
 
 
-@pytest.mark.parametrize("subscriber_side_effect", [(ConfigurationException())])
+@pytest.mark.parametrize("subscriber_side_effect", [ConfigurationException()])
 async def test_subscriber_configuration_failure(
     hass: HomeAssistant,
     error_caplog: pytest.LogCaptureFixture,

--- a/tests/components/nest/test_init.py
+++ b/tests/components/nest/test_init.py
@@ -124,7 +124,7 @@ async def test_setup_subscriber_failure(
     setup_base_platform,
     expected_log_message: str,
 ) -> None:
-    """Test configuration error."""
+    """Test subscriber error handling (SubscriberException and SubscriberTimeoutException)."""
     await setup_base_platform()
 
     entries = hass.config_entries.async_entries(DOMAIN)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve Nest error message wording in test before setup, and mark the quality scale item as completed. The motivation is that subscriber errors due to a network timeout are most commonly associated with a users ipv6 network misconfigured. ([example](https://github.com/home-assistant/core/issues/139485)) So, when this specific timeout exception fires we add a hint that the user should check their ipv6 configuration -- and google is often a first ipv6 destination. (A better fix would be to more directly detect home assistant ipv6 misconfigurations, but we don't have a plan for that)

This adds translations for all exceptions on startup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
