### PR TITLE
Display error when forming new ZHA network fails

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -680,6 +680,13 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
 
         try:
             await self._form_network_task
+        except Exception as exc:
+            _LOGGER.exception("Failed to form new network")
+            self._progress_error = AbortFlow(
+                reason="cannot_form_network",
+                description_placeholders={"error": str(exc)},
+            )
+            return self.async_show_progress_done(next_step_id="progress_failed")
         finally:
             self._form_network_task = None
 

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "abort": {
+      "cannot_form_network": "Could not form a new Zigbee network.\n\nError: {error}",
       "cannot_resolve_path": "Could not resolve device path: {path}",
       "cannot_restore_backup": "The adapter you are restoring to does not properly support backup restoration. Please upgrade the firmware.\n\nError: {error}",
       "cannot_restore_backup_no_ieee_confirm": "The adapter you are restoring to has outdated firmware and cannot write the adapter IEEE address multiple times. Please upgrade the firmware or confirm permanent overwrite in the previous step.",
@@ -1923,6 +1924,7 @@
   },
   "options": {
     "abort": {
+      "cannot_form_network": "[%key:component::zha::config::abort::cannot_form_network%]",
       "cannot_resolve_path": "[%key:component::zha::config::abort::cannot_resolve_path%]",
       "cannot_restore_backup": "[%key:component::zha::config::abort::cannot_restore_backup%]",
       "cannot_restore_backup_no_ieee_confirm": "[%key:component::zha::config::abort::cannot_restore_backup_no_ieee_confirm%]",

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -1813,6 +1813,36 @@ async def test_formation_strategy_form_initial_network(
     assert result2["type"] is FlowResultType.CREATE_ENTRY
 
 
+async def test_formation_strategy_form_initial_network_failure(
+    advanced_pick_radio: RadioPicker, mock_app: AsyncMock, hass: HomeAssistant
+) -> None:
+    """Test forming a new network that fails with an exception."""
+    # Mock form_network to raise an exception
+    mock_app.form_network.side_effect = DelayedAsyncMock(
+        side_effect=Exception("Network formation failed")
+    )
+
+    result = await advanced_pick_radio(RadioType.ezsp)
+    result_form = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": config_flow.FORMATION_FORM_NEW_NETWORK},
+    )
+
+    result2 = await consume_progress_flow(
+        hass,
+        flow_id=result_form["flow_id"],
+        valid_step_ids=("form_new_network",),
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "cannot_form_network"
+    assert "Network formation failed" in result2["description_placeholders"]["error"]
+
+    # Verify form_network was called
+    mock_app.form_network.assert_called_once()
+
+
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 async def test_onboarding_auto_formation_new_hardware(


### PR DESCRIPTION
## Proposed change

This broadly catches all exceptions when ZHA network formation fails, displays a user-facing error message, and logs further detail. Before this PR, the UI spinner for the config flow progress task would spin endlessly, providing no feedback.

Example error message:
<img width="376" height="199" alt="Bildschirmfoto 2025-12-03 um 17 03 57" src="https://github.com/user-attachments/assets/a336a285-8364-4863-ab76-b182306fbda9" />

We want to broadly catch all exceptions for now, as there's an issue in HA Core where unexpected exceptions (in config flows progress tasks) are swallowed due to an underlying issue. Related PRs for that:
- https://github.com/home-assistant/core/pull/157662
- https://github.com/home-assistant/core/pull/157691

### Background

We're seeing multiple people run into an issue where ZHA network formation fails for some unknown reason, causing them to end up with an endless spinner. Due to the Core issue, there's nothing in the logs about the error. Related issues:
- https://community.home-assistant.io/t/zbt-2-frustrations-forming-a-new-network/956361
- https://github.com/home-assistant/core/issues/157856

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
