### PR TITLE
Remove uneeded async_setup_component from trigger/condition tests

### DIFF
--- a/tests/components/__init__.py
+++ b/tests/components/__init__.py
@@ -38,8 +38,6 @@ async def target_entities(
     - included: List of entity_ids meant to be targeted.
     - excluded: List of entity_ids not meant to be targeted.
     """
-    await async_setup_component(hass, domain, {})
-
     config_entry = MockConfigEntry(domain="test")
     config_entry.add_to_hass(hass)
 

--- a/tests/components/alarm_control_panel/test_trigger.py
+++ b/tests/components/alarm_control_panel/test_trigger.py
@@ -11,7 +11,6 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.const import ATTR_LABEL_ID, ATTR_SUPPORTED_FEATURES, CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.setup import async_setup_component
 
 from tests.components import (
     StateDescription,
@@ -154,8 +153,6 @@ async def test_alarm_control_panel_state_trigger_behavior_any(
     states: list[StateDescription],
 ) -> None:
     """Test that the alarm control panel state trigger fires when any alarm control panel state changes to a specific state."""
-    await async_setup_component(hass, "alarm_control_panel", {})
-
     other_entity_ids = set(target_alarm_control_panels) - {entity_id}
 
     # Set all alarm control panels, including the tested one, to the initial state
@@ -266,8 +263,6 @@ async def test_alarm_control_panel_state_trigger_behavior_first(
     states: list[StateDescription],
 ) -> None:
     """Test that the alarm control panel state trigger fires when the first alarm control panel changes to a specific state."""
-    await async_setup_component(hass, "alarm_control_panel", {})
-
     other_entity_ids = set(target_alarm_control_panels) - {entity_id}
 
     # Set all alarm control panels, including the tested one, to the initial state
@@ -377,8 +372,6 @@ async def test_alarm_control_panel_state_trigger_behavior_last(
     states: list[StateDescription],
 ) -> None:
     """Test that the alarm_control_panel state trigger fires when the last alarm_control_panel changes to a specific state."""
-    await async_setup_component(hass, "alarm_control_panel", {})
-
     other_entity_ids = set(target_alarm_control_panels) - {entity_id}
 
     # Set all alarm control panels, including the tested one, to the initial state

--- a/tests/components/assist_satellite/test_trigger.py
+++ b/tests/components/assist_satellite/test_trigger.py
@@ -8,7 +8,6 @@ import pytest
 from homeassistant.components.assist_satellite.entity import AssistSatelliteState
 from homeassistant.const import ATTR_LABEL_ID, CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.setup import async_setup_component
 
 from tests.components import (
     StateDescription,
@@ -105,8 +104,6 @@ async def test_assist_satellite_state_trigger_behavior_any(
     states: list[StateDescription],
 ) -> None:
     """Test that the assist satellite state trigger fires when any assist satellite state changes to a specific state."""
-    await async_setup_component(hass, "assist_satellite", {})
-
     other_entity_ids = set(target_assist_satellites) - {entity_id}
 
     # Set all assist satellites, including the tested one, to the initial state
@@ -174,8 +171,6 @@ async def test_assist_satellite_state_trigger_behavior_first(
     states: list[StateDescription],
 ) -> None:
     """Test that the assist satellite state trigger fires when the first assist satellite changes to a specific state."""
-    await async_setup_component(hass, "assist_satellite", {})
-
     other_entity_ids = set(target_assist_satellites) - {entity_id}
 
     # Set all assist satellites, including the tested one, to the initial state
@@ -242,8 +237,6 @@ async def test_assist_satellite_state_trigger_behavior_last(
     states: list[StateDescription],
 ) -> None:
     """Test that the assist_satellite state trigger fires when the last assist_satellite changes to a specific state."""
-    await async_setup_component(hass, "assist_satellite", {})
-
     other_entity_ids = set(target_assist_satellites) - {entity_id}
 
     # Set all assist satellites, including the tested one, to the initial state

--- a/tests/components/binary_sensor/test_trigger.py
+++ b/tests/components/binary_sensor/test_trigger.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.setup import async_setup_component
 
 from tests.components import (
     StateDescription,
@@ -101,8 +100,6 @@ async def test_binary_sensor_state_attribute_trigger_behavior_any(
     states: list[StateDescription],
 ) -> None:
     """Test that the binary sensor state trigger fires when any binary sensor state changes to a specific state."""
-    await async_setup_component(hass, "binary_sensor", {})
-
     other_entity_ids = set(target_binary_sensors["included"]) - {entity_id}
     excluded_entity_ids = set(target_binary_sensors["excluded"]) - {entity_id}
 
@@ -172,8 +169,6 @@ async def test_binary_sensor_state_attribute_trigger_behavior_first(
     states: list[StateDescription],
 ) -> None:
     """Test that the binary sensor state trigger fires when the first binary sensor state changes to a specific state."""
-    await async_setup_component(hass, "binary_sensor", {})
-
     other_entity_ids = set(target_binary_sensors["included"]) - {entity_id}
     excluded_entity_ids = set(target_binary_sensors["excluded"]) - {entity_id}
 
@@ -242,8 +237,6 @@ async def test_binary_sensor_state_attribute_trigger_behavior_last(
     states: list[StateDescription],
 ) -> None:
     """Test that the binary sensor state trigger fires when the last binary sensor state changes to a specific state."""
-    await async_setup_component(hass, "binary_sensor", {})
-
     other_entity_ids = set(target_binary_sensors["included"]) - {entity_id}
     excluded_entity_ids = set(target_binary_sensors["excluded"]) - {entity_id}
 

--- a/tests/components/climate/test_trigger.py
+++ b/tests/components/climate/test_trigger.py
@@ -12,7 +12,6 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.const import ATTR_LABEL_ID, CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.setup import async_setup_component
 
 from tests.components import (
     StateDescription,
@@ -107,8 +106,6 @@ async def test_climate_state_trigger_behavior_any(
     states: list[StateDescription],
 ) -> None:
     """Test that the climate state trigger fires when any climate state changes to a specific state."""
-    await async_setup_component(hass, "climate", {})
-
     other_entity_ids = set(target_climates) - {entity_id}
 
     # Set all climates, including the tested climate, to the initial state
@@ -171,8 +168,6 @@ async def test_climate_state_attribute_trigger_behavior_any(
     states: list[StateDescription],
 ) -> None:
     """Test that the climate state trigger fires when any climate state changes to a specific state."""
-    await async_setup_component(hass, "climate", {})
-
     other_entity_ids = set(target_climates) - {entity_id}
 
     # Set all climates, including the tested climate, to the initial state
@@ -239,8 +234,6 @@ async def test_climate_state_trigger_behavior_first(
     states: list[StateDescription],
 ) -> None:
     """Test that the climate state trigger fires when the first climate changes to a specific state."""
-    await async_setup_component(hass, "climate", {})
-
     other_entity_ids = set(target_climates) - {entity_id}
 
     # Set all climates, including the tested climate, to the initial state
@@ -302,8 +295,6 @@ async def test_climate_state_attribute_trigger_behavior_first(
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
     """Test that the climate state trigger fires when any climate state changes to a specific state."""
-    await async_setup_component(hass, "climate", {})
-
     other_entity_ids = set(target_climates) - {entity_id}
 
     # Set all climates, including the tested climate, to the initial state
@@ -369,8 +360,6 @@ async def test_climate_state_trigger_behavior_last(
     states: list[StateDescription],
 ) -> None:
     """Test that the climate state trigger fires when the last climate changes to a specific state."""
-    await async_setup_component(hass, "climate", {})
-
     other_entity_ids = set(target_climates) - {entity_id}
 
     # Set all climates, including the tested climate, to the initial state
@@ -431,8 +420,6 @@ async def test_climate_state_attribute_trigger_behavior_last(
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
     """Test that the climate state trigger fires when any climate state changes to a specific state."""
-    await async_setup_component(hass, "climate", {})
-
     other_entity_ids = set(target_climates) - {entity_id}
 
     # Set all climates, including the tested climate, to the initial state

--- a/tests/components/fan/test_trigger.py
+++ b/tests/components/fan/test_trigger.py
@@ -7,7 +7,6 @@ import pytest
 
 from homeassistant.const import ATTR_LABEL_ID, CONF_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.setup import async_setup_component
 
 from tests.components import (
     StateDescription,
@@ -91,8 +90,6 @@ async def test_fan_state_trigger_behavior_any(
     states: list[StateDescription],
 ) -> None:
     """Test that the fan state trigger fires when any fan state changes to a specific state."""
-    await async_setup_component(hass, "fan", {})
-
     other_entity_ids = set(target_fans) - {entity_id}
 
     # Set all fans, including the tested fan, to the initial state
@@ -150,8 +147,6 @@ async def test_fan_state_trigger_behavior_first(
     states: list[StateDescription],
 ) -> None:
     """Test that the fan state trigger fires when the first fan changes to a specific state."""
-    await async_setup_component(hass, "fan", {})
-
     other_entity_ids = set(target_fans) - {entity_id}
 
     # Set all fans, including the tested fan, to the initial state
@@ -208,8 +203,6 @@ async def test_fan_state_trigger_behavior_last(
     states: list[StateDescription],
 ) -> None:
     """Test that the fan state trigger fires when the last fan changes to a specific state."""
-    await async_setup_component(hass, "fan", {})
-
     other_entity_ids = set(target_fans) - {entity_id}
 
     # Set all fans, including the tested fan, to the initial state

--- a/tests/components/lawn_mower/test_trigger.py
+++ b/tests/components/lawn_mower/test_trigger.py
@@ -8,7 +8,6 @@ import pytest
 from homeassistant.components.lawn_mower import LawnMowerActivity
 from homeassistant.const import ATTR_LABEL_ID, CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.setup import async_setup_component
 
 from tests.components import (
     StateDescription,
@@ -105,8 +104,6 @@ async def test_lawn_mower_state_trigger_behavior_any(
     states: list[StateDescription],
 ) -> None:
     """Test that the lawn mower state trigger fires when any lawn mower state changes to a specific state."""
-    await async_setup_component(hass, "lawn_mower", {})
-
     other_entity_ids = set(target_lawn_mowers) - {entity_id}
 
     # Set all lawn mowers, including the tested one, to the initial state
@@ -174,8 +171,6 @@ async def test_lawn_mower_state_trigger_behavior_first(
     states: list[StateDescription],
 ) -> None:
     """Test that the lawn mower state trigger fires when the first lawn mower changes to a specific state."""
-    await async_setup_component(hass, "lawn_mower", {})
-
     other_entity_ids = set(target_lawn_mowers) - {entity_id}
 
     # Set all lawn mowers, including the tested one, to the initial state
@@ -242,8 +237,6 @@ async def test_lawn_mower_state_trigger_behavior_last(
     states: list[StateDescription],
 ) -> None:
     """Test that the lawn_mower state trigger fires when the last lawn_mower changes to a specific state."""
-    await async_setup_component(hass, "lawn_mower", {})
-
     other_entity_ids = set(target_lawn_mowers) - {entity_id}
 
     # Set all lawn mowers, including the tested one, to the initial state

--- a/tests/components/light/test_condition.py
+++ b/tests/components/light/test_condition.py
@@ -152,8 +152,6 @@ async def test_light_state_condition_behavior_any(
     other_state: str,
 ) -> None:
     """Test the light state condition with the 'any' behavior."""
-    await async_setup_component(hass, "light", {})
-
     other_entity_ids = set(target_lights) - {entity_id}
 
     # Set all lights, including the tested light, to the initial state
@@ -235,8 +233,6 @@ async def test_light_state_condition_behavior_all(
     other_state: str,
 ) -> None:
     """Test the light state condition with the 'all' behavior."""
-    await async_setup_component(hass, "light", {})
-
     # Set state for two switches to ensure that they don't impact the condition
     hass.states.async_set("switch.label_switch_1", STATE_OFF)
     hass.states.async_set("switch.label_switch_2", STATE_ON)

--- a/tests/components/light/test_trigger.py
+++ b/tests/components/light/test_trigger.py
@@ -7,7 +7,6 @@ import pytest
 
 from homeassistant.const import ATTR_LABEL_ID, CONF_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.setup import async_setup_component
 
 from tests.components import (
     StateDescription,
@@ -91,8 +90,6 @@ async def test_light_state_trigger_behavior_any(
     states: list[StateDescription],
 ) -> None:
     """Test that the light state trigger fires when any light state changes to a specific state."""
-    await async_setup_component(hass, "light", {})
-
     other_entity_ids = set(target_lights) - {entity_id}
 
     # Set all lights, including the tested light, to the initial state
@@ -150,8 +147,6 @@ async def test_light_state_trigger_behavior_first(
     states: list[StateDescription],
 ) -> None:
     """Test that the light state trigger fires when the first light changes to a specific state."""
-    await async_setup_component(hass, "light", {})
-
     other_entity_ids = set(target_lights) - {entity_id}
 
     # Set all lights, including the tested light, to the initial state
@@ -208,8 +203,6 @@ async def test_light_state_trigger_behavior_last(
     states: list[StateDescription],
 ) -> None:
     """Test that the light state trigger fires when the last light changes to a specific state."""
-    await async_setup_component(hass, "light", {})
-
     other_entity_ids = set(target_lights) - {entity_id}
 
     # Set all lights, including the tested light, to the initial state

--- a/tests/components/media_player/test_trigger.py
+++ b/tests/components/media_player/test_trigger.py
@@ -8,7 +8,6 @@ import pytest
 from homeassistant.components.media_player import MediaPlayerState
 from homeassistant.const import ATTR_LABEL_ID, CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.setup import async_setup_component
 
 from tests.components import (
     StateDescription,
@@ -94,8 +93,6 @@ async def test_media_player_state_trigger_behavior_any(
     states: list[StateDescription],
 ) -> None:
     """Test that the media player state trigger fires when any media player state changes to a specific state."""
-    await async_setup_component(hass, "media_player", {})
-
     other_entity_ids = set(target_media_players) - {entity_id}
 
     # Set all media players, including the tested media player, to the initial state
@@ -156,8 +153,6 @@ async def test_media_player_state_trigger_behavior_first(
     states: list[StateDescription],
 ) -> None:
     """Test that the media player state trigger fires when the first media player changes to a specific state."""
-    await async_setup_component(hass, "media_player", {})
-
     other_entity_ids = set(target_media_players) - {entity_id}
 
     # Set all media players, including the tested media player, to the initial state
@@ -217,8 +212,6 @@ async def test_media_player_state_trigger_behavior_last(
     states: list[StateDescription],
 ) -> None:
     """Test that the media player state trigger fires when the last media player changes to a specific state."""
-    await async_setup_component(hass, "media_player", {})
-
     other_entity_ids = set(target_media_players) - {entity_id}
 
     # Set all media players, including the tested media player, to the initial state

--- a/tests/components/text/test_trigger.py
+++ b/tests/components/text/test_trigger.py
@@ -12,7 +12,6 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.setup import async_setup_component
 
 from tests.components import (
     StateDescription,
@@ -153,8 +152,6 @@ async def test_text_state_trigger_behavior_any(
     states: list[StateDescription],
 ) -> None:
     """Test that the text state trigger fires when any text state changes to a specific state."""
-    await async_setup_component(hass, "text", {})
-
     other_entity_ids = set(target_texts) - {entity_id}
 
     # Set all texts, including the tested text, to the initial state

--- a/tests/components/vacuum/test_trigger.py
+++ b/tests/components/vacuum/test_trigger.py
@@ -8,7 +8,6 @@ import pytest
 from homeassistant.components.vacuum import VacuumActivity
 from homeassistant.const import ATTR_LABEL_ID, CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.setup import async_setup_component
 
 from tests.components import (
     StateDescription,
@@ -105,8 +104,6 @@ async def test_vacuum_state_trigger_behavior_any(
     states: list[StateDescription],
 ) -> None:
     """Test that the vacuum state trigger fires when any vacuum state changes to a specific state."""
-    await async_setup_component(hass, "vacuum", {})
-
     other_entity_ids = set(target_vacuums) - {entity_id}
 
     # Set all vacuums, including the tested one, to the initial state
@@ -174,8 +171,6 @@ async def test_vacuum_state_trigger_behavior_first(
     states: list[StateDescription],
 ) -> None:
     """Test that the vacuum state trigger fires when the first vacuum changes to a specific state."""
-    await async_setup_component(hass, "vacuum", {})
-
     other_entity_ids = set(target_vacuums) - {entity_id}
 
     # Set all vacuums, including the tested one, to the initial state
@@ -242,8 +237,6 @@ async def test_vacuum_state_trigger_behavior_last(
     states: list[StateDescription],
 ) -> None:
     """Test that the vacuum state trigger fires when the last vacuum changes to a specific state."""
-    await async_setup_component(hass, "vacuum", {})
-
     other_entity_ids = set(target_vacuums) - {entity_id}
 
     # Set all vacuums, including the tested one, to the initial state


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Arming triggers loads the integration providing the triggers, so we don't set them up manually in the tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
