### PR TITLE
Log config flow progress task errors instead of silently discarding them

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -6,6 +6,7 @@ import abc
 import asyncio
 from collections import defaultdict
 from collections.abc import Callable, Container, Coroutine, Hashable, Iterable, Mapping
+from contextlib import suppress
 import copy
 from dataclasses import dataclass
 from enum import StrEnum
@@ -536,7 +537,9 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
 
                     # Notify frontend to refresh before aborting
                     flow.async_notify_flow_changed()
-                    self.async_abort(flow.flow_id)
+
+                    with suppress(UnknownFlow):
+                        self.async_abort(flow.flow_id)
 
             def schedule_configure(_: asyncio.Task) -> None:
                 self.hass.async_create_task(call_configure())

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -534,6 +534,10 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
                 except Exception:
                     _LOGGER.exception("Error processing progress task for %s", flow)
 
+                    # Notify frontend to refresh before aborting
+                    flow.async_notify_flow_changed()
+                    self.async_abort(flow.flow_id)
+
             def schedule_configure(_: asyncio.Task) -> None:
                 self.hass.async_create_task(call_configure())
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -526,10 +526,11 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         ):
             # The flow's progress task was changed, register a callback on it
             async def call_configure() -> None:
+                if self._progress.get(flow.flow_id) is None:
+                    return
+
                 try:
                     await self._async_configure(flow.flow_id)
-                except UnknownFlow:
-                    pass
                 except Exception:
                     _LOGGER.exception("Error processing progress task for %s", flow)
 

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -691,6 +691,66 @@ async def test_show_progress_error(
     assert result["reason"] == "error"
 
 
+async def test_show_progress_task_callback_exception_logging(
+    hass: HomeAssistant, manager: MockFlowManager, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that exceptions in progress task callback are caught and logged."""
+    manager.hass = hass
+    task_evt = asyncio.Event()
+
+    @manager.mock_reg_handler("test")
+    class TestFlow(data_entry_flow.FlowHandler):
+        VERSION = 5
+        _progress_task: asyncio.Task[None] | None = None
+
+        async def _long_running_task(self) -> None:
+            await task_evt.wait()
+            raise TypeError("Internal error from task")
+
+        async def async_step_init(self, user_input=None):
+            if user_input is not None:
+                return await self.async_step_next()
+
+            return self.async_show_form(step_id="init")
+
+        async def async_step_next(self, user_input=None):
+            if self._progress_task is None:
+                self._progress_task = self.hass.async_create_task(
+                    self._long_running_task(), name="test_flow_task"
+                )
+
+            if not self._progress_task.done():
+                return self.async_show_progress(
+                    step_id="next",
+                    progress_action="task",
+                    progress_task=self._progress_task,
+                )
+
+            try:
+                await self._progress_task
+            finally:
+                self._progress_task = None
+
+            return self.async_show_progress_done(next_step_id="final")
+
+        async def async_step_final(self, user_input=None):
+            raise RuntimeError("Test error from final step, should not be reached")
+
+    # Start the config flow, it'll be in a progress state for a bit
+    init_result = await manager.async_init("test")
+    result = await manager.async_configure(init_result["flow_id"], {})
+    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+
+    # Then trigger an error within the task
+    with caplog.at_level(logging.ERROR):
+        task_evt.set()
+        await hass.async_block_till_done()
+
+    # We log a traceback
+    assert "Internal error from task" in caplog.text
+    assert "Error processing progress task for" in caplog.text
+
+
 async def test_show_progress_hidden_from_frontend(
     hass: HomeAssistant, manager: MockFlowManager
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Config flow progress steps rely on a very precarious function: `task.add_done_callback`. This is a low-level asyncio primitive and comes with a fun feature: unhandled exceptions are swallowed, bypassing the event loop uncaught exception handler. They just disappear. This PR logs and catches them explicitly.

I've added `flow.async_notify_flow_changed()` before `self.async_abort(flow.flow_id)` to get the frontend to move on from the broken config flow progress spinner and show a generic `Error: Invalid flow specified` dialog. Without this change, the frontend does not actually error out properly, we don't seem to have a simple way to modify the config flow result at runtime from the callback

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
