### PR TITLE
Add a delay to switch statuses on Transmission

### DIFF
--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -13,7 +13,7 @@ from .coordinator import TransmissionConfigEntry, TransmissionDataUpdateCoordina
 from .entity import TransmissionEntity
 
 PARALLEL_UPDATES = 0
-AFTER_WRITE_SLEEP = 1
+AFTER_WRITE_SLEEP = 2
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -72,7 +72,6 @@ class TransmissionSwitch(TransmissionEntity, SwitchEntity):
         await self.hass.async_add_executor_job(
             self.entity_description.on_func, self.coordinator
         )
-        self.async_write_ha_state()
         await asyncio.sleep(AFTER_WRITE_SLEEP)
         await self.coordinator.async_request_refresh()
 
@@ -81,6 +80,5 @@ class TransmissionSwitch(TransmissionEntity, SwitchEntity):
         await self.hass.async_add_executor_job(
             self.entity_description.off_func, self.coordinator
         )
-        self.async_write_ha_state()
         await asyncio.sleep(AFTER_WRITE_SLEEP)
         await self.coordinator.async_request_refresh()

--- a/tests/components/transmission/conftest.py
+++ b/tests/components/transmission/conftest.py
@@ -104,7 +104,7 @@ def mock_torrent():
 
 
 @pytest.fixture(autouse=True)
-def patch_sleep() -> Generator[AsyncMock]:
+def patch_sleep() -> Generator[None]:
     """Fixture to remove sleep in tests."""
     with patch("homeassistant.components.transmission.switch.AFTER_WRITE_SLEEP", 0):
         yield

--- a/tests/components/transmission/conftest.py
+++ b/tests/components/transmission/conftest.py
@@ -101,3 +101,10 @@ def mock_torrent():
         return Torrent(fields=torrent_data)
 
     return _create_mock_torrent
+
+
+@pytest.fixture(autouse=True)
+def patch_sleep() -> Generator[AsyncMock]:
+    """Fixture to remove sleep in tests."""
+    with patch("homeassistant.components.transmission.switch.AFTER_WRITE_SLEEP", 0):
+        yield

--- a/tests/components/transmission/test_switch.py
+++ b/tests/components/transmission/test_switch.py
@@ -116,7 +116,7 @@ async def test_turtle_mode_switch(
     alt_speed_enabled: bool,
     expected_state: str,
 ) -> None:
-    """Test turtle mode switch with sleep delay."""
+    """Test turtle mode switch."""
     client = mock_transmission_client.return_value
 
     current_alt_speed = not alt_speed_enabled
@@ -135,13 +135,12 @@ async def test_turtle_mode_switch(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    with patch("homeassistant.components.transmission.switch.AFTER_WRITE_SLEEP", 2):
-        await hass.services.async_call(
-            SWITCH_DOMAIN,
-            service,
-            {ATTR_ENTITY_ID: "switch.transmission_turtle_mode"},
-            blocking=True,
-        )
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: "switch.transmission_turtle_mode"},
+        blocking=True,
+    )
 
     client.set_session.assert_called_once_with(alt_speed_enabled=alt_speed_enabled)
 

--- a/tests/components/transmission/test_switch.py
+++ b/tests/components/transmission/test_switch.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from transmission_rpc.session import Session
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
@@ -101,10 +102,10 @@ async def test_on_off_switch_with_torrents(
 
 
 @pytest.mark.parametrize(
-    ("service", "alt_speed_enabled"),
+    ("service", "alt_speed_enabled", "expected_state"),
     [
-        (SERVICE_TURN_ON, True),
-        (SERVICE_TURN_OFF, False),
+        (SERVICE_TURN_ON, True, "on"),
+        (SERVICE_TURN_OFF, False, "off"),
     ],
 )
 async def test_turtle_mode_switch(
@@ -113,19 +114,37 @@ async def test_turtle_mode_switch(
     mock_config_entry: MockConfigEntry,
     service: str,
     alt_speed_enabled: bool,
+    expected_state: str,
 ) -> None:
-    """Test turtle mode switch."""
+    """Test turtle mode switch with sleep delay."""
     client = mock_transmission_client.return_value
+
+    current_alt_speed = not alt_speed_enabled
+
+    def set_session_side_effect(**kwargs):
+        nonlocal current_alt_speed
+        if "alt_speed_enabled" in kwargs:
+            current_alt_speed = kwargs["alt_speed_enabled"]
+
+    client.set_session.side_effect = set_session_side_effect
+    client.get_session.side_effect = lambda: Session(
+        fields={"alt-speed-enabled": current_alt_speed}
+    )
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        service,
-        {ATTR_ENTITY_ID: "switch.transmission_turtle_mode"},
-        blocking=True,
-    )
+    with patch("homeassistant.components.transmission.switch.AFTER_WRITE_SLEEP", 2):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: "switch.transmission_turtle_mode"},
+            blocking=True,
+        )
 
     client.set_session.assert_called_once_with(alt_speed_enabled=alt_speed_enabled)
+
+    state = hass.states.get("switch.transmission_turtle_mode")
+    assert state is not None
+    assert state.state == expected_state

--- a/tests/components/transmission/test_switch.py
+++ b/tests/components/transmission/test_switch.py
@@ -10,6 +10,8 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -129,3 +131,51 @@ async def test_turtle_mode_switch(
     )
 
     client.set_session.assert_called_once_with(alt_speed_enabled=alt_speed_enabled)
+
+
+async def test_turtle_mode_optimistic_state(
+    hass: HomeAssistant,
+    mock_transmission_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test toggling updates optimistic state correctly.
+
+    When users toggle the switch multiple times in quick succession,
+    each action should update the optimistic state immediately.
+    This test verifies that rapid ON→OFF→ON toggles work correctly
+    with the timestamp-based optimistic state mechanism.
+    """
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.transmission_turtle_mode")
+    assert state.state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.transmission_turtle_mode"},
+        blocking=True,
+    )
+    state = hass.states.get("switch.transmission_turtle_mode")
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.transmission_turtle_mode"},
+        blocking=True,
+    )
+    state = hass.states.get("switch.transmission_turtle_mode")
+    assert state.state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.transmission_turtle_mode"},
+        blocking=True,
+    )
+    state = hass.states.get("switch.transmission_turtle_mode")
+    assert state.state == STATE_ON

--- a/tests/components/transmission/test_switch.py
+++ b/tests/components/transmission/test_switch.py
@@ -10,8 +10,6 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
-    STATE_OFF,
-    STATE_ON,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -131,51 +129,3 @@ async def test_turtle_mode_switch(
     )
 
     client.set_session.assert_called_once_with(alt_speed_enabled=alt_speed_enabled)
-
-
-async def test_turtle_mode_optimistic_state(
-    hass: HomeAssistant,
-    mock_transmission_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test toggling updates optimistic state correctly.
-
-    When users toggle the switch multiple times in quick succession,
-    each action should update the optimistic state immediately.
-    This test verifies that rapid ON→OFF→ON toggles work correctly
-    with the timestamp-based optimistic state mechanism.
-    """
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("switch.transmission_turtle_mode")
-    assert state.state == STATE_OFF
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "switch.transmission_turtle_mode"},
-        blocking=True,
-    )
-    state = hass.states.get("switch.transmission_turtle_mode")
-    assert state.state == STATE_ON
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "switch.transmission_turtle_mode"},
-        blocking=True,
-    )
-    state = hass.states.get("switch.transmission_turtle_mode")
-    assert state.state == STATE_OFF
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "switch.transmission_turtle_mode"},
-        blocking=True,
-    )
-    state = hass.states.get("switch.transmission_turtle_mode")
-    assert state.state == STATE_ON


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a delay to switches statuses as Transmission has a delay in reporting the new state, causing the switches to toggle back, then to their real value next update.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
