### PR TITLE
Add Cloud mode support to Ollama integration

### DIFF
--- a/homeassistant/components/ollama/const.py
+++ b/homeassistant/components/ollama/const.py
@@ -7,6 +7,12 @@ DEFAULT_NAME = "Ollama"
 CONF_MODEL = "model"
 CONF_PROMPT = "prompt"
 CONF_THINK = "think"
+CONF_MODE = "mode"
+CONF_API_KEY = "api_key"
+
+MODE_LOCAL = "local"
+MODE_CLOUD = "cloud"
+CLOUD_URL = "https://ollama.com"
 
 CONF_KEEP_ALIVE = "keep_alive"
 DEFAULT_KEEP_ALIVE = -1  # seconds. -1 = indefinite, 0 = never

--- a/homeassistant/components/ollama/strings.json
+++ b/homeassistant/components/ollama/strings.json
@@ -5,14 +5,31 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "Invalid authentication credentials",
       "invalid_url": "[%key:common::config_flow::error::invalid_host%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
-      "user": {
+      "cloud": {
+        "data": {
+          "api_key": "API key"
+        },
+        "data_description": {
+          "api_key": "Create an API key at https://ollama.com/settings/keys"
+        },
+        "description": "Connect to Ollama Cloud. Cloud models run on Ollama's servers without requiring a local GPU."
+      },
+      "local": {
         "data": {
           "url": "[%key:common::config_flow::data::url%]"
-        }
+        },
+        "description": "Connect to a local Ollama server."
+      },
+      "user": {
+        "data": {
+          "mode": "Connection mode"
+        },
+        "description": "Choose how you want to connect to Ollama."
       }
     }
   },


### PR DESCRIPTION
## Proposed change

This PR adds optional support for **Ollama Cloud** as an additional execution
endpoint for the existing Ollama integration.

Until now, Home Assistant could only communicate with a **local Ollama daemon**.
With this change, users can create integration instances that point either to:

- a **local Ollama service** (current and default behaviour), or  
- the **Ollama Cloud API** (`https://ollama.com/api/chat`) using an API key.

Both modes are implemented as first-class configuration paths inside the
integration. Multiple instances can coexist, and each one can expose its own
conversation agents and AI tasks. The migration logic ensures that existing
entries are transparently upgraded to the new flow and default to **Local**.

The goal of this PR is not to replace or redefine how Ollama should be used in
Home Assistant, but to unlock an additional configuration option for users who:

- cannot or do not want to run the local daemon,
- use Home Assistant OS or Container without the ability to install additional
  system services,
- rely on large models that run only in the cloud.

The change is intentionally scoped so that we can refine the direction together
during review—feedback on API design, UX decisions, and integration boundaries
is very welcome.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to the feature request for Ollama Cloud support.
- Link to documentation pull request: *to be added after review consensus*
- The PR includes support for config flow, data migration, conversation agent,
  AI task handling, and error handling for remote calls.

### Tests

Full tests have been added for the new Cloud path, covering:

- config flow (including authentication errors, connection failures, and
  invalid input),
- entry migration of existing local configurations,
- remote API communication and error surface,
- conversation and AI task execution paths using the cloud backend.

The local path continues to be tested as before, and shared logic is exercised
through both configurations.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a
      diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
