### PR TITLE
Fix user store not loaded on restart

### DIFF
--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -39,8 +39,13 @@ async def async_user_store(hass: HomeAssistant, user_id: str) -> UserStore:
     stores = hass.data.setdefault(DATA_STORAGE, {})
     if (future := stores.get(user_id)) is None:
         future = stores[user_id] = hass.loop.create_future()
-        store = UserStore(hass, user_id)
-        await store.async_load()
+        try:
+            store = UserStore(hass, user_id)
+            await store.async_load()
+        except BaseException as ex:
+            del stores[user_id]
+            future.set_exception(ex)
+            raise
         future.set_result(store)
 
     return await future

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -39,12 +39,12 @@ async def async_user_store(hass: HomeAssistant, user_id: str) -> UserStore:
     stores = hass.data.setdefault(DATA_STORAGE, {})
     if (future := stores.get(user_id)) is None:
         future = stores[user_id] = hass.loop.create_future()
+        store = UserStore(hass, user_id)
         try:
-            store = UserStore(hass, user_id)
             await store.async_load()
-        except BaseException:
+        except BaseException as ex:
             del stores[user_id]
-            future.cancel()
+            future.set_exception(ex)
             raise
         future.set_result(store)
 

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -42,9 +42,9 @@ async def async_user_store(hass: HomeAssistant, user_id: str) -> UserStore:
         try:
             store = UserStore(hass, user_id)
             await store.async_load()
-        except BaseException as ex:
+        except BaseException:
             del stores[user_id]
-            future.set_exception(ex)
+            future.cancel()
             raise
         future.set_result(store)
 

--- a/tests/components/frontend/test_storage.py
+++ b/tests/components/frontend/test_storage.py
@@ -611,5 +611,5 @@ async def test_user_store_concurrent_access(
     # All results should be the same store instance with loaded data
     assert results[0] is results[1] is results[2]
     assert results[0].data == {"test-key": "test-value"}
-    # Store should only be loaded once due to Event synchronization
+    # Store should only be loaded once due to Future synchronization
     assert load_count == 1


### PR DESCRIPTION
## Proposed change

Fixes https://github.com/home-assistant/frontend/issues/28173 reported in front-end.
On a restart, the sidebar user data wasn't loaded properly because of the websocket event was sent before the user data was loaded. Which caused a reset of the siderbar.
We didn't have the issue with system storage because it was using singleton. Unfortunately, we can not use singleton here as the data is stored per user.
I replicated the singleton logic using asyncio event to ensure the data is loaded when we get the user store.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
