### PR TITLE
Migrate Tuya climate (swing) to use wrapper class

### DIFF
--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -63,7 +63,7 @@ class _RoundedIntegerWrapper(DPCodeIntegerWrapper):
 
 @dataclass(kw_only=True)
 class _SwingModeWrapper(DeviceWrapper):
-    """An integer that always rounds its value."""
+    """Wrapper for managing climate swing mode operations across multiple DPCodes."""
 
     on_off: DPCodeBooleanWrapper | None = None
     horizontal: DPCodeBooleanWrapper | None = None
@@ -72,7 +72,7 @@ class _SwingModeWrapper(DeviceWrapper):
 
     @classmethod
     def find_dpcode(cls, device: CustomerDevice) -> Self | None:
-        """Find and return a DPCodeTypeInformationWrapper for the given DP codes."""
+        """Find and return a _SwingModeWrapper for the given DP codes."""
         on_off = DPCodeBooleanWrapper.find_dpcode(
             device, (DPCode.SWING, DPCode.SHAKE), prefer_function=True
         )
@@ -99,7 +99,7 @@ class _SwingModeWrapper(DeviceWrapper):
         return None
 
     def read_device_status(self, device: CustomerDevice) -> str | None:
-        """Read and round the device status."""
+        """Read the device swing mode."""
         if self.on_off and self.on_off.read_device_status(device):
             return SWING_ON
 

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Self
 
 from tuya_sharing import CustomerDevice, Manager
 
@@ -32,7 +32,12 @@ from .const import (
     DPCode,
 )
 from .entity import TuyaEntity
-from .models import DPCodeBooleanWrapper, DPCodeEnumWrapper, DPCodeIntegerWrapper
+from .models import (
+    DeviceWrapper,
+    DPCodeBooleanWrapper,
+    DPCodeEnumWrapper,
+    DPCodeIntegerWrapper,
+)
 
 TUYA_HVAC_TO_HA = {
     "auto": HVACMode.HEAT_COOL,
@@ -54,6 +59,84 @@ class _RoundedIntegerWrapper(DPCodeIntegerWrapper):
         if (value := super().read_device_status(device)) is None:
             return None
         return round(value)
+
+
+@dataclass(kw_only=True)
+class _SwingModeWrapper(DeviceWrapper):
+    """An integer that always rounds its value."""
+
+    on_off: DPCodeBooleanWrapper | None = None
+    horizontal: DPCodeBooleanWrapper | None = None
+    vertical: DPCodeBooleanWrapper | None = None
+    modes: list[str]
+
+    @classmethod
+    def find_dpcode(cls, device: CustomerDevice) -> Self | None:
+        """Find and return a DPCodeTypeInformationWrapper for the given DP codes."""
+        on_off = DPCodeBooleanWrapper.find_dpcode(
+            device, (DPCode.SWING, DPCode.SHAKE), prefer_function=True
+        )
+        horizontal = DPCodeBooleanWrapper.find_dpcode(
+            device, DPCode.SWITCH_HORIZONTAL, prefer_function=True
+        )
+        vertical = DPCodeBooleanWrapper.find_dpcode(
+            device, DPCode.SWITCH_VERTICAL, prefer_function=True
+        )
+        if on_off or horizontal or vertical:
+            modes = [SWING_OFF]
+            if on_off:
+                modes.append(SWING_ON)
+            if horizontal:
+                modes.append(SWING_HORIZONTAL)
+            if vertical:
+                modes.append(SWING_VERTICAL)
+            return cls(
+                on_off=on_off,
+                horizontal=horizontal,
+                vertical=vertical,
+                modes=modes,
+            )
+        return None
+
+    def read_device_status(self, device: CustomerDevice) -> str | None:
+        """Read and round the device status."""
+        if self.on_off and self.on_off.read_device_status(device):
+            return SWING_ON
+
+        horizontal = (
+            self.horizontal.read_device_status(device) if self.horizontal else None
+        )
+        vertical = self.vertical.read_device_status(device) if self.vertical else None
+        if horizontal and vertical:
+            return SWING_BOTH
+        if horizontal:
+            return SWING_HORIZONTAL
+        if vertical:
+            return SWING_VERTICAL
+
+        return SWING_OFF
+
+    def get_update_commands(
+        self, device: CustomerDevice, value: str
+    ) -> list[dict[str, Any]]:
+        """Set new target swing operation."""
+        commands = []
+        if self.on_off:
+            commands.extend(self.on_off.get_update_commands(device, value == SWING_ON))
+
+        if self.vertical:
+            commands.extend(
+                self.vertical.get_update_commands(
+                    device, value in (SWING_BOTH, SWING_VERTICAL)
+                )
+            )
+        if self.horizontal:
+            commands.extend(
+                self.horizontal.get_update_commands(
+                    device, value in (SWING_BOTH, SWING_HORIZONTAL)
+                )
+            )
+        return commands
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -205,15 +288,7 @@ async def async_setup_entry(
                             device, DPCode.MODE, prefer_function=True
                         ),
                         set_temperature_wrapper=temperature_wrappers[1],
-                        swing_wrapper=DPCodeBooleanWrapper.find_dpcode(
-                            device, (DPCode.SWING, DPCode.SHAKE), prefer_function=True
-                        ),
-                        swing_h_wrapper=DPCodeBooleanWrapper.find_dpcode(
-                            device, DPCode.SWITCH_HORIZONTAL, prefer_function=True
-                        ),
-                        swing_v_wrapper=DPCodeBooleanWrapper.find_dpcode(
-                            device, DPCode.SWITCH_VERTICAL, prefer_function=True
-                        ),
+                        swing_wrapper=_SwingModeWrapper.find_dpcode(device),
                         switch_wrapper=DPCodeBooleanWrapper.find_dpcode(
                             device, DPCode.SWITCH, prefer_function=True
                         ),
@@ -250,9 +325,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         fan_mode_wrapper: DPCodeEnumWrapper | None,
         hvac_mode_wrapper: DPCodeEnumWrapper | None,
         set_temperature_wrapper: DPCodeIntegerWrapper | None,
-        swing_wrapper: DPCodeBooleanWrapper | None,
-        swing_h_wrapper: DPCodeBooleanWrapper | None,
-        swing_v_wrapper: DPCodeBooleanWrapper | None,
+        swing_wrapper: _SwingModeWrapper | None,
         switch_wrapper: DPCodeBooleanWrapper | None,
         target_humidity_wrapper: _RoundedIntegerWrapper | None,
         temperature_unit: UnitOfTemperature,
@@ -268,8 +341,6 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         self._hvac_mode_wrapper = hvac_mode_wrapper
         self._set_temperature = set_temperature_wrapper
         self._swing_wrapper = swing_wrapper
-        self._swing_h_wrapper = swing_h_wrapper
-        self._swing_v_wrapper = swing_v_wrapper
         self._switch_wrapper = switch_wrapper
         self._target_humidity_wrapper = target_humidity_wrapper
         self._attr_temperature_unit = temperature_unit
@@ -324,17 +395,9 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
             self._attr_fan_modes = fan_mode_wrapper.type_information.range
 
         # Determine swing modes
-        if swing_wrapper or swing_h_wrapper or swing_v_wrapper:
+        if swing_wrapper:
             self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
-            self._attr_swing_modes = [SWING_OFF]
-            if swing_wrapper:
-                self._attr_swing_modes.append(SWING_ON)
-
-            if swing_h_wrapper:
-                self._attr_swing_modes.append(SWING_HORIZONTAL)
-
-            if swing_v_wrapper:
-                self._attr_swing_modes.append(SWING_VERTICAL)
+            self._attr_swing_modes = swing_wrapper.modes
 
         if switch_wrapper:
             self._attr_supported_features |= (
@@ -372,27 +435,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set new target swing operation."""
-        commands = []
-        if self._swing_wrapper:
-            commands.extend(
-                self._swing_wrapper.get_update_commands(
-                    self.device, swing_mode == SWING_ON
-                )
-            )
-        if self._swing_v_wrapper:
-            commands.extend(
-                self._swing_v_wrapper.get_update_commands(
-                    self.device, swing_mode in (SWING_BOTH, SWING_VERTICAL)
-                )
-            )
-        if self._swing_h_wrapper:
-            commands.extend(
-                self._swing_h_wrapper.get_update_commands(
-                    self.device, swing_mode in (SWING_BOTH, SWING_HORIZONTAL)
-                )
-            )
-        if commands:
-            await self._async_send_commands(commands)
+        await self._async_send_wrapper_updates(self._swing_wrapper, swing_mode)
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -457,21 +500,9 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         return self._read_wrapper(self._fan_mode_wrapper)
 
     @property
-    def swing_mode(self) -> str:
+    def swing_mode(self) -> str | None:
         """Return swing mode."""
-        if self._read_wrapper(self._swing_wrapper):
-            return SWING_ON
-
-        horizontal = self._read_wrapper(self._swing_h_wrapper)
-        vertical = self._read_wrapper(self._swing_v_wrapper)
-        if horizontal and vertical:
-            return SWING_BOTH
-        if horizontal:
-            return SWING_HORIZONTAL
-        if vertical:
-            return SWING_VERTICAL
-
-        return SWING_OFF
+        return self._read_wrapper(self._swing_wrapper)
 
     async def async_turn_on(self) -> None:
         """Turn the device on, retaining current HVAC (if supported)."""

--- a/homeassistant/components/tuya/entity.py
+++ b/homeassistant/components/tuya/entity.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, LOGGER, TUYA_HA_SIGNAL_UPDATE_ENTITY
-from .models import DPCodeWrapper
+from .models import DeviceWrapper
 
 
 class TuyaEntity(Entity):
@@ -64,18 +64,20 @@ class TuyaEntity(Entity):
     async def _async_send_commands(self, commands: list[dict[str, Any]]) -> None:
         """Send a list of commands to the device."""
         LOGGER.debug("Sending commands for device %s: %s", self.device.id, commands)
+        if not commands:
+            return
         await self.hass.async_add_executor_job(
             self.device_manager.send_commands, self.device.id, commands
         )
 
-    def _read_wrapper(self, wrapper: DPCodeWrapper | None) -> Any | None:
+    def _read_wrapper(self, wrapper: DeviceWrapper | None) -> Any | None:
         """Read the wrapper device status."""
         if wrapper is None:
             return None
         return wrapper.read_device_status(self.device)
 
     async def _async_send_wrapper_updates(
-        self, wrapper: DPCodeWrapper | None, value: Any
+        self, wrapper: DeviceWrapper | None, value: Any
     ) -> None:
         """Send command to the device."""
         if wrapper is None:

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -165,8 +165,22 @@ _TYPE_INFORMATION_MAPPINGS: dict[DPType, type[TypeInformation]] = {
 }
 
 
-class DPCodeWrapper:
-    """Base DPCode wrapper.
+class DeviceWrapper:
+    """Base device wrapper."""
+
+    def read_device_status(self, device: CustomerDevice) -> Any | None:
+        """Read device status and convert to a Home Assistant value."""
+        raise NotImplementedError
+
+    def get_update_commands(
+        self, device: CustomerDevice, value: Any
+    ) -> list[dict[str, Any]]:
+        """Generate update commands for a Home Assistant action."""
+        raise NotImplementedError
+
+
+class DPCodeWrapper(DeviceWrapper):
+    """Base device wrapper for a single DPCode.
 
     Used as a common interface for referring to a DPCode, and
     access read conversion routines.
@@ -185,13 +199,6 @@ class DPCodeWrapper:
         Private helper method for `read_device_status`.
         """
         return device.status.get(self.dpcode)
-
-    def read_device_status(self, device: CustomerDevice) -> Any | None:
-        """Read the device value for the dpcode.
-
-        The raw device status is converted to a Home Assistant value.
-        """
-        raise NotImplementedError
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
         """Convert a Home Assistant value back to a raw device value.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #156232

Combine the current three boolean wrappers into a single "enum" behavior wrapper.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
