### PR TITLE
Improve Tuya HVACMode handling

### DIFF
--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -478,23 +478,21 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode | None:
         """Return hvac mode."""
-        if self._switch_wrapper is None and self._hvac_mode_wrapper is None:
-            return None
-        # If the switch is off, hvac mode is off as well.
-        # Unless the switch doesn't exists of course...
+        # If the switch is off, we can ignore hvac mode.
+        switch_status: bool | None
         if (switch_status := self._read_wrapper(self._switch_wrapper)) is False:
             return HVACMode.OFF
 
-        # If the mode is known and maps to an HVAC mode, return it.
-        if (mode := self._read_wrapper(self._hvac_mode_wrapper)) and (
-            hvac_mode := TUYA_HVAC_TO_HA.get(mode)
-        ):
-            return hvac_mode
+        # If we don't have a mode wrapper, return switch only mode.
+        if self._hvac_mode_wrapper is None:
+            if switch_status is True:
+                return self.entity_description.switch_only_hvac_mode
+            return None
 
-        # If hvac_mode is unknown, return the switch only mode.
-        if switch_status:
-            return self.entity_description.switch_only_hvac_mode
-        return HVACMode.OFF
+        # If we do have a mode wrapper, check if the mode maps to an HVAC mode.
+        if (hvac_status := self._read_wrapper(self._hvac_mode_wrapper)) is None:
+            return None
+        return TUYA_HVAC_TO_HA.get(hvac_status)
 
     @property
     def preset_mode(self) -> str | None:

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -478,7 +478,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode | None:
         """Return hvac mode."""
-        # If the switch is off, we can ignore hvac mode.
+        # If the switch is off, hvac mode is off.
         switch_status: bool | None
         if (switch_status := self._read_wrapper(self._switch_wrapper)) is False:
             return HVACMode.OFF

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -476,8 +476,10 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         return self._read_wrapper(self._target_humidity_wrapper)
 
     @property
-    def hvac_mode(self) -> HVACMode:
+    def hvac_mode(self) -> HVACMode | None:
         """Return hvac mode."""
+        if self._switch_wrapper is None and self._hvac_mode_wrapper is None:
+            return None
         # If the switch is off, hvac mode is off as well.
         # Unless the switch doesn't exists of course...
         if (switch_status := self._read_wrapper(self._switch_wrapper)) is False:

--- a/tests/components/tuya/snapshots/test_climate.ambr
+++ b/tests/components/tuya/snapshots/test_climate.ambr
@@ -651,7 +651,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_platform_setup_and_discovery[climate.itc_308_wifi_thermostat-entry]
@@ -713,7 +713,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_platform_setup_and_discovery[climate.kabinet-entry]
@@ -1007,7 +1007,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_platform_setup_and_discovery[climate.polotentsosushitel-entry]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Related to #157876 / #158258 / #158452
- if the climate entity is missing both switch and mode wrapper, it now returns `None` (previously returned OFF)
- if the climate entity has a mode wrapper, but the mode wrapper returns an invalid value (not present in enum), it now returns `None` (previously returned default `switch_only_hvac_mode`)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
