### PR TITLE
Reduce naming verbosity in Bang & Olufsen

### DIFF
--- a/homeassistant/components/bang_olufsen/__init__.py
+++ b/homeassistant/components/bang_olufsen/__init__.py
@@ -21,29 +21,29 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.util.ssl import get_default_context
 
 from .const import DOMAIN
-from .websocket import BangOlufsenWebsocket
+from .websocket import BeoWebsocket
 
 
 @dataclass
-class BangOlufsenData:
+class BeoData:
     """Dataclass for API client and WebSocket client."""
 
-    websocket: BangOlufsenWebsocket
+    websocket: BeoWebsocket
     client: MozartClient
 
 
-type BangOlufsenConfigEntry = ConfigEntry[BangOlufsenData]
+type BeoConfigEntry = ConfigEntry[BeoData]
 
 PLATFORMS = [Platform.EVENT, Platform.MEDIA_PLAYER]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: BangOlufsenConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: BeoConfigEntry) -> bool:
     """Set up from a config entry."""
 
     # Remove casts to str
     assert entry.unique_id
 
-    # Create device now as BangOlufsenWebsocket needs a device for debug logging, firing events etc.
+    # Create device now as BeoWebsocket needs a device for debug logging, firing events etc.
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
@@ -68,10 +68,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: BangOlufsenConfigEntry) 
         await client.close_api_client()
         raise ConfigEntryNotReady(f"Unable to connect to {entry.title}") from error
 
-    websocket = BangOlufsenWebsocket(hass, entry, client)
+    websocket = BeoWebsocket(hass, entry, client)
 
     # Add the websocket and API client
-    entry.runtime_data = BangOlufsenData(websocket, client)
+    entry.runtime_data = BeoData(websocket, client)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -82,9 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BangOlufsenConfigEntry) 
     return True
 
 
-async def async_unload_entry(
-    hass: HomeAssistant, entry: BangOlufsenConfigEntry
-) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: BeoConfigEntry) -> bool:
     """Unload a config entry."""
     # Close the API client and WebSocket notification listener
     entry.runtime_data.client.disconnect_notifications()

--- a/homeassistant/components/bang_olufsen/config_flow.py
+++ b/homeassistant/components/bang_olufsen/config_flow.py
@@ -47,7 +47,7 @@ _exception_map = {
 }
 
 
-class BangOlufsenConfigFlowHandler(ConfigFlow, domain=DOMAIN):
+class BeoConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
     _beolink_jid = ""

--- a/homeassistant/components/bang_olufsen/const.py
+++ b/homeassistant/components/bang_olufsen/const.py
@@ -14,7 +14,7 @@ from homeassistant.components.media_player import (
 )
 
 
-class BangOlufsenSource:
+class BeoSource:
     """Class used for associating device source ids with friendly names. May not include all sources."""
 
     DEEZER: Final[Source] = Source(name="Deezer", id="deezer")
@@ -26,7 +26,7 @@ class BangOlufsenSource:
     URI_STREAMER: Final[Source] = Source(name="Audio Streamer", id="uriStreamer")
 
 
-BANG_OLUFSEN_STATES: dict[str, MediaPlayerState] = {
+BEO_STATES: dict[str, MediaPlayerState] = {
     # Dict used for translating device states to Home Assistant states.
     "started": MediaPlayerState.PLAYING,
     "buffering": MediaPlayerState.PLAYING,
@@ -40,19 +40,19 @@ BANG_OLUFSEN_STATES: dict[str, MediaPlayerState] = {
 }
 
 # Dict used for translating Home Assistant settings to device repeat settings.
-BANG_OLUFSEN_REPEAT_FROM_HA: dict[RepeatMode, str] = {
+BEO_REPEAT_FROM_HA: dict[RepeatMode, str] = {
     RepeatMode.ALL: "all",
     RepeatMode.ONE: "track",
     RepeatMode.OFF: "none",
 }
 # Dict used for translating device repeat settings to Home Assistant settings.
-BANG_OLUFSEN_REPEAT_TO_HA: dict[str, RepeatMode] = {
-    value: key for key, value in BANG_OLUFSEN_REPEAT_FROM_HA.items()
+BEO_REPEAT_TO_HA: dict[str, RepeatMode] = {
+    value: key for key, value in BEO_REPEAT_FROM_HA.items()
 }
 
 
 # Media types for play_media
-class BangOlufsenMediaType(StrEnum):
+class BeoMediaType(StrEnum):
     """Bang & Olufsen specific media types."""
 
     FAVOURITE = "favourite"
@@ -63,7 +63,7 @@ class BangOlufsenMediaType(StrEnum):
     OVERLAY_TTS = "overlay_tts"
 
 
-class BangOlufsenModel(StrEnum):
+class BeoModel(StrEnum):
     """Enum for compatible model names."""
 
     # Mozart devices
@@ -82,7 +82,7 @@ class BangOlufsenModel(StrEnum):
     BEOREMOTE_ONE = "Beoremote One"
 
 
-class BangOlufsenAttribute(StrEnum):
+class BeoAttribute(StrEnum):
     """Enum for extra_state_attribute keys."""
 
     BEOLINK = "beolink"
@@ -93,7 +93,7 @@ class BangOlufsenAttribute(StrEnum):
 
 
 # Physical "buttons" on devices
-class BangOlufsenButtons(StrEnum):
+class BeoButtons(StrEnum):
     """Enum for device buttons."""
 
     BLUETOOTH = "Bluetooth"
@@ -140,7 +140,7 @@ class WebsocketNotification(StrEnum):
 DOMAIN: Final[str] = "bang_olufsen"
 
 # Default values for configuration.
-DEFAULT_MODEL: Final[str] = BangOlufsenModel.BEOSOUND_BALANCE
+DEFAULT_MODEL: Final[str] = BeoModel.BEOSOUND_BALANCE
 
 # Configuration.
 CONF_SERIAL_NUMBER: Final = "serial_number"
@@ -148,7 +148,7 @@ CONF_BEOLINK_JID: Final = "jid"
 
 # Models to choose from in manual configuration.
 SELECTABLE_MODELS: list[str] = [
-    model.value for model in BangOlufsenModel if model != BangOlufsenModel.BEOREMOTE_ONE
+    model.value for model in BeoModel if model != BeoModel.BEOREMOTE_ONE
 ]
 
 MANUFACTURER: Final[str] = "Bang & Olufsen"
@@ -160,15 +160,15 @@ ATTR_ITEM_NUMBER: Final[str] = "in"
 ATTR_FRIENDLY_NAME: Final[str] = "fn"
 
 # Power states.
-BANG_OLUFSEN_ON: Final[str] = "on"
+BEO_ON: Final[str] = "on"
 
 VALID_MEDIA_TYPES: Final[tuple] = (
-    BangOlufsenMediaType.FAVOURITE,
-    BangOlufsenMediaType.DEEZER,
-    BangOlufsenMediaType.RADIO,
-    BangOlufsenMediaType.TTS,
-    BangOlufsenMediaType.TIDAL,
-    BangOlufsenMediaType.OVERLAY_TTS,
+    BeoMediaType.FAVOURITE,
+    BeoMediaType.DEEZER,
+    BeoMediaType.RADIO,
+    BeoMediaType.TTS,
+    BeoMediaType.TIDAL,
+    BeoMediaType.OVERLAY_TTS,
     MediaType.MUSIC,
     MediaType.URL,
     MediaType.CHANNEL,
@@ -246,7 +246,7 @@ FALLBACK_SOURCES: Final[SourceArray] = SourceArray(
 )
 
 # Device events
-BANG_OLUFSEN_WEBSOCKET_EVENT: Final[str] = f"{DOMAIN}_websocket_event"
+BEO_WEBSOCKET_EVENT: Final[str] = f"{DOMAIN}_websocket_event"
 
 # Dict used to translate native Bang & Olufsen event names to string.json compatible ones
 EVENT_TRANSLATION_MAP: dict[str, str] = {
@@ -263,7 +263,7 @@ EVENT_TRANSLATION_MAP: dict[str, str] = {
 
 CONNECTION_STATUS: Final[str] = "CONNECTION_STATUS"
 
-DEVICE_BUTTONS: Final[list[str]] = [x.value for x in BangOlufsenButtons]
+DEVICE_BUTTONS: Final[list[str]] = [x.value for x in BeoButtons]
 
 
 DEVICE_BUTTON_EVENTS: Final[list[str]] = [

--- a/homeassistant/components/bang_olufsen/diagnostics.py
+++ b/homeassistant/components/bang_olufsen/diagnostics.py
@@ -10,13 +10,13 @@ from homeassistant.const import CONF_MODEL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import BangOlufsenConfigEntry
+from . import BeoConfigEntry
 from .const import DOMAIN
 from .util import get_device_buttons
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, config_entry: BangOlufsenConfigEntry
+    hass: HomeAssistant, config_entry: BeoConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
 

--- a/homeassistant/components/bang_olufsen/entity.py
+++ b/homeassistant/components/bang_olufsen/entity.py
@@ -24,8 +24,8 @@ from homeassistant.helpers.entity import Entity
 from .const import DOMAIN
 
 
-class BangOlufsenBase:
-    """Base class for BangOlufsen Home Assistant objects."""
+class BeoBase:
+    """Base class for Bang & Olufsen Home Assistant objects."""
 
     def __init__(self, entry: ConfigEntry, client: MozartClient) -> None:
         """Initialize the object."""
@@ -51,8 +51,8 @@ class BangOlufsenBase:
         )
 
 
-class BangOlufsenEntity(Entity, BangOlufsenBase):
-    """Base Entity for BangOlufsen entities."""
+class BeoEntity(Entity, BeoBase):
+    """Base Entity for Bang & Olufsen entities."""
 
     _attr_has_entity_name = True
     _attr_should_poll = False

--- a/homeassistant/components/bang_olufsen/media_player.py
+++ b/homeassistant/components/bang_olufsen/media_player.py
@@ -69,11 +69,11 @@ from homeassistant.helpers.entity_platform import (
 )
 from homeassistant.util.dt import utcnow
 
-from . import BangOlufsenConfigEntry
+from . import BeoConfigEntry
 from .const import (
-    BANG_OLUFSEN_REPEAT_FROM_HA,
-    BANG_OLUFSEN_REPEAT_TO_HA,
-    BANG_OLUFSEN_STATES,
+    BEO_REPEAT_FROM_HA,
+    BEO_REPEAT_TO_HA,
+    BEO_STATES,
     BEOLINK_JOIN_SOURCES,
     BEOLINK_JOIN_SOURCES_TO_UPPER,
     CONF_BEOLINK_JID,
@@ -82,12 +82,12 @@ from .const import (
     FALLBACK_SOURCES,
     MANUFACTURER,
     VALID_MEDIA_TYPES,
-    BangOlufsenAttribute,
-    BangOlufsenMediaType,
-    BangOlufsenSource,
+    BeoAttribute,
+    BeoMediaType,
+    BeoSource,
     WebsocketNotification,
 )
-from .entity import BangOlufsenEntity
+from .entity import BeoEntity
 from .util import get_serial_number_from_jid
 
 PARALLEL_UPDATES = 0
@@ -96,7 +96,7 @@ SCAN_INTERVAL = timedelta(seconds=30)
 
 _LOGGER = logging.getLogger(__name__)
 
-BANG_OLUFSEN_FEATURES = (
+BEO_FEATURES = (
     MediaPlayerEntityFeature.BROWSE_MEDIA
     | MediaPlayerEntityFeature.CLEAR_PLAYLIST
     | MediaPlayerEntityFeature.GROUPING
@@ -119,15 +119,13 @@ BANG_OLUFSEN_FEATURES = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: BangOlufsenConfigEntry,
+    config_entry: BeoConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a Media Player entity from config entry."""
     # Add MediaPlayer entity
     async_add_entities(
-        new_entities=[
-            BangOlufsenMediaPlayer(config_entry, config_entry.runtime_data.client)
-        ],
+        new_entities=[BeoMediaPlayer(config_entry, config_entry.runtime_data.client)],
         update_before_add=True,
     )
 
@@ -187,7 +185,7 @@ async def async_setup_entry(
     )
 
 
-class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
+class BeoMediaPlayer(BeoEntity, MediaPlayerEntity):
     """Representation of a media player."""
 
     _attr_name = None
@@ -288,7 +286,7 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
             queue_settings = await self._client.get_settings_queue(_request_timeout=5)
 
             if queue_settings.repeat is not None:
-                self._attr_repeat = BANG_OLUFSEN_REPEAT_TO_HA[queue_settings.repeat]
+                self._attr_repeat = BEO_REPEAT_TO_HA[queue_settings.repeat]
 
             if queue_settings.shuffle is not None:
                 self._attr_shuffle = queue_settings.shuffle
@@ -408,8 +406,8 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
 
         # Check if source is line-in or optical and progress should be updated
         if self._source_change.id in (
-            BangOlufsenSource.LINE_IN.id,
-            BangOlufsenSource.SPDIF.id,
+            BeoSource.LINE_IN.id,
+            BeoSource.SPDIF.id,
         ):
             self._playback_progress = PlaybackProgress(progress=0)
 
@@ -450,10 +448,8 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
 
         # Add Beolink self
         self._beolink_attributes = {
-            BangOlufsenAttribute.BEOLINK: {
-                BangOlufsenAttribute.BEOLINK_SELF: {
-                    self.device_entry.name: self._beolink_jid
-                }
+            BeoAttribute.BEOLINK: {
+                BeoAttribute.BEOLINK_SELF: {self.device_entry.name: self._beolink_jid}
             }
         }
 
@@ -461,12 +457,12 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
         peers = await self._client.get_beolink_peers()
 
         if len(peers) > 0:
-            self._beolink_attributes[BangOlufsenAttribute.BEOLINK][
-                BangOlufsenAttribute.BEOLINK_PEERS
+            self._beolink_attributes[BeoAttribute.BEOLINK][
+                BeoAttribute.BEOLINK_PEERS
             ] = {}
             for peer in peers:
-                self._beolink_attributes[BangOlufsenAttribute.BEOLINK][
-                    BangOlufsenAttribute.BEOLINK_PEERS
+                self._beolink_attributes[BeoAttribute.BEOLINK][
+                    BeoAttribute.BEOLINK_PEERS
                 ][peer.friendly_name] = peer.jid
 
         # Add Beolink listeners / leader
@@ -488,8 +484,8 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
             # Add self
             group_members.append(self.entity_id)
 
-            self._beolink_attributes[BangOlufsenAttribute.BEOLINK][
-                BangOlufsenAttribute.BEOLINK_LEADER
+            self._beolink_attributes[BeoAttribute.BEOLINK][
+                BeoAttribute.BEOLINK_LEADER
             ] = {
                 self._remote_leader.friendly_name: self._remote_leader.jid,
             }
@@ -527,8 +523,8 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
                                 beolink_listener.jid
                             )
                             break
-                self._beolink_attributes[BangOlufsenAttribute.BEOLINK][
-                    BangOlufsenAttribute.BEOLINK_LISTENERS
+                self._beolink_attributes[BeoAttribute.BEOLINK][
+                    BeoAttribute.BEOLINK_LISTENERS
                 ] = beolink_listeners_attribute
 
         self._attr_group_members = group_members
@@ -600,7 +596,7 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
     @property
     def supported_features(self) -> MediaPlayerEntityFeature:
         """Flag media player features that are supported."""
-        features = BANG_OLUFSEN_FEATURES
+        features = BEO_FEATURES
 
         # Add seeking if supported by the current source
         if self._source_change.is_seekable is True:
@@ -611,7 +607,7 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
     @property
     def state(self) -> MediaPlayerState:
         """Return the current state of the media player."""
-        return BANG_OLUFSEN_STATES[self._state]
+        return BEO_STATES[self._state]
 
     @property
     def volume_level(self) -> float | None:
@@ -631,10 +627,10 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
     def media_content_type(self) -> MediaType | str | None:
         """Return the current media type."""
         content_type = {
-            BangOlufsenSource.URI_STREAMER.id: MediaType.URL,
-            BangOlufsenSource.DEEZER.id: BangOlufsenMediaType.DEEZER,
-            BangOlufsenSource.TIDAL.id: BangOlufsenMediaType.TIDAL,
-            BangOlufsenSource.NET_RADIO.id: BangOlufsenMediaType.RADIO,
+            BeoSource.URI_STREAMER.id: MediaType.URL,
+            BeoSource.DEEZER.id: BeoMediaType.DEEZER,
+            BeoSource.TIDAL.id: BeoMediaType.TIDAL,
+            BeoSource.NET_RADIO.id: BeoMediaType.RADIO,
         }
         # Hard to determine content type.
         if self._source_change.id in content_type:
@@ -765,9 +761,7 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
     async def async_set_repeat(self, repeat: RepeatMode) -> None:
         """Set playback queues to repeat."""
         await self._client.set_settings_queue(
-            play_queue_settings=PlayQueueSettings(
-                repeat=BANG_OLUFSEN_REPEAT_FROM_HA[repeat]
-            )
+            play_queue_settings=PlayQueueSettings(repeat=BEO_REPEAT_FROM_HA[repeat])
         )
 
     async def async_set_shuffle(self, shuffle: bool) -> None:
@@ -871,7 +865,7 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
                         self._volume.level.level + offset_volume, 100
                     )
 
-            if media_type == BangOlufsenMediaType.OVERLAY_TTS:
+            if media_type == BeoMediaType.OVERLAY_TTS:
                 # Bang & Olufsen cloud TTS
                 overlay_play_request.text_to_speech = (
                     OverlayPlayRequestTextToSpeechTextToSpeech(
@@ -888,14 +882,14 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
 
         # The "provider" media_type may not be suitable for overlay all the time.
         # Use it for now.
-        elif media_type == BangOlufsenMediaType.TTS:
+        elif media_type == BeoMediaType.TTS:
             await self._client.post_overlay_play(
                 overlay_play_request=OverlayPlayRequest(
                     uri=Uri(location=media_id),
                 )
             )
 
-        elif media_type == BangOlufsenMediaType.RADIO:
+        elif media_type == BeoMediaType.RADIO:
             await self._client.run_provided_scene(
                 scene_properties=SceneProperties(
                     action_list=[
@@ -907,13 +901,13 @@ class BangOlufsenMediaPlayer(BangOlufsenEntity, MediaPlayerEntity):
                 )
             )
 
-        elif media_type == BangOlufsenMediaType.FAVOURITE:
+        elif media_type == BeoMediaType.FAVOURITE:
             await self._client.activate_preset(id=int(media_id))
 
-        elif media_type in (BangOlufsenMediaType.DEEZER, BangOlufsenMediaType.TIDAL):
+        elif media_type in (BeoMediaType.DEEZER, BeoMediaType.TIDAL):
             try:
                 # Play Deezer flow.
-                if media_id == "flow" and media_type == BangOlufsenMediaType.DEEZER:
+                if media_id == "flow" and media_type == BeoMediaType.DEEZER:
                     deezer_id = None
 
                     if "id" in kwargs[ATTR_MEDIA_EXTRA]:

--- a/homeassistant/components/bang_olufsen/util.py
+++ b/homeassistant/components/bang_olufsen/util.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import DEVICE_BUTTONS, DOMAIN, BangOlufsenButtons, BangOlufsenModel
+from .const import DEVICE_BUTTONS, DOMAIN, BeoButtons, BeoModel
 
 
 def get_device(hass: HomeAssistant, unique_id: str) -> DeviceEntry:
@@ -40,16 +40,16 @@ async def get_remotes(client: MozartClient) -> list[PairedRemote]:
     ]
 
 
-def get_device_buttons(model: BangOlufsenModel) -> list[str]:
+def get_device_buttons(model: BeoModel) -> list[str]:
     """Get supported buttons for a given model."""
     buttons = DEVICE_BUTTONS.copy()
 
     # Beosound Premiere does not have a bluetooth button
-    if model == BangOlufsenModel.BEOSOUND_PREMIERE:
-        buttons.remove(BangOlufsenButtons.BLUETOOTH)
+    if model == BeoModel.BEOSOUND_PREMIERE:
+        buttons.remove(BeoButtons.BLUETOOTH)
 
     # Beoconnect Core does not have any buttons
-    elif model == BangOlufsenModel.BEOCONNECT_CORE:
+    elif model == BeoModel.BEOCONNECT_CORE:
         buttons = []
 
     return buttons

--- a/homeassistant/components/bang_olufsen/websocket.py
+++ b/homeassistant/components/bang_olufsen/websocket.py
@@ -27,20 +27,20 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util.enum import try_parse_enum
 
 from .const import (
-    BANG_OLUFSEN_WEBSOCKET_EVENT,
+    BEO_WEBSOCKET_EVENT,
     CONNECTION_STATUS,
     DOMAIN,
     EVENT_TRANSLATION_MAP,
-    BangOlufsenModel,
+    BeoModel,
     WebsocketNotification,
 )
-from .entity import BangOlufsenBase
+from .entity import BeoBase
 from .util import get_device, get_remotes
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class BangOlufsenWebsocket(BangOlufsenBase):
+class BeoWebsocket(BeoBase):
     """The WebSocket listeners."""
 
     def __init__(
@@ -48,7 +48,7 @@ class BangOlufsenWebsocket(BangOlufsenBase):
     ) -> None:
         """Initialize the WebSocket listeners."""
 
-        BangOlufsenBase.__init__(self, entry, client)
+        BeoBase.__init__(self, entry, client)
 
         self.hass = hass
         self._device = get_device(hass, self._unique_id)
@@ -178,7 +178,7 @@ class BangOlufsenWebsocket(BangOlufsenBase):
                     self.entry.entry_id
                 )
                 if device.serial_number is not None
-                and device.model == BangOlufsenModel.BEOREMOTE_ONE
+                and device.model == BeoModel.BEOREMOTE_ONE
             ]
             # Get paired remotes from device
             remote_serial_numbers = [
@@ -274,4 +274,4 @@ class BangOlufsenWebsocket(BangOlufsenBase):
         }
 
         _LOGGER.debug("%s", debug_notification)
-        self.hass.bus.async_fire(BANG_OLUFSEN_WEBSOCKET_EVENT, debug_notification)
+        self.hass.bus.async_fire(BEO_WEBSOCKET_EVENT, debug_notification)

--- a/tests/components/bang_olufsen/const.py
+++ b/tests/components/bang_olufsen/const.py
@@ -29,7 +29,7 @@ from homeassistant.components.bang_olufsen.const import (
     ATTR_SERIAL_NUMBER,
     ATTR_TYPE_NUMBER,
     CONF_BEOLINK_JID,
-    BangOlufsenSource,
+    BeoSource,
 )
 from homeassistant.const import CONF_HOST, CONF_MODEL, CONF_NAME
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -148,7 +148,7 @@ TEST_DATA_ZEROCONF_IPV6 = ZeroconfServiceInfo(
 TEST_SOURCE = Source(
     name="Tidal", id="tidal", is_seekable=True, is_enabled=True, is_playable=True
 )
-TEST_AUDIO_SOURCES = [TEST_SOURCE.name, BangOlufsenSource.LINE_IN.name]
+TEST_AUDIO_SOURCES = [TEST_SOURCE.name, BeoSource.LINE_IN.name]
 TEST_VIDEO_SOURCES = ["HDMI A"]
 TEST_SOURCES = TEST_AUDIO_SOURCES + TEST_VIDEO_SOURCES
 TEST_FALLBACK_SOURCES = [

--- a/tests/components/bang_olufsen/snapshots/test_media_player.ambr
+++ b/tests/components/bang_olufsen/snapshots/test_media_player.ambr
@@ -2,16 +2,16 @@
 # name: test_async_beolink_allstandby
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -50,16 +50,16 @@
 # name: test_async_beolink_expand[all_discovered-True-None-log_messages0-3]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -71,7 +71,7 @@
         'listener_not_in_hass-1111.1111111.33333333@products.bang-olufsen.com',
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
-      'media_content_type': <BangOlufsenMediaType.TIDAL: 'tidal'>,
+      'media_content_type': <BeoMediaType.TIDAL: 'tidal'>,
       'repeat': <RepeatMode.OFF: 'off'>,
       'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
@@ -99,16 +99,16 @@
 # name: test_async_beolink_expand[all_discovered-True-expand_side_effect1-log_messages1-3]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -120,7 +120,7 @@
         'listener_not_in_hass-1111.1111111.33333333@products.bang-olufsen.com',
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
-      'media_content_type': <BangOlufsenMediaType.TIDAL: 'tidal'>,
+      'media_content_type': <BeoMediaType.TIDAL: 'tidal'>,
       'repeat': <RepeatMode.OFF: 'off'>,
       'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
@@ -148,16 +148,16 @@
 # name: test_async_beolink_expand[beolink_jids-parameter_value2-None-log_messages2-2]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -169,7 +169,7 @@
         'listener_not_in_hass-1111.1111111.33333333@products.bang-olufsen.com',
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
-      'media_content_type': <BangOlufsenMediaType.TIDAL: 'tidal'>,
+      'media_content_type': <BeoMediaType.TIDAL: 'tidal'>,
       'repeat': <RepeatMode.OFF: 'off'>,
       'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
@@ -197,16 +197,16 @@
 # name: test_async_beolink_expand[beolink_jids-parameter_value3-expand_side_effect3-log_messages3-2]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -218,7 +218,7 @@
         'listener_not_in_hass-1111.1111111.33333333@products.bang-olufsen.com',
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
-      'media_content_type': <BangOlufsenMediaType.TIDAL: 'tidal'>,
+      'media_content_type': <BeoMediaType.TIDAL: 'tidal'>,
       'repeat': <RepeatMode.OFF: 'off'>,
       'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
@@ -246,16 +246,16 @@
 # name: test_async_beolink_join[service_parameters0-method_parameters0]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -294,16 +294,16 @@
 # name: test_async_beolink_join[service_parameters1-method_parameters1]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -342,16 +342,16 @@
 # name: test_async_beolink_join[service_parameters2-method_parameters2]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -390,16 +390,16 @@
 # name: test_async_beolink_join_invalid[service_parameters0-expected_result0]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -438,16 +438,16 @@
 # name: test_async_beolink_join_invalid[service_parameters1-expected_result1]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -486,16 +486,16 @@
 # name: test_async_beolink_join_invalid[service_parameters2-expected_result2]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -534,16 +534,16 @@
 # name: test_async_beolink_unexpand
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -582,16 +582,16 @@
 # name: test_async_join_players[group_members0-1-0]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -603,7 +603,7 @@
         'listener_not_in_hass-1111.1111111.33333333@products.bang-olufsen.com',
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
-      'media_content_type': <BangOlufsenMediaType.TIDAL: 'tidal'>,
+      'media_content_type': <BeoMediaType.TIDAL: 'tidal'>,
       'repeat': <RepeatMode.OFF: 'off'>,
       'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
@@ -631,16 +631,16 @@
 # name: test_async_join_players[group_members0-1-0].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.22222222@products.bang-olufsen.com',
         }),
       }),
@@ -680,16 +680,16 @@
 # name: test_async_join_players[group_members1-0-1]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -701,7 +701,7 @@
         'listener_not_in_hass-1111.1111111.33333333@products.bang-olufsen.com',
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
-      'media_content_type': <BangOlufsenMediaType.TIDAL: 'tidal'>,
+      'media_content_type': <BeoMediaType.TIDAL: 'tidal'>,
       'repeat': <RepeatMode.OFF: 'off'>,
       'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
@@ -729,16 +729,16 @@
 # name: test_async_join_players[group_members1-0-1].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.22222222@products.bang-olufsen.com',
         }),
       }),
@@ -778,16 +778,16 @@
 # name: test_async_join_players_invalid[source0-group_members0-expected_result0-invalid_source]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -828,16 +828,16 @@
 # name: test_async_join_players_invalid[source0-group_members0-expected_result0-invalid_source].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.22222222@products.bang-olufsen.com',
         }),
       }),
@@ -877,16 +877,16 @@
 # name: test_async_join_players_invalid[source1-group_members1-expected_result1-invalid_grouping_entity]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -898,7 +898,7 @@
         'listener_not_in_hass-1111.1111111.33333333@products.bang-olufsen.com',
         'listener_not_in_hass-1111.1111111.44444444@products.bang-olufsen.com',
       ]),
-      'media_content_type': <BangOlufsenMediaType.TIDAL: 'tidal'>,
+      'media_content_type': <BeoMediaType.TIDAL: 'tidal'>,
       'repeat': <RepeatMode.OFF: 'off'>,
       'shuffle': False,
       'sound_mode': 'Test Listening Mode (123)',
@@ -926,16 +926,16 @@
 # name: test_async_join_players_invalid[source1-group_members1-expected_result1-invalid_grouping_entity].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.22222222@products.bang-olufsen.com',
         }),
       }),
@@ -975,16 +975,16 @@
 # name: test_async_unjoin_player
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -1023,15 +1023,15 @@
 # name: test_async_update_beolink_listener
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LEADER: 'leader'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LEADER: 'leader'>: dict({
           'Laundry room Core': '1111.1111111.22222222@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.11111111@products.bang-olufsen.com',
         }),
       }),
@@ -1069,16 +1069,16 @@
 # name: test_async_update_beolink_listener.1
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <BangOlufsenAttribute.BEOLINK: 'beolink'>: dict({
-        <BangOlufsenAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
+      <BeoAttribute.BEOLINK: 'beolink'>: dict({
+        <BeoAttribute.BEOLINK_LISTENERS: 'listeners'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_PEERS: 'peers'>: dict({
+        <BeoAttribute.BEOLINK_PEERS: 'peers'>: dict({
           'Bedroom Premiere': '1111.1111111.33333333@products.bang-olufsen.com',
           'Lounge room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
         }),
-        <BangOlufsenAttribute.BEOLINK_SELF: 'self'>: dict({
+        <BeoAttribute.BEOLINK_SELF: 'self'>: dict({
           'Living room Balance': '1111.1111111.22222222@products.bang-olufsen.com',
         }),
       }),

--- a/tests/components/bang_olufsen/test_media_player.py
+++ b/tests/components/bang_olufsen/test_media_player.py
@@ -21,11 +21,11 @@ from syrupy.filters import props
 from voluptuous import Invalid, MultipleInvalid
 
 from homeassistant.components.bang_olufsen.const import (
-    BANG_OLUFSEN_REPEAT_FROM_HA,
-    BANG_OLUFSEN_STATES,
+    BEO_REPEAT_FROM_HA,
+    BEO_STATES,
     DOMAIN,
-    BangOlufsenMediaType,
-    BangOlufsenSource,
+    BeoMediaType,
+    BeoSource,
 )
 from homeassistant.components.media_player import (
     ATTR_GROUP_MEMBERS,
@@ -354,7 +354,7 @@ async def test_async_update_playback_state(
     [
         # URI source, url media type expected
         (
-            BangOlufsenSource.URI_STREAMER,
+            BeoSource.URI_STREAMER,
             MediaType.URL,
             TEST_PLAYBACK_PROGRESS.progress,
             PlaybackContentMetadata(),
@@ -362,7 +362,7 @@ async def test_async_update_playback_state(
         ),
         # Line-In source, music media type expected, progress 0 expected
         (
-            BangOlufsenSource.LINE_IN,
+            BeoSource.LINE_IN,
             MediaType.MUSIC,
             0,
             PlaybackContentMetadata(),
@@ -370,24 +370,24 @@ async def test_async_update_playback_state(
         ),
         # Tidal source, tidal media type expected, media content id expected
         (
-            BangOlufsenSource.TIDAL,
-            BangOlufsenMediaType.TIDAL,
+            BeoSource.TIDAL,
+            BeoMediaType.TIDAL,
             TEST_PLAYBACK_PROGRESS.progress,
             PlaybackContentMetadata(source_internal_id="123"),
             True,
         ),
         # Deezer source, deezer media type expected, media content id expected
         (
-            BangOlufsenSource.DEEZER,
-            BangOlufsenMediaType.DEEZER,
+            BeoSource.DEEZER,
+            BeoMediaType.DEEZER,
             TEST_PLAYBACK_PROGRESS.progress,
             PlaybackContentMetadata(source_internal_id="123"),
             True,
         ),
         # Radio source, radio media type expected, media content id expected
         (
-            BangOlufsenSource.NET_RADIO,
-            BangOlufsenMediaType.RADIO,
+            BeoSource.NET_RADIO,
+            BeoMediaType.RADIO,
             TEST_PLAYBACK_PROGRESS.progress,
             PlaybackContentMetadata(source_internal_id="123"),
             True,
@@ -454,7 +454,7 @@ async def test_async_turn_off(
 
     assert (states := hass.states.get(TEST_MEDIA_PLAYER_ENTITY_ID))
     assert TEST_PLAYBACK_STATE_TURN_OFF.value
-    assert states.state == BANG_OLUFSEN_STATES[TEST_PLAYBACK_STATE_TURN_OFF.value]
+    assert states.state == BEO_STATES[TEST_PLAYBACK_STATE_TURN_OFF.value]
 
     # Check API call
     mock_mozart_client.post_standby.assert_called_once()
@@ -513,7 +513,7 @@ async def test_async_update_beolink_line_in(
     beolink_callback = mock_mozart_client.get_notification_notifications.call_args[0][0]
 
     # Set source
-    source_change_callback(BangOlufsenSource.LINE_IN)
+    source_change_callback(BeoSource.LINE_IN)
     await beolink_callback(WebsocketNotificationTag(value="beolinkListeners"))
 
     assert (states := hass.states.get(TEST_MEDIA_PLAYER_ENTITY_ID))
@@ -669,7 +669,7 @@ async def test_async_media_play_pause(
 
     assert (states := hass.states.get(TEST_MEDIA_PLAYER_ENTITY_ID))
     assert initial_state.value
-    assert states.state == BANG_OLUFSEN_STATES[initial_state.value]
+    assert states.state == BEO_STATES[initial_state.value]
 
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
@@ -696,7 +696,7 @@ async def test_async_media_stop(
 
     assert (states := hass.states.get(TEST_MEDIA_PLAYER_ENTITY_ID))
     assert TEST_PLAYBACK_STATE_PLAYING.value
-    assert states.state == BANG_OLUFSEN_STATES[TEST_PLAYBACK_STATE_PLAYING.value]
+    assert states.state == BEO_STATES[TEST_PLAYBACK_STATE_PLAYING.value]
 
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
@@ -731,7 +731,7 @@ async def test_async_media_next_track(
         # Seekable source, seek expected
         (TEST_SOURCE, does_not_raise(), 1),
         # Non seekable source, seek shouldn't work
-        (BangOlufsenSource.LINE_IN, pytest.raises(HomeAssistantError), 0),
+        (BeoSource.LINE_IN, pytest.raises(HomeAssistantError), 0),
         # Malformed source, seek shouldn't work
         (Source(), pytest.raises(HomeAssistantError), 0),
     ],
@@ -1331,7 +1331,7 @@ async def test_async_join_players(
     [
         # Invalid source
         (
-            BangOlufsenSource.LINE_IN,
+            BeoSource.LINE_IN,
             [TEST_MEDIA_PLAYER_ENTITY_ID_2],
             pytest.raises(ServiceValidationError),
             "invalid_source",
@@ -1653,7 +1653,7 @@ async def test_async_set_repeat(
 
     # Set the return value of the repeat endpoint to match service call
     mock_mozart_client.get_settings_queue.return_value = PlayQueueSettings(
-        repeat=BANG_OLUFSEN_REPEAT_FROM_HA[repeat]
+        repeat=BEO_REPEAT_FROM_HA[repeat]
     )
 
     await hass.services.async_call(
@@ -1666,12 +1666,10 @@ async def test_async_set_repeat(
         blocking=True,
     )
     mock_mozart_client.set_settings_queue.assert_called_once_with(
-        play_queue_settings=PlayQueueSettings(
-            repeat=BANG_OLUFSEN_REPEAT_FROM_HA[repeat]
-        )
+        play_queue_settings=PlayQueueSettings(repeat=BEO_REPEAT_FROM_HA[repeat])
     )
 
-    # Test the BANG_OLUFSEN_REPEAT_TO_HA dict by checking property value
+    # Test the BEO_REPEAT_TO_HA dict by checking property value
     assert (states := hass.states.get(TEST_MEDIA_PLAYER_ENTITY_ID))
     assert states.attributes[ATTR_MEDIA_REPEAT] == repeat
 

--- a/tests/components/bang_olufsen/test_websocket.py
+++ b/tests/components/bang_olufsen/test_websocket.py
@@ -13,7 +13,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.bang_olufsen.const import (
-    BANG_OLUFSEN_WEBSOCKET_EVENT,
+    BEO_WEBSOCKET_EVENT,
     CONNECTION_STATUS,
     DOMAIN,
     WebsocketNotification,
@@ -376,8 +376,8 @@ async def test_on_all_notifications_raw(
 
     mock_event_callback = Mock()
 
-    # Listen to BANG_OLUFSEN_WEBSOCKET_EVENT events
-    hass.bus.async_listen(BANG_OLUFSEN_WEBSOCKET_EVENT, mock_event_callback)
+    # Listen to BEO_WEBSOCKET_EVENT events
+    hass.bus.async_listen(BEO_WEBSOCKET_EVENT, mock_event_callback)
 
     # Trigger the notification
     all_notifications_raw_callback(raw_notification)
@@ -386,5 +386,5 @@ async def test_on_all_notifications_raw(
     assert str(raw_notification_full) in caplog.text
 
     mocked_call = mock_event_callback.call_args[0][0].as_dict()
-    assert mocked_call["event_type"] == BANG_OLUFSEN_WEBSOCKET_EVENT
+    assert mocked_call["event_type"] == BEO_WEBSOCKET_EVENT
     assert mocked_call["data"] == raw_notification_full


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, many classes in the bang_olufsen integration have the `BangOlufsen` prefix and constants `BANG_OLUFSEN`. This means that class names can be become very long, such as: `BangOlufsenRemoteKeyEvent`.

This PR reduces the length of these classes and constants by using `Beo` and `BEO` as prefixes instead, so `BangOlufsenRemoteKeyEvent` -> `BeoRemoteKeyEvent`.

The "Beo" prefix is widely used in Bang & Olufsen products.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
