### PR TITLE
Set account number as required for Anglian Water config entry

### DIFF
--- a/homeassistant/components/anglian_water/config_flow.py
+++ b/homeassistant/components/anglian_water/config_flow.py
@@ -30,6 +30,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): selector.TextSelector(
             selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
         ),
+        vol.Required(CONF_ACCOUNT_NUMBER): selector.TextSelector(),
     }
 )
 
@@ -68,33 +69,18 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
                         self.hass,
                         cookie_jar=CookieJar(quote_cookie=False),
                     ),
-                    account_number=user_input.get(CONF_ACCOUNT_NUMBER),
+                    account_number=user_input[CONF_ACCOUNT_NUMBER],
                 )
             )
             if isinstance(validation_response, BaseAuth):
-                account_number = (
-                    user_input.get(CONF_ACCOUNT_NUMBER)
-                    or validation_response.account_number
-                )
-                await self.async_set_unique_id(account_number)
+                await self.async_set_unique_id(user_input[CONF_ACCOUNT_NUMBER])
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
-                    title=account_number,
+                    title=user_input[CONF_ACCOUNT_NUMBER],
                     data={
                         **user_input,
                         CONF_ACCESS_TOKEN: validation_response.refresh_token,
-                        CONF_ACCOUNT_NUMBER: account_number,
                     },
-                )
-            if validation_response == "smart_meter_unavailable":
-                return self.async_show_form(
-                    step_id="user",
-                    data_schema=STEP_USER_DATA_SCHEMA.extend(
-                        {
-                            vol.Required(CONF_ACCOUNT_NUMBER): selector.TextSelector(),
-                        }
-                    ),
-                    errors={"base": validation_response},
                 )
             errors["base"] = validation_response
 

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -40,6 +40,7 @@ async def test_full_flow(
         user_input={
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
+            CONF_ACCOUNT_NUMBER: ACCOUNT_NUMBER,
         },
     )
 
@@ -74,6 +75,7 @@ async def test_already_configured(
         user_input={
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
+            CONF_ACCOUNT_NUMBER: ACCOUNT_NUMBER,
         },
     )
 
@@ -107,6 +109,7 @@ async def test_auth_recover_exception(
         user_input={
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
+            CONF_ACCOUNT_NUMBER: ACCOUNT_NUMBER,
         },
     )
 
@@ -123,6 +126,7 @@ async def test_auth_recover_exception(
         user_input={
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
+            CONF_ACCOUNT_NUMBER: ACCOUNT_NUMBER,
         },
     )
 
@@ -164,6 +168,7 @@ async def test_account_recover_exception(
         user_input={
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
+            CONF_ACCOUNT_NUMBER: ACCOUNT_NUMBER,
         },
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will be part 1 of this bugfix, another is to follow up.

During the initial PR we discussed how the account number field should be configured, in the end we decided to only show it if the initial smart meter validation fails.

Unfortunately the data from the API is not 100% reliable as mentioned in #157902 and despite our validations progressing without issue, it is clear an account still may not be active.

This PR introduces the account number as a mandatory field for setup, a version bump to the config flow is not required as we always stored the account number anyway.

I've also added the pyanglianwater library to the loggers in the manifest.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #157902
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
