### PR TITLE
Add integration type to rpi_power

### DIFF
--- a/homeassistant/components/rpi_power/manifest.json
+++ b/homeassistant/components/rpi_power/manifest.json
@@ -4,6 +4,7 @@
   "codeowners": ["@shenxn", "@swetoast"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/rpi_power",
+  "integration_type": "hardware",
   "iot_class": "local_polling",
   "loggers": ["rpi_bad_power"],
   "requirements": ["rpi-bad-power==0.1.0"],

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5445,7 +5445,7 @@
           "name": "Raspberry Pi"
         },
         "rpi_power": {
-          "integration_type": "hub",
+          "integration_type": "hardware",
           "config_flow": true,
           "iot_class": "local_polling"
         },


### PR DESCRIPTION
## Proposed change

Add `integration_type: "hardware"` to the Raspberry Pi Power Supply Checker integration manifest. This integration monitors a single hardware device (RPi power supply).

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)