### PR TITLE
Fix local_file camera content_type update and improve Windows compati…

### DIFF
--- a/homeassistant/components/local_file/camera.py
+++ b/homeassistant/components/local_file/camera.py
@@ -84,6 +84,9 @@ class LocalFile(Camera):
         ):
             raise ServiceValidationError(f"Path {file_path} is not accessible")
         self._file_path = file_path
+        content, _ = mimetypes.guess_type(file_path)
+        if content is not None:
+            self.content_type = content
         self.schedule_update_ha_state()
 
     @property

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -8,7 +8,10 @@ from contextlib import contextmanager
 import dataclasses
 from datetime import datetime
 import errno
-import fcntl
+try:
+    import fcntl
+except ImportError:
+    fcntl = None  # type: ignore[assignment]
 from io import TextIOWrapper
 import json
 import logging
@@ -135,7 +138,8 @@ def ensure_single_execution(config_dir: str) -> Generator[SingleExecutionLock]:
         # Try to acquire an exclusive, non-blocking lock
         # This will raise BlockingIOError if lock is already held
         try:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            if fcntl:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError:
             # Another instance is already running
             _report_existing_instance(lock_file_path, config_dir)

--- a/homeassistant/util/resource.py
+++ b/homeassistant/util/resource.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import logging
 import os
-import resource
+try:
+    import resource
+except ImportError:
+    resource = None  # type: ignore[assignment]
 from typing import Final
 
 _LOGGER = logging.getLogger(__name__)
@@ -15,6 +18,9 @@ DEFAULT_SOFT_FILE_LIMIT: Final = 2048
 
 def set_open_file_descriptor_limit() -> None:
     """Set the maximum open file descriptor soft limit."""
+    if resource is None:
+        return
+
     try:
         # Check environment variable first, then use default
         soft_limit = int(os.environ.get("SOFT_FILE_LIMIT", DEFAULT_SOFT_FILE_LIMIT))


### PR DESCRIPTION
 # Addressed Issue
- The local_file camera platform failed to update the content_type attribute when the file_path was changed via the update_file_path service. 
- This resulted inincorrect MIME types being reported (e.g., continuing to report image/jpeg even after switching to a .png file). 
- Additionally, the project contained hard dependencies on Unix-only modules (fcntl, resource) in core utility files (runner.py, util/resource.py), which prevented tests from running successfully on Windows development environments.

# What you have reengineered
- `homeassistant/components/local_file/camera.py`: Refactored the update_file_path method to explicitly recalculate and update self.content_type using mimetypes.guess_type whenever the file path changes.
- `tests/components/local_file/test_camera.py`: implemented a new regression test test_update_file_path_updates_content_type to verify that the content type updates correctly. 
- Added @pytest.mark.enable_socket to handle Windows ProactorEventLoop constraints during testing.
- `homeassistant/runner.py` & `homeassistant/util/resource.py`: Refactored imports for fcntl and resource to be optional/conditional. This allows the modules to import safely on Windows, gracefully skipping Unix-specific operations (like file locking or setting resource limits) instead of crashing.

# Reengineering strategy or approach used
- Test-Driven Fix: I adopted a test-first approach by creating a reproduction case that failed on the existing code (confirming the bug) before implementing the fix.
- Platform Agnostic Refactoring: I applied defensive coding patterns (try...except ImportError) to core system utilities. This decoupled the codebase from strict OS dependencies, allowing the test suite to execute on Windows without breaking core functionality.
- Atomic Logic Update: I identified that the content type detection logic was isolated in the __init__ method. I duplicated the minimal necessary logic into the update handler to ensure state consistency without requiring a full entity reload.

# Impact of changes
- Correctness: The local_file camera now accurately reports MIME types for dynamically changing files, ensuring proper rendering in client applications.
- Cross-Platform Compatibility: The core codebase is now testable on Windows, significantly improving the developer experience and lowering the barrier for contributors using non-Unix operating systems.
- Robustness: The added test case prevents future regressions of this specific bug.