### PR TITLE
Add diagnostics for Anglian Water integration

### DIFF
--- a/homeassistant/components/anglian_water/diagnostics.py
+++ b/homeassistant/components/anglian_water/diagnostics.py
@@ -62,20 +62,15 @@ async def async_get_device_diagnostics(
     device_entry: DeviceEntry,
 ) -> dict[str, Any]:
     """Get diagnostics for a device entry."""
-    if not device_entry.serial_number:
-        return {}
-    smart_meter = config_entry.runtime_data.api.meters.get(
-        device_entry.serial_number, None
-    )
-    if smart_meter is not None:
-        meter = smart_meter.to_dict()
-    else:
-        meter = {}
+    # At this point the device will always be registered with a serial number.
+    # The API always returns a serial number for any type of meter.
+    assert device_entry.serial_number
+    smart_meter = config_entry.runtime_data.api.meters.get(device_entry.serial_number)
+    assert smart_meter
     return async_redact_data(
         {
             "device_entry_id": device_entry.id,
-            "config_entry": device_entry.config_entries,
-            "meter": meter,
+            "meter": smart_meter.to_dict(),
         },
         REDACTED_FIELDS,
     )

--- a/homeassistant/components/anglian_water/diagnostics.py
+++ b/homeassistant/components/anglian_water/diagnostics.py
@@ -1,0 +1,81 @@
+"""Home Assistant Anglian Water Diagnostics."""
+
+from typing import Any
+
+from pyanglianwater.enum import UsagesReadGranularity
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from .const import CONF_ACCOUNT_NUMBER
+from .coordinator import AnglianWaterConfigEntry
+
+REDACTED_FIELDS = [
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    CONF_ACCESS_TOKEN,
+    CONF_ACCOUNT_NUMBER,
+    "refresh_token",
+    "address",
+    "formatted_address",
+    "business_partner_number",
+    "account_number",
+    "sub_building_name",
+    "house_number",
+    "street",
+    "city",
+    "postcode",
+    "move_in_date",
+    "payment_type",
+    "payment_arrangement_type",
+    "serial",
+    "serial_number",
+    "meter_serial_number",
+]
+
+# For some reason AW store the meter serial number under 3 different keys.
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry: AnglianWaterConfigEntry,
+) -> dict[str, Any]:
+    """Get diagnostics for a config entry."""
+    return async_redact_data(
+        {
+            "config_entry": config_entry.data,
+            "options": config_entry.options,
+            "anglian_water": config_entry.runtime_data.api.to_dict(),
+            "metering_data": await config_entry.runtime_data.api.get_usages(
+                interval=UsagesReadGranularity.HOURLY, update_cache=False
+            ),
+        },
+        REDACTED_FIELDS,
+    )
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant,
+    config_entry: AnglianWaterConfigEntry,
+    device_entry: DeviceEntry,
+) -> dict[str, Any]:
+    """Get diagnostics for a device entry."""
+    if not device_entry.serial_number:
+        return {}
+    smart_meter = config_entry.runtime_data.api.meters.get(
+        device_entry.serial_number, None
+    )
+    if smart_meter is not None:
+        meter = smart_meter.to_dict()
+    else:
+        meter = {}
+    return async_redact_data(
+        {
+            "device_entry_id": device_entry.id,
+            "config_entry": device_entry.config_entries,
+            "meter": meter,
+        },
+        REDACTED_FIELDS,
+    )

--- a/tests/components/anglian_water/conftest.py
+++ b/tests/components/anglian_water/conftest.py
@@ -38,6 +38,14 @@ def mock_smart_meter() -> SmartMeter:
     mock.latest_read = 50
     mock.yesterday_water_cost = 0.5
     mock.yesterday_sewerage_cost = 0.5
+    # For diagnostic tests
+    mock.to_dict.return_value = {
+        "serial_number": mock.serial_number,
+        "latest_read": mock.latest_read,
+        "get_yesterday_consumption": mock.get_yesterday_consumption,
+        "yesterday_water_cost": mock.yesterday_water_cost,
+        "yesterday_sewerage_cost": mock.yesterday_sewerage_cost,
+    }
     return mock
 
 
@@ -82,6 +90,12 @@ def mock_anglian_water_client(
         mock_client.account_config = {"meter_type": "SmartMeter"}
         mock_client.updated_data_callbacks = []
         mock_client.validate_smart_meter.return_value = None
+        # For diagnostic tests
+        mock_client.get_usages.return_value = []
+        mock_client.to_dict.return_value = {
+            "account_config": mock_client.account_config,
+            "meters": {sn: meter.to_dict() for sn, meter in mock_client.meters.items()},
+        }
         yield mock_client
 
 

--- a/tests/components/anglian_water/snapshots/test_diagnostics.ambr
+++ b/tests/components/anglian_water/snapshots/test_diagnostics.ambr
@@ -1,0 +1,40 @@
+# serializer version: 1
+# name: test_device_diagnostics
+  dict({
+    'meter': dict({
+      'get_yesterday_consumption': 50,
+      'latest_read': 50,
+      'serial_number': '**REDACTED**',
+      'yesterday_sewerage_cost': 0.5,
+      'yesterday_water_cost': 0.5,
+    }),
+  })
+# ---
+# name: test_entry_diagnostics
+  dict({
+    'anglian_water': dict({
+      'account_config': dict({
+        'meter_type': 'SmartMeter',
+      }),
+      'meters': dict({
+        'TESTSN': dict({
+          'get_yesterday_consumption': 50,
+          'latest_read': 50,
+          'serial_number': '**REDACTED**',
+          'yesterday_sewerage_cost': 0.5,
+          'yesterday_water_cost': 0.5,
+        }),
+      }),
+    }),
+    'config_entry': dict({
+      'access_token': '**REDACTED**',
+      'account_number': '**REDACTED**',
+      'password': '**REDACTED**',
+      'username': '**REDACTED**',
+    }),
+    'metering_data': list([
+    ]),
+    'options': dict({
+    }),
+  })
+# ---

--- a/tests/components/anglian_water/test_diagnostics.py
+++ b/tests/components/anglian_water/test_diagnostics.py
@@ -1,0 +1,59 @@
+"""Diagnostic tests for Anglian Water."""
+
+from unittest.mock import AsyncMock
+
+from syrupy.assertion import SnapshotAssertion
+from syrupy.filters import props
+
+from homeassistant.components.anglian_water.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import (
+    get_diagnostics_for_config_entry,
+    get_diagnostics_for_device,
+)
+from tests.typing import ClientSessionGenerator
+
+
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_client: AsyncMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test config entry diagnostics."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert (
+        await get_diagnostics_for_config_entry(hass, hass_client, mock_config_entry)
+        == snapshot
+    )
+
+
+async def test_device_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test device diagnostics."""
+    await setup_integration(hass, mock_config_entry)
+
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "TESTSN")})
+    assert device
+    assert await get_diagnostics_for_device(
+        hass, hass_client, mock_config_entry, device
+    ) == snapshot(
+        exclude=props(
+            "device_entry_id",
+            "created_at",
+            "modified_at",
+        )
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds device and config entry diagnostics to Anglian Water integration.

This outputs reading information for water meters (when requesting both config entry and device diagnostics) and account information (when requesting config entry diagnostics).

This will be valuable for diagnosing issues off the back of #157757

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
