### PR TITLE
Implement Device Tracker for `surepetcare` Pets

### DIFF
--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -28,7 +28,12 @@ from .coordinator import SurePetcareDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.LOCK, Platform.SENSOR]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.DEVICE_TRACKER,
+    Platform.LOCK,
+    Platform.SENSOR,
+]
 SCAN_INTERVAL = timedelta(minutes=3)
 
 

--- a/homeassistant/components/surepetcare/device_tracker.py
+++ b/homeassistant/components/surepetcare/device_tracker.py
@@ -1,0 +1,76 @@
+"""Support for Sure PetCare pet device tracking."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from surepy.entities import SurepyEntity
+from surepy.entities.pet import Pet as SurepyPet
+from surepy.enums import EntityType, Location
+
+from homeassistant.components.device_tracker import TrackerEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SurePetcareDataCoordinator
+from .entity import SurePetcareEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Sure PetCare device tracker entities based on a config entry."""
+    coordinator: SurePetcareDataCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[SurePetcareDeviceTracker] = [
+        SurePetcareDeviceTracker(surepy_entity.id, coordinator)
+        for surepy_entity in coordinator.data.values()
+        if surepy_entity.type == EntityType.PET
+    ]
+
+    async_add_entities(entities)
+
+
+class SurePetcareDeviceTracker(SurePetcareEntity, TrackerEntity):
+    """Sure Petcare pet device tracker."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+
+    def __init__(
+        self,
+        surepetcare_id: int,
+        coordinator: SurePetcareDataCoordinator,
+    ) -> None:
+        """Initialize the pet device tracker."""
+        super().__init__(surepetcare_id, coordinator)
+        self._attr_unique_id = f"{self._device_id}-tracker"
+
+    @callback
+    def _update_attr(self, surepy_entity: SurepyEntity) -> None:
+        """Update the tracker attributes from the Sure Pet entity."""
+        surepy_entity = cast(SurepyPet, surepy_entity)
+        state = surepy_entity.location
+
+        try:
+            location = Location(state.where)
+            if location == Location.INSIDE:
+                self._attr_location_name = STATE_HOME
+            elif location == Location.OUTSIDE:
+                self._attr_location_name = STATE_NOT_HOME
+            else:
+                self._attr_location_name = None
+
+            self._attr_extra_state_attributes = {
+                "since": state.since,
+            }
+        except ValueError:
+            self._attr_extra_state_attributes = {
+                "since": None,
+            }
+            self._attr_location_name = None

--- a/tests/components/surepetcare/__init__.py
+++ b/tests/components/surepetcare/__init__.py
@@ -81,7 +81,23 @@ MOCK_PET = {
     "status": {},
 }
 
+MOCK_PET_OUTDOOR = {
+    "id": 24681,
+    "household_id": HOUSEHOLD_ID,
+    "name": "Pet Outdoor",
+    "position": {"since": "2020-08-23T23:15:30", "where": 2},
+    "status": {},
+}
+
+MOCK_PET_UNKNOWN = {
+    "id": 24682,
+    "household_id": HOUSEHOLD_ID,
+    "name": "Pet Unknown",
+    "position": {"since": "2020-08-23T23:20:45", "where": -1},
+    "status": {},
+}
+
 MOCK_API_DATA = {
     "devices": [MOCK_HUB, MOCK_CAT_FLAP, MOCK_PET_FLAP, MOCK_FEEDER, MOCK_FELAQUA],
-    "pets": [MOCK_PET],
+    "pets": [MOCK_PET, MOCK_PET_OUTDOOR, MOCK_PET_UNKNOWN],
 }

--- a/tests/components/surepetcare/conftest.py
+++ b/tests/components/surepetcare/conftest.py
@@ -40,7 +40,7 @@ async def mock_config_entry_setup(hass: HomeAssistant) -> MockConfigEntry:
         CONF_TOKEN: "token",
         "feeders": [12345],
         "flaps": [13579, 13576],
-        "pets": [24680],
+        "pets": [24680, 24681, 24682],
     }
     entry = MockConfigEntry(domain=DOMAIN, data=data)
     entry.add_to_hass(hass)

--- a/tests/components/surepetcare/test_device_tracker.py
+++ b/tests/components/surepetcare/test_device_tracker.py
@@ -1,0 +1,55 @@
+"""The tests for the Sure Petcare device tracker platform."""
+
+from homeassistant.components.device_tracker import ATTR_SOURCE_TYPE, SourceType
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import HOUSEHOLD_ID
+
+from tests.common import MockConfigEntry
+
+EXPECTED_ENTITY_IDS = {
+    "device_tracker.pet": f"{HOUSEHOLD_ID}-24680-tracker",
+    "device_tracker.pet_outdoor": f"{HOUSEHOLD_ID}-24681-tracker",
+    "device_tracker.pet_unknown": f"{HOUSEHOLD_ID}-24682-tracker",
+}
+
+
+async def test_device_tracker(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    surepetcare,
+    mock_config_entry_setup: MockConfigEntry,
+) -> None:
+    """Test the creation of device tracker entities."""
+    state_entity_ids = hass.states.async_entity_ids()
+
+    # Expected states for each pet based on their "where" value
+    expected_states = {
+        "device_tracker.pet": STATE_HOME,  # where: 1 (inside)
+        "device_tracker.pet_outdoor": STATE_NOT_HOME,  # where: 2 (outside)
+        "device_tracker.pet_unknown": "unknown",  # where: -1 (unknown)
+    }
+
+    # Expected extra state attributes for each pet
+    expected_attributes = {
+        "device_tracker.pet": {"since": "2020-08-23T23:10:50"},
+        "device_tracker.pet_outdoor": {"since": "2020-08-23T23:15:30"},
+        "device_tracker.pet_unknown": {"since": "2020-08-23T23:20:45"},
+    }
+
+    for entity_id, unique_id in EXPECTED_ENTITY_IDS.items():
+        assert entity_id in state_entity_ids
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == expected_states[entity_id]
+        assert state.attributes[ATTR_SOURCE_TYPE] == SourceType.GPS
+
+        # Check extra state attributes
+        expected_attrs = expected_attributes[entity_id]
+        assert state.attributes["since"] == expected_attrs["since"]
+
+        entity = entity_registry.async_get(entity_id)
+        assert entity is not None
+        assert entity.unique_id == unique_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows those who have added their Pets as "People" within Home Assistant to attach the device tracker to them, opening up the use of cards that show presence information for a person rather than just a binary sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42026
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
