### PR TITLE
Add read support for MQTT config entry version to 2.1

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -79,6 +79,7 @@ from .const import (
     DEFAULT_RETAIN,
     DOMAIN,
     ENTITY_PLATFORMS,
+    ENTRY_OPTION_FIELDS,
     MQTT_CONNECTION_STATE,
     TEMPLATE_ERRORS,
     Platform,
@@ -380,19 +381,26 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
     data: dict[str, Any] = dict(entry.data)
     options: dict[str, Any] = dict(entry.options)
-    if entry.version > 2 or (entry.version == 1 and entry.minor_version < 2):
+    if entry.version > 2 or (entry.version == 2 and entry.minor_version > 1):
         # This means the user has downgraded from a future version
-        # Or there is an unsupported older entry version
+        # We allow read support for version 2.1
         return False
 
-    if entry.version == 1 and entry.minor_version == 2:
-        # From 2026.1 we write version 2.1
+    if entry.version == 1 and entry.minor_version < 2:
+        # Can be removed when the config entry is bumped to version 2.1
+        # with HA Core 2026.7.0. Read support for version 2.1 is expected with 2026.1
+        # From 2026.7 we will write version 2.1
+        for key in ENTRY_OPTION_FIELDS:
+            if key not in data:
+                continue
+            options[key] = data.pop(key)
+        # Write version 1.2 for backwards compatibility
         hass.config_entries.async_update_entry(
             entry,
             data=data,
             options=options,
-            version=CONFIG_ENTRY_VERSION,
-            minor_version=CONFIG_ENTRY_MINOR_VERSION,
+            version=1,
+            minor_version=2,
         )
 
     _LOGGER.debug(

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -3952,9 +3952,8 @@ REAUTH_SCHEMA = vol.Schema(
 class FlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
-    # Can be bumped to version 2.1 with HA Core 2026.1.0
-    VERSION = CONFIG_ENTRY_VERSION  # 1
-    MINOR_VERSION = CONFIG_ENTRY_MINOR_VERSION  # 2
+    VERSION = CONFIG_ENTRY_VERSION  # 2
+    MINOR_VERSION = CONFIG_ENTRY_MINOR_VERSION  # 1
 
     _hassio_discovery: dict[str, Any] | None = None
     _addon_manager: AddonManager

--- a/homeassistant/components/mqtt/const.py
+++ b/homeassistant/components/mqtt/const.py
@@ -5,7 +5,7 @@ import logging
 import jinja2
 
 from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
-from homeassistant.const import CONF_DISCOVERY, CONF_PAYLOAD, Platform
+from homeassistant.const import CONF_PAYLOAD, Platform
 from homeassistant.exceptions import TemplateError
 
 ATTR_DISCOVERY_HASH = "discovery_hash"
@@ -381,19 +381,8 @@ MQTT_PROCESSED_SUBSCRIPTIONS = "mqtt_processed_subscriptions"
 PAYLOAD_EMPTY_JSON = "{}"
 PAYLOAD_NONE = "None"
 
-CONFIG_ENTRY_VERSION = 1
-CONFIG_ENTRY_MINOR_VERSION = 2
-
-# Split mqtt entry data and options
-# Can be removed when config entry is bumped to version 2.1
-# with HA Core 2026.1.0. Read support for version 2.1 is expected before 2026.1
-# From 2026.1 we will write version 2.1
-ENTRY_OPTION_FIELDS = (
-    CONF_DISCOVERY,
-    CONF_DISCOVERY_PREFIX,
-    "birth_message",
-    "will_message",
-)
+CONFIG_ENTRY_VERSION = 2
+CONFIG_ENTRY_MINOR_VERSION = 1
 
 ENTITY_PLATFORMS = [
     Platform.ALARM_CONTROL_PANEL,

--- a/homeassistant/components/mqtt/const.py
+++ b/homeassistant/components/mqtt/const.py
@@ -5,7 +5,7 @@ import logging
 import jinja2
 
 from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
-from homeassistant.const import CONF_PAYLOAD, Platform
+from homeassistant.const import CONF_DISCOVERY, CONF_PAYLOAD, Platform
 from homeassistant.exceptions import TemplateError
 
 ATTR_DISCOVERY_HASH = "discovery_hash"
@@ -383,6 +383,17 @@ PAYLOAD_NONE = "None"
 
 CONFIG_ENTRY_VERSION = 2
 CONFIG_ENTRY_MINOR_VERSION = 1
+
+# Split mqtt entry data and options
+# Can be removed when config entry is bumped to version 2.1
+# with HA Core 2026.7.0. Read support for version 2.1 is expected from 2026.1
+# From 2026.7 we will write version 2.1
+ENTRY_OPTION_FIELDS = (
+    CONF_DISCOVERY,
+    CONF_DISCOVERY_PREFIX,
+    "birth_message",
+    "will_message",
+)
 
 ENTITY_PLATFORMS = [
     Platform.ALARM_CONTROL_PANEL,

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -386,8 +386,8 @@ async def test_user_connection_works(
         "port": 1883,
     }
     # Check we have the latest Config Entry version
-    assert result["result"].version == 1
-    assert result["result"].minor_version == 2
+    assert result["result"].version == 2
+    assert result["result"].minor_version == 1
     # Check we tried the connection
     assert len(mock_try_connection.mock_calls) == 1
     # Check config entry got setup
@@ -2588,9 +2588,8 @@ async def test_reconfigure_no_changed_password(
         "expected_minor_version",
     ),
     [
-        (1, 1, MOCK_ENTRY_DATA | MOCK_ENTRY_OPTIONS, {}, 1, 2),
-        (1, 2, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS, 1, 2),
-        (1, 3, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS, 1, 3),
+        (1, 2, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS, 2, 1),
+        (2, 1, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS, 2, 1),
     ],
 )
 @pytest.mark.usefixtures("mock_reload_after_entry_update")
@@ -2631,11 +2630,10 @@ async def test_migrate_config_entry(
         "minor_version",
         "data",
         "options",
-        "expected_version",
-        "expected_minor_version",
     ),
     [
-        (2, 1, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS, 2, 1),
+        (1, 1, MOCK_ENTRY_DATA | MOCK_ENTRY_OPTIONS, {}),
+        (3, 1, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS),
     ],
 )
 @pytest.mark.usefixtures("mock_reload_after_entry_update")
@@ -2646,8 +2644,6 @@ async def test_migrate_of_incompatible_config_entry(
     minor_version: int,
     data: dict[str, Any],
     options: dict[str, Any],
-    expected_version: int,
-    expected_minor_version: int,
 ) -> None:
     """Test migrating a config entry."""
     config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
@@ -2660,8 +2656,6 @@ async def test_migrate_of_incompatible_config_entry(
         minor_version=minor_version,
     )
     await hass.async_block_till_done()
-    assert config_entry.version == expected_version
-    assert config_entry.minor_version == expected_minor_version
 
     # Try to start MQTT with incompatible config entry
     with pytest.raises(AssertionError):

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -2588,7 +2588,8 @@ async def test_reconfigure_no_changed_password(
         "expected_minor_version",
     ),
     [
-        (1, 2, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS, 2, 1),
+        (1, 1, MOCK_ENTRY_DATA | MOCK_ENTRY_OPTIONS, {}, 1, 2),
+        (1, 2, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS, 1, 2),
         (2, 1, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS, 2, 1),
     ],
 )
@@ -2632,7 +2633,7 @@ async def test_migrate_config_entry(
         "options",
     ),
     [
-        (1, 1, MOCK_ENTRY_DATA | MOCK_ENTRY_OPTIONS, {}),
+        (2, 2, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS),
         (3, 1, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change MQTT config entry version to 2.1 and add read support for this version.
From HA Core 2025.1.0 the MQTT broker data and options were split to a reconfigure flow and options flow. From 2026.7.0 we do not support upgrades from versions < 2026.1.0, and then we write version 2.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
