### PR TITLE
Redesign frontend.set_theme service form

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
     EVENT_THEMES_UPDATED,
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.icon import async_get_icons
 from homeassistant.helpers.json import json_dumps_sorted
@@ -576,8 +576,7 @@ async def _async_setup_themes(
             name not in (DEFAULT_THEME, VALUE_NO_THEME)
             and name not in hass.data[DATA_THEMES]
         ):
-            _LOGGER.warning("Theme %s not found", name)
-            return
+            raise ServiceValidationError(f"Theme {name} not found")
 
         light_mode = mode == "light"
 
@@ -610,19 +609,17 @@ async def _async_setup_themes(
         name_dark = call.data.get(CONF_NAME_DARK)
 
         if (
-            name
+            name is not None
             and name not in (DEFAULT_THEME, VALUE_NO_THEME)
             and name not in hass.data[DATA_THEMES]
         ):
-            _LOGGER.warning("Theme %s not found", name)
-            return
+            raise ServiceValidationError(f"Theme {name} not found")
         if (
-            name_dark
+            name_dark is not None
             and name_dark not in (DEFAULT_THEME, VALUE_NO_THEME)
             and name_dark not in hass.data[DATA_THEMES]
         ):
-            _LOGGER.warning("Theme %s not found", name_dark)
-            return
+            raise ServiceValidationError(f"Theme {name_dark} not found")
 
         if name:
             hass.data[DATA_DEFAULT_THEME] = (

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -577,32 +577,34 @@ async def _async_setup_themes(
             MANIFEST_JSON.update_key("theme_color", DEFAULT_THEME_COLOR)
         hass.bus.async_fire(EVENT_THEMES_UPDATED)
 
-    def update_hass_theme(theme: str, light: bool) -> None:
-        theme_key = DATA_DEFAULT_THEME if light else DATA_DEFAULT_DARK_THEME
-        if theme == VALUE_NO_THEME:
-            to_set = DEFAULT_THEME if light else None
-        else:
-            _LOGGER.info(
-                "Theme %s set as default %s theme", theme, "light" if light else "dark"
-            )
-            to_set = theme
-        hass.data[theme_key] = to_set
-
     @callback
     def set_theme(call: ServiceCall) -> None:
         """Set backend-preferred theme."""
+
+        def _update_hass_theme(theme: str, light: bool) -> None:
+            theme_key = DATA_DEFAULT_THEME if light else DATA_DEFAULT_DARK_THEME
+            if theme == VALUE_NO_THEME:
+                to_set = DEFAULT_THEME if light else None
+            else:
+                _LOGGER.info(
+                    "Theme %s set as default %s theme",
+                    theme,
+                    "light" if light else "dark",
+                )
+                to_set = theme
+            hass.data[theme_key] = to_set
 
         name = call.data.get(CONF_NAME)
         if name is not None and CONF_MODE in call.data:
             mode = call.data.get("mode", "light")
             light_mode = mode == "light"
-            update_hass_theme(name, light_mode)
+            _update_hass_theme(name, light_mode)
         else:
             name_dark = call.data.get(CONF_NAME_DARK)
             if name:
-                update_hass_theme(name, True)
+                _update_hass_theme(name, True)
             if name_dark:
-                update_hass_theme(name_dark, False)
+                _update_hass_theme(name_dark, False)
 
         store.async_delay_save(
             lambda: {

--- a/homeassistant/components/frontend/services.yaml
+++ b/homeassistant/components/frontend/services.yaml
@@ -3,17 +3,15 @@
 set_theme:
   fields:
     name:
-      required: true
+      required: false
       example: "default"
       selector:
         theme:
           include_default: true
-    mode:
-      default: "light"
+    name_dark:
+      required: false
+      example: "default"
       selector:
-        select:
-          options:
-            - "dark"
-            - "light"
-          translation_key: mode
+        theme:
+          include_default: true
 reload_themes:

--- a/homeassistant/components/frontend/strings.json
+++ b/homeassistant/components/frontend/strings.json
@@ -24,7 +24,7 @@
           "name": "Dark theme override"
         }
       },
-      "name": "Set the theme"
+      "name": "Set theme"
     }
   }
 }

--- a/homeassistant/components/frontend/strings.json
+++ b/homeassistant/components/frontend/strings.json
@@ -13,18 +13,18 @@
       "name": "Reload themes"
     },
     "set_theme": {
-      "description": "Sets the default theme Home Assistant uses. Can be overridden by a user.",
+      "description": "Sets the theme Home Assistant uses. Can be overridden by a user.",
       "fields": {
         "name": {
-          "description": "Name of the theme to use when a light mode client requests the default theme.",
+          "description": "Name of the theme that is used by default.",
           "name": "Theme"
         },
         "name_dark": {
-          "description": "Name of the theme to use when a dark mode client requests the default theme.",
-          "name": "Dark theme"
+          "description": "Alternative dark-mode theme that is used by default.",
+          "name": "Dark theme override"
         }
       },
-      "name": "Set the default theme"
+      "name": "Set the theme"
     }
   }
 }

--- a/homeassistant/components/frontend/strings.json
+++ b/homeassistant/components/frontend/strings.json
@@ -16,12 +16,12 @@
       "description": "Sets the default theme Home Assistant uses. Can be overridden by a user.",
       "fields": {
         "name": {
-          "description": "Name of the theme to use when a light-mode client requests the default theme.",
+          "description": "Name of the theme to use when a light mode client requests the default theme.",
           "name": "Theme"
         },
         "name_dark": {
-          "description": "Name of the theme to use when a dark-mode client requests the default theme.",
-          "name": "Dark Theme"
+          "description": "Name of the theme to use when a dark mode client requests the default theme.",
+          "name": "Dark theme"
         }
       },
       "name": "Set the default theme"

--- a/homeassistant/components/frontend/strings.json
+++ b/homeassistant/components/frontend/strings.json
@@ -7,14 +7,6 @@
       "name": "Winter mode"
     }
   },
-  "selector": {
-    "mode": {
-      "options": {
-        "dark": "Dark",
-        "light": "Light"
-      }
-    }
-  },
   "services": {
     "reload_themes": {
       "description": "Reloads themes from the YAML-configuration.",
@@ -23,13 +15,13 @@
     "set_theme": {
       "description": "Sets the default theme Home Assistant uses. Can be overridden by a user.",
       "fields": {
-        "mode": {
-          "description": "Theme mode.",
-          "name": "Mode"
-        },
         "name": {
-          "description": "Name of a theme.",
+          "description": "Name of the theme to use when a light-mode client requests the default theme.",
           "name": "Theme"
+        },
+        "name_dark": {
+          "description": "Name of the theme to use when a dark-mode client requests the default theme.",
+          "name": "Dark Theme"
         }
       },
       "name": "Set the default theme"

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from aiohttp.test_utils import TestClient
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+import voluptuous as vol
 
 from homeassistant.components.frontend import (
     CONF_EXTRA_JS_URL_ES5,
@@ -27,7 +28,7 @@ from homeassistant.components.frontend import (
 )
 from homeassistant.components.websocket_api import TYPE_RESULT
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import async_get_integration
 from homeassistant.setup import async_setup_component
 
@@ -343,7 +344,7 @@ async def test_themes_set_theme_wrong_name(
     """Test frontend.set_theme service called with wrong name."""
 
     with pytest.raises(
-        ServiceValidationError,
+        vol.error.MultipleInvalid,
         match="Theme wrong not found",
     ):
         await hass.services.async_call(
@@ -447,7 +448,7 @@ async def test_themes_set_dark_theme_wrong_name(
 ) -> None:
     """Test frontend.set_theme service called with mode dark and wrong name."""
     with pytest.raises(
-        ServiceValidationError,
+        vol.error.MultipleInvalid,
         match="Theme wrong not found",
     ):
         await hass.services.async_call(DOMAIN, "set_theme", schema, blocking=True)
@@ -470,7 +471,7 @@ async def test_themes_reload_themes(
         return_value={DOMAIN: {CONF_THEMES: {"sad": {"primary-color": "blue"}}}},
     ):
         with pytest.raises(
-            ServiceValidationError,
+            vol.error.MultipleInvalid,
             match="Theme happy not found",
         ):
             await hass.services.async_call(

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -27,7 +27,7 @@ from homeassistant.components.frontend import (
 )
 from homeassistant.components.websocket_api import TYPE_RESULT
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.loader import async_get_integration
 from homeassistant.setup import async_setup_component
 
@@ -342,9 +342,13 @@ async def test_themes_set_theme_wrong_name(
 ) -> None:
     """Test frontend.set_theme service called with wrong name."""
 
-    await hass.services.async_call(
-        DOMAIN, "set_theme", {"name": "wrong"}, blocking=True
-    )
+    with pytest.raises(
+        ServiceValidationError,
+        match="Theme wrong not found",
+    ):
+        await hass.services.async_call(
+            DOMAIN, "set_theme", {"name": "wrong"}, blocking=True
+        )
 
     await themes_ws_client.send_json({"id": 5, "type": "frontend/get_themes"})
 
@@ -442,7 +446,11 @@ async def test_themes_set_dark_theme_wrong_name(
     hass: HomeAssistant, themes_ws_client: MockHAClientWebSocket, schema
 ) -> None:
     """Test frontend.set_theme service called with mode dark and wrong name."""
-    await hass.services.async_call(DOMAIN, "set_theme", schema, blocking=True)
+    with pytest.raises(
+        ServiceValidationError,
+        match="Theme wrong not found",
+    ):
+        await hass.services.async_call(DOMAIN, "set_theme", schema, blocking=True)
 
     await themes_ws_client.send_json({"id": 5, "type": "frontend/get_themes"})
 
@@ -461,9 +469,13 @@ async def test_themes_reload_themes(
         "homeassistant.components.frontend.async_hass_config_yaml",
         return_value={DOMAIN: {CONF_THEMES: {"sad": {"primary-color": "blue"}}}},
     ):
-        await hass.services.async_call(
-            DOMAIN, "set_theme", {"name": "happy"}, blocking=True
-        )
+        with pytest.raises(
+            ServiceValidationError,
+            match="Theme happy not found",
+        ):
+            await hass.services.async_call(
+                DOMAIN, "set_theme", {"name": "happy"}, blocking=True
+            )
         await hass.services.async_call(DOMAIN, "reload_themes", blocking=True)
 
     await themes_ws_client.send_json({"id": 5, "type": "frontend/get_themes"})

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -279,6 +279,30 @@ async def test_themes_save_storage(
     }
 
 
+@pytest.mark.usefixtures("frontend_themes")
+async def test_themes_save_storage_new_schema(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that theme settings are restores after restart."""
+
+    await hass.services.async_call(
+        DOMAIN, "set_theme", {"name": "happy", "name_dark": "dark"}, blocking=True
+    )
+
+    # To trigger the call_later
+    freezer.tick(60.0)
+    async_fire_time_changed(hass)
+    # To execute the save
+    await hass.async_block_till_done()
+
+    assert hass_storage[THEMES_STORAGE_KEY]["data"] == {
+        "frontend_default_theme": "happy",
+        "frontend_default_dark_theme": "dark",
+    }
+
+
 async def test_themes_set_theme(
     hass: HomeAssistant, themes_ws_client: MockHAClientWebSocket
 ) -> None:
@@ -371,14 +395,54 @@ async def test_themes_set_dark_theme(
     assert msg["result"]["default_dark_theme"] == "light_and_dark"
 
 
-@pytest.mark.usefixtures("frontend")
-async def test_themes_set_dark_theme_wrong_name(
+async def test_themes_set_combined_theme(
     hass: HomeAssistant, themes_ws_client: MockHAClientWebSocket
 ) -> None:
-    """Test frontend.set_theme service called with mode dark and wrong name."""
+    """Test frontend.set_theme service setting both light and dark modes."""
+
     await hass.services.async_call(
-        DOMAIN, "set_theme", {"name": "wrong", "mode": "dark"}, blocking=True
+        DOMAIN, "set_theme", {"name_dark": "dark"}, blocking=True
     )
+
+    await themes_ws_client.send_json({"id": 5, "type": "frontend/get_themes"})
+    msg = await themes_ws_client.receive_json()
+
+    assert msg["result"]["default_theme"] == "default"
+    assert msg["result"]["default_dark_theme"] == "dark"
+
+    await hass.services.async_call(
+        DOMAIN, "set_theme", {"name": "happy"}, blocking=True
+    )
+
+    await themes_ws_client.send_json({"id": 6, "type": "frontend/get_themes"})
+    msg = await themes_ws_client.receive_json()
+
+    assert msg["result"]["default_theme"] == "happy"
+    assert msg["result"]["default_dark_theme"] == "dark"
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_theme",
+        {"name": "light_only", "name_dark": "dark_only"},
+        blocking=True,
+    )
+
+    await themes_ws_client.send_json({"id": 7, "type": "frontend/get_themes"})
+    msg = await themes_ws_client.receive_json()
+
+    assert msg["result"]["default_theme"] == "light_only"
+    assert msg["result"]["default_dark_theme"] == "dark_only"
+
+
+@pytest.mark.usefixtures("frontend")
+@pytest.mark.parametrize(
+    ("schema"), [{"name": "wrong", "mode": "dark"}, {"name_dark": "wrong"}]
+)
+async def test_themes_set_dark_theme_wrong_name(
+    hass: HomeAssistant, themes_ws_client: MockHAClientWebSocket, schema
+) -> None:
+    """Test frontend.set_theme service called with mode dark and wrong name."""
+    await hass.services.async_call(DOMAIN, "set_theme", schema, blocking=True)
 
     await themes_ws_client.send_json({"id": 5, "type": "frontend/get_themes"})
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
The current service schema for `frontend.set_theme` I think is not very intuitive, and I think it's misleading to a lot of users. 
<img width="755" height="389" alt="image" src="https://github.com/user-attachments/assets/3183abc8-e3fe-4af7-8072-f34b13616e5a" />

I believe when users see the radio buttons for light/dark, they intuitively think that calling this service can somehow change their UI to dark or light mode, and they get confused when calling this service seems to have no effect, e.g. because their client is set to light mode, and they keep changing the dark mode theme which doesn't affect them. Which I don't really blame them because the descriptions on this screen doesn't really explain what is happening. 


I think it would be much more intuitive here if we just show two separate theme selectors (and clearly describe their use):

<img width="697" height="357" alt="image" src="https://github.com/user-attachments/assets/2ccb4ea7-1da5-472d-8222-1ed6d949b058" />

Then I think it's much clearer to understand that this service does not influence the light/dark setting of a client. 

The old schema will still work the same, this just adds a new schema that can set one or both modes in a single call. 

Will update docs on approval. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/20977
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42624
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
