### PR TITLE
Let AuthenticationRequired also trigger the reauth flow in MusicAssistant

### DIFF
--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -18,6 +18,7 @@ from music_assistant_models.enums import EventType
 from music_assistant_models.errors import (
     ActionUnavailable,
     AuthenticationFailed,
+    AuthenticationRequired,
     InvalidToken,
     MusicAssistantError,
 )
@@ -99,7 +100,7 @@ async def async_setup_entry(  # noqa: C901
             translation_key="invalid_server_version",
         )
         raise ConfigEntryNotReady(f"Invalid server version: {err}") from err
-    except (AuthenticationFailed, InvalidToken) as err:
+    except (AuthenticationRequired, AuthenticationFailed, InvalidToken) as err:
         raise ConfigEntryAuthFailed(
             f"Authentication failed for {mass_url}: {err}"
         ) from err

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -170,18 +170,19 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
         self.token = discovery_info.config["auth_token"]
 
         self.server_info = server_info
-        await self.async_set_unique_id(server_info.server_id)
 
         # Check if there's an existing entry
-        if entry := self.hass.config_entries.async_entry_for_domain_unique_id(
-            DOMAIN, server_info.server_id
-        ):
+        if entry := await self.async_set_unique_id(server_info.server_id):
             # Update the entry with new URL and token
             if self.hass.config_entries.async_update_entry(
                 entry, data={**entry.data, CONF_URL: self.url, CONF_TOKEN: self.token}
             ):
-                # If entry is in failed auth state, reload it
-                if entry.state is ConfigEntryState.SETUP_ERROR:
+                # Reload the entry if it's in a state that can be reloaded
+                if entry.state in (
+                    ConfigEntryState.LOADED,
+                    ConfigEntryState.SETUP_ERROR,
+                    ConfigEntryState.SETUP_RETRY,
+                ):
                     self.hass.config_entries.async_schedule_reload(entry.entry_id)
 
             # Abort since entry already exists

--- a/tests/components/music_assistant/test_init.py
+++ b/tests/components/music_assistant/test_init.py
@@ -5,18 +5,24 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 from music_assistant_models.enums import EventType
-from music_assistant_models.errors import ActionUnavailable
+from music_assistant_models.errors import ActionUnavailable, AuthenticationRequired
 
 from homeassistant.components.music_assistant.const import (
     ATTR_CONF_EXPOSE_PLAYER_TO_HA,
     DOMAIN,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.setup import async_setup_component
 
 from .common import setup_integration_from_fixtures, trigger_subscription_callback
 
+from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 
@@ -151,3 +157,35 @@ async def test_player_config_expose_to_ha_toggle(
     assert entity_registry.async_get(entity_id)
     device_entry = device_registry.async_get_device({(DOMAIN, player_id)})
     assert device_entry
+
+
+async def test_authentication_required_triggers_reauth(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test that AuthenticationRequired exception triggers reauth flow."""
+    # Create a config entry
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Music Assistant",
+        data={"url": "http://localhost:8095", "token": "old_token"},
+        unique_id="test_server_id",
+    )
+    config_entry.add_to_hass(hass)
+
+    # Mock the client to raise AuthenticationRequired during connect
+    music_assistant_client.connect.side_effect = AuthenticationRequired(
+        "Authentication required"
+    )
+
+    # Try to set up the integration
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify the entry is in SETUP_ERROR state (auth failed)
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    # Verify a reauth repair issue was created
+    issue_reg = ir.async_get(hass)
+    issue_id = f"config_entry_reauth_{DOMAIN}_{config_entry.entry_id}"
+    assert issue_reg.async_get_issue("homeassistant", issue_id)


### PR DESCRIPTION
## Proposed change

Fixes a small oversight in the Music Assistant integration handling where the AuthenticationRequired error should also trigger the reauth flow. It handles the situation of a migration where previously the connection to the server was without token and now the server requires auth.

Also handles the case where the integration was previously configured using the manual URL and now can utilize the internal hassio addon flow, so we update the existing entry and reload it if it's in a failed state. 

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
