### PR TITLE
Prevent startup blocking when a friend’s trophy summary is private on PlayStation Network

### DIFF
--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -251,13 +251,7 @@ class PlaystationNetworkFriendDataCoordinator(
     def _update_data(self) -> PlaystationNetworkData:
         """Update friend status data."""
         try:
-            return PlaystationNetworkData(
-                username=self.user.online_id,
-                account_id=self.user.account_id,
-                presence=self.user.get_presence(),
-                profile=self.profile,
-                trophy_summary=self.user.trophy_summary(),
-            )
+            presence = self.user.get_presence()
         except PSNAWPForbiddenError as error:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -266,6 +260,21 @@ class PlaystationNetworkFriendDataCoordinator(
             ) from error
         except PSNAWPError:
             raise
+
+        try:
+            trophy_summary = self.user.trophy_summary()
+        except PSNAWPForbiddenError:
+            trophy_summary = None
+        except PSNAWPError:
+            raise
+
+        return PlaystationNetworkData(
+            username=self.user.online_id,
+            account_id=self.user.account_id,
+            profile=self.profile,
+            presence=presence,
+            trophy_summary=trophy_summary,
+        )
 
     async def update_data(self) -> PlaystationNetworkData:
         """Update friend status data."""

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -265,8 +265,6 @@ class PlaystationNetworkFriendDataCoordinator(
             trophy_summary = self.user.trophy_summary()
         except PSNAWPForbiddenError:
             trophy_summary = None
-        except PSNAWPError:
-            raise
 
         return PlaystationNetworkData(
             username=self.user.online_id,


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some PlayStation Network users allow their presence data to be visible while keeping their trophy summary private. For the 2025.12 release, trophy data was enabled also for friends. This caused startup to block when attempting to retrieve trophy information of friends whose trophy information is set to private. 
 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
