### PR TITLE
Bump bosch-alarm-mode2 to v0.4.10

### DIFF
--- a/homeassistant/components/bosch_alarm/__init__.py
+++ b/homeassistant/components/bosch_alarm/__init__.py
@@ -68,9 +68,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschAlarmConfigEntry) -
         config_entry_id=entry.entry_id,
         connections={(CONNECTION_NETWORK_MAC, mac)} if mac else set(),
         identifiers={(DOMAIN, entry.unique_id or entry.entry_id)},
-        name=f"Bosch {panel.model}",
+        name=f"Bosch {panel.model.name}",
         manufacturer="Bosch Security Systems",
-        model=panel.model,
+        model=panel.model.name,
         sw_version=panel.firmware_version,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/bosch_alarm/config_flow.py
+++ b/homeassistant/components/bosch_alarm/config_flow.py
@@ -83,7 +83,7 @@ async def try_connect(
     finally:
         await panel.disconnect()
 
-    return (panel.model, panel.serial_number)
+    return (panel.model.name, panel.serial_number)
 
 
 class BoschAlarmConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/bosch_alarm/diagnostics.py
+++ b/homeassistant/components/bosch_alarm/diagnostics.py
@@ -20,7 +20,8 @@ async def async_get_config_entry_diagnostics(
     return {
         "entry_data": async_redact_data(entry.data, TO_REDACT),
         "data": {
-            "model": entry.runtime_data.model,
+            "model": entry.runtime_data.model.name,
+            "family": entry.runtime_data.model.family.name,
             "serial_number": entry.runtime_data.serial_number,
             "protocol_version": entry.runtime_data.protocol_version,
             "firmware_version": entry.runtime_data.firmware_version,

--- a/homeassistant/components/bosch_alarm/entity.py
+++ b/homeassistant/components/bosch_alarm/entity.py
@@ -26,7 +26,7 @@ class BoschAlarmEntity(Entity):
         self._attr_should_poll = False
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, unique_id)},
-            name=f"Bosch {panel.model}",
+            name=f"Bosch {panel.model.name}",
             manufacturer="Bosch Security Systems",
         )
 

--- a/homeassistant/components/bosch_alarm/manifest.json
+++ b/homeassistant/components/bosch_alarm/manifest.json
@@ -12,5 +12,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["bosch-alarm-mode2==0.4.6"]
+  "requirements": ["bosch-alarm-mode2==0.4.10"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -675,7 +675,7 @@ bluetooth-data-tools==1.28.4
 bond-async==0.2.1
 
 # homeassistant.components.bosch_alarm
-bosch-alarm-mode2==0.4.6
+bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
 boschshcpy==0.2.107

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -609,7 +609,7 @@ bluetooth-data-tools==1.28.4
 bond-async==0.2.1
 
 # homeassistant.components.bosch_alarm
-bosch-alarm-mode2==0.4.6
+bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
 boschshcpy==0.2.107

--- a/tests/components/bosch_alarm/conftest.py
+++ b/tests/components/bosch_alarm/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+from bosch_alarm_mode2.const import PANEL_FAMILY, PanelModel
 from bosch_alarm_mode2.panel import Area, Door, Output, Point
 from bosch_alarm_mode2.utils import Observable
 import pytest
@@ -39,10 +40,10 @@ def model(request: pytest.FixtureRequest) -> Generator[str]:
 
 @pytest.fixture
 def extra_config_entry_data(
-    model: str, model_name: str, config_flow_data: dict[str, Any]
+    model: str, panel_model: PanelModel, config_flow_data: dict[str, Any]
 ) -> dict[str, Any]:
     """Return extra config entry data."""
-    return {CONF_MODEL: model_name} | config_flow_data
+    return {CONF_MODEL: panel_model.name} | config_flow_data
 
 
 @pytest.fixture(params=[None])
@@ -64,12 +65,12 @@ def config_flow_data(model: str) -> dict[str, Any]:
 
 
 @pytest.fixture
-def model_name(model: str) -> str | None:
+def panel_model(model: str) -> PanelModel | None:
     """Return extra config entry data."""
     return {
-        "solution_3000": "Solution 3000",
-        "amax_3000": "AMAX 3000",
-        "b5512": "B5512 (US1B)",
+        "solution_3000": PanelModel("Solution 3000", PANEL_FAMILY.SOLUTION),
+        "amax_3000": PanelModel("AMAX 3000", PANEL_FAMILY.AMAX),
+        "b5512": PanelModel("B5512 (US1B)", PANEL_FAMILY.BG_SERIES),
     }.get(model)
 
 
@@ -166,7 +167,7 @@ def mock_panel(
     door: AsyncMock,
     output: AsyncMock,
     points: dict[int, AsyncMock],
-    model_name: str,
+    panel_model: str,
     serial_number: str | None,
 ) -> Generator[AsyncMock]:
     """Define a fixture to set up Bosch Alarm."""
@@ -181,7 +182,7 @@ def mock_panel(
         client.doors = {1: door}
         client.outputs = {1: output}
         client.points = points
-        client.model = model_name
+        client.model = panel_model
         client.faults = []
         client.events = []
         client.panel_faults_ids = []

--- a/tests/components/bosch_alarm/snapshots/test_diagnostics.ambr
+++ b/tests/components/bosch_alarm/snapshots/test_diagnostics.ambr
@@ -28,6 +28,7 @@
           'open': False,
         }),
       ]),
+      'family': 'AMAX',
       'firmware_version': '1.0.0',
       'history_events': list([
       ]),
@@ -124,6 +125,7 @@
           'open': False,
         }),
       ]),
+      'family': 'BG_SERIES',
       'firmware_version': '1.0.0',
       'history_events': list([
       ]),
@@ -219,6 +221,7 @@
           'open': False,
         }),
       ]),
+      'family': 'SOLUTION',
       'firmware_version': '1.0.0',
       'history_events': list([
       ]),

--- a/tests/components/bosch_alarm/test_config_flow.py
+++ b/tests/components/bosch_alarm/test_config_flow.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock
 
+from bosch_alarm_mode2.const import PANEL_FAMILY, PanelModel
 import pytest
 
 from homeassistant.components.bosch_alarm.const import DOMAIN
@@ -22,7 +23,7 @@ async def test_form_user(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_panel: AsyncMock,
-    model_name: str,
+    panel_model: PanelModel,
     serial_number: str,
     config_flow_data: dict[str, Any],
 ) -> None:
@@ -45,13 +46,13 @@ async def test_form_user(
         config_flow_data,
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Bosch {model_name}"
+    assert result["title"] == f"Bosch {panel_model.name}"
     assert (
         result["data"]
         == {
             CONF_HOST: "1.1.1.1",
             CONF_PORT: 7700,
-            CONF_MODEL: model_name,
+            CONF_MODEL: panel_model.name,
         }
         | config_flow_data
     )
@@ -211,7 +212,7 @@ async def test_dhcp_can_finish(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_panel: AsyncMock,
-    model_name: str,
+    panel_model: PanelModel,
     serial_number: str,
     config_flow_data: dict[str, Any],
 ) -> None:
@@ -237,12 +238,12 @@ async def test_dhcp_can_finish(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Bosch {model_name}"
+    assert result["title"] == f"Bosch {panel_model.name}"
     assert result["data"] == {
         CONF_HOST: "1.1.1.1",
         CONF_MAC: "34:ea:34:b4:3b:5a",
         CONF_PORT: 7700,
-        CONF_MODEL: model_name,
+        CONF_MODEL: panel_model.name,
         **config_flow_data,
     }
 
@@ -258,7 +259,7 @@ async def test_dhcp_exceptions(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_panel: AsyncMock,
-    model_name: str,
+    panel_model: PanelModel,
     serial_number: str,
     config_flow_data: dict[str, Any],
     exception: Exception,
@@ -316,7 +317,7 @@ async def test_dhcp_discovery_if_panel_setup_config_flow(
     mock_config_entry: MockConfigEntry,
     mock_panel: AsyncMock,
     serial_number: str,
-    model_name: str,
+    panel_model: PanelModel,
     config_flow_data: dict[str, Any],
 ) -> None:
     """Test DHCP discovery doesn't fail if a different panel was set up via config flow."""
@@ -346,12 +347,12 @@ async def test_dhcp_discovery_if_panel_setup_config_flow(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Bosch {model_name}"
+    assert result["title"] == f"Bosch {panel_model.name}"
     assert result["data"] == {
         CONF_HOST: "4.5.6.7",
         CONF_MAC: "34:ea:34:b4:3b:5a",
         CONF_PORT: 7700,
-        CONF_MODEL: model_name,
+        CONF_MODEL: panel_model.name,
         **config_flow_data,
     }
     assert mock_config_entry.unique_id == serial_number
@@ -395,7 +396,7 @@ async def test_dhcp_updates_mac(
     mock_setup_entry: AsyncMock,
     mock_config_entry: MockConfigEntry,
     mock_panel: AsyncMock,
-    model_name: str,
+    panel_model: PanelModel,
     serial_number: str,
     config_flow_data: dict[str, Any],
 ) -> None:
@@ -424,7 +425,7 @@ async def test_reauth_flow_success(
     mock_setup_entry: AsyncMock,
     mock_config_entry: MockConfigEntry,
     mock_panel: AsyncMock,
-    model_name: str,
+    panel_model: PanelModel,
     serial_number: str,
     config_flow_data: dict[str, Any],
 ) -> None:
@@ -459,7 +460,7 @@ async def test_reauth_flow_error(
     mock_setup_entry: AsyncMock,
     mock_config_entry: MockConfigEntry,
     mock_panel: AsyncMock,
-    model_name: str,
+    panel_model: PanelModel,
     serial_number: str,
     config_flow_data: dict[str, Any],
     exception: Exception,
@@ -494,7 +495,7 @@ async def test_reconfig_flow(
     mock_setup_entry: AsyncMock,
     mock_config_entry: MockConfigEntry,
     mock_panel: AsyncMock,
-    model_name: str,
+    panel_model: PanelModel,
     serial_number: str,
     config_flow_data: dict[str, Any],
 ) -> None:
@@ -529,7 +530,7 @@ async def test_reconfig_flow(
     assert mock_config_entry.data == {
         CONF_HOST: "1.1.1.1",
         CONF_PORT: 7700,
-        CONF_MODEL: model_name,
+        CONF_MODEL: panel_model.name,
         **config_flow_data,
     }
 
@@ -540,7 +541,7 @@ async def test_reconfig_flow_incorrect_model(
     mock_setup_entry: AsyncMock,
     mock_config_entry: MockConfigEntry,
     mock_panel: AsyncMock,
-    model_name: str,
+    panel_model: PanelModel,
     serial_number: str,
     config_flow_data: dict[str, Any],
 ) -> None:
@@ -556,7 +557,7 @@ async def test_reconfig_flow_incorrect_model(
         },
     )
 
-    mock_panel.model = "Solution 3000"
+    mock_panel.model = PanelModel("Solution 3000", family=PANEL_FAMILY.SOLUTION)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"

--- a/tests/components/bosch_alarm/test_diagnostics.py
+++ b/tests/components/bosch_alarm/test_diagnostics.py
@@ -3,6 +3,7 @@
 from typing import Any
 from unittest.mock import AsyncMock
 
+from bosch_alarm_mode2.const import PanelModel
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
@@ -19,7 +20,7 @@ async def test_diagnostics(
     hass_client: ClientSessionGenerator,
     mock_panel: AsyncMock,
     area: AsyncMock,
-    model_name: str,
+    panel_model: PanelModel,
     serial_number: str,
     snapshot: SnapshotAssertion,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump bosch-alarm-mode2 to v0.4.10. 

Fixes an issue where a command was implemented incorrectly on some panels, and this was causing their network modules to lock up in some scenarios and no longer communicate with home assistant without a restart.

The panel model was changed from being stored as a string to being stored as a class that contains both the model name and its family, so references to the panel model have also been updated to support this change.

https://github.com/mag1024/bosch-alarm-mode2/compare/v0.4.6...v0.4.10

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
