### PR TITLE
Move Tuya type information classes to separate module

### DIFF
--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -35,8 +35,8 @@ from .models import (
     DPCodeEnumWrapper,
     DPCodeIntegerWrapper,
     DPCodeJsonWrapper,
-    IntegerTypeData,
 )
+from .type_information import IntegerTypeInformation
 from .util import remap_value
 
 
@@ -138,24 +138,24 @@ class _ColorTempWrapper(DPCodeIntegerWrapper):
         )
 
 
-DEFAULT_H_TYPE = IntegerTypeData(
+DEFAULT_H_TYPE = IntegerTypeInformation(
     dpcode=DPCode.COLOUR_DATA_HSV, min=1, scale=0, max=360, step=1
 )
-DEFAULT_S_TYPE = IntegerTypeData(
+DEFAULT_S_TYPE = IntegerTypeInformation(
     dpcode=DPCode.COLOUR_DATA_HSV, min=1, scale=0, max=255, step=1
 )
-DEFAULT_V_TYPE = IntegerTypeData(
+DEFAULT_V_TYPE = IntegerTypeInformation(
     dpcode=DPCode.COLOUR_DATA_HSV, min=1, scale=0, max=255, step=1
 )
 
 
-DEFAULT_H_TYPE_V2 = IntegerTypeData(
+DEFAULT_H_TYPE_V2 = IntegerTypeInformation(
     dpcode=DPCode.COLOUR_DATA_HSV, min=1, scale=0, max=360, step=1
 )
-DEFAULT_S_TYPE_V2 = IntegerTypeData(
+DEFAULT_S_TYPE_V2 = IntegerTypeInformation(
     dpcode=DPCode.COLOUR_DATA_HSV, min=1, scale=0, max=1000, step=1
 )
-DEFAULT_V_TYPE_V2 = IntegerTypeData(
+DEFAULT_V_TYPE_V2 = IntegerTypeInformation(
     dpcode=DPCode.COLOUR_DATA_HSV, min=1, scale=0, max=1000, step=1
 )
 
@@ -578,15 +578,15 @@ def _get_color_data_wrapper(
     if function_data := json_loads_object(
         cast(str, color_data_wrapper.type_information.type_data)
     ):
-        color_data_wrapper.h_type = IntegerTypeData(
+        color_data_wrapper.h_type = IntegerTypeInformation(
             dpcode=color_data_wrapper.dpcode,
             **cast(dict, function_data["h"]),
         )
-        color_data_wrapper.s_type = IntegerTypeData(
+        color_data_wrapper.s_type = IntegerTypeInformation(
             dpcode=color_data_wrapper.dpcode,
             **cast(dict, function_data["s"]),
         )
-        color_data_wrapper.v_type = IntegerTypeData(
+        color_data_wrapper.v_type = IntegerTypeInformation(
             dpcode=color_data_wrapper.dpcode,
             **cast(dict, function_data["v"]),
         )

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import base64
-from dataclasses import dataclass
-from typing import Any, Literal, Self, cast, overload
+from typing import Any, Self
 
 from tuya_sharing import CustomerDevice
 
-from homeassistant.util.json import json_loads, json_loads_object
+from homeassistant.util.json import json_loads
 
 from .const import LOGGER, DPType
-from .util import parse_dptype, remap_value
+from .type_information import (
+    EnumTypeInformation,
+    IntegerTypeInformation,
+    TypeInformation,
+    find_dpcode,
+)
 
 # Dictionary to track logged warnings to avoid spamming logs
 # Keyed by device ID
@@ -30,139 +34,6 @@ def _should_log_warning(device_id: str, warning_key: str) -> bool:
         return False
     DEVICE_WARNINGS[device_id].add(warning_key)
     return True
-
-
-@dataclass(kw_only=True)
-class TypeInformation:
-    """Type information.
-
-    As provided by the SDK, from `device.function` / `device.status_range`.
-    """
-
-    dpcode: str
-    type_data: str | None = None
-
-    @classmethod
-    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
-        """Load JSON string and return a TypeInformation object."""
-        return cls(dpcode=dpcode, type_data=type_data)
-
-
-@dataclass(kw_only=True)
-class IntegerTypeData(TypeInformation):
-    """Integer Type Data."""
-
-    min: int
-    max: int
-    scale: int
-    step: int
-    unit: str | None = None
-
-    @property
-    def max_scaled(self) -> float:
-        """Return the max scaled."""
-        return self.scale_value(self.max)
-
-    @property
-    def min_scaled(self) -> float:
-        """Return the min scaled."""
-        return self.scale_value(self.min)
-
-    @property
-    def step_scaled(self) -> float:
-        """Return the step scaled."""
-        return self.step / (10**self.scale)
-
-    def scale_value(self, value: int) -> float:
-        """Scale a value."""
-        return value / (10**self.scale)
-
-    def scale_value_back(self, value: float) -> int:
-        """Return raw value for scaled."""
-        return round(value * (10**self.scale))
-
-    def remap_value_to(
-        self,
-        value: float,
-        to_min: float = 0,
-        to_max: float = 255,
-        reverse: bool = False,
-    ) -> float:
-        """Remap a value from this range to a new range."""
-        return remap_value(value, self.min, self.max, to_min, to_max, reverse)
-
-    def remap_value_from(
-        self,
-        value: float,
-        from_min: float = 0,
-        from_max: float = 255,
-        reverse: bool = False,
-    ) -> float:
-        """Remap a value from its current range to this range."""
-        return remap_value(value, from_min, from_max, self.min, self.max, reverse)
-
-    @classmethod
-    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
-        """Load JSON string and return a IntegerTypeData object."""
-        if not (parsed := cast(dict[str, Any] | None, json_loads_object(type_data))):
-            return None
-
-        return cls(
-            dpcode=dpcode,
-            type_data=type_data,
-            min=int(parsed["min"]),
-            max=int(parsed["max"]),
-            scale=int(parsed["scale"]),
-            step=int(parsed["step"]),
-            unit=parsed.get("unit"),
-        )
-
-
-@dataclass(kw_only=True)
-class BitmapTypeInformation(TypeInformation):
-    """Bitmap type information."""
-
-    label: list[str]
-
-    @classmethod
-    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
-        """Load JSON string and return a BitmapTypeInformation object."""
-        if not (parsed := json_loads_object(type_data)):
-            return None
-        return cls(
-            dpcode=dpcode,
-            type_data=type_data,
-            **cast(dict[str, list[str]], parsed),
-        )
-
-
-@dataclass(kw_only=True)
-class EnumTypeData(TypeInformation):
-    """Enum Type Data."""
-
-    range: list[str]
-
-    @classmethod
-    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
-        """Load JSON string and return a EnumTypeData object."""
-        if not (parsed := json_loads_object(type_data)):
-            return None
-        return cls(
-            dpcode=dpcode,
-            type_data=type_data,
-            **cast(dict[str, list[str]], parsed),
-        )
-
-
-_TYPE_INFORMATION_MAPPINGS: dict[DPType, type[TypeInformation]] = {
-    DPType.BITMAP: BitmapTypeInformation,
-    DPType.BOOLEAN: TypeInformation,
-    DPType.ENUM: EnumTypeData,
-    DPType.INTEGER: IntegerTypeData,
-    DPType.JSON: TypeInformation,
-    DPType.RAW: TypeInformation,
-    DPType.STRING: TypeInformation,
-}
 
 
 class DeviceWrapper:
@@ -303,8 +174,8 @@ class DPCodeJsonWrapper(DPCodeTypeInformationWrapper[TypeInformation]):
         return json_loads(raw_value)
 
 
-class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
-    """Simple wrapper for EnumTypeData values."""
+class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
+    """Simple wrapper for EnumTypeInformation values."""
 
     DPTYPE = DPType.ENUM
 
@@ -342,12 +213,12 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
         )
 
 
-class DPCodeIntegerWrapper(DPCodeTypeInformationWrapper[IntegerTypeData]):
-    """Simple wrapper for IntegerTypeData values."""
+class DPCodeIntegerWrapper(DPCodeTypeInformationWrapper[IntegerTypeInformation]):
+    """Simple wrapper for IntegerTypeInformation values."""
 
     DPTYPE = DPType.INTEGER
 
-    def __init__(self, dpcode: str, type_information: IntegerTypeData) -> None:
+    def __init__(self, dpcode: str, type_information: IntegerTypeInformation) -> None:
         """Init DPCodeIntegerWrapper."""
         super().__init__(dpcode, type_information)
         self.native_unit = type_information.unit
@@ -414,82 +285,3 @@ class DPCodeBitmapBitWrapper(DPCodeWrapper):
                 type_information.dpcode, type_information.label.index(bitmap_key)
             )
         return None
-
-
-@overload
-def find_dpcode(
-    device: CustomerDevice,
-    dpcodes: str | tuple[str, ...] | None,
-    *,
-    prefer_function: bool = False,
-    dptype: Literal[DPType.BITMAP],
-) -> BitmapTypeInformation | None: ...
-
-
-@overload
-def find_dpcode(
-    device: CustomerDevice,
-    dpcodes: str | tuple[str, ...] | None,
-    *,
-    prefer_function: bool = False,
-    dptype: Literal[DPType.ENUM],
-) -> EnumTypeData | None: ...
-
-
-@overload
-def find_dpcode(
-    device: CustomerDevice,
-    dpcodes: str | tuple[str, ...] | None,
-    *,
-    prefer_function: bool = False,
-    dptype: Literal[DPType.INTEGER],
-) -> IntegerTypeData | None: ...
-
-
-@overload
-def find_dpcode(
-    device: CustomerDevice,
-    dpcodes: str | tuple[str, ...] | None,
-    *,
-    prefer_function: bool = False,
-    dptype: Literal[DPType.BOOLEAN, DPType.JSON, DPType.RAW],
-) -> TypeInformation | None: ...
-
-
-def find_dpcode(
-    device: CustomerDevice,
-    dpcodes: str | tuple[str, ...] | None,
-    *,
-    prefer_function: bool = False,
-    dptype: DPType,
-) -> TypeInformation | None:
-    """Find type information for a matching DP code available for this device."""
-    if not (type_information_cls := _TYPE_INFORMATION_MAPPINGS.get(dptype)):
-        raise NotImplementedError(f"find_dpcode not supported for {dptype}")
-
-    if dpcodes is None:
-        return None
-
-    if not isinstance(dpcodes, tuple):
-        dpcodes = (dpcodes,)
-
-    lookup_tuple = (
-        (device.function, device.status_range)
-        if prefer_function
-        else (device.status_range, device.function)
-    )
-
-    for dpcode in dpcodes:
-        for device_specs in lookup_tuple:
-            if (
-                (current_definition := device_specs.get(dpcode))
-                and parse_dptype(current_definition.type) is dptype
-                and (
-                    type_information := type_information_cls.from_json(
-                        dpcode=dpcode, type_data=current_definition.values
-                    )
-                )
-            ):
-                return type_information
-
-    return None

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -26,7 +26,6 @@ from .const import (
 )
 from .entity import TuyaEntity
 from .models import DPCodeIntegerWrapper
-from .type_information import IntegerTypeInformation
 
 NUMBERS: dict[DeviceCategory, tuple[NumberEntityDescription, ...]] = {
     DeviceCategory.BH: (
@@ -483,8 +482,6 @@ async def async_setup_entry(
 
 class TuyaNumberEntity(TuyaEntity, NumberEntity):
     """Tuya Number Entity."""
-
-    _number: IntegerTypeInformation | None = None
 
     def __init__(
         self,

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -25,7 +25,8 @@ from .const import (
     DPCode,
 )
 from .entity import TuyaEntity
-from .models import DPCodeIntegerWrapper, IntegerTypeData
+from .models import DPCodeIntegerWrapper
+from .type_information import IntegerTypeInformation
 
 NUMBERS: dict[DeviceCategory, tuple[NumberEntityDescription, ...]] = {
     DeviceCategory.BH: (
@@ -483,7 +484,7 @@ async def async_setup_entry(
 class TuyaNumberEntity(TuyaEntity, NumberEntity):
     """Tuya Number Entity."""
 
-    _number: IntegerTypeData | None = None
+    _number: IntegerTypeInformation | None = None
 
     def __init__(
         self,

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -46,12 +46,12 @@ from .models import (
     DPCodeJsonWrapper,
     DPCodeTypeInformationWrapper,
     DPCodeWrapper,
-    EnumTypeData,
 )
 from .raw_data_models import ElectricityData
+from .type_information import EnumTypeInformation
 
 
-class _WindDirectionWrapper(DPCodeTypeInformationWrapper[EnumTypeData]):
+class _WindDirectionWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
     """Custom DPCode Wrapper for converting enum to wind direction."""
 
     DPTYPE = DPType.ENUM

--- a/homeassistant/components/tuya/type_information.py
+++ b/homeassistant/components/tuya/type_information.py
@@ -1,4 +1,4 @@
-"""Tuya Home Assistant type information classes."""
+"""Type information classes for the Tuya integration."""
 
 from __future__ import annotations
 
@@ -55,7 +55,7 @@ class EnumTypeInformation(TypeInformation):
 
     @classmethod
     def from_json(cls, dpcode: str, type_data: str) -> Self | None:
-        """Load JSON string and return a EnumTypeInformation object."""
+        """Load JSON string and return an EnumTypeInformation object."""
         if not (parsed := json_loads_object(type_data)):
             return None
         return cls(
@@ -120,7 +120,7 @@ class IntegerTypeInformation(TypeInformation):
 
     @classmethod
     def from_json(cls, dpcode: str, type_data: str) -> Self | None:
-        """Load JSON string and return a IntegerTypeInformation object."""
+        """Load JSON string and return an IntegerTypeInformation object."""
         if not (parsed := cast(dict[str, Any] | None, json_loads_object(type_data))):
             return None
 

--- a/homeassistant/components/tuya/type_information.py
+++ b/homeassistant/components/tuya/type_information.py
@@ -1,0 +1,225 @@
+"""Tuya Home Assistant type information classes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Self, cast, overload
+
+from tuya_sharing import CustomerDevice
+
+from homeassistant.util.json import json_loads_object
+
+from .const import DPType
+from .util import parse_dptype, remap_value
+
+
+@dataclass(kw_only=True)
+class TypeInformation:
+    """Type information.
+
+    As provided by the SDK, from `device.function` / `device.status_range`.
+    """
+
+    dpcode: str
+    type_data: str | None = None
+
+    @classmethod
+    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
+        """Load JSON string and return a TypeInformation object."""
+        return cls(dpcode=dpcode, type_data=type_data)
+
+
+@dataclass(kw_only=True)
+class BitmapTypeInformation(TypeInformation):
+    """Bitmap type information."""
+
+    label: list[str]
+
+    @classmethod
+    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
+        """Load JSON string and return a BitmapTypeInformation object."""
+        if not (parsed := json_loads_object(type_data)):
+            return None
+        return cls(
+            dpcode=dpcode,
+            type_data=type_data,
+            **cast(dict[str, list[str]], parsed),
+        )
+
+
+@dataclass(kw_only=True)
+class EnumTypeInformation(TypeInformation):
+    """Enum type information."""
+
+    range: list[str]
+
+    @classmethod
+    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
+        """Load JSON string and return a EnumTypeInformation object."""
+        if not (parsed := json_loads_object(type_data)):
+            return None
+        return cls(
+            dpcode=dpcode,
+            type_data=type_data,
+            **cast(dict[str, list[str]], parsed),
+        )
+
+
+@dataclass(kw_only=True)
+class IntegerTypeInformation(TypeInformation):
+    """Integer type information."""
+
+    min: int
+    max: int
+    scale: int
+    step: int
+    unit: str | None = None
+
+    @property
+    def max_scaled(self) -> float:
+        """Return the max scaled."""
+        return self.scale_value(self.max)
+
+    @property
+    def min_scaled(self) -> float:
+        """Return the min scaled."""
+        return self.scale_value(self.min)
+
+    @property
+    def step_scaled(self) -> float:
+        """Return the step scaled."""
+        return self.step / (10**self.scale)
+
+    def scale_value(self, value: int) -> float:
+        """Scale a value."""
+        return value / (10**self.scale)
+
+    def scale_value_back(self, value: float) -> int:
+        """Return raw value for scaled."""
+        return round(value * (10**self.scale))
+
+    def remap_value_to(
+        self,
+        value: float,
+        to_min: float = 0,
+        to_max: float = 255,
+        reverse: bool = False,
+    ) -> float:
+        """Remap a value from this range to a new range."""
+        return remap_value(value, self.min, self.max, to_min, to_max, reverse)
+
+    def remap_value_from(
+        self,
+        value: float,
+        from_min: float = 0,
+        from_max: float = 255,
+        reverse: bool = False,
+    ) -> float:
+        """Remap a value from its current range to this range."""
+        return remap_value(value, from_min, from_max, self.min, self.max, reverse)
+
+    @classmethod
+    def from_json(cls, dpcode: str, type_data: str) -> Self | None:
+        """Load JSON string and return a IntegerTypeInformation object."""
+        if not (parsed := cast(dict[str, Any] | None, json_loads_object(type_data))):
+            return None
+
+        return cls(
+            dpcode=dpcode,
+            type_data=type_data,
+            min=int(parsed["min"]),
+            max=int(parsed["max"]),
+            scale=int(parsed["scale"]),
+            step=int(parsed["step"]),
+            unit=parsed.get("unit"),
+        )
+
+
+_TYPE_INFORMATION_MAPPINGS: dict[DPType, type[TypeInformation]] = {
+    DPType.BITMAP: BitmapTypeInformation,
+    DPType.BOOLEAN: TypeInformation,
+    DPType.ENUM: EnumTypeInformation,
+    DPType.INTEGER: IntegerTypeInformation,
+    DPType.JSON: TypeInformation,
+    DPType.RAW: TypeInformation,
+    DPType.STRING: TypeInformation,
+}
+
+
+@overload
+def find_dpcode(
+    device: CustomerDevice,
+    dpcodes: str | tuple[str, ...] | None,
+    *,
+    prefer_function: bool = False,
+    dptype: Literal[DPType.BITMAP],
+) -> BitmapTypeInformation | None: ...
+
+
+@overload
+def find_dpcode(
+    device: CustomerDevice,
+    dpcodes: str | tuple[str, ...] | None,
+    *,
+    prefer_function: bool = False,
+    dptype: Literal[DPType.ENUM],
+) -> EnumTypeInformation | None: ...
+
+
+@overload
+def find_dpcode(
+    device: CustomerDevice,
+    dpcodes: str | tuple[str, ...] | None,
+    *,
+    prefer_function: bool = False,
+    dptype: Literal[DPType.INTEGER],
+) -> IntegerTypeInformation | None: ...
+
+
+@overload
+def find_dpcode(
+    device: CustomerDevice,
+    dpcodes: str | tuple[str, ...] | None,
+    *,
+    prefer_function: bool = False,
+    dptype: Literal[DPType.BOOLEAN, DPType.JSON, DPType.RAW],
+) -> TypeInformation | None: ...
+
+
+def find_dpcode(
+    device: CustomerDevice,
+    dpcodes: str | tuple[str, ...] | None,
+    *,
+    prefer_function: bool = False,
+    dptype: DPType,
+) -> TypeInformation | None:
+    """Find type information for a matching DP code available for this device."""
+    if not (type_information_cls := _TYPE_INFORMATION_MAPPINGS.get(dptype)):
+        raise NotImplementedError(f"find_dpcode not supported for {dptype}")
+
+    if dpcodes is None:
+        return None
+
+    if not isinstance(dpcodes, tuple):
+        dpcodes = (dpcodes,)
+
+    lookup_tuple = (
+        (device.function, device.status_range)
+        if prefer_function
+        else (device.status_range, device.function)
+    )
+
+    for dpcode in dpcodes:
+        for device_specs in lookup_tuple:
+            if (
+                (current_definition := device_specs.get(dpcode))
+                and parse_dptype(current_definition.type) is dptype
+                and (
+                    type_information := type_information_cls.from_json(
+                        dpcode=dpcode, type_data=current_definition.values
+                    )
+                )
+            ):
+                return type_information
+
+    return None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Move `TypeInformation` classes and corresponding `find_dpcode` function to separate module
- Rename `EnumTypeData` to `EnumTypeInformation`
- Rename `IntegerTypeData` to `IntegerTypeInformation`
- Reorder `TypeInformation` classes in alphabetical order in the new module
- Cleanup unused attribute `_number` in number platform

No functionnality changes - preliminary work for improving Tuya data validation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
