### PR TITLE
Implement "timer remaining" for shelly

### DIFF
--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-import time
 from typing import Final, cast
 
 from aioshelly.block_device import Block
@@ -44,6 +43,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.entity_registry import RegistryEntry
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import StateType
+from homeassistant.util import dt as dt_util
 
 from .const import CONF_SLEEP_PERIOD, ROLE_GENERIC
 from .coordinator import ShellyBlockCoordinator, ShellyConfigEntry, ShellyRpcCoordinator
@@ -207,17 +207,30 @@ class RpcSwitchTimerSensor(ShellyRpcAttributeEntity, SensorEntity):
     entity_description: RpcSensorDescription
     _update_unsub: CALLBACK_TYPE | None = None
 
+    def __init__(
+        self,
+        coordinator: ShellyRpcCoordinator,
+        key: str,
+        attribute: str,
+        description: RpcSensorDescription,
+    ) -> None:
+        """Initialize timer sensor."""
+        super().__init__(coordinator, key, attribute, description)
+        self.configure_translation_attributes()
+
     def _get_timer_remaining_seconds(self) -> int | None:
         """Get timer remaining time in seconds."""
         timer_started_at = self.status.get("timer_started_at")
         timer_duration = self.status.get("timer_duration")
 
-        # Timer not active
-        if timer_started_at is None or timer_started_at == 0 or timer_duration is None:
+        # Timer not active or invalid types
+        if not isinstance(timer_started_at, (int, float)) or timer_started_at == 0:
+            return None
+        if not isinstance(timer_duration, (int, float)) or timer_duration is None:
             return None
 
         # Calculate elapsed time
-        current_time = time.time()
+        current_time = dt_util.utcnow().timestamp()
         elapsed = current_time - timer_started_at
         timer_remaining = timer_duration - elapsed
 
@@ -232,10 +245,9 @@ class RpcSwitchTimerSensor(ShellyRpcAttributeEntity, SensorEntity):
         """Return timer remaining time in seconds."""
         return self._get_timer_remaining_seconds()
 
-    # pylint: disable-next=hass-missing-super-call
     async def async_added_to_hass(self) -> None:
         """When entity is added to HASS."""
-        self.async_on_remove(self.coordinator.async_add_listener(self._update_callback))
+        await super().async_added_to_hass()
         self.async_on_remove(self._cancel_update_interval)
         self._check_and_schedule_updates()
 
@@ -249,6 +261,7 @@ class RpcSwitchTimerSensor(ShellyRpcAttributeEntity, SensorEntity):
     @callback
     def _update_timer_state(self, _: datetime) -> None:
         """Update timer state every second."""
+        self._check_and_schedule_updates()
         self.async_write_ha_state()
 
     @callback

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta
+import time
 from typing import Final, cast
 
 from aioshelly.block_device import Block
@@ -37,9 +39,10 @@ from homeassistant.const import (
     UnitOfVolumeFlowRate,
     UnitOfVolumetricFlux,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.entity_registry import RegistryEntry
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import StateType
 
 from .const import CONF_SLEEP_PERIOD, ROLE_GENERIC
@@ -196,6 +199,79 @@ class RpcBluTrvSensor(RpcSensor):
         self._attr_device_info = get_blu_trv_device_info(
             coordinator.device.config[key], ble_addr, coordinator.mac, fw_ver
         )
+
+
+class RpcSwitchTimerSensor(ShellyRpcAttributeEntity, SensorEntity):
+    """Represent a RPC switch timer sensor."""
+
+    entity_description: RpcSensorDescription
+    _update_unsub: CALLBACK_TYPE | None = None
+
+    def _get_timer_remaining_seconds(self) -> int | None:
+        """Get timer remaining time in seconds."""
+        timer_started_at = self.status.get("timer_started_at")
+        timer_duration = self.status.get("timer_duration")
+
+        # Timer not active
+        if timer_started_at is None or timer_started_at == 0 or timer_duration is None:
+            return None
+
+        # Calculate elapsed time
+        current_time = time.time()
+        elapsed = current_time - timer_started_at
+        timer_remaining = timer_duration - elapsed
+
+        # Timer expired
+        if timer_remaining <= 0:
+            return None
+
+        return int(timer_remaining)
+
+    @property
+    def native_value(self) -> int | None:
+        """Return timer remaining time in seconds."""
+        return self._get_timer_remaining_seconds()
+
+    # pylint: disable-next=hass-missing-super-call
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to HASS."""
+        self.async_on_remove(self.coordinator.async_add_listener(self._update_callback))
+        self.async_on_remove(self._cancel_update_interval)
+        self._check_and_schedule_updates()
+
+    @callback
+    def _cancel_update_interval(self) -> None:
+        """Cancel the update interval subscription."""
+        if self._update_unsub:
+            self._update_unsub()
+            self._update_unsub = None
+
+    @callback
+    def _update_timer_state(self, _: datetime) -> None:
+        """Update timer state every second."""
+        self.async_write_ha_state()
+
+    @callback
+    def _check_and_schedule_updates(self) -> None:
+        """Check timer state and schedule/cancel per-second updates."""
+        timer_active = self._get_timer_remaining_seconds() is not None
+
+        if timer_active and self._update_unsub is None:
+            # Timer is active, start per-second updates
+            self._update_unsub = async_track_time_interval(
+                self.hass,
+                self._update_timer_state,
+                timedelta(seconds=1),
+            )
+        elif not timer_active and self._update_unsub is not None:
+            # Timer stopped, cancel updates
+            self._cancel_update_interval()
+
+    @callback
+    def _update_callback(self) -> None:
+        """Handle device update."""
+        self._check_and_schedule_updates()
+        self.async_write_ha_state()
 
 
 BLOCK_SENSORS: dict[tuple[str, str], BlockSensorDescription] = {
@@ -1721,6 +1797,18 @@ RPC_SENSORS: Final = {
             (right := status["right"]) is not None
             and right.get("vial", {}).get("level", -1) != -1
         ),
+    ),
+    "timer_remaining": RpcSensorDescription(
+        key="switch",
+        sub_key="timer_remaining",
+        translation_key="timer_remaining",
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        supported=lambda status: True,
+        entity_class=RpcSwitchTimerSensor,
     ),
 }
 

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -514,6 +514,9 @@
       "timer_remaining": {
         "name": "Timer remaining"
       },
+      "timer_remaining_with_channel_name": {
+        "name": "{channel_name} timer remaining"
+      },
       "valve_position": {
         "name": "Valve position"
       },

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -511,6 +511,9 @@
       "tilt": {
         "name": "Tilt"
       },
+      "timer_remaining": {
+        "name": "Timer remaining"
+      },
       "valve_position": {
         "name": "Valve position"
       },

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1,6 +1,7 @@
 """Tests for Shelly sensor platform."""
 
 from copy import deepcopy
+import time
 from unittest.mock import Mock, PropertyMock
 
 from aioshelly.const import MODEL_BLU_GATEWAY_G3, MODEL_EM3
@@ -36,6 +37,7 @@ from homeassistant.const import (
     UnitOfFrequency,
     UnitOfPower,
     UnitOfTemperature,
+    UnitOfTime,
     UnitOfVolume,
 )
 from homeassistant.core import HomeAssistant, State
@@ -2218,3 +2220,48 @@ async def test_rpc_rgbcct_sensors(
     assert entry.unique_id == "123456789ABC-rgbcct:0-energy_rgbcct"
     assert entry.name is None
     assert entry.translation_key is None  # entity with device class and no channel name
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_rpc_switch_timer_remaining_sensor(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    entity_registry: EntityRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test timer remaining sensor for switch component."""
+    # Timer started 10 seconds ago, duration 60, so 50 seconds remaining
+    current_time = time.time()
+    timer_started_at = current_time - 10.0
+    timer_duration = 60
+
+    status = {
+        "sys": {},
+        "switch:0": {
+            "id": 0,
+            "output": True,
+            "timer_started_at": timer_started_at,
+            "timer_duration": timer_duration,
+        },
+    }
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+    await init_integration(hass, 3)
+
+    entity_id = f"{SENSOR_DOMAIN}.test_name_test_switch_0_timer_remaining"
+
+    assert (state := hass.states.get(entity_id))
+    # Sensor should return integer seconds remaining (approximately 50, allowing for timing)
+    assert int(state.state) in (49, 50)
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.DURATION
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTime.SECONDS
+
+    mutate_rpc_device_status(
+        monkeypatch, mock_rpc_device, "switch:0", "timer_started_at", 0
+    )
+    mock_rpc_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_UNKNOWN
+
+    assert (entry := entity_registry.async_get(entity_id))
+    assert entry.unique_id == "123456789ABC-switch:0-timer_remaining"

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1,7 +1,6 @@
 """Tests for Shelly sensor platform."""
 
 from copy import deepcopy
-import time
 from unittest.mock import Mock, PropertyMock
 
 from aioshelly.const import MODEL_BLU_GATEWAY_G3, MODEL_EM3
@@ -2221,16 +2220,20 @@ async def test_rpc_rgbcct_sensors(
     assert entry.name is None
     assert entry.translation_key is None  # entity with device class and no channel name
 
+
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_rpc_switch_timer_remaining_sensor(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
     entity_registry: EntityRegistry,
     monkeypatch: pytest.MonkeyPatch,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test timer remaining sensor for switch component."""
+    # Freeze time for deterministic test
+    freezer.move_to("2025-01-15 12:00:00+00:00")
     # Timer started 10 seconds ago, duration 60, so 50 seconds remaining
-    current_time = time.time()
+    current_time = 1736942400.0  # 2025-01-15 12:00:00 UTC
     timer_started_at = current_time - 10.0
     timer_duration = 60
 
@@ -2249,8 +2252,7 @@ async def test_rpc_switch_timer_remaining_sensor(
     entity_id = f"{SENSOR_DOMAIN}.test_name_test_switch_0_timer_remaining"
 
     assert (state := hass.states.get(entity_id))
-    # Sensor should return integer seconds remaining (approximately 50, allowing for timing)
-    assert int(state.state) in (49, 50)
+    assert state.state == "50"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.DURATION
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTime.SECONDS
 


### PR DESCRIPTION
First split of #157058 implementing RPC version and "Timer remaining" only.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support to **show** the remaining time of a timer

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
