### PR TITLE
Fix inverted kelvin issue

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -635,14 +635,14 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
             # Support legacy mireds in template light.
             temperature = int(render)
             if (min_kelvin := self._attr_min_color_temp_kelvin) is not None:
-                min_mireds = color_util.color_temperature_kelvin_to_mired(min_kelvin)
-            else:
-                min_mireds = DEFAULT_MIN_MIREDS
-
-            if (max_kelvin := self._attr_max_color_temp_kelvin) is not None:
-                max_mireds = color_util.color_temperature_kelvin_to_mired(max_kelvin)
+                max_mireds = color_util.color_temperature_kelvin_to_mired(min_kelvin)
             else:
                 max_mireds = DEFAULT_MAX_MIREDS
+
+            if (max_kelvin := self._attr_max_color_temp_kelvin) is not None:
+                min_mireds = color_util.color_temperature_kelvin_to_mired(max_kelvin)
+            else:
+                min_mireds = DEFAULT_MIN_MIREDS
             if min_mireds <= temperature <= max_mireds:
                 self._attr_color_temp_kelvin = (
                     color_util.color_temperature_mired_to_kelvin(temperature)
@@ -856,42 +856,36 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
 
         try:
             if render in (None, "None", ""):
-                self._attr_max_mireds = DEFAULT_MAX_MIREDS
-                self._attr_max_color_temp_kelvin = None
+                self._attr_min_color_temp_kelvin = None
                 return
 
-            self._attr_max_mireds = max_mireds = int(render)
-            self._attr_max_color_temp_kelvin = (
-                color_util.color_temperature_mired_to_kelvin(max_mireds)
+            self._attr_min_color_temp_kelvin = (
+                color_util.color_temperature_mired_to_kelvin(int(render))
             )
         except ValueError:
             _LOGGER.exception(
                 "Template must supply an integer temperature within the range for"
                 " this light, or 'None'"
             )
-            self._attr_max_mireds = DEFAULT_MAX_MIREDS
-            self._attr_max_color_temp_kelvin = None
+            self._attr_min_color_temp_kelvin = None
 
     @callback
     def _update_min_mireds(self, render):
         """Update the min mireds from the template."""
         try:
             if render in (None, "None", ""):
-                self._attr_min_mireds = DEFAULT_MIN_MIREDS
-                self._attr_min_color_temp_kelvin = None
+                self._attr_max_color_temp_kelvin = None
                 return
 
-            self._attr_min_mireds = min_mireds = int(render)
-            self._attr_min_color_temp_kelvin = (
-                color_util.color_temperature_mired_to_kelvin(min_mireds)
+            self._attr_max_color_temp_kelvin = (
+                color_util.color_temperature_mired_to_kelvin(int(render))
             )
         except ValueError:
             _LOGGER.exception(
                 "Template must supply an integer temperature within the range for"
                 " this light, or 'None'"
             )
-            self._attr_min_mireds = DEFAULT_MIN_MIREDS
-            self._attr_min_color_temp_kelvin = None
+            self._attr_max_color_temp_kelvin = None
 
     @callback
     def _update_supports_transition(self, render):

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -2345,19 +2345,20 @@ async def test_effect_template(
     ],
 )
 @pytest.mark.parametrize(
-    ("expected_min_mireds", "attribute_template"),
+    ("expected_min_mireds", "expected_max_kelvin", "attribute_template"),
     [
-        (118, "{{118}}"),
-        (153, "{{x - 12}}"),
-        (153, "None"),
-        (153, "{{ none }}"),
-        (153, ""),
-        (153, "{{ 'a' }}"),
+        (118, 8474, "{{118}}"),
+        (153, 6535, "{{x - 12}}"),
+        (153, 6535, "None"),
+        (153, 6535, "{{ none }}"),
+        (153, 6535, ""),
+        (153, 6535, "{{ 'a' }}"),
     ],
 )
 async def test_min_mireds_template(
     hass: HomeAssistant,
-    expected_min_mireds,
+    expected_min_mireds: int,
+    expected_max_kelvin: int,
     style: ConfigurationStyle,
     setup_light_with_mireds,
 ) -> None:
@@ -2369,6 +2370,7 @@ async def test_min_mireds_template(
     state = hass.states.get("light.test_template_light")
     assert state is not None
     assert state.attributes.get("min_mireds") == expected_min_mireds
+    assert state.attributes.get("max_color_temp_kelvin") == expected_max_kelvin
 
 
 @pytest.mark.parametrize("count", [1])
@@ -2381,19 +2383,20 @@ async def test_min_mireds_template(
     ],
 )
 @pytest.mark.parametrize(
-    ("expected_max_mireds", "attribute_template"),
+    ("expected_max_mireds", "expected_min_kelvin", "attribute_template"),
     [
-        (488, "{{488}}"),
-        (500, "{{x - 12}}"),
-        (500, "None"),
-        (500, "{{ none }}"),
-        (500, ""),
-        (500, "{{ 'a' }}"),
+        (488, 2049, "{{488}}"),
+        (500, 2000, "{{x - 12}}"),
+        (500, 2000, "None"),
+        (500, 2000, "{{ none }}"),
+        (500, 2000, ""),
+        (500, 2000, "{{ 'a' }}"),
     ],
 )
 async def test_max_mireds_template(
     hass: HomeAssistant,
-    expected_max_mireds,
+    expected_max_mireds: int,
+    expected_min_kelvin: int,
     style: ConfigurationStyle,
     setup_light_with_mireds,
 ) -> None:
@@ -2405,6 +2408,7 @@ async def test_max_mireds_template(
     state = hass.states.get("light.test_template_light")
     assert state is not None
     assert state.attributes.get("max_mireds") == expected_max_mireds
+    assert state.attributes.get("min_color_temp_kelvin") == expected_min_kelvin
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix an issue where I accidentally inverted kelvin when cleaning up the light integration.  Also removed references to _attr_min_mired and _attr_max_mired

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/158045
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
