### PR TITLE
Replace bare Exception with specific exceptions in Growatt

### DIFF
--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -1,11 +1,11 @@
 """The Growatt server PV inverter sensor integration."""
 
 from collections.abc import Mapping
-import json
+from json import JSONDecodeError
 import logging
 
 import growattServer
-import requests
+from requests import RequestException
 
 from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -37,7 +37,7 @@ def get_device_list_classic(
     # Log in to api and fetch first plant if no plant id is defined.
     try:
         login_response = api.login(config[CONF_USERNAME], config[CONF_PASSWORD])
-    except (requests.RequestException, json.JSONDecodeError) as ex:
+    except (RequestException, JSONDecodeError) as ex:
         raise ConfigEntryError(
             f"Error communicating with Growatt API during login: {ex}"
         ) from ex
@@ -54,7 +54,7 @@ def get_device_list_classic(
     if plant_id == DEFAULT_PLANT_ID:
         try:
             plant_info = api.plant_list(user_id)
-        except (requests.RequestException, json.JSONDecodeError) as ex:
+        except (RequestException, JSONDecodeError) as ex:
             raise ConfigEntryError(
                 f"Error communicating with Growatt API during plant list: {ex}"
             ) from ex
@@ -65,7 +65,7 @@ def get_device_list_classic(
     # Get a list of devices for specified plant to add sensors for.
     try:
         devices = api.device_list(plant_id)
-    except (requests.RequestException, json.JSONDecodeError) as ex:
+    except (RequestException, JSONDecodeError) as ex:
         raise ConfigEntryError(
             f"Error communicating with Growatt API during device list: {ex}"
         ) from ex

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -1,9 +1,11 @@
 """The Growatt server PV inverter sensor integration."""
 
 from collections.abc import Mapping
+import json
 import logging
 
 import growattServer
+import requests
 
 from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -35,8 +37,7 @@ def get_device_list_classic(
     # Log in to api and fetch first plant if no plant id is defined.
     try:
         login_response = api.login(config[CONF_USERNAME], config[CONF_PASSWORD])
-        # DEBUG: Log the actual response structure
-    except Exception as ex:
+    except (requests.RequestException, json.JSONDecodeError) as ex:
         raise ConfigEntryError(
             f"Error communicating with Growatt API during login: {ex}"
         ) from ex
@@ -53,7 +54,7 @@ def get_device_list_classic(
     if plant_id == DEFAULT_PLANT_ID:
         try:
             plant_info = api.plant_list(user_id)
-        except Exception as ex:
+        except (requests.RequestException, json.JSONDecodeError) as ex:
             raise ConfigEntryError(
                 f"Error communicating with Growatt API during plant list: {ex}"
             ) from ex
@@ -64,7 +65,7 @@ def get_device_list_classic(
     # Get a list of devices for specified plant to add sensors for.
     try:
         devices = api.device_list(plant_id)
-    except Exception as ex:
+    except (requests.RequestException, json.JSONDecodeError) as ex:
         raise ConfigEntryError(
             f"Error communicating with Growatt API during device list: {ex}"
         ) from ex

--- a/homeassistant/components/growatt_server/quality_scale.yaml
+++ b/homeassistant/components/growatt_server/quality_scale.yaml
@@ -28,9 +28,7 @@ rules:
     status: todo
     comment: Update server URL dropdown to show regional descriptions (e.g., 'China', 'United States') instead of raw URLs.
   docs-installation-parameters: todo
-  entity-unavailable:
-    status: todo
-    comment: Replace bare Exception catches in __init__.py with specific growattServer exceptions.
+  entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace bare Exception catches in __init__.py with growattServer.GrowattError. This improves exception specificity for API communication errors in:
- api.login() calls
- api.plant_list() calls
- api.device_list() calls

Mark entity-unavailable as done in quality_scale.yaml.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
