### PR TITLE
Fix unit parsing in Tuya climate entities

### DIFF
--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -208,6 +208,18 @@ def _get_temperature_wrappers(
         device, DPCode.TEMP_SET_F, prefer_function=True
     )
 
+    # If there is a temp unit convert dpcode, override empty units
+    if (
+        temp_unit_convert := DPCodeEnumWrapper.find_dpcode(
+            device, DPCode.TEMP_UNIT_CONVERT
+        )
+    ) is not None:
+        for wrapper in (temp_current, temp_current_f, temp_set, temp_set_f):
+            if wrapper is not None and not wrapper.type_information.unit:
+                wrapper.type_information.unit = temp_unit_convert.read_device_status(
+                    device
+                )
+
     # Get wrappers for celsius and fahrenheit
     # We need to check the unit of measurement
     current_celsius = _get_temperature_wrapper(

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -182,7 +182,11 @@ async def _create_device(hass: HomeAssistant, mock_device_code: str) -> Customer
         key: DeviceFunction(
             code=key,
             type=value["type"],
-            values=json_dumps(value["value"]),
+            values=(
+                values
+                if isinstance(values := value["value"], str)
+                else json_dumps(values)
+            ),
         )
         for key, value in details["function"].items()
     }
@@ -190,7 +194,11 @@ async def _create_device(hass: HomeAssistant, mock_device_code: str) -> Customer
         key: DeviceStatusRange(
             code=key,
             type=value["type"],
-            values=json_dumps(value["value"]),
+            values=(
+                values
+                if isinstance(values := value["value"], str)
+                else json_dumps(values)
+            ),
         )
         for key, value in details["status_range"].items()
     }

--- a/tests/components/tuya/fixtures/wk_B0eP8qYAdpUo4yR9.json
+++ b/tests/components/tuya/fixtures/wk_B0eP8qYAdpUo4yR9.json
@@ -1,0 +1,53 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "ITC-308-WIFI Thermostat",
+  "category": "wk",
+  "product_id": "B0eP8qYAdpUo4yR9",
+  "product_name": "ITC-308-WIFI Thermostat",
+  "online": true,
+  "sub": false,
+  "time_zone": "+01:00",
+  "active_time": "2022-02-08T10:49:39+00:00",
+  "create_time": "2022-02-08T10:49:39+00:00",
+  "update_time": "2022-02-08T10:49:39+00:00",
+  "function": {
+    "temp_unit_convert": {
+      "type": "Enum",
+      "value": "{\"range\":[\"c\",\"f\"]}"
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\",\"min\":-400,\"max\":2120,\"scale\":1,\"step\":5}"
+    }
+  },
+  "status_range": {
+    "temp_unit_convert": {
+      "type": "Enum",
+      "value": "{\"range\":[\"c\",\"f\"]}"
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2103\",\"min\":-500,\"max\":1200,\"scale\":1,\"step\":10}"
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\",\"min\":-400,\"max\":2120,\"scale\":1,\"step\":5}"
+    },
+    "temp_current_f": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2109\",\"min\":-500,\"max\":2480,\"scale\":1,\"step\":10}"
+    }
+  },
+  "status": {
+    "temp_unit_convert": "c",
+    "temp_current": 340,
+    "temp_set": 350,
+    "temp_current_f": 932
+  },
+  "set_up": true,
+  "support_local": true,
+  "warnings": null
+}

--- a/tests/components/tuya/snapshots/test_climate.ambr
+++ b/tests/components/tuya/snapshots/test_climate.ambr
@@ -654,6 +654,68 @@
     'state': 'off',
   })
 # ---
+# name: test_platform_setup_and_discovery[climate.itc_308_wifi_thermostat-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+      ]),
+      'max_temp': 212.0,
+      'min_temp': -40.0,
+      'target_temp_step': 0.5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.itc_308_wifi_thermostat',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': None,
+    'unique_id': 'tuya.9Ry4oUpdAYq8Pe0Bkw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[climate.itc_308_wifi_thermostat-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 34.0,
+      'friendly_name': 'ITC-308-WIFI Thermostat',
+      'hvac_modes': list([
+      ]),
+      'max_temp': 212.0,
+      'min_temp': -40.0,
+      'supported_features': <ClimateEntityFeature: 1>,
+      'target_temp_step': 0.5,
+      'temperature': 35.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.itc_308_wifi_thermostat',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[climate.kabinet-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -1448,6 +1510,15 @@
     'max_temp': 95,
     'min_temp': 45,
     'target_temp_step': 1.0,
+  })
+# ---
+# name: test_us_customary_system[climate.itc_308_wifi_thermostat]
+  ReadOnlyDict({
+    'current_temperature': 93,
+    'max_temp': 414,
+    'min_temp': -40,
+    'target_temp_step': 0.5,
+    'temperature': 95,
   })
 # ---
 # name: test_us_customary_system[climate.kabinet]

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -1301,6 +1301,37 @@
     'via_device_id': None,
   })
 # ---
+# name: test_device_registry[9Ry4oUpdAYq8Pe0Bkw]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tuya',
+        '9Ry4oUpdAYq8Pe0Bkw',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Tuya',
+    'model': 'ITC-308-WIFI Thermostat',
+    'model_id': 'B0eP8qYAdpUo4yR9',
+    'name': 'ITC-308-WIFI Thermostat',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_device_registry[9c1vlsxoscm]
   DeviceRegistryEntrySnapshot({
     'area_id': None,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support for TEMP_UNIT_CONVERT data point was accidentaly removed in #156977
 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #157921
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
