### PR TITLE
Use _async_send_commands in Tuya base entity

### DIFF
--- a/homeassistant/components/tuya/entity.py
+++ b/homeassistant/components/tuya/entity.py
@@ -61,28 +61,25 @@ class TuyaEntity(Entity):
     ) -> None:
         self.async_write_ha_state()
 
-    def _send_command(self, commands: list[dict[str, Any]]) -> None:
-        """Send command to the device."""
-        LOGGER.debug("Sending commands for device %s: %s", self.device.id, commands)
-        self.device_manager.send_commands(self.device.id, commands)
-
     async def _async_send_commands(self, commands: list[dict[str, Any]]) -> None:
         """Send a list of commands to the device."""
-        await self.hass.async_add_executor_job(self._send_command, commands)
+        LOGGER.debug("Sending commands for device %s: %s", self.device.id, commands)
+        await self.hass.async_add_executor_job(
+            self.device_manager.send_commands, self.device.id, commands
+        )
 
-    def _read_wrapper(self, dpcode_wrapper: DPCodeWrapper | None) -> Any | None:
+    def _read_wrapper(self, wrapper: DPCodeWrapper | None) -> Any | None:
         """Read the wrapper device status."""
-        if dpcode_wrapper is None:
+        if wrapper is None:
             return None
-        return dpcode_wrapper.read_device_status(self.device)
+        return wrapper.read_device_status(self.device)
 
     async def _async_send_wrapper_updates(
-        self, dpcode_wrapper: DPCodeWrapper | None, value: Any
+        self, wrapper: DPCodeWrapper | None, value: Any
     ) -> None:
         """Send command to the device."""
-        if dpcode_wrapper is None:
+        if wrapper is None or not (
+            commands := wrapper.get_update_commands(self.device, value)
+        ):
             return
-        await self.hass.async_add_executor_job(
-            self._send_command,
-            dpcode_wrapper.get_update_commands(self.device, value),
-        )
+        await self._async_send_commands(commands)

--- a/homeassistant/components/tuya/entity.py
+++ b/homeassistant/components/tuya/entity.py
@@ -78,8 +78,8 @@ class TuyaEntity(Entity):
         self, wrapper: DPCodeWrapper | None, value: Any
     ) -> None:
         """Send command to the device."""
-        if wrapper is None or not (
-            commands := wrapper.get_update_commands(self.device, value)
-        ):
+        if wrapper is None:
             return
-        await self._async_send_commands(commands)
+        await self._async_send_commands(
+            wrapper.get_update_commands(self.device, value),
+        )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Migrate `_async_send_wrapper_updates` to use `_async_send_commands`
- Update `_async_send_commands` to call manager method directly
- Drop now unused `send_command` helper
- Rename `dpcode_wrapper` to `wrapper`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
