### PR TITLE
Remove description_configured from condition and trigger translations

### DIFF
--- a/homeassistant/components/alarm_control_panel/strings.json
+++ b/homeassistant/components/alarm_control_panel/strings.json
@@ -160,7 +160,6 @@
   "triggers": {
     "armed": {
       "description": "Triggers when an alarm is armed.",
-      "description_configured": "[%key:component::alarm_control_panel::triggers::armed::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::alarm_control_panel::common::trigger_behavior_description%]",
@@ -171,7 +170,6 @@
     },
     "armed_away": {
       "description": "Triggers when an alarm is armed away.",
-      "description_configured": "[%key:component::alarm_control_panel::triggers::armed_away::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::alarm_control_panel::common::trigger_behavior_description%]",
@@ -182,7 +180,6 @@
     },
     "armed_home": {
       "description": "Triggers when an alarm is armed home.",
-      "description_configured": "[%key:component::alarm_control_panel::triggers::armed_home::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::alarm_control_panel::common::trigger_behavior_description%]",
@@ -193,7 +190,6 @@
     },
     "armed_night": {
       "description": "Triggers when an alarm is armed night.",
-      "description_configured": "[%key:component::alarm_control_panel::triggers::armed_night::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::alarm_control_panel::common::trigger_behavior_description%]",
@@ -204,7 +200,6 @@
     },
     "armed_vacation": {
       "description": "Triggers when an alarm is armed vacation.",
-      "description_configured": "[%key:component::alarm_control_panel::triggers::armed_vacation::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::alarm_control_panel::common::trigger_behavior_description%]",
@@ -215,7 +210,6 @@
     },
     "disarmed": {
       "description": "Triggers when an alarm is disarmed.",
-      "description_configured": "[%key:component::alarm_control_panel::triggers::disarmed::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::alarm_control_panel::common::trigger_behavior_description%]",
@@ -226,7 +220,6 @@
     },
     "triggered": {
       "description": "Triggers when an alarm is triggered.",
-      "description_configured": "[%key:component::alarm_control_panel::triggers::triggered::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::alarm_control_panel::common::trigger_behavior_description%]",

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -113,7 +113,6 @@
   "triggers": {
     "idle": {
       "description": "Triggers when an Assist satellite becomes idle.",
-      "description_configured": "[%key:component::assist_satellite::triggers::idle::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::assist_satellite::common::trigger_behavior_description%]",
@@ -124,7 +123,6 @@
     },
     "listening": {
       "description": "Triggers when an Assist satellite starts listening.",
-      "description_configured": "[%key:component::assist_satellite::triggers::listening::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::assist_satellite::common::trigger_behavior_description%]",
@@ -135,7 +133,6 @@
     },
     "processing": {
       "description": "Triggers when an Assist satellite is processing.",
-      "description_configured": "[%key:component::assist_satellite::triggers::processing::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::assist_satellite::common::trigger_behavior_description%]",
@@ -146,7 +143,6 @@
     },
     "responding": {
       "description": "Triggers when an Assist satellite is responding.",
-      "description_configured": "[%key:component::assist_satellite::triggers::responding::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::assist_satellite::common::trigger_behavior_description%]",

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -300,7 +300,6 @@
   "triggers": {
     "started_cooling": {
       "description": "Triggers when a climate started cooling.",
-      "description_configured": "[%key:component::climate::triggers::started_cooling::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::climate::common::trigger_behavior_description%]",
@@ -311,7 +310,6 @@
     },
     "started_drying": {
       "description": "Triggers when a climate started drying.",
-      "description_configured": "[%key:component::climate::triggers::started_drying::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::climate::common::trigger_behavior_description%]",
@@ -322,7 +320,6 @@
     },
     "started_heating": {
       "description": "Triggers when a climate starts to heat.",
-      "description_configured": "[%key:component::climate::triggers::started_heating::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::climate::common::trigger_behavior_description%]",
@@ -333,7 +330,6 @@
     },
     "turned_off": {
       "description": "Triggers when a climate is turned off.",
-      "description_configured": "[%key:component::climate::triggers::turned_off::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::climate::common::trigger_behavior_description%]",
@@ -344,7 +340,6 @@
     },
     "turned_on": {
       "description": "Triggers when a climate is turned on.",
-      "description_configured": "[%key:component::climate::triggers::turned_on::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::climate::common::trigger_behavior_description%]",

--- a/homeassistant/components/cover/strings.json
+++ b/homeassistant/components/cover/strings.json
@@ -161,7 +161,6 @@
   "triggers": {
     "awning_opened": {
       "description": "Triggers when an awning opens.",
-      "description_configured": "[%key:component::cover::triggers::awning_opened::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::cover::common::trigger_behavior_description_awning%]",
@@ -176,7 +175,6 @@
     },
     "blind_opened": {
       "description": "Triggers when a blind opens.",
-      "description_configured": "[%key:component::cover::triggers::blind_opened::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::cover::common::trigger_behavior_description_blind%]",
@@ -191,7 +189,6 @@
     },
     "curtain_opened": {
       "description": "Triggers when a curtain opens.",
-      "description_configured": "[%key:component::cover::triggers::curtain_opened::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::cover::common::trigger_behavior_description_curtain%]",
@@ -206,7 +203,6 @@
     },
     "door_opened": {
       "description": "Triggers when a door opens.",
-      "description_configured": "[%key:component::cover::triggers::door_opened::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::cover::common::trigger_behavior_description_door%]",
@@ -221,7 +217,6 @@
     },
     "garage_opened": {
       "description": "Triggers when a garage door opens.",
-      "description_configured": "[%key:component::cover::triggers::garage_opened::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::cover::common::trigger_behavior_description_garage%]",
@@ -236,7 +231,6 @@
     },
     "gate_opened": {
       "description": "Triggers when a gate opens.",
-      "description_configured": "[%key:component::cover::triggers::gate_opened::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::cover::common::trigger_behavior_description_gate%]",
@@ -251,7 +245,6 @@
     },
     "shade_opened": {
       "description": "Triggers when a shade opens.",
-      "description_configured": "[%key:component::cover::triggers::shade_opened::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::cover::common::trigger_behavior_description_shade%]",
@@ -266,7 +259,6 @@
     },
     "shutter_opened": {
       "description": "Triggers when a shutter opens.",
-      "description_configured": "[%key:component::cover::triggers::shutter_opened::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::cover::common::trigger_behavior_description_shutter%]",
@@ -281,7 +273,6 @@
     },
     "window_opened": {
       "description": "Triggers when a window opens.",
-      "description_configured": "[%key:component::cover::triggers::window_opened::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::cover::common::trigger_behavior_description_window%]",

--- a/homeassistant/components/fan/strings.json
+++ b/homeassistant/components/fan/strings.json
@@ -167,7 +167,6 @@
   "triggers": {
     "turned_off": {
       "description": "Triggers when a fan is turned off.",
-      "description_configured": "[%key:component::fan::triggers::turned_off::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::fan::common::trigger_behavior_description%]",
@@ -178,7 +177,6 @@
     },
     "turned_on": {
       "description": "Triggers when a fan is turned on.",
-      "description_configured": "[%key:component::fan::triggers::turned_on::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::fan::common::trigger_behavior_description%]",

--- a/homeassistant/components/lawn_mower/strings.json
+++ b/homeassistant/components/lawn_mower/strings.json
@@ -42,7 +42,6 @@
   "triggers": {
     "docked": {
       "description": "Triggers when a lawn mower has docked.",
-      "description_configured": "[%key:component::lawn_mower::triggers::docked::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::lawn_mower::common::trigger_behavior_description%]",
@@ -53,7 +52,6 @@
     },
     "errored": {
       "description": "Triggers when a lawn mower has errored.",
-      "description_configured": "[%key:component::lawn_mower::triggers::errored::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::lawn_mower::common::trigger_behavior_description%]",
@@ -64,7 +62,6 @@
     },
     "paused_mowing": {
       "description": "Triggers when a lawn mower has paused mowing.",
-      "description_configured": "[%key:component::lawn_mower::triggers::paused_mowing::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::lawn_mower::common::trigger_behavior_description%]",
@@ -75,7 +72,6 @@
     },
     "started_mowing": {
       "description": "Triggers when a lawn mower has started mowing.",
-      "description_configured": "[%key:component::lawn_mower::triggers::started_mowing::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::lawn_mower::common::trigger_behavior_description%]",

--- a/homeassistant/components/light/strings.json
+++ b/homeassistant/components/light/strings.json
@@ -43,7 +43,6 @@
   "conditions": {
     "is_off": {
       "description": "Test if a light is off.",
-      "description_configured": "[%key:component::light::conditions::is_off::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::light::common::condition_behavior_description%]",
@@ -54,7 +53,6 @@
     },
     "is_on": {
       "description": "Test if a light is on.",
-      "description_configured": "[%key:component::light::conditions::is_on::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::light::common::condition_behavior_description%]",
@@ -513,7 +511,6 @@
   "triggers": {
     "turned_off": {
       "description": "Triggers when a light is turned off.",
-      "description_configured": "[%key:component::light::triggers::turned_off::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::light::common::trigger_behavior_description%]",
@@ -524,7 +521,6 @@
     },
     "turned_on": {
       "description": "Triggers when a light is turned on.",
-      "description_configured": "[%key:component::light::triggers::turned_on::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::light::common::trigger_behavior_description%]",

--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -382,7 +382,6 @@
   "triggers": {
     "stopped_playing": {
       "description": "Triggers when a media player stops playing.",
-      "description_configured": "[%key:component::media_player::triggers::stopped_playing::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::media_player::common::trigger_behavior_description%]",

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -1563,7 +1563,6 @@
   "triggers": {
     "_": {
       "description": "When a specific message is received on a given MQTT topic.",
-      "description_configured": "When an MQTT message has been received",
       "fields": {
         "payload": {
           "description": "The payload to trigger on.",

--- a/homeassistant/components/text/strings.json
+++ b/homeassistant/components/text/strings.json
@@ -46,7 +46,6 @@
   "triggers": {
     "changed": {
       "description": "Triggers when the text changes.",
-      "description_configured": "[%key:component::text::triggers::changed::description%]",
       "name": "When the text changes"
     }
   }

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -114,7 +114,6 @@
   "triggers": {
     "docked": {
       "description": "Triggers when a vacuum cleaner has docked.",
-      "description_configured": "[%key:component::vacuum::triggers::docked::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::vacuum::common::trigger_behavior_description%]",
@@ -125,7 +124,6 @@
     },
     "errored": {
       "description": "Triggers when a vacuum cleaner has errored.",
-      "description_configured": "[%key:component::vacuum::triggers::errored::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::vacuum::common::trigger_behavior_description%]",
@@ -136,7 +134,6 @@
     },
     "paused_cleaning": {
       "description": "Triggers when a vacuum cleaner has paused cleaning.",
-      "description_configured": "[%key:component::vacuum::triggers::paused_cleaning::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::vacuum::common::trigger_behavior_description%]",
@@ -147,7 +144,6 @@
     },
     "started_cleaning": {
       "description": "Triggers when a vacuum cleaner has started cleaning.",
-      "description_configured": "[%key:component::vacuum::triggers::started_cleaning::description%]",
       "fields": {
         "behavior": {
           "description": "[%key:component::vacuum::common::trigger_behavior_description%]",

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -475,7 +475,6 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                 {
                     vol.Required("name"): translation_value_validator,
                     vol.Required("description"): translation_value_validator,
-                    vol.Required("description_configured"): translation_value_validator,
                     vol.Optional("fields"): cv.schema_with_slug_keys(
                         {
                             vol.Required("name"): str,
@@ -491,7 +490,6 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                 {
                     vol.Required("name"): translation_value_validator,
                     vol.Required("description"): translation_value_validator,
-                    vol.Required("description_configured"): translation_value_validator,
                     vol.Optional("fields"): cv.schema_with_slug_keys(
                         {
                             vol.Required("name"): str,

--- a/tests/hassfest/test_conditions.py
+++ b/tests/hassfest/test_conditions.py
@@ -42,7 +42,6 @@ CONDITION_DESCRIPTIONS = {
                 "_": {
                     "name": "Sun",
                     "description": "When the sun is above/below the horizon",
-                    "description_configured": "When a the sun rises or sets.",
                     "fields": {
                         "after": {"name": "After event", "description": "The event."},
                         "after_offset": {

--- a/tests/hassfest/test_triggers.py
+++ b/tests/hassfest/test_triggers.py
@@ -39,7 +39,6 @@ TRIGGER_DESCRIPTIONS = {
                 "_": {
                     "name": "MQTT",
                     "description": "When a specific message is received on a given MQTT topic.",
-                    "description_configured": "When an MQTT message has been received",
                     "fields": {
                         "event": {"name": "Event", "description": "The event."},
                         "offset": {"name": "Offset", "description": "The offset."},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove `description_configured` from condition and trigger translations

Rationale: The way we imagined this would be used didn't quite work out, and in all the newly created conditions and triggers `description_configured` is just an alias for another translation key

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
