### PR TITLE
Do not create `restart` button for sleeping gen2+ Shelly devices

### DIFF
--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -199,8 +199,8 @@ async def async_setup_entry(
     """Set up button entities."""
     entry_data = config_entry.runtime_data
     coordinator: ShellyRpcCoordinator | ShellyBlockCoordinator | None
-    entry_gen = get_device_entry_gen(config_entry)
-    if entry_gen in RPC_GENERATIONS:
+    device_gen = get_device_entry_gen(config_entry)
+    if device_gen in RPC_GENERATIONS:
         coordinator = entry_data.rpc
     else:
         coordinator = entry_data.block
@@ -215,7 +215,8 @@ async def async_setup_entry(
 
     # Remove the 'restart' button for sleeping devices as it was mistakenly
     # added in https://github.com/home-assistant/core/pull/154673
-    if entry_gen in RPC_GENERATIONS and config_entry.data[CONF_SLEEP_PERIOD]:
+    entry_sleep_period = config_entry.data[CONF_SLEEP_PERIOD]
+    if device_gen in RPC_GENERATIONS and entry_sleep_period:
         async_remove_shelly_entity(hass, BUTTON_PLATFORM, f"{coordinator.mac}-reboot")
 
     entities: list[ShellyButton] = []
@@ -232,7 +233,7 @@ async def async_setup_entry(
         return
 
     # add RPC buttons
-    if config_entry.data[CONF_SLEEP_PERIOD]:
+    if entry_sleep_period:
         async_setup_entry_rpc(
             hass,
             config_entry,

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -199,7 +199,8 @@ async def async_setup_entry(
     """Set up button entities."""
     entry_data = config_entry.runtime_data
     coordinator: ShellyRpcCoordinator | ShellyBlockCoordinator | None
-    if get_device_entry_gen(config_entry) in RPC_GENERATIONS:
+    entry_gen = get_device_entry_gen(config_entry)
+    if entry_gen in RPC_GENERATIONS:
         coordinator = entry_data.rpc
     else:
         coordinator = entry_data.block
@@ -214,10 +215,7 @@ async def async_setup_entry(
 
     # Remove the 'restart' button for sleeping devices as it was mistakenly
     # added in https://github.com/home-assistant/core/pull/154673
-    if (
-        get_device_entry_gen(config_entry) in RPC_GENERATIONS
-        and coordinator.sleep_period > 0
-    ):
+    if entry_gen in RPC_GENERATIONS and coordinator.sleep_period > 0:
         async_remove_shelly_entity(hass, BUTTON_PLATFORM, f"{coordinator.mac}-reboot")
 
     entities: list[ShellyButton] = []

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -44,6 +44,7 @@ from .entity import (
 )
 from .utils import (
     async_remove_orphaned_entities,
+    async_remove_shelly_entity,
     format_ble_addr,
     get_blu_trv_device_info,
     get_device_entry_gen,
@@ -210,6 +211,11 @@ async def async_setup_entry(
         await er.async_migrate_entries(
             hass, config_entry.entry_id, partial(async_migrate_unique_ids, coordinator)
         )
+
+    # Remove the 'restart' button for sleeping devices as it was mistakenly
+    # added in https://github.com/home-assistant/core/pull/154673
+    if coordinator.sleep_period == 0:
+        async_remove_shelly_entity(hass, BUTTON_PLATFORM, f"{coordinator.mac}-reboot")
 
     entities: list[ShellyButton] = []
 

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -80,6 +80,7 @@ BUTTONS: Final[list[ShellyButtonDescription[Any]]] = [
         device_class=ButtonDeviceClass.RESTART,
         entity_category=EntityCategory.CONFIG,
         press_action="trigger_reboot",
+        supported=lambda coordinator: coordinator.sleep_period == 0,
     ),
     ShellyButtonDescription[ShellyBlockCoordinator](
         key="self_test",

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -214,7 +214,10 @@ async def async_setup_entry(
 
     # Remove the 'restart' button for sleeping devices as it was mistakenly
     # added in https://github.com/home-assistant/core/pull/154673
-    if coordinator.sleep_period > 0:
+    if (
+        get_device_entry_gen(config_entry) in RPC_GENERATIONS
+        and coordinator.sleep_period > 0
+    ):
         async_remove_shelly_entity(hass, BUTTON_PLATFORM, f"{coordinator.mac}-reboot")
 
     entities: list[ShellyButton] = []

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -215,7 +215,7 @@ async def async_setup_entry(
 
     # Remove the 'restart' button for sleeping devices as it was mistakenly
     # added in https://github.com/home-assistant/core/pull/154673
-    if entry_gen in RPC_GENERATIONS and coordinator.sleep_period > 0:
+    if entry_gen in RPC_GENERATIONS and config_entry.data[CONF_SLEEP_PERIOD]:
         async_remove_shelly_entity(hass, BUTTON_PLATFORM, f"{coordinator.mac}-reboot")
 
     entities: list[ShellyButton] = []

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -214,7 +214,7 @@ async def async_setup_entry(
 
     # Remove the 'restart' button for sleeping devices as it was mistakenly
     # added in https://github.com/home-assistant/core/pull/154673
-    if coordinator.sleep_period == 0:
+    if coordinator.sleep_period > 0:
         async_remove_shelly_entity(hass, BUTTON_PLATFORM, f"{coordinator.mac}-reboot")
 
     entities: list[ShellyButton] = []

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -554,3 +554,30 @@ async def test_wall_display_screen_buttons(
         blocking=True,
     )
     mock_rpc_device.wall_display_set_screen.assert_called_once_with(value=value)
+
+
+async def test_rpc_remove_restart_button_for_sleeping_devices(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    device_registry: DeviceRegistry,
+    entity_registry: EntityRegistry,
+) -> None:
+    """Test RPC remove restart button for sleeping devices."""
+    config_entry = await init_integration(hass, 2, sleep_period=1000, skip_setup=True)
+    device_entry = register_device(device_registry, config_entry)
+    entity_id = register_entity(
+        hass,
+        BUTTON_DOMAIN,
+        "test_name_restart",
+        "reboot",
+        config_entry,
+        device_id=device_entry.id,
+    )
+
+    assert entity_registry.async_get(entity_id) is not None
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get(entity_id) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After merge #154673, the `restart` button is created for sleeping gen2+ devices, which is incorrect. These devices sleep almost all the time, so using the `restart` button is practically impossible.
This PR:
- removes existing `restart` buttons for sleeping gen2 devices
- adds a condition so that this entity is not recreated for sleeping devices

I don't think this change is a breaking change because it was practically impossible to use incorrectly created entities. If I'm wrong, please let me know and I'll add a description in the breaking change section.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
