### PR TITLE
Bump area registry to version 1.9 and sort areas

### DIFF
--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -40,7 +40,7 @@ EVENT_AREA_REGISTRY_UPDATED: EventType[EventAreaRegistryUpdatedData] = EventType
 )
 STORAGE_KEY = "core.area_registry"
 STORAGE_VERSION_MAJOR = 1
-STORAGE_VERSION_MINOR = 8
+STORAGE_VERSION_MINOR = 9
 
 
 class _AreaStoreData(TypedDict):
@@ -156,6 +156,13 @@ class AreaRegistryStore(Store[AreasRegistryStoreData]):
                 for area in old_data["areas"]:
                     area["humidity_entity_id"] = None
                     area["temperature_entity_id"] = None
+
+            if old_minor_version < 9:
+                # Version 1.9 sorts the areas by name
+                old_data["areas"] = sorted(
+                    old_data["areas"],
+                    key=lambda area: area["name"].casefold(),
+                )
 
         if old_major_version > 1:
             raise NotImplementedError

--- a/tests/helpers/test_area_registry.py
+++ b/tests/helpers/test_area_registry.py
@@ -1,6 +1,6 @@
 """Tests for the Area Registry."""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from functools import partial
 from typing import Any
 
@@ -438,15 +438,64 @@ async def test_migration_from_1_1(
     """Test migration from version 1.1."""
     hass_storage[ar.STORAGE_KEY] = {
         "version": 1,
-        "data": {"areas": [{"id": "12345A", "name": "mock"}]},
+        "data": {
+            "areas": [
+                {"id": "12345A", "name": "AAA"},
+                {"id": "12345B", "name": "CCC"},
+                {"id": "12345C", "name": "bbb"},
+            ]
+        },
     }
 
     await ar.async_load(hass)
     registry = ar.async_get(hass)
 
     # Test data was loaded
-    entry = registry.async_get_or_create("mock")
+    entry = registry.async_get_or_create("AAA")
     assert entry.id == "12345A"
+
+    # Check sort order
+    assert list(registry.async_list_areas()) == [
+        ar.AreaEntry(
+            name="AAA",
+            created_at=datetime(1970, 1, 1, 0, 0, tzinfo=UTC),
+            modified_at=datetime(1970, 1, 1, 0, 0, tzinfo=UTC),
+            aliases=set(),
+            floor_id=None,
+            humidity_entity_id=None,
+            icon=None,
+            id="12345A",
+            labels=set(),
+            picture=None,
+            temperature_entity_id=None,
+        ),
+        ar.AreaEntry(
+            name="bbb",
+            created_at=datetime(1970, 1, 1, 0, 0, tzinfo=UTC),
+            modified_at=datetime(1970, 1, 1, 0, 0, tzinfo=UTC),
+            aliases=set(),
+            floor_id=None,
+            humidity_entity_id=None,
+            icon=None,
+            id="12345C",
+            labels=set(),
+            picture=None,
+            temperature_entity_id=None,
+        ),
+        ar.AreaEntry(
+            name="CCC",
+            created_at=datetime(1970, 1, 1, 0, 0, tzinfo=UTC),
+            modified_at=datetime(1970, 1, 1, 0, 0, tzinfo=UTC),
+            aliases=set(),
+            floor_id=None,
+            humidity_entity_id=None,
+            icon=None,
+            id="12345B",
+            labels=set(),
+            picture=None,
+            temperature_entity_id=None,
+        ),
+    ]
 
     # Check we store migrated data
     await flush_store(registry._store)
@@ -458,17 +507,43 @@ async def test_migration_from_1_1(
             "areas": [
                 {
                     "aliases": [],
+                    "created_at": "1970-01-01T00:00:00+00:00",
                     "floor_id": None,
+                    "humidity_entity_id": None,
                     "icon": None,
                     "id": "12345A",
                     "labels": [],
-                    "name": "mock",
-                    "picture": None,
-                    "created_at": "1970-01-01T00:00:00+00:00",
                     "modified_at": "1970-01-01T00:00:00+00:00",
+                    "name": "AAA",
+                    "picture": None,
                     "temperature_entity_id": None,
+                },
+                {
+                    "aliases": [],
+                    "created_at": "1970-01-01T00:00:00+00:00",
+                    "floor_id": None,
                     "humidity_entity_id": None,
-                }
+                    "icon": None,
+                    "id": "12345C",
+                    "labels": [],
+                    "modified_at": "1970-01-01T00:00:00+00:00",
+                    "name": "bbb",
+                    "picture": None,
+                    "temperature_entity_id": None,
+                },
+                {
+                    "aliases": [],
+                    "created_at": "1970-01-01T00:00:00+00:00",
+                    "floor_id": None,
+                    "humidity_entity_id": None,
+                    "icon": None,
+                    "id": "12345B",
+                    "labels": [],
+                    "modified_at": "1970-01-01T00:00:00+00:00",
+                    "name": "CCC",
+                    "picture": None,
+                    "temperature_entity_id": None,
+                },
             ]
         },
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump area registry to version 1.9 and sort areas

Sort order is:
- By area name, ignoring case (using simple casefold, nothing fancy)

Sorting existing areas was forgotten when allowing users to sort their areas manually in PR https://github.com/home-assistant/core/pull/156802; frontend now respects the sort order in the area registry which in most cases is not as expected. This PR does a minimal effort attempt of sorting existing areas.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
