### PR TITLE
Change ZHA strings for incorrect adapter state

### DIFF
--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1914,11 +1914,11 @@
       "title": "Zigbee network settings have changed"
     },
     "wrong_silabs_firmware_installed_nabucasa": {
-      "description": "Your Zigbee adapter is currently in an incorrect state: {firmware_type}.\n\nThe device may have Thread or Multiprotocol firmware installed, or it may be stuck in the bootloader. If so, try to unplug the adapter temporarily.\n\nIf the issue persists and you need to install Zigbee firmware:\n - Go to Settings > System > Hardware, select the device and select Configure.\n - Select the 'Migrate Zigbee to a new adapter' option and follow the instructions.",
+      "description": "Your Zigbee adapter is currently in an incorrect state: {firmware_type}.\n\nThe device may have Thread or Multiprotocol firmware installed, or it may be stuck in the bootloader. To resolve this, try to unplug the adapter temporarily.\n\nIf the issue persists and you need to install Zigbee firmware:\n - Go to Settings > System > Hardware, select the device and select Configure.\n - Select the 'Migrate Zigbee to a new adapter' option and follow the instructions.",
       "title": "Zigbee adapter in incorrect state"
     },
     "wrong_silabs_firmware_installed_other": {
-      "description": "Your Zigbee adapter is currently in an incorrect state: {firmware_type}.\n\nThe device may have Thread or Multiprotocol firmware installed, or it may be stuck in the bootloader. If so, try to unplug the adapter temporarily.\n\nIf the issue persists and you need to install Zigbee firmware, follow your Zigbee adapter manufacturer's instructions for how to do this.",
+      "description": "Your Zigbee adapter is currently in an incorrect state: {firmware_type}.\n\nThe device may have Thread or Multiprotocol firmware installed, or it may be stuck in the bootloader. To resolve this, try to unplug the adapter temporarily.\n\nIf the issue persists and you need to install Zigbee firmware, follow your Zigbee adapter manufacturer's instructions for how to do this.",
       "title": "[%key:component::zha::issues::wrong_silabs_firmware_installed_nabucasa::title%]"
     }
   },

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1914,11 +1914,11 @@
       "title": "Zigbee network settings have changed"
     },
     "wrong_silabs_firmware_installed_nabucasa": {
-      "description": "Your Zigbee adapter is currently in an incorrect state: {firmware_type}.\n\nThe device may have Thread or Multiprotocol firmware installed, or it may be stuck in the bootloader. To resolve this, try to unplug the adapter temporarily.\n\nIf the issue persists and you need to install Zigbee firmware:\n - Go to Settings > System > Hardware, select the device and select Configure.\n - Select the 'Migrate Zigbee to a new adapter' option and follow the instructions.",
+      "description": "Your Zigbee adapter is currently in an incorrect state: {firmware_type}.\n\nThe device may have Thread or multiprotocol firmware installed, or it may be stuck in the bootloader. To resolve this, try to unplug the adapter temporarily.\n\nIf the issue persists and you need to install Zigbee firmware:\n - Go to Settings > System > Hardware, select the device and select Configure.\n - Select the 'Migrate Zigbee to a new adapter' option and follow the instructions.",
       "title": "Zigbee adapter in incorrect state"
     },
     "wrong_silabs_firmware_installed_other": {
-      "description": "Your Zigbee adapter is currently in an incorrect state: {firmware_type}.\n\nThe device may have Thread or Multiprotocol firmware installed, or it may be stuck in the bootloader. To resolve this, try to unplug the adapter temporarily.\n\nIf the issue persists and you need to install Zigbee firmware, follow your Zigbee adapter manufacturer's instructions for how to do this.",
+      "description": "Your Zigbee adapter is currently in an incorrect state: {firmware_type}.\n\nThe device may have Thread or multiprotocol firmware installed, or it may be stuck in the bootloader. To resolve this, try to unplug the adapter temporarily.\n\nIf the issue persists and you need to install Zigbee firmware, follow your Zigbee adapter manufacturer's instructions for how to do this.",
       "title": "[%key:component::zha::issues::wrong_silabs_firmware_installed_nabucasa::title%]"
     }
   },

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1914,11 +1914,11 @@
       "title": "Zigbee network settings have changed"
     },
     "wrong_silabs_firmware_installed_nabucasa": {
-      "description": "Your Zigbee adapter was previously used with multiprotocol (Zigbee and Thread) and still has multiprotocol firmware installed: ({firmware_type}).\n\nTo run your adapter exclusively with ZHA, you need to install the Zigbee firmware:\n - Go to Settings > System > Hardware, select the device and select Configure.\n - Select the 'Migrate Zigbee to a new adapter' option and follow the instructions.",
-      "title": "Zigbee adapter with multiprotocol firmware detected"
+      "description": "Your Zigbee adapter is currently in an incorrect state: {firmware_type}.\n\nThe device may have Thread or Multiprotocol firmware installed, or it may be stuck in the bootloader. If so, try to unplug the adapter temporarily.\n\nIf the issue persists and you need to install Zigbee firmware:\n - Go to Settings > System > Hardware, select the device and select Configure.\n - Select the 'Migrate Zigbee to a new adapter' option and follow the instructions.",
+      "title": "Zigbee adapter in incorrect state"
     },
     "wrong_silabs_firmware_installed_other": {
-      "description": "Your Zigbee adapter was previously used with multiprotocol (Zigbee and Thread) and still has multiprotocol firmware installed: ({firmware_type}).\n\nTo run your adapter exclusively with ZHA, you need to install Zigbee firmware. Follow your Zigbee adapter manufacturer's instructions for how to do this.",
+      "description": "Your Zigbee adapter is currently in an incorrect state: {firmware_type}.\n\nThe device may have Thread or Multiprotocol firmware installed, or it may be stuck in the bootloader. If so, try to unplug the adapter temporarily.\n\nIf the issue persists and you need to install Zigbee firmware, follow your Zigbee adapter manufacturer's instructions for how to do this.",
       "title": "[%key:component::zha::issues::wrong_silabs_firmware_installed_nabucasa::title%]"
     }
   },


### PR DESCRIPTION
## Proposed change

This changes the ZHA string for the "incorrect firmware installed" repair to be more broad and also cover the state of the adapter being stuck in the bootloader or just having Thread firmware installed.

Specifically "multiprotocol" firmware is mentioned now, which is rarely the case.

### Background

Currently, there's a (rare) issue where ZBT can get stuck in the bootloader after a firmware update.
Due to recent changes in the flasher library, we currently no longer try to get the adapter out of that state.


### Goal

The goal of this changed string is just to avoid user confusion if they get stuck in this state after installing a firmware update. Users shouldn't need to be confused about multiprotocol firmware suddenly being installed, or the update having installed some wrong firmware in general, so that's why this is changed to a more relaxed "Incorrect state" error that also encompasses the "stuck in bootloader" state.


### Future

In the future, we should have both (1) a fix for the device getting stuck in the bootloader and likely (2) a method to get the device out of the bootloader if possible (but only if we don't risk bricking the device if there's incorrect firmware installed when there's bootloader triggers).

As soon as these underlying issues are fixed (in another major HA release), this string will be updated again to just show "Incorrect firmware installed", but avoid the explicit mention of multiprotocol.


### Images of updated repair dialogs

HA Connect series adapter in incorrect state | Third-party adapter in incorrect state
--- | ---
<img width="562" height="283" alt="image" src="https://github.com/user-attachments/assets/706faf3d-928e-40f3-bb1d-63d2a77a3547" /> | <img width="568" height="253" alt="image" src="https://github.com/user-attachments/assets/afef50a1-eb13-4cac-a655-736bf6aea764" />


(Not sure why the font is a bit weird on my instance right now. Maybe recent Core/Frontend changes, as I'm also seeing this for other repairs. Not a result of the changes from this PR though.)


### Alternatives

Alternatively, I've also thought about adding another repair/translation that's just shown if the device is stuck in the bootloader. Then, we'd have one variant for incorrect firmware and one for the adapter being in the bootloader.
I think adding that might be a bit too much for a patch release, so I've opted for this variant, for now.


## Type of change


- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
