### PR TITLE
Refactor DemoLight attributes to use standardized cached property names

### DIFF
--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -126,40 +126,35 @@ class DemoLight(LightEntity):
         """Initialize the light."""
         self._attr_translation_key = translation_key
         self._available = True
-        self._brightness = brightness
-        self._ct = ct or random.choice(LIGHT_TEMPS)
-        self._effect = effect
-        self._effect_list = effect_list
-        self._hs_color = hs_color
-        self._rgbw_color = rgbw_color
-        self._rgbww_color = rgbww_color
-        self._state = state
-        self._unique_id = unique_id
+        self._attr_brightness = brightness
+        self._attr_color_temp_kelvin = ct or random.choice(LIGHT_TEMPS)
+        self._attr_effect = effect
+        self._attr_effect_list = effect_list
+        self._attr_hs_color = hs_color
+        self._attr_rgbw_color = rgbw_color
+        self._attr_rgbww_color = rgbww_color
+        self._attr_is_on = state
+        self._attr_unique_id = unique_id
         if hs_color:
-            self._color_mode = ColorMode.HS
+            self._attr_color_mode = ColorMode.HS
         elif rgbw_color:
-            self._color_mode = ColorMode.RGBW
+            self._attr_color_mode = ColorMode.RGBW
         elif rgbww_color:
-            self._color_mode = ColorMode.RGBWW
+            self._attr_color_mode = ColorMode.RGBWW
         else:
-            self._color_mode = ColorMode.COLOR_TEMP
+            self._attr_color_mode = ColorMode.COLOR_TEMP
         if not supported_color_modes:
             supported_color_modes = SUPPORT_DEMO
-        self._color_modes = supported_color_modes
-        if self._effect_list is not None:
+        self._attr_supported_color_modes = supported_color_modes
+        if self._attr_effect_list is not None:
             self._attr_supported_features |= LightEntityFeature.EFFECT
         self._attr_device_info = DeviceInfo(
             identifiers={
                 # Serial numbers are unique identifiers within a specific domain
-                (DOMAIN, self.unique_id)
+                (DOMAIN, self._attr_unique_id)
             },
             name=device_name,
         )
-
-    @property
-    def unique_id(self) -> str:
-        """Return unique ID for light."""
-        return self._unique_id
 
     @property
     def available(self) -> bool:
@@ -168,85 +163,35 @@ class DemoLight(LightEntity):
         # should implement this to inform Home Assistant accordingly.
         return self._available
 
-    @property
-    def brightness(self) -> int:
-        """Return the brightness of this light between 0..255."""
-        return self._brightness
-
-    @property
-    def color_mode(self) -> str | None:
-        """Return the color mode of the light."""
-        return self._color_mode
-
-    @property
-    def hs_color(self) -> tuple[int, int] | None:
-        """Return the hs color value."""
-        return self._hs_color
-
-    @property
-    def rgbw_color(self) -> tuple[int, int, int, int] | None:
-        """Return the rgbw color value."""
-        return self._rgbw_color
-
-    @property
-    def rgbww_color(self) -> tuple[int, int, int, int, int] | None:
-        """Return the rgbww color value."""
-        return self._rgbww_color
-
-    @property
-    def color_temp_kelvin(self) -> int | None:
-        """Return the color temperature value in Kelvin."""
-        return self._ct
-
-    @property
-    def effect_list(self) -> list[str] | None:
-        """Return the list of supported effects."""
-        return self._effect_list
-
-    @property
-    def effect(self) -> str | None:
-        """Return the current effect."""
-        return self._effect
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if light is on."""
-        return self._state
-
-    @property
-    def supported_color_modes(self) -> set[ColorMode]:
-        """Flag supported color modes."""
-        return self._color_modes
-
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
-        self._state = True
+        self._attr_is_on = True
 
         if ATTR_BRIGHTNESS in kwargs:
-            self._brightness = kwargs[ATTR_BRIGHTNESS]
+            self._attr_brightness = kwargs[ATTR_BRIGHTNESS]
 
         if ATTR_COLOR_TEMP_KELVIN in kwargs:
-            self._color_mode = ColorMode.COLOR_TEMP
-            self._ct = kwargs[ATTR_COLOR_TEMP_KELVIN]
+            self._attr_color_mode = ColorMode.COLOR_TEMP
+            self._attr_color_temp_kelvin = kwargs[ATTR_COLOR_TEMP_KELVIN]
 
         if ATTR_EFFECT in kwargs:
-            self._effect = kwargs[ATTR_EFFECT]
+            self._attr_effect = kwargs[ATTR_EFFECT]
 
         if ATTR_HS_COLOR in kwargs:
-            self._color_mode = ColorMode.HS
-            self._hs_color = kwargs[ATTR_HS_COLOR]
+            self._attr_color_mode = ColorMode.HS
+            self._attr_hs_color = kwargs[ATTR_HS_COLOR]
 
         if ATTR_RGBW_COLOR in kwargs:
-            self._color_mode = ColorMode.RGBW
-            self._rgbw_color = kwargs[ATTR_RGBW_COLOR]
+            self._attr_color_mode = ColorMode.RGBW
+            self._attr_rgbw_color = kwargs[ATTR_RGBW_COLOR]
 
         if ATTR_RGBWW_COLOR in kwargs:
-            self._color_mode = ColorMode.RGBWW
-            self._rgbww_color = kwargs[ATTR_RGBWW_COLOR]
+            self._attr_color_mode = ColorMode.RGBWW
+            self._attr_rgbww_color = kwargs[ATTR_RGBWW_COLOR]
 
         if ATTR_WHITE in kwargs:
-            self._color_mode = ColorMode.WHITE
-            self._brightness = kwargs[ATTR_WHITE]
+            self._attr_color_mode = ColorMode.WHITE
+            self._attr_brightness = kwargs[ATTR_WHITE]
 
         # As we have disabled polling, we need to inform
         # Home Assistant about updates in our state ourselves.
@@ -254,7 +199,7 @@ class DemoLight(LightEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
-        self._state = False
+        self._attr_is_on = False
 
         # As we have disabled polling, we need to inform
         # Home Assistant about updates in our state ourselves.

--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -125,7 +125,7 @@ class DemoLight(LightEntity):
     ) -> None:
         """Initialize the light."""
         self._attr_translation_key = translation_key
-        self._available = True
+        self._attr_available = True
         self._attr_brightness = brightness
         self._attr_color_temp_kelvin = ct or random.choice(LIGHT_TEMPS)
         self._attr_effect = effect
@@ -155,13 +155,6 @@ class DemoLight(LightEntity):
             },
             name=device_name,
         )
-
-    @property
-    def available(self) -> bool:
-        """Return availability."""
-        # This demo light is always available, but well-behaving components
-        # should implement this to inform Home Assistant accordingly.
-        return self._available
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
### The addressed issue
The `DemoLight` class in `homeassistant/components/demo/light.py` was utilising a legacy `@property` decorator pattern with instance variables, instead of making use of the `_attr_` cached attribute pattern introduced later.

### Solution
Refactoring to standardised attribute names:

* Replaced custom private variables (e.g., `_brightness`, `_ct`, `_effect`, `_state`, `_unique_id`, etc.) with standardised `LightEntity` attribute names (e.g., `_attr_brightness`, `_attr_color_temp_kelvin`, `_attr_effect`, `_attr_is_on`, `_attr_unique_id`, etc.) for better consistency and integration.
* The cached_attributes and the standardised attribute names are inherited from the parent class, and therefore the relevant `@property` fields were removed
* Updated all references throughout the class to use the new `_attr_*` attributes, including in initialization and state update methods.
* Replaced `available` property with cached `_attr_available` property

### Reengineering strategy or approach used
Rework strategy (specifically code refactoring) is used to improve the internal code quality of the `DemoLight` class without altering its external behavior. It is an iterative approach where a small, isolated improvement is done while the rest of the system remains unchanged.

### Impact of changes
* Code Quality:  Improved code quality and consistency
* Performance: Cached attributes reduce unnecessary procedure calls for attribute access and additionally avoids recalculation of the value when retrieving the property.
* Maintainability: Aligns the demo integration with the standard expected of reference implementations, ensuring it serves as a correct example for new developers

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests