### PR TITLE
Add subscribe preview feature endpoint to labs

### DIFF
--- a/homeassistant/components/labs/__init__.py
+++ b/homeassistant/components/labs/__init__.py
@@ -7,11 +7,10 @@ in the Home Assistant Labs UI for users to enable or disable.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import logging
 
 from homeassistant.const import EVENT_LABS_UPDATED
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.generated.labs import LABS_PREVIEW_FEATURES
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.storage import Store
@@ -19,6 +18,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_custom_components
 
 from .const import DOMAIN, LABS_DATA, STORAGE_KEY, STORAGE_VERSION
+from .helpers import async_is_preview_feature_enabled, async_listen
 from .models import (
     EventLabsUpdatedData,
     LabPreviewFeature,
@@ -135,55 +135,3 @@ async def _async_scan_all_preview_features(
 
     _LOGGER.debug("Loaded %d total lab preview features", len(preview_features))
     return preview_features
-
-
-@callback
-def async_is_preview_feature_enabled(
-    hass: HomeAssistant, domain: str, preview_feature: str
-) -> bool:
-    """Check if a lab preview feature is enabled.
-
-    Args:
-        hass: HomeAssistant instance
-        domain: Integration domain
-        preview_feature: Preview feature name
-
-    Returns:
-        True if the preview feature is enabled, False otherwise
-    """
-    if LABS_DATA not in hass.data:
-        return False
-
-    labs_data = hass.data[LABS_DATA]
-    return (domain, preview_feature) in labs_data.data.preview_feature_status
-
-
-@callback
-def async_listen(
-    hass: HomeAssistant,
-    domain: str,
-    preview_feature: str,
-    listener: Callable[[], None],
-) -> Callable[[], None]:
-    """Listen for changes to a specific preview feature.
-
-    Args:
-        hass: HomeAssistant instance
-        domain: Integration domain
-        preview_feature: Preview feature name
-        listener: Callback to invoke when the preview feature is toggled
-
-    Returns:
-        Callable to unsubscribe from the listener
-    """
-
-    @callback
-    def _async_feature_updated(event: Event[EventLabsUpdatedData]) -> None:
-        """Handle labs feature update event."""
-        if (
-            event.data["domain"] == domain
-            and event.data["preview_feature"] == preview_feature
-        ):
-            listener()
-
-    return hass.bus.async_listen(EVENT_LABS_UPDATED, _async_feature_updated)

--- a/homeassistant/components/labs/helpers.py
+++ b/homeassistant/components/labs/helpers.py
@@ -1,0 +1,63 @@
+"""Helper functions for the Home Assistant Labs integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from homeassistant.const import EVENT_LABS_UPDATED
+from homeassistant.core import Event, HomeAssistant, callback
+
+from .const import LABS_DATA
+from .models import EventLabsUpdatedData
+
+
+@callback
+def async_is_preview_feature_enabled(
+    hass: HomeAssistant, domain: str, preview_feature: str
+) -> bool:
+    """Check if a lab preview feature is enabled.
+
+    Args:
+        hass: HomeAssistant instance
+        domain: Integration domain
+        preview_feature: Preview feature name
+
+    Returns:
+        True if the preview feature is enabled, False otherwise
+    """
+    if LABS_DATA not in hass.data:
+        return False
+
+    labs_data = hass.data[LABS_DATA]
+    return (domain, preview_feature) in labs_data.data.preview_feature_status
+
+
+@callback
+def async_listen(
+    hass: HomeAssistant,
+    domain: str,
+    preview_feature: str,
+    listener: Callable[[], None],
+) -> Callable[[], None]:
+    """Listen for changes to a specific preview feature.
+
+    Args:
+        hass: HomeAssistant instance
+        domain: Integration domain
+        preview_feature: Preview feature name
+        listener: Callback to invoke when the preview feature is toggled
+
+    Returns:
+        Callable to unsubscribe from the listener
+    """
+
+    @callback
+    def _async_feature_updated(event: Event[EventLabsUpdatedData]) -> None:
+        """Handle labs feature update event."""
+        if (
+            event.data["domain"] == domain
+            and event.data["preview_feature"] == preview_feature
+        ):
+            listener()
+
+    return hass.bus.async_listen(EVENT_LABS_UPDATED, _async_feature_updated)

--- a/homeassistant/components/labs/websocket_api.py
+++ b/homeassistant/components/labs/websocket_api.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.components.backup import async_get_manager
 from homeassistant.const import EVENT_LABS_UPDATED
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 
 from .const import LABS_DATA
 from .models import EventLabsUpdatedData
@@ -20,6 +20,7 @@ def async_setup(hass: HomeAssistant) -> None:
     """Set up the number websocket API."""
     websocket_api.async_register_command(hass, websocket_list_preview_features)
     websocket_api.async_register_command(hass, websocket_update_preview_feature)
+    websocket_api.async_register_command(hass, websocket_subscribe_feature)
 
 
 @callback
@@ -108,3 +109,57 @@ async def websocket_update_preview_feature(
     hass.bus.async_fire(EVENT_LABS_UPDATED, event_data)
 
     connection.send_result(msg["id"])
+
+
+@callback
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "labs/subscribe",
+        vol.Required("domain"): str,
+        vol.Required("preview_feature"): str,
+    }
+)
+def websocket_subscribe_feature(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Subscribe to a specific lab preview feature updates."""
+    domain = msg["domain"]
+    preview_feature_key = msg["preview_feature"]
+    labs_data = hass.data[LABS_DATA]
+
+    preview_feature_id = f"{domain}.{preview_feature_key}"
+
+    if preview_feature_id not in labs_data.preview_features:
+        connection.send_error(
+            msg["id"],
+            websocket_api.ERR_NOT_FOUND,
+            f"Preview feature {preview_feature_id} not found",
+        )
+        return
+
+    preview_feature = labs_data.preview_features[preview_feature_id]
+
+    @callback
+    def async_handle_event(event: Event[EventLabsUpdatedData]) -> None:
+        """Handle labs updated event."""
+        if (
+            event.data["domain"] != domain
+            or event.data["preview_feature"] != preview_feature_key
+        ):
+            return
+        enabled = (domain, preview_feature_key) in labs_data.data.preview_feature_status
+        connection.send_message(
+            websocket_api.event_message(
+                msg["id"],
+                preview_feature.to_dict(enabled=enabled),
+            )
+        )
+
+    connection.subscriptions[msg["id"]] = hass.bus.async_listen(
+        EVENT_LABS_UPDATED, async_handle_event
+    )
+
+    enabled = (domain, preview_feature_key) in labs_data.data.preview_feature_status
+    connection.send_result(msg["id"], preview_feature.to_dict(enabled=enabled))

--- a/tests/components/labs/test_websocket_api.py
+++ b/tests/components/labs/test_websocket_api.py
@@ -695,3 +695,182 @@ async def test_websocket_backup_timeout_handling(
 
     assert not msg["success"]
     assert msg["error"]["code"] == "unknown_error"
+
+
+async def test_websocket_subscribe_feature(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test subscribing to a specific preview feature."""
+    hass.config.components.add("kitchen_sink")
+    assert await async_setup(hass, {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "labs/subscribe",
+            "domain": "kitchen_sink",
+            "preview_feature": "special_repair",
+        }
+    )
+    msg = await client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] == {
+        "preview_feature": "special_repair",
+        "domain": "kitchen_sink",
+        "enabled": False,
+        "is_built_in": True,
+        "feedback_url": ANY,
+        "learn_more_url": ANY,
+        "report_issue_url": ANY,
+    }
+
+
+async def test_websocket_subscribe_feature_receives_updates(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test that subscription receives updates when feature is toggled."""
+    hass.config.components.add("kitchen_sink")
+    assert await async_setup(hass, {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "labs/subscribe",
+            "domain": "kitchen_sink",
+            "preview_feature": "special_repair",
+        }
+    )
+    subscribe_msg = await client.receive_json()
+    assert subscribe_msg["success"]
+    subscription_id = subscribe_msg["id"]
+
+    await client.send_json_auto_id(
+        {
+            "type": "labs/update",
+            "domain": "kitchen_sink",
+            "preview_feature": "special_repair",
+            "enabled": True,
+        }
+    )
+
+    # Event message arrives before the update result
+    event_msg = await client.receive_json()
+    assert event_msg["id"] == subscription_id
+    assert event_msg["type"] == "event"
+    assert event_msg["event"] == {
+        "preview_feature": "special_repair",
+        "domain": "kitchen_sink",
+        "enabled": True,
+        "is_built_in": True,
+        "feedback_url": ANY,
+        "learn_more_url": ANY,
+        "report_issue_url": ANY,
+    }
+
+    update_msg = await client.receive_json()
+    assert update_msg["success"]
+
+
+async def test_websocket_subscribe_nonexistent_feature(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test subscribing to a preview feature that doesn't exist."""
+    assert await async_setup(hass, {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "labs/subscribe",
+            "domain": "nonexistent",
+            "preview_feature": "feature",
+        }
+    )
+    msg = await client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_found"
+    assert "not found" in msg["error"]["message"].lower()
+
+
+async def test_websocket_subscribe_does_not_require_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test that subscribe does not require admin privileges."""
+    hass_admin_user.groups = []
+
+    hass.config.components.add("kitchen_sink")
+    assert await async_setup(hass, {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "labs/subscribe",
+            "domain": "kitchen_sink",
+            "preview_feature": "special_repair",
+        }
+    )
+    msg = await client.receive_json()
+
+    assert msg["success"]
+
+
+async def test_websocket_subscribe_only_receives_subscribed_feature_updates(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test that subscription only receives updates for the subscribed feature."""
+    hass.config.components.add("kitchen_sink")
+    assert await async_setup(hass, {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "labs/subscribe",
+            "domain": "kitchen_sink",
+            "preview_feature": "special_repair",
+        }
+    )
+    subscribe_msg = await client.receive_json()
+    assert subscribe_msg["success"]
+
+    # Fire an event for a different feature
+    hass.bus.async_fire(
+        EVENT_LABS_UPDATED,
+        {"domain": "other_domain", "preview_feature": "other_feature", "enabled": True},
+    )
+    await hass.async_block_till_done()
+
+    await client.send_json_auto_id(
+        {
+            "type": "labs/update",
+            "domain": "kitchen_sink",
+            "preview_feature": "special_repair",
+            "enabled": True,
+        }
+    )
+
+    # Event message arrives before the update result
+    # Should only receive event for subscribed feature, not the other one
+    event_msg = await client.receive_json()
+    assert event_msg["type"] == "event"
+    assert event_msg["event"]["domain"] == "kitchen_sink"
+    assert event_msg["event"]["preview_feature"] == "special_repair"
+
+    update_msg = await client.receive_json()
+    assert update_msg["success"]


### PR DESCRIPTION
## Proposed change

Add subscribe preview feature endpoint to labs.
This will allow non-admin user to fetch dedicated feature (for example, showing snowflakes for non-admin users)
For now, it returns the full feature object but we can also consider to only return the enabled boolean.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/pull/28352
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
