### PR TITLE
Allow non strict response_format structures for Cloud LLM generation

### DIFF
--- a/homeassistant/components/cloud/entity.py
+++ b/homeassistant/components/cloud/entity.py
@@ -561,7 +561,7 @@ class BaseCloudLLMEntity(Entity):
                         "schema": _format_structured_output(
                             structure, chat_log.llm_api
                         ),
-                        "strict": True,
+                        "strict": False,
                     },
                 }
 

--- a/tests/components/cloud/test_entity.py
+++ b/tests/components/cloud/test_entity.py
@@ -248,6 +248,7 @@ async def test_async_handle_chat_log_service_sets_structured_output_non_strict(
     async def _fake_delta_stream(
         self: conversation.ChatLog,
         agent_id: str,
+        stream,
     ):
         content = conversation.AssistantContent(
             agent_id=agent_id, content='{"value": "ok"}'

--- a/tests/components/cloud/test_entity.py
+++ b/tests/components/cloud/test_entity.py
@@ -11,6 +11,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components import conversation
+from homeassistant.components.cloud.const import AI_TASK_ENTITY_UNIQUE_ID, DOMAIN
 from homeassistant.components.cloud.entity import (
     BaseCloudLLMEntity,
     _convert_content_to_param,
@@ -18,7 +19,8 @@ from homeassistant.components.cloud.entity import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import llm, selector
+from homeassistant.helpers import entity_registry as er, llm, selector
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
@@ -221,35 +223,63 @@ async def test_prepare_chat_for_generation_passes_messages_through(
     assert response["conversation_id"] == "conversation-id"
 
 
-async def test_async_handle_chat_log_sets_structured_output_non_strict(
-    hass: HomeAssistant, cloud_entity: BaseCloudLLMEntity
+async def test_async_handle_chat_log_service_sets_structured_output_non_strict(
+    hass: HomeAssistant,
+    cloud: MagicMock,
+    entity_registry: er.EntityRegistry,
+    mock_cloud_login: None,
 ) -> None:
-    """Ensure structured output requests always disable strict validation."""
-    chat_log = conversation.ChatLog(hass, "conversation-id")
-    chat_log.async_add_user_content(conversation.UserContent(content="ping"))
-    structure = vol.Schema({vol.Required("value"): str})
+    """Ensure structured output requests always disable strict validation via service."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
 
-    async_generate_data = AsyncMock(return_value=object())
-    cloud_entity._cloud.llm.async_generate_data = async_generate_data
+    on_start_callback = cloud.register_on_start.call_args[0][0]
+    await on_start_callback()
+    await hass.async_block_till_done()
 
-    def _empty_delta_stream(*args, **kwargs):
-        async def _generator():
-            for _ in range(0):
-                yield None
+    entity_id = entity_registry.async_get_entity_id(
+        "ai_task", DOMAIN, AI_TASK_ENTITY_UNIQUE_ID
+    )
+    assert entity_id is not None
 
-        return _generator()
+    async def _empty_stream():
+        return
+
+    async def _fake_delta_stream(
+        self: conversation.ChatLog,
+        agent_id: str,
+    ):
+        content = conversation.AssistantContent(
+            agent_id=agent_id, content='{"value": "ok"}'
+        )
+        self.async_add_assistant_content_without_tools(content)
+        yield content
+
+    cloud.llm.async_generate_data = AsyncMock(return_value=_empty_stream())
 
     with patch(
-        "homeassistant.components.cloud.entity._transform_stream",
-        new=_empty_delta_stream,
+        "homeassistant.components.conversation.chat_log.ChatLog.async_add_delta_content_stream",
+        _fake_delta_stream,
     ):
-        await cloud_entity._async_handle_chat_log(
+        await hass.services.async_call(
             "ai_task",
-            chat_log,
-            structure_name="Device Report",
-            structure=structure,
+            "generate_data",
+            {
+                "entity_id": entity_id,
+                "task_name": "Device Report",
+                "instructions": "Provide value.",
+                "structure": {
+                    "value": {
+                        "selector": {"text": None},
+                        "required": True,
+                    }
+                },
+            },
+            blocking=True,
+            return_response=True,
         )
 
-    async_generate_data.assert_awaited_once()
-    call_kwargs = async_generate_data.call_args.kwargs
-    assert call_kwargs["response_format"]["json_schema"]["strict"] is False
+    cloud.llm.async_generate_data.assert_awaited_once()
+    _, kwargs = cloud.llm.async_generate_data.call_args
+
+    assert kwargs["response_format"]["json_schema"]["strict"] is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR allows non strict structures when calling `ai_task.generate_data` or `conversation`.
[HA defines the `required` as optional](https://www.home-assistant.io/integrations/ai_task/#action-ai_taskgenerate_data), and we were making it required, so if users didn't specified it, the LLM server would throw an error.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
