### PR TITLE
Accept URLs in WLED Host input

### DIFF
--- a/homeassistant/components/wled/config_flow.py
+++ b/homeassistant/components/wled/config_flow.py
@@ -27,11 +27,10 @@ from .coordinator import WLEDConfigEntry
 
 def _normalize_host(host: str) -> str:
     """Normalize host by extracting hostname if a URL is provided."""
-    if "://" in host:
-        try:
-            return yarl.URL(host).host or host
-        except ValueError:
-            pass
+    try:
+        return yarl.URL(host).host or host
+    except ValueError:
+        pass
     return host
 
 

--- a/homeassistant/components/wled/config_flow.py
+++ b/homeassistant/components/wled/config_flow.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from typing import Any
-import urllib.parse
 
 import voluptuous as vol
 from wled import WLED, Device, WLEDConnectionError, WLEDUnsupportedVersionError
+import yarl
 
 from homeassistant.components import onboarding
 from homeassistant.config_entries import (
@@ -29,7 +29,7 @@ def _normalize_host(host: str) -> str:
     """Normalize host by extracting hostname if a URL is provided."""
     if "://" in host:
         try:
-            return urllib.parse.urlparse(host).hostname or host
+            return yarl.URL(host).host or host
         except ValueError:
             pass
     return host

--- a/homeassistant/components/wled/config_flow.py
+++ b/homeassistant/components/wled/config_flow.py
@@ -79,16 +79,12 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
                     )
                     return self.async_update_reload_and_abort(
                         entry,
-                        data_updates={
-                            CONF_HOST: host,
-                        },
+                        data_updates={CONF_HOST: host},
                     )
                 self._abort_if_unique_id_configured(updates={CONF_HOST: host})
                 return self.async_create_entry(
                     title=device.info.name,
-                    data={
-                        CONF_HOST: host,
-                    },
+                    data={CONF_HOST: host},
                 )
         data_schema = vol.Schema({vol.Required(CONF_HOST): str})
         if self.source == SOURCE_RECONFIGURE:

--- a/tests/components/wled/test_config_flow.py
+++ b/tests/components/wled/test_config_flow.py
@@ -23,6 +23,7 @@ from tests.common import MockConfigEntry
         "192.168.1.123",
         "http://192.168.1.123",
         "https://192.168.1.123/settings",
+        "https://192.168.1.123:80/settings",
     ],
 )
 async def test_full_user_flow_implementation(
@@ -38,7 +39,7 @@ async def test_full_user_flow_implementation(
     assert result.get("type") is FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_HOST: "192.168.1.123"}
+        result["flow_id"], user_input={CONF_HOST: host_input}
     )
 
     assert result.get("title") == "WLED RGB Light"

--- a/tests/components/wled/test_config_flow.py
+++ b/tests/components/wled/test_config_flow.py
@@ -17,7 +17,17 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.usefixtures("mock_setup_entry", "mock_wled")
-async def test_full_user_flow_implementation(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    "host_input",
+    [
+        "192.168.1.123",
+        "http://192.168.1.123",
+        "https://192.168.1.123/settings",
+    ],
+)
+async def test_full_user_flow_implementation(
+    hass: HomeAssistant, host_input: str
+) -> None:
     """Test the full manual user flow from start to finish."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR improves the WLED config flow by allowing users to enter full URLs in the Host field, including values prefixed with `http://` or `https://.` Previously, such inputs caused connection errors or prevented proper duplicate entry detection.

This makes the setup process more tolerant of real world input. When users copy the address of their WLED device directly from the browser, modern browsers often hide the scheme in the address bar, which leads to unintentionally pasting the full URL into Home Assistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
