### PR TITLE
Fix ZHA network formation

### DIFF
--- a/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
@@ -39,8 +39,6 @@ from .const import (
     NABU_CASA_FIRMWARE_RELEASES_URL,
     PID,
     PRODUCT,
-    RADIO_TX_POWER_DBM_BY_COUNTRY,
-    RADIO_TX_POWER_DBM_DEFAULT,
     SERIAL_NUMBER,
     VID,
 )
@@ -113,21 +111,6 @@ class ZBT2FirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
             step_id="install_thread_firmware",
             next_step_id="finish_thread_installation",
         )
-
-    def _extra_zha_hardware_options(self) -> dict[str, Any]:
-        """Return extra ZHA hardware options."""
-        country = self.hass.config.country
-
-        if country is None:
-            tx_power = RADIO_TX_POWER_DBM_DEFAULT
-        else:
-            tx_power = RADIO_TX_POWER_DBM_BY_COUNTRY.get(
-                country, RADIO_TX_POWER_DBM_DEFAULT
-            )
-
-        return {
-            "tx_power": tx_power,
-        }
 
 
 class HomeAssistantConnectZBT2ConfigFlow(

--- a/homeassistant/components/homeassistant_connect_zbt2/const.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/const.py
@@ -1,7 +1,5 @@
 """Constants for the Home Assistant Connect ZBT-2 integration."""
 
-from homeassistant.generated.countries import COUNTRIES
-
 DOMAIN = "homeassistant_connect_zbt2"
 
 NABU_CASA_FIRMWARE_RELEASES_URL = (
@@ -19,59 +17,3 @@ VID = "vid"
 DEVICE = "device"
 
 HARDWARE_NAME = "Home Assistant Connect ZBT-2"
-
-RADIO_TX_POWER_DBM_DEFAULT = 8
-RADIO_TX_POWER_DBM_BY_COUNTRY = {
-    # EU Member States
-    "AT": 10,
-    "BE": 10,
-    "BG": 10,
-    "HR": 10,
-    "CY": 10,
-    "CZ": 10,
-    "DK": 10,
-    "EE": 10,
-    "FI": 10,
-    "FR": 10,
-    "DE": 10,
-    "GR": 10,
-    "HU": 10,
-    "IE": 10,
-    "IT": 10,
-    "LV": 10,
-    "LT": 10,
-    "LU": 10,
-    "MT": 10,
-    "NL": 10,
-    "PL": 10,
-    "PT": 10,
-    "RO": 10,
-    "SK": 10,
-    "SI": 10,
-    "ES": 10,
-    "SE": 10,
-    # EEA Members
-    "IS": 10,
-    "LI": 10,
-    "NO": 10,
-    # Standards harmonized with RED or ETSI
-    "CH": 10,
-    "GB": 10,
-    "TR": 10,
-    "AL": 10,
-    "BA": 10,
-    "GE": 10,
-    "MD": 10,
-    "ME": 10,
-    "MK": 10,
-    "RS": 10,
-    "UA": 10,
-    # Other CEPT nations
-    "AD": 10,
-    "AZ": 10,
-    "MC": 10,
-    "SM": 10,
-    "VA": 10,
-}
-
-assert set(RADIO_TX_POWER_DBM_BY_COUNTRY) <= COUNTRIES

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -444,10 +444,6 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         # This step is necessary to prevent `user_input` from being passed through
         return await self.async_step_continue_zigbee()
 
-    def _extra_zha_hardware_options(self) -> dict[str, Any]:
-        """Return extra ZHA hardware options."""
-        return {}
-
     async def async_step_continue_zigbee(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -470,7 +466,6 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
                 },
                 "radio_type": "ezsp",
                 "flow_strategy": self._zigbee_flow_strategy,
-                **self._extra_zha_hardware_options(),
             },
         )
         return self._continue_zha_flow(result)

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -15,7 +15,7 @@ from typing import Any
 import voluptuous as vol
 from zha.application.const import RadioType
 import zigpy.backups
-from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH, CONF_NWK_TX_POWER
+from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 from zigpy.exceptions import CannotWriteNetworkSettings, DestructiveWriteNetworkSettings
 
 from homeassistant.components import onboarding, usb
@@ -196,7 +196,6 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
         self._restore_backup_task: asyncio.Task[None] | None = None
         self._reset_old_radio_task: asyncio.Task[None] | None = None
         self._form_network_task: asyncio.Task[None] | None = None
-        self._extra_network_config: dict[str, Any] = {}
 
         # Progress flow steps cannot abort so we need to store the abort reason and then
         # re-raise it in a dedicated step
@@ -658,7 +657,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
 
     async def _async_form_new_network(self) -> None:
         """Do the work of forming a new network."""
-        await self._radio_mgr.async_form_network(config=self._extra_network_config)
+        await self._radio_mgr.async_form_network()
         # Load the newly formed network settings to get the network info
         await self._radio_mgr.async_load_network_settings()
 
@@ -1067,9 +1066,6 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
         device_settings = discovery_data["port"]
         device_path = device_settings[CONF_DEVICE_PATH]
         self._flow_strategy = discovery_data.get("flow_strategy")
-
-        if "tx_power" in discovery_data:
-            self._extra_network_config[CONF_NWK_TX_POWER] = discovery_data["tx_power"]
 
         await self._set_unique_id_and_update_ignored_flow(
             unique_id=f"{name}_{radio_type.name}_{device_path}",

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -323,7 +323,7 @@ class ZhaRadioManager:
 
         return backup
 
-    async def async_form_network(self, config: dict[str, Any] | None) -> None:
+    async def async_form_network(self) -> None:
         """Form a brand-new network."""
 
         # When forming a new network, we delete the ZHA database to prevent old devices
@@ -332,7 +332,7 @@ class ZhaRadioManager:
             await self.hass.async_add_executor_job(os.remove, self.zigpy_database_path)
 
         async with self.create_zigpy_app() as app:
-            await app.form_network(config=config)
+            await app.form_network()
 
     async def async_reset_adapter(self) -> None:
         """Reset the current adapter."""

--- a/tests/components/homeassistant_connect_zbt2/test_config_flow.py
+++ b/tests/components/homeassistant_connect_zbt2/test_config_flow.py
@@ -50,23 +50,8 @@ def setup_entry_fixture() -> Generator[AsyncMock]:
         yield mock_setup_entry
 
 
-@pytest.mark.parametrize(
-    ("country", "expected_tx_power"),
-    [
-        ("US", 8),
-        ("NL", 10),
-        ("JP", 8),
-        ("DE", 10),
-    ],
-)
-async def test_config_flow_zigbee(
-    hass: HomeAssistant,
-    country: str,
-    expected_tx_power: int,
-) -> None:
+async def test_config_flow_zigbee(hass: HomeAssistant) -> None:
     """Test Zigbee config flow for Connect ZBT-2."""
-    hass.config.country = country
-
     fw_type = ApplicationType.EZSP
     fw_version = "7.4.4.0 build 0"
     model = "Home Assistant Connect ZBT-2"
@@ -160,7 +145,6 @@ async def test_config_flow_zigbee(
             "flow_control": "hardware",
         },
         "radio_type": fw_type.value,
-        "tx_power": expected_tx_power,
     }
 
 
@@ -400,7 +384,6 @@ async def test_options_flow(
             "flow_control": "hardware",
         },
         "radio_type": "ezsp",
-        "tx_power": 8,
     }
 
 

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -19,6 +19,7 @@ import uuid
 import pytest
 from serial.tools.list_ports_common import ListPortInfo
 from zha.application.const import RadioType
+from zigpy.application import ControllerApplication
 from zigpy.backups import BackupManager
 import zigpy.config
 from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH, SCHEMA_DEVICE
@@ -97,9 +98,11 @@ def mock_multipan_platform():
 @pytest.fixture(autouse=True)
 def mock_app() -> Generator[AsyncMock]:
     """Mock zigpy app interface."""
-    mock_app = AsyncMock()
+    mock_app = create_autospec(ControllerApplication, instance=True)
     mock_app.backups = create_autospec(BackupManager, instance=True)
     mock_app.backups.backups = []
+
+    mock_app.state = MagicMock()
     mock_app.state.network_info.extended_pan_id = zigpy.types.EUI64.convert(
         "AABBCCDDEE000000"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Zigpy now sets the TX power itself based on the passed through HA `country`. This PR fixes unit tests to use less mocks (which masked the issue) and reverts #155855, since it is no longer necessary.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
