### PR TITLE
Add support for "Indoor Only" mode on Sure Petcare pets/flaps

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1568,8 +1568,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/sunricher_dali/ @niracler
 /tests/components/sunricher_dali/ @niracler
 /homeassistant/components/supla/ @mwegrzynek
-/homeassistant/components/surepetcare/ @benleb @danielhiversen
-/tests/components/surepetcare/ @benleb @danielhiversen
+/homeassistant/components/surepetcare/ @benleb @danielhiversen @AlexC
+/tests/components/surepetcare/ @benleb @danielhiversen @AlexC
 /homeassistant/components/swiss_hydrological_data/ @fabaff
 /homeassistant/components/swiss_public_transport/ @fabaff @miaucl
 /tests/components/swiss_public_transport/ @fabaff @miaucl

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -28,7 +28,7 @@ from .coordinator import SurePetcareDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.LOCK, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.LOCK, Platform.SENSOR, Platform.SWITCH]
 SCAN_INTERVAL = timedelta(minutes=3)
 
 

--- a/homeassistant/components/surepetcare/const.py
+++ b/homeassistant/components/surepetcare/const.py
@@ -21,3 +21,7 @@ ATTR_FLAP_ID = "flap_id"
 ATTR_LOCATION = "location"
 ATTR_LOCK_STATE = "lock_state"
 ATTR_PET_NAME = "pet_name"
+
+# pet profile modes
+PROFILE_INDOOR = 3  # indoor mode - pet can enter but cannot exit
+PROFILE_OUTDOOR = 2  # outdoor/normal mode - pet can enter and exit

--- a/homeassistant/components/surepetcare/manifest.json
+++ b/homeassistant/components/surepetcare/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "surepetcare",
   "name": "Sure Petcare",
-  "codeowners": ["@benleb", "@danielhiversen"],
+  "codeowners": ["@benleb", "@danielhiversen", "@AlexC"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/surepetcare",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/surepetcare/strings.json
+++ b/homeassistant/components/surepetcare/strings.json
@@ -28,7 +28,7 @@
   "entity": {
     "switch": {
       "indoor_mode": {
-        "name": "{pet_name} indoor only mode"
+        "name": "{pet_name} indoor-only mode"
       }
     }
   },

--- a/homeassistant/components/surepetcare/strings.json
+++ b/homeassistant/components/surepetcare/strings.json
@@ -25,6 +25,13 @@
       }
     }
   },
+  "entity": {
+    "switch": {
+      "indoor_mode": {
+        "name": "{pet_name} indoor only mode"
+      }
+    }
+  },
   "services": {
     "set_lock_state": {
       "description": "Sets lock state.",

--- a/homeassistant/components/surepetcare/switch.py
+++ b/homeassistant/components/surepetcare/switch.py
@@ -84,15 +84,6 @@ class SurePetcareIndoorModeSwitch(SurePetcareEntity, SwitchEntity):
         """Return true if entity is available."""
         return self._available and super().available
 
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return extra state attributes."""
-        return {
-            "pet_name": self._pet.name,
-            "flap_name": self._flap.name,
-            "profile_id": self._profile_id,
-        }
-
     @callback
     def _update_attr(self, surepy_entity: SurepyEntity) -> None:
         """Update the state from the flap's tag data."""

--- a/homeassistant/components/surepetcare/switch.py
+++ b/homeassistant/components/surepetcare/switch.py
@@ -1,0 +1,146 @@
+"""Support for Sure PetCare Flaps switches."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from surepy.const import BASE_RESOURCE
+from surepy.entities import SurepyEntity
+from surepy.entities.pet import Pet as SurepyPet
+from surepy.enums import EntityType
+from surepy.exceptions import SurePetcareError
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN, PROFILE_INDOOR, PROFILE_OUTDOOR
+from .coordinator import SurePetcareDataCoordinator
+from .entity import SurePetcareEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Sure PetCare switches on a config entry."""
+
+    coordinator: SurePetcareDataCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    pets_by_tag_id: dict[int, SurepyPet] = {}
+    for entity in coordinator.data.values():
+        if entity.type == EntityType.PET:
+            pet = cast(SurepyPet, entity)
+            if pet.tag_id is not None:
+                pets_by_tag_id[pet.tag_id] = pet
+
+    entities: list[SurePetcareIndoorModeSwitch] = []
+    for entity in coordinator.data.values():
+        if entity.type in [EntityType.CAT_FLAP, EntityType.PET_FLAP]:
+            for tag_data in entity.raw_data().get("tags", []):
+                tag_id = tag_data.get("id")
+                if tag_id in pets_by_tag_id:
+                    entities.append(
+                        SurePetcareIndoorModeSwitch(
+                            pet=pets_by_tag_id[tag_id],
+                            flap=entity,
+                            coordinator=coordinator,
+                        )
+                    )
+
+    async_add_entities(entities)
+
+
+class SurePetcareIndoorModeSwitch(SurePetcareEntity, SwitchEntity):
+    """A switch implementation for Sure Petcare pet indoor mode."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "indoor_mode"
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        pet: SurepyPet,
+        flap: SurepyEntity,
+        coordinator: SurePetcareDataCoordinator,
+    ) -> None:
+        """Initialize a Sure Petcare indoor mode switch."""
+        self._pet = pet
+        self._flap = flap
+        self._profile_id: int | None = None
+        self._available = False
+
+        # Initialize with flap_id so the entity is attached to the flap device
+        super().__init__(flap.id, coordinator)
+
+        self._attr_unique_id = f"{self._device_id}-{pet.id}-indoor_mode"
+        self._attr_translation_placeholders = {"pet_name": pet.name}
+
+    @property
+    def available(self) -> bool:
+        """Return true if entity is available."""
+        return self._available and super().available
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        return {
+            "pet_name": self._pet.name,
+            "flap_name": self._flap.name,
+            "profile_id": self._profile_id,
+        }
+
+    @callback
+    def _update_attr(self, surepy_entity: SurepyEntity) -> None:
+        """Update the state from the flap's tag data."""
+        tags_by_id = {
+            tag.get("id"): tag for tag in surepy_entity.raw_data().get("tags", [])
+        }
+
+        pet_tag = tags_by_id.get(self._pet.tag_id)
+        if pet_tag is None:
+            # Pet no longer configured for this flap
+            self._available = False
+            self._profile_id = None
+            return
+
+        self._available = True
+        self._profile_id = pet_tag.get("profile", PROFILE_OUTDOOR)
+        self._attr_is_on = self._profile_id == PROFILE_INDOOR
+
+    async def _async_set_profile(self, profile: int) -> None:
+        """Set the pet's profile on this flap."""
+        try:
+            await self.coordinator.surepy.sac.call(
+                method="PUT",
+                resource=f"{BASE_RESOURCE}/device/{self._flap.id}/tag/{self._pet.tag_id}",
+                json={"profile": profile},
+            )
+        except SurePetcareError as err:
+            await self.coordinator.async_request_refresh()
+            mode = "indoor" if profile == PROFILE_INDOOR else "outdoor"
+            raise HomeAssistantError(
+                f"Failed to set {self._pet.name} {mode} mode on {self._flap.name}"
+            ) from err
+
+        # Update state immediately after successful API call
+        self._profile_id = profile
+        self._attr_is_on = profile == PROFILE_INDOOR
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the switch (set indoor mode)."""
+        if self._attr_is_on:
+            return
+
+        await self._async_set_profile(PROFILE_INDOOR)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the switch (set outdoor mode)."""
+        if not self._attr_is_on:
+            return
+
+        await self._async_set_profile(PROFILE_OUTDOOR)

--- a/tests/components/surepetcare/__init__.py
+++ b/tests/components/surepetcare/__init__.py
@@ -1,5 +1,13 @@
 """Tests for Sure Petcare integration."""
 
+from unittest.mock import AsyncMock
+
+from homeassistant.components.surepetcare.const import DOMAIN
+from homeassistant.components.surepetcare.coordinator import SurePetcareDataCoordinator
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
 HOUSEHOLD_ID = 987654321
 HUB_ID = 123456789
 
@@ -56,6 +64,10 @@ MOCK_CAT_FLAP = {
         "signal": {"device_rssi": 65, "hub_rssi": 64},
         "online": True,
     },
+    # id: tag ID (matches pet's tag_id), profile: 3 = indoor only (HA switch ON)
+    "tags": [
+        {"id": 246801, "profile": 3},
+    ],
 }
 
 MOCK_PET_FLAP = {
@@ -71,10 +83,15 @@ MOCK_PET_FLAP = {
         "signal": {"device_rssi": 70, "hub_rssi": 65},
         "online": True,
     },
+    # id: tag ID (matches pet's tag_id), profile: 2 = outdoor (HA switch OFF)
+    "tags": [
+        {"id": 246801, "profile": 2},
+    ],
 }
 
 MOCK_PET = {
     "id": 24680,
+    "tag_id": 246801,  # Tag ID used to match against flap tags
     "household_id": HOUSEHOLD_ID,
     "name": "Pet",
     "position": {"since": "2020-08-23T23:10:50", "where": 1},
@@ -85,3 +102,15 @@ MOCK_API_DATA = {
     "devices": [MOCK_HUB, MOCK_CAT_FLAP, MOCK_PET_FLAP, MOCK_FEEDER, MOCK_FELAQUA],
     "pets": [MOCK_PET],
 }
+
+
+async def setup_integration(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    surepetcare_mock: AsyncMock,
+) -> SurePetcareDataCoordinator:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    return hass.data[DOMAIN][config_entry.entry_id]

--- a/tests/components/surepetcare/conftest.py
+++ b/tests/components/surepetcare/conftest.py
@@ -3,11 +3,10 @@
 from unittest.mock import patch
 
 import pytest
-from surepy import MESTART_RESOURCE
+from surepy.const import MESTART_RESOURCE
 
 from homeassistant.components.surepetcare.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
-from homeassistant.core import HomeAssistant
 
 from . import MOCK_API_DATA
 
@@ -15,6 +14,7 @@ from tests.common import MockConfigEntry
 
 
 async def _mock_call(method, resource):
+    """Mock API call that only handles the initial GET request."""
     if method == "GET" and resource == MESTART_RESOURCE:
         return {"data": MOCK_API_DATA}
     return None
@@ -32,17 +32,16 @@ async def surepetcare():
 
 
 @pytest.fixture
-async def mock_config_entry_setup(hass: HomeAssistant) -> MockConfigEntry:
-    """Help setting up a mocked config entry."""
-    data = {
-        CONF_USERNAME: "test-username",
-        CONF_PASSWORD: "test-password",
-        CONF_TOKEN: "token",
-        "feeders": [12345],
-        "flaps": [13579, 13576],
-        "pets": [24680],
-    }
-    entry = MockConfigEntry(domain=DOMAIN, data=data)
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    return entry
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+            CONF_TOKEN: "token",
+            "feeders": [12345],
+            "flaps": [13579, 13576],
+            "pets": [24680],
+        },
+    )

--- a/tests/components/surepetcare/snapshots/test_switch.ambr
+++ b/tests/components/surepetcare/snapshots/test_switch.ambr
@@ -37,10 +37,7 @@
 # name: test_switches[switch.cat_flap_pet_indoor_only_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'flap_name': 'Cat Flap',
       'friendly_name': 'Cat flap Pet indoor only mode',
-      'pet_name': 'Pet',
-      'profile_id': 3,
     }),
     'context': <ANY>,
     'entity_id': 'switch.cat_flap_pet_indoor_only_mode',
@@ -88,10 +85,7 @@
 # name: test_switches[switch.pet_flap_pet_indoor_only_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'flap_name': 'Pet Flap',
       'friendly_name': 'Pet flap Pet indoor only mode',
-      'pet_name': 'Pet',
-      'profile_id': 2,
     }),
     'context': <ANY>,
     'entity_id': 'switch.pet_flap_pet_indoor_only_mode',

--- a/tests/components/surepetcare/snapshots/test_switch.ambr
+++ b/tests/components/surepetcare/snapshots/test_switch.ambr
@@ -1,0 +1,103 @@
+# serializer version: 1
+# name: test_switches[switch.cat_flap_pet_indoor_only_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.cat_flap_pet_indoor_only_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Pet indoor only mode',
+    'platform': 'surepetcare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indoor_mode',
+    'unique_id': '987654321-13579-24680-indoor_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.cat_flap_pet_indoor_only_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'flap_name': 'Cat Flap',
+      'friendly_name': 'Cat flap Pet indoor only mode',
+      'pet_name': 'Pet',
+      'profile_id': 3,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.cat_flap_pet_indoor_only_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.pet_flap_pet_indoor_only_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.pet_flap_pet_indoor_only_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Pet indoor only mode',
+    'platform': 'surepetcare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indoor_mode',
+    'unique_id': '987654321-13576-24680-indoor_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.pet_flap_pet_indoor_only_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'flap_name': 'Pet Flap',
+      'friendly_name': 'Pet flap Pet indoor only mode',
+      'pet_name': 'Pet',
+      'profile_id': 2,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.pet_flap_pet_indoor_only_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -3,7 +3,7 @@
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import HOUSEHOLD_ID, HUB_ID
+from . import HOUSEHOLD_ID, HUB_ID, setup_integration
 
 from tests.common import MockConfigEntry
 
@@ -20,9 +20,10 @@ async def test_binary_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     surepetcare,
-    mock_config_entry_setup: MockConfigEntry,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the generation of unique ids."""
+    await setup_integration(hass, mock_config_entry, surepetcare)
     state_entity_ids = hass.states.async_entity_ids()
 
     for entity_id, unique_id in EXPECTED_ENTITY_IDS.items():

--- a/tests/components/surepetcare/test_lock.py
+++ b/tests/components/surepetcare/test_lock.py
@@ -6,7 +6,7 @@ from surepy.exceptions import SurePetcareError
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import HOUSEHOLD_ID, MOCK_CAT_FLAP, MOCK_PET_FLAP
+from . import HOUSEHOLD_ID, MOCK_CAT_FLAP, MOCK_PET_FLAP, setup_integration
 
 from tests.common import MockConfigEntry
 
@@ -24,9 +24,10 @@ async def test_locks(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     surepetcare,
-    mock_config_entry_setup: MockConfigEntry,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the generation of unique ids."""
+    await setup_integration(hass, mock_config_entry, surepetcare)
     state_entity_ids = hass.states.async_entity_ids()
 
     for entity_id, unique_id in EXPECTED_ENTITY_IDS.items():
@@ -81,9 +82,10 @@ async def test_locks(
 
 
 async def test_lock_failing(
-    hass: HomeAssistant, surepetcare, mock_config_entry_setup: MockConfigEntry
+    hass: HomeAssistant, surepetcare, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test handling of lock failing."""
+    await setup_integration(hass, mock_config_entry, surepetcare)
     surepetcare.lock_in.side_effect = SurePetcareError
     surepetcare.lock_out.side_effect = SurePetcareError
     surepetcare.lock.side_effect = SurePetcareError
@@ -98,9 +100,10 @@ async def test_lock_failing(
 
 
 async def test_unlock_failing(
-    hass: HomeAssistant, surepetcare, mock_config_entry_setup: MockConfigEntry
+    hass: HomeAssistant, surepetcare, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test handling of unlock failing."""
+    await setup_integration(hass, mock_config_entry, surepetcare)
     entity_id = list(EXPECTED_ENTITY_IDS)[0]
 
     await hass.services.async_call(

--- a/tests/components/surepetcare/test_sensor.py
+++ b/tests/components/surepetcare/test_sensor.py
@@ -3,7 +3,7 @@
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import HOUSEHOLD_ID, MOCK_FELAQUA
+from . import HOUSEHOLD_ID, MOCK_FELAQUA, setup_integration
 
 from tests.common import MockConfigEntry
 
@@ -19,9 +19,10 @@ async def test_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     surepetcare,
-    mock_config_entry_setup: MockConfigEntry,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the generation of unique ids."""
+    await setup_integration(hass, mock_config_entry, surepetcare)
     state_entity_ids = hass.states.async_entity_ids()
 
     for entity_id, unique_id in EXPECTED_ENTITY_IDS.items():

--- a/tests/components/surepetcare/test_switch.py
+++ b/tests/components/surepetcare/test_switch.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, call, patch
 
 import pytest
 from surepy.const import BASE_RESOURCE, MESTART_RESOURCE
-from surepy.exceptions import SurePetcareError
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.surepetcare.const import PROFILE_INDOOR, PROFILE_OUTDOOR
@@ -20,11 +19,9 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 
 async def _mock_call_with_put_device_error(method, resource, json=None):
-    """Mock API call that fails on PUT to update device tags, succeeds on GET for refresh."""
-    # Fail on PUT to update device tags
+    """Mock API call that returns None on PUT (simulating 5XX error), succeeds on GET for refresh."""
     if method == "PUT" and "/tag/" in resource:
-        raise SurePetcareError("Test API error")
-    # Succeed on GET for refresh
+        return None
     if method == "GET" and resource == MESTART_RESOURCE:
         return {"data": MOCK_API_DATA}
     return None

--- a/tests/components/surepetcare/test_switch.py
+++ b/tests/components/surepetcare/test_switch.py
@@ -1,0 +1,318 @@
+"""Tests for Sure PetCare switches."""
+
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+from surepy.const import BASE_RESOURCE, MESTART_RESOURCE
+from surepy.exceptions import SurePetcareError
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.surepetcare.const import PROFILE_INDOOR, PROFILE_OUTDOOR
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import MOCK_API_DATA, MOCK_CAT_FLAP, MOCK_PET, MOCK_PET_FLAP, setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def _mock_call_with_put_device_error(method, resource, json=None):
+    """Mock API call that fails on PUT to update device tags, succeeds on GET for refresh."""
+    # Fail on PUT to update device tags
+    if method == "PUT" and "/tag/" in resource:
+        raise SurePetcareError("Test API error")
+    # Succeed on GET for refresh
+    if method == "GET" and resource == MESTART_RESOURCE:
+        return {"data": MOCK_API_DATA}
+    return None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switches(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    surepetcare,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test switch entities."""
+    with patch("homeassistant.components.surepetcare.PLATFORMS", [Platform.SWITCH]):
+        await setup_integration(hass, mock_config_entry, surepetcare)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switch_turn_on(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test turning on the switch (setting indoor mode)."""
+    await setup_integration(hass, mock_config_entry, surepetcare)
+    entity_id = "switch.pet_flap_pet_indoor_only_mode"
+
+    # Verify initial state is off
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+    surepetcare.call = AsyncMock(
+        return_value={
+            "data": {
+                "id": MOCK_PET["tag_id"],
+                "device_id": MOCK_PET_FLAP["id"],
+                "profile": PROFILE_INDOOR,
+            }
+        }
+    )
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    surepetcare.call.assert_called_once_with(
+        method="PUT",
+        resource=f"{BASE_RESOURCE}/device/{MOCK_PET_FLAP['id']}/tag/{MOCK_PET['tag_id']}",
+        json={"profile": PROFILE_INDOOR},
+    )
+
+    # Verify state changed to on
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switch_turn_off(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test turning off the switch (setting outdoor mode)."""
+    await setup_integration(hass, mock_config_entry, surepetcare)
+    entity_id = "switch.cat_flap_pet_indoor_only_mode"
+
+    # Verify initial state is on
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+
+    surepetcare.call = AsyncMock(
+        return_value={
+            "data": {
+                "id": MOCK_PET["tag_id"],
+                "device_id": MOCK_CAT_FLAP["id"],
+                "profile": PROFILE_OUTDOOR,
+            }
+        }
+    )
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_off",
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    surepetcare.call.assert_called_once_with(
+        method="PUT",
+        resource=f"{BASE_RESOURCE}/device/{MOCK_CAT_FLAP['id']}/tag/{MOCK_PET['tag_id']}",
+        json={"profile": PROFILE_OUTDOOR},
+    )
+
+    # Verify state changed to off
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switch_turn_on_already_on(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test turning on a switch that's already on (no redundant API call)."""
+    await setup_integration(hass, mock_config_entry, surepetcare)
+    entity_id = "switch.cat_flap_pet_indoor_only_mode"
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+
+    surepetcare.call = AsyncMock()
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    surepetcare.call.assert_not_called()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switch_turn_off_already_off(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test turning off a switch that's already off (no redundant API call)."""
+    await setup_integration(hass, mock_config_entry, surepetcare)
+    entity_id = "switch.pet_flap_pet_indoor_only_mode"
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+    surepetcare.call = AsyncMock()
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_off",
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    surepetcare.call.assert_not_called()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switch_turn_on_api_error(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test error handling when API call fails during turn_on."""
+    await setup_integration(hass, mock_config_entry, surepetcare)
+    entity_id = "switch.pet_flap_pet_indoor_only_mode"
+
+    # Verify initial state is off
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+    surepetcare.call = AsyncMock(side_effect=_mock_call_with_put_device_error)
+
+    with pytest.raises(
+        HomeAssistantError, match="Failed to set Pet indoor mode on Pet Flap"
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            "turn_on",
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    surepetcare.call.assert_has_calls(
+        [
+            call(
+                method="PUT",
+                resource=f"{BASE_RESOURCE}/device/{MOCK_PET_FLAP['id']}/tag/{MOCK_PET['tag_id']}",
+                json={"profile": PROFILE_INDOOR},
+            ),
+            call(method="GET", resource=MESTART_RESOURCE),  # refresh after error
+        ]
+    )
+
+    # Verify state remains off after error
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switch_turn_off_api_error(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test error handling when API call fails during turn_off."""
+    await setup_integration(hass, mock_config_entry, surepetcare)
+    entity_id = "switch.cat_flap_pet_indoor_only_mode"
+
+    # Verify initial state is on
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+
+    surepetcare.call = AsyncMock(side_effect=_mock_call_with_put_device_error)
+
+    with pytest.raises(
+        HomeAssistantError, match="Failed to set Pet outdoor mode on Cat Flap"
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            "turn_off",
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    surepetcare.call.assert_has_calls(
+        [
+            call(
+                method="PUT",
+                resource=f"{BASE_RESOURCE}/device/{MOCK_CAT_FLAP['id']}/tag/{MOCK_PET['tag_id']}",
+                json={"profile": PROFILE_OUTDOOR},
+            ),
+            call(method="GET", resource=MESTART_RESOURCE),  # refresh after error
+        ]
+    )
+
+    # Verify state remains on after error
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switch_pet_removed_from_flap(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test switch becomes unavailable when pet is removed from flap configuration."""
+    coordinator = await setup_integration(hass, mock_config_entry, surepetcare)
+    entity_id = "switch.cat_flap_pet_indoor_only_mode"
+
+    # Verify initial state is on
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+
+    async def mock_call_without_pet(method, resource, json=None):
+        if method == "GET" and resource == MESTART_RESOURCE:
+            return {
+                "data": {
+                    "devices": [
+                        {
+                            **MOCK_CAT_FLAP,
+                            "tags": [],  # Pet removed from flap configuration
+                        },
+                    ],
+                    "pets": [MOCK_PET],
+                }
+            }
+        return None
+
+    surepetcare.call = AsyncMock(side_effect=mock_call_without_pet)
+
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # Verify entity is now unavailable
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "unavailable"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR allows users to configure "Indoor Only" mode for their (cat) flaps, a feature which is part of the official Sure Petcare application and currently missing from this integration. When a pet is configured as "Indoor Only" they are unable to exit through the (cat) flap, however they can always enter again (should they escape through a window, for example).

This has been implemented by using a switch entity for each pet-flap combination, and calls the appropriate API endpoint using the surepy library. Each switch is attached to flap devices for logical grouping, and is disabled by default to reduce entity clutter.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #136035
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42172
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
