### PR TITLE
Remove unnecessary instanciating in Tuya find_dpcode

### DIFF
--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -372,7 +372,7 @@ class _CustomDPCodeWrapper(DPCodeWrapper):
     _valid_values: set[bool | float | int | str]
 
     def __init__(
-        self, dpcode: DPCode, valid_values: set[bool | float | int | str]
+        self, dpcode: str, valid_values: set[bool | float | int | str]
     ) -> None:
         """Init CustomDPCodeBooleanWrapper."""
         super().__init__(dpcode)
@@ -390,7 +390,7 @@ def _get_dpcode_wrapper(
     description: TuyaBinarySensorEntityDescription,
 ) -> DPCodeWrapper | None:
     """Get DPCode wrapper for an entity description."""
-    dpcode = description.dpcode or DPCode(description.key)
+    dpcode = description.dpcode or description.key
     if description.bitmap_key is not None:
         return DPCodeBitmapBitWrapper.find_dpcode(
             device, dpcode, bitmap_key=description.bitmap_key

--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
 from tuya_sharing import CustomerDevice, Manager
 
@@ -390,7 +391,7 @@ def _get_dpcode_wrapper(
     description: TuyaBinarySensorEntityDescription,
 ) -> DPCodeWrapper | None:
     """Get DPCode wrapper for an entity description."""
-    dpcode = description.dpcode or DPCode(description.key)
+    dpcode = description.dpcode or description.key
     if description.bitmap_key is not None:
         return DPCodeBitmapBitWrapper.find_dpcode(
             device, dpcode, bitmap_key=description.bitmap_key
@@ -403,7 +404,7 @@ def _get_dpcode_wrapper(
     if dpcode not in device.status:
         return None
     return _CustomDPCodeWrapper(
-        dpcode,
+        cast(DPCode, dpcode),
         description.on_value
         if isinstance(description.on_value, set)
         else {description.on_value},

--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import cast
 
 from tuya_sharing import CustomerDevice, Manager
 
@@ -391,7 +390,7 @@ def _get_dpcode_wrapper(
     description: TuyaBinarySensorEntityDescription,
 ) -> DPCodeWrapper | None:
     """Get DPCode wrapper for an entity description."""
-    dpcode = description.dpcode or description.key
+    dpcode = description.dpcode or DPCode(description.key)
     if description.bitmap_key is not None:
         return DPCodeBitmapBitWrapper.find_dpcode(
             device, dpcode, bitmap_key=description.bitmap_key
@@ -404,7 +403,7 @@ def _get_dpcode_wrapper(
     if dpcode not in device.status:
         return None
     return _CustomDPCodeWrapper(
-        cast(DPCode, dpcode),
+        dpcode,
         description.on_value
         if isinstance(description.on_value, set)
         else {description.on_value},

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -49,7 +49,7 @@ def _has_a_valid_dpcode(
     device: CustomerDevice, description: TuyaHumidifierEntityDescription
 ) -> bool:
     """Check if the device has at least one valid DP code."""
-    properties_to_check: list[str | DPCode | tuple[DPCode, ...] | None] = [
+    properties_to_check: list[str | tuple[str, ...] | None] = [
         # Main control switch
         description.dpcode or description.key,
         # Other humidity properties

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -49,9 +49,9 @@ def _has_a_valid_dpcode(
     device: CustomerDevice, description: TuyaHumidifierEntityDescription
 ) -> bool:
     """Check if the device has at least one valid DP code."""
-    properties_to_check: list[str | DPCode | tuple[DPCode, ...] | None] = [
+    properties_to_check: list[DPCode | tuple[DPCode, ...] | None] = [
         # Main control switch
-        description.dpcode or description.key,
+        description.dpcode or DPCode(description.key),
         # Other humidity properties
         description.current_humidity,
         description.humidity,
@@ -107,7 +107,7 @@ async def async_setup_entry(
                         ),
                         switch_wrapper=DPCodeBooleanWrapper.find_dpcode(
                             device,
-                            description.dpcode or description.key,
+                            description.dpcode or DPCode(description.key),
                             prefer_function=True,
                         ),
                         target_humidity_wrapper=_RoundedIntegerWrapper.find_dpcode(

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -49,9 +49,9 @@ def _has_a_valid_dpcode(
     device: CustomerDevice, description: TuyaHumidifierEntityDescription
 ) -> bool:
     """Check if the device has at least one valid DP code."""
-    properties_to_check: list[DPCode | tuple[DPCode, ...] | None] = [
+    properties_to_check: list[str | DPCode | tuple[DPCode, ...] | None] = [
         # Main control switch
-        description.dpcode or DPCode(description.key),
+        description.dpcode or description.key,
         # Other humidity properties
         description.current_humidity,
         description.humidity,
@@ -107,7 +107,7 @@ async def async_setup_entry(
                         ),
                         switch_wrapper=DPCodeBooleanWrapper.find_dpcode(
                             device,
-                            description.dpcode or DPCode(description.key),
+                            description.dpcode or description.key,
                             prefer_function=True,
                         ),
                         target_humidity_wrapper=_RoundedIntegerWrapper.find_dpcode(

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -459,10 +459,10 @@ def find_dpcode(
     if dpcodes is None:
         return None
 
-    if isinstance(dpcodes, str):
-        dpcodes = (DPCode(dpcodes),)
-    elif not isinstance(dpcodes, tuple):
-        dpcodes = (dpcodes,)
+    if not isinstance(dpcodes, tuple):
+        # Cast to DPCode for type checking purposes
+        # Custom integration may pass unknown codes here
+        dpcodes = (cast(DPCode, dpcodes),)
 
     lookup_tuple = (
         (device.function, device.status_range)

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -10,7 +10,7 @@ from tuya_sharing import CustomerDevice
 
 from homeassistant.util.json import json_loads, json_loads_object
 
-from .const import LOGGER, DPCode, DPType
+from .const import LOGGER, DPType
 from .util import parse_dptype, remap_value
 
 # Dictionary to track logged warnings to avoid spamming logs
@@ -218,7 +218,7 @@ class DPCodeTypeInformationWrapper[T: TypeInformation](DPCodeWrapper):
     DPTYPE: DPType
     type_information: T
 
-    def __init__(self, dpcode: DPCode, type_information: T) -> None:
+    def __init__(self, dpcode: str, type_information: T) -> None:
         """Init DPCodeWrapper."""
         super().__init__(dpcode)
         self.type_information = type_information
@@ -227,7 +227,7 @@ class DPCodeTypeInformationWrapper[T: TypeInformation](DPCodeWrapper):
     def find_dpcode(
         cls,
         device: CustomerDevice,
-        dpcodes: str | DPCode | tuple[DPCode, ...] | None,
+        dpcodes: str | tuple[str, ...] | None,
         *,
         prefer_function: bool = False,
     ) -> Self | None:
@@ -336,7 +336,7 @@ class DPCodeIntegerWrapper(DPCodeTypeInformationWrapper[IntegerTypeData]):
 
     DPTYPE = DPType.INTEGER
 
-    def __init__(self, dpcode: DPCode, type_information: IntegerTypeData) -> None:
+    def __init__(self, dpcode: str, type_information: IntegerTypeData) -> None:
         """Init DPCodeIntegerWrapper."""
         super().__init__(dpcode, type_information)
         self.native_unit = type_information.unit
@@ -391,7 +391,7 @@ class DPCodeBitmapBitWrapper(DPCodeWrapper):
     def find_dpcode(
         cls,
         device: CustomerDevice,
-        dpcodes: str | DPCode | tuple[DPCode, ...],
+        dpcodes: str | tuple[str, ...],
         *,
         bitmap_key: str,
     ) -> Self | None:
@@ -408,7 +408,7 @@ class DPCodeBitmapBitWrapper(DPCodeWrapper):
 @overload
 def find_dpcode(
     device: CustomerDevice,
-    dpcodes: str | DPCode | tuple[DPCode, ...] | None,
+    dpcodes: str | tuple[str, ...] | None,
     *,
     prefer_function: bool = False,
     dptype: Literal[DPType.BITMAP],
@@ -418,7 +418,7 @@ def find_dpcode(
 @overload
 def find_dpcode(
     device: CustomerDevice,
-    dpcodes: str | DPCode | tuple[DPCode, ...] | None,
+    dpcodes: str | tuple[str, ...] | None,
     *,
     prefer_function: bool = False,
     dptype: Literal[DPType.ENUM],
@@ -428,7 +428,7 @@ def find_dpcode(
 @overload
 def find_dpcode(
     device: CustomerDevice,
-    dpcodes: str | DPCode | tuple[DPCode, ...] | None,
+    dpcodes: str | tuple[str, ...] | None,
     *,
     prefer_function: bool = False,
     dptype: Literal[DPType.INTEGER],
@@ -438,7 +438,7 @@ def find_dpcode(
 @overload
 def find_dpcode(
     device: CustomerDevice,
-    dpcodes: str | DPCode | tuple[DPCode, ...] | None,
+    dpcodes: str | tuple[str, ...] | None,
     *,
     prefer_function: bool = False,
     dptype: Literal[DPType.BOOLEAN, DPType.JSON, DPType.RAW],

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -461,7 +461,8 @@ def find_dpcode(
 
     if not isinstance(dpcodes, tuple):
         # Cast to DPCode for type checking purposes
-        # Custom integration may pass unknown codes here
+        # Custom integration or quirk extensions may pass valid codes
+        # that are part of DPCode enum
         dpcodes = (cast(DPCode, dpcodes),)
 
     lookup_tuple = (

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -39,11 +39,11 @@ class TypeInformation:
     As provided by the SDK, from `device.function` / `device.status_range`.
     """
 
-    dpcode: DPCode
+    dpcode: str
     type_data: str | None = None
 
     @classmethod
-    def from_json(cls, dpcode: DPCode, type_data: str) -> Self | None:
+    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
         """Load JSON string and return a TypeInformation object."""
         return cls(dpcode=dpcode, type_data=type_data)
 
@@ -102,7 +102,7 @@ class IntegerTypeData(TypeInformation):
         return remap_value(value, from_min, from_max, self.min, self.max, reverse)
 
     @classmethod
-    def from_json(cls, dpcode: DPCode, type_data: str) -> Self | None:
+    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
         """Load JSON string and return a IntegerTypeData object."""
         if not (parsed := cast(dict[str, Any] | None, json_loads_object(type_data))):
             return None
@@ -125,7 +125,7 @@ class BitmapTypeInformation(TypeInformation):
     label: list[str]
 
     @classmethod
-    def from_json(cls, dpcode: DPCode, type_data: str) -> Self | None:
+    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
         """Load JSON string and return a BitmapTypeInformation object."""
         if not (parsed := json_loads_object(type_data)):
             return None
@@ -143,7 +143,7 @@ class EnumTypeData(TypeInformation):
     range: list[str]
 
     @classmethod
-    def from_json(cls, dpcode: DPCode, type_data: str) -> Self | None:
+    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
         """Load JSON string and return a EnumTypeData object."""
         if not (parsed := json_loads_object(type_data)):
             return None
@@ -175,7 +175,7 @@ class DPCodeWrapper:
     native_unit: str | None = None
     suggested_unit: str | None = None
 
-    def __init__(self, dpcode: DPCode) -> None:
+    def __init__(self, dpcode: str) -> None:
         """Init DPCodeWrapper."""
         self.dpcode = dpcode
 
@@ -376,7 +376,7 @@ class DPCodeStringWrapper(DPCodeTypeInformationWrapper[TypeInformation]):
 class DPCodeBitmapBitWrapper(DPCodeWrapper):
     """Simple wrapper for a specific bit in bitmap values."""
 
-    def __init__(self, dpcode: DPCode, mask: int) -> None:
+    def __init__(self, dpcode: str, mask: int) -> None:
         """Init DPCodeBitmapWrapper."""
         super().__init__(dpcode)
         self._mask = mask
@@ -447,7 +447,7 @@ def find_dpcode(
 
 def find_dpcode(
     device: CustomerDevice,
-    dpcodes: str | DPCode | tuple[DPCode, ...] | None,
+    dpcodes: str | tuple[str, ...] | None,
     *,
     prefer_function: bool = False,
     dptype: DPType,
@@ -460,10 +460,7 @@ def find_dpcode(
         return None
 
     if not isinstance(dpcodes, tuple):
-        # Cast to DPCode for type checking purposes
-        # Custom integration or quirk extensions may pass valid codes
-        # that are part of DPCode enum
-        dpcodes = (cast(DPCode, dpcodes),)
+        dpcodes = (dpcodes,)
 
     lookup_tuple = (
         (device.function, device.status_range)

--- a/homeassistant/components/tuya/util.py
+++ b/homeassistant/components/tuya/util.py
@@ -20,16 +20,14 @@ _DPTYPE_MAPPING: dict[str, DPType] = {
 
 
 def get_dpcode(
-    device: CustomerDevice, dpcodes: str | DPCode | tuple[DPCode, ...] | None
-) -> DPCode | None:
+    device: CustomerDevice, dpcodes: str | tuple[str, ...] | None
+) -> str | None:
     """Get the first matching DPCode from the device or return None."""
     if dpcodes is None:
         return None
 
-    if isinstance(dpcodes, DPCode):
+    if not isinstance(dpcodes, tuple):
         dpcodes = (dpcodes,)
-    elif isinstance(dpcodes, str):
-        dpcodes = (DPCode(dpcodes),)
 
     for dpcode in dpcodes:
         if (
@@ -70,19 +68,23 @@ class ActionDPCodeNotFoundError(ServiceValidationError):
     """Custom exception for action DP code not found errors."""
 
     def __init__(
-        self, device: CustomerDevice, expected: str | DPCode | tuple[DPCode, ...] | None
+        self, device: CustomerDevice, expected: str | tuple[str, ...] | None
     ) -> None:
         """Initialize the error with device and expected DP codes."""
         if expected is None:
             expected = ()  # empty tuple for no expected codes
-        elif isinstance(expected, str):
-            expected = (DPCode(expected),)
+        elif not isinstance(expected, tuple):
+            expected = (expected,)
 
         super().__init__(
             translation_domain=DOMAIN,
             translation_key="action_dpcode_not_found",
             translation_placeholders={
-                "expected": str(sorted([dp.value for dp in expected])),
+                "expected": str(
+                    sorted(
+                        [dp.value if isinstance(dp, DPCode) else dp for dp in expected]
+                    )
+                ),
                 "available": str(sorted(device.function.keys())),
             },
         )

--- a/homeassistant/components/tuya/util.py
+++ b/homeassistant/components/tuya/util.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from tuya_sharing import CustomerDevice
 
 from homeassistant.exceptions import ServiceValidationError
@@ -26,10 +28,8 @@ def get_dpcode(
     if dpcodes is None:
         return None
 
-    if isinstance(dpcodes, DPCode):
-        dpcodes = (dpcodes,)
-    elif isinstance(dpcodes, str):
-        dpcodes = (DPCode(dpcodes),)
+    if not isinstance(dpcodes, tuple):
+        dpcodes = (cast(DPCode, dpcodes),)
 
     for dpcode in dpcodes:
         if (

--- a/homeassistant/components/tuya/util.py
+++ b/homeassistant/components/tuya/util.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import cast
-
 from tuya_sharing import CustomerDevice
 
 from homeassistant.exceptions import ServiceValidationError
@@ -28,8 +26,10 @@ def get_dpcode(
     if dpcodes is None:
         return None
 
-    if not isinstance(dpcodes, tuple):
-        dpcodes = (cast(DPCode, dpcodes),)
+    if isinstance(dpcodes, DPCode):
+        dpcodes = (dpcodes,)
+    elif isinstance(dpcodes, str):
+        dpcodes = (DPCode(dpcodes),)
 
     for dpcode in dpcodes:
         if (


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current instanciating of DPCode from string prevents code re-use in custom integrations or quirk implementation that are the target of the refactor, one of the main drivers of #156232.

This refactors such that:
- update `DPCodeWrapper.dpcode` typing to `str`
- `_has_a_valid_dpcode`, `get_dpcode` and `find_dpcode` accept `str | tuple[str, ...] | None` as input

Please consider for beta.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
