### PR TITLE
Add basic auth support to remote_calendar

### DIFF
--- a/homeassistant/components/remote_calendar/client.py
+++ b/homeassistant/components/remote_calendar/client.py
@@ -1,12 +1,22 @@
-"""Specifies the parameter for the httpx download."""
+"""HTTP client for fetching remote calendar data."""
 
-from httpx import AsyncClient, Response, Timeout
+from httpx import AsyncClient, Auth, BasicAuth, Response, Timeout
 
 
-async def get_calendar(client: AsyncClient, url: str) -> Response:
+async def get_calendar(
+    client: AsyncClient,
+    url: str,
+    username: str | None = None,
+    password: str | None = None,
+) -> Response:
     """Make an HTTP GET request using Home Assistant's async HTTPX client with timeout."""
+    auth: Auth | None = None
+    if username is not None and password is not None:
+        auth = BasicAuth(username, password)
+
     return await client.get(
         url,
+        auth=auth,
         follow_redirects=True,
         timeout=Timeout(5, read=30, write=5, pool=5),
     )

--- a/homeassistant/components/remote_calendar/config_flow.py
+++ b/homeassistant/components/remote_calendar/config_flow.py
@@ -17,16 +17,20 @@ from .ics import InvalidIcsException, parse_calendar
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema({
-    vol.Required(CONF_CALENDAR_NAME): str,
-    vol.Required(CONF_URL): str,
-    vol.Required(CONF_VERIFY_SSL, default=True): bool,
-})
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_CALENDAR_NAME): str,
+        vol.Required(CONF_URL): str,
+        vol.Required(CONF_VERIFY_SSL, default=True): bool,
+    }
+)
 
-STEP_AUTH_DATA_SCHEMA = vol.Schema({
-    vol.Required(CONF_USERNAME): str,
-    vol.Required(CONF_PASSWORD): str,
-})
+STEP_AUTH_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
 
 
 class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -48,9 +52,9 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA
             )
         errors: dict[str, str] = {}
-        self._async_abort_entries_match({
-            CONF_CALENDAR_NAME: user_input[CONF_CALENDAR_NAME]
-        })
+        self._async_abort_entries_match(
+            {CONF_CALENDAR_NAME: user_input[CONF_CALENDAR_NAME]}
+        )
         if user_input[CONF_URL].startswith("webcal://"):
             user_input[CONF_URL] = user_input[CONF_URL].replace(
                 "webcal://", "https://", 1

--- a/homeassistant/components/remote_calendar/config_flow.py
+++ b/homeassistant/components/remote_calendar/config_flow.py
@@ -8,7 +8,7 @@ from httpx import HTTPError, InvalidURL, TimeoutException
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_URL, CONF_VERIFY_SSL
+from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .client import get_calendar
@@ -25,11 +25,23 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_AUTH_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
 
 class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Remote Calendar."""
 
     VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        super().__init__()
+        self.data: dict[str, Any] = {}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -39,8 +51,7 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA
             )
-        errors: dict = {}
-        _LOGGER.debug("User input: %s", user_input)
+        errors: dict[str, str] = {}
         self._async_abort_entries_match(
             {CONF_CALENDAR_NAME: user_input[CONF_CALENDAR_NAME]}
         )
@@ -52,6 +63,11 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
         client = get_async_client(self.hass, verify_ssl=user_input[CONF_VERIFY_SSL])
         try:
             res = await get_calendar(client, user_input[CONF_URL])
+            if res.status_code == HTTPStatus.UNAUTHORIZED:
+                www_auth = res.headers.get("www-authenticate", "").lower()
+                if "basic" in www_auth:
+                    self.data = user_input
+                    return await self.async_step_auth()
             if res.status_code == HTTPStatus.FORBIDDEN:
                 errors["base"] = "forbidden"
                 return self.async_show_form(
@@ -81,5 +97,58 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_auth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the authentication step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="auth",
+                data_schema=STEP_AUTH_DATA_SCHEMA,
+            )
+
+        errors: dict[str, str] = {}
+        client = get_async_client(self.hass, verify_ssl=self.data[CONF_VERIFY_SSL])
+        try:
+            res = await get_calendar(
+                client,
+                self.data[CONF_URL],
+                username=user_input[CONF_USERNAME],
+                password=user_input[CONF_PASSWORD],
+            )
+            if res.status_code == HTTPStatus.UNAUTHORIZED:
+                errors["base"] = "invalid_auth"
+            elif res.status_code == HTTPStatus.FORBIDDEN:
+                return self.async_abort(reason="forbidden")
+            else:
+                res.raise_for_status()
+        except TimeoutException:
+            errors["base"] = "timeout_connect"
+        except (HTTPError, InvalidURL):
+            errors["base"] = "cannot_connect"
+        else:
+            if not errors:
+                try:
+                    await parse_calendar(self.hass, res.text)
+                except InvalidIcsException:
+                    return self.async_abort(reason="invalid_ics_file")
+                else:
+                    return self.async_create_entry(
+                        title=self.data[CONF_CALENDAR_NAME],
+                        data={
+                            **self.data,
+                            CONF_USERNAME: user_input[CONF_USERNAME],
+                            CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        },
+                    )
+
+        return self.async_show_form(
+            step_id="auth",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_AUTH_DATA_SCHEMA, user_input
+            ),
             errors=errors,
         )

--- a/homeassistant/components/remote_calendar/config_flow.py
+++ b/homeassistant/components/remote_calendar/config_flow.py
@@ -125,12 +125,14 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="forbidden")
             else:
                 res.raise_for_status()
-        except TimeoutException:
+        except TimeoutException as err:
             errors["base"] = "timeout_connect"
-        except HTTPError:
+            _LOGGER.debug(
+                "A timeout error occurred: %s", str(err) or type(err).__name__
+            )
+        except (HTTPError, InvalidURL) as err:
             errors["base"] = "cannot_connect"
-        except InvalidURL:
-            errors["base"] = "cannot_connect"
+            _LOGGER.debug("An error occurred: %s", str(err) or type(err).__name__)
         else:
             if not errors:
                 try:

--- a/homeassistant/components/remote_calendar/config_flow.py
+++ b/homeassistant/components/remote_calendar/config_flow.py
@@ -17,20 +17,16 @@ from .ics import InvalidIcsException, parse_calendar
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_CALENDAR_NAME): str,
-        vol.Required(CONF_URL): str,
-        vol.Required(CONF_VERIFY_SSL, default=True): bool,
-    }
-)
+STEP_USER_DATA_SCHEMA = vol.Schema({
+    vol.Required(CONF_CALENDAR_NAME): str,
+    vol.Required(CONF_URL): str,
+    vol.Required(CONF_VERIFY_SSL, default=True): bool,
+})
 
-STEP_AUTH_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
-    }
-)
+STEP_AUTH_DATA_SCHEMA = vol.Schema({
+    vol.Required(CONF_USERNAME): str,
+    vol.Required(CONF_PASSWORD): str,
+})
 
 
 class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -52,9 +48,9 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA
             )
         errors: dict[str, str] = {}
-        self._async_abort_entries_match(
-            {CONF_CALENDAR_NAME: user_input[CONF_CALENDAR_NAME]}
-        )
+        self._async_abort_entries_match({
+            CONF_CALENDAR_NAME: user_input[CONF_CALENDAR_NAME]
+        })
         if user_input[CONF_URL].startswith("webcal://"):
             user_input[CONF_URL] = user_input[CONF_URL].replace(
                 "webcal://", "https://", 1
@@ -127,7 +123,9 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                 res.raise_for_status()
         except TimeoutException:
             errors["base"] = "timeout_connect"
-        except (HTTPError, InvalidURL):
+        except HTTPError:
+            errors["base"] = "cannot_connect"
+        except InvalidURL:
             errors["base"] = "cannot_connect"
         else:
             if not errors:

--- a/homeassistant/components/remote_calendar/coordinator.py
+++ b/homeassistant/components/remote_calendar/coordinator.py
@@ -7,7 +7,7 @@ from httpx import HTTPError, InvalidURL, TimeoutException
 from ical.calendar import Calendar
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_URL, CONF_VERIFY_SSL
+from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -46,11 +46,18 @@ class RemoteCalendarDataUpdateCoordinator(DataUpdateCoordinator[Calendar]):
             hass, verify_ssl=config_entry.data.get(CONF_VERIFY_SSL, True)
         )
         self._url = config_entry.data[CONF_URL]
+        self._username: str | None = config_entry.data.get(CONF_USERNAME)
+        self._password: str | None = config_entry.data.get(CONF_PASSWORD)
 
     async def _async_update_data(self) -> Calendar:
         """Update data from the url."""
         try:
-            res = await get_calendar(self._client, self._url)
+            res = await get_calendar(
+                self._client,
+                self._url,
+                username=self._username,
+                password=self._password,
+            )
             res.raise_for_status()
         except TimeoutException as err:
             _LOGGER.debug("%s: %s", self._url, str(err) or type(err).__name__)

--- a/homeassistant/components/remote_calendar/strings.json
+++ b/homeassistant/components/remote_calendar/strings.json
@@ -13,6 +13,17 @@
       "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]"
     },
     "step": {
+      "auth": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "The password for HTTP Basic Authentication.",
+          "username": "The username for HTTP Basic Authentication."
+        },
+        "description": "The calendar requires authentication."
+      },
       "user": {
         "data": {
           "calendar_name": "Calendar name",
@@ -25,17 +36,6 @@
           "verify_ssl": "[%key:common::config_flow::description::verify_ssl%]"
         },
         "description": "Please choose a name for the calendar to be imported"
-      },
-      "auth": {
-        "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
-        },
-        "data_description": {
-          "username": "The username for HTTP Basic Authentication.",
-          "password": "The password for HTTP Basic Authentication."
-        },
-        "description": "The calendar requires authentication."
       }
     }
   },

--- a/homeassistant/components/remote_calendar/strings.json
+++ b/homeassistant/components/remote_calendar/strings.json
@@ -1,11 +1,14 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "forbidden": "[%key:component::remote_calendar::config::error::forbidden%]",
+      "invalid_ics_file": "[%key:component::remote_calendar::config::error::invalid_ics_file%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "forbidden": "The server understood the request but refuses to authorize it.",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_ics_file": "There was a problem reading the calendar information. See the error log for additional details.",
       "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]"
     },
@@ -22,6 +25,17 @@
           "verify_ssl": "[%key:common::config_flow::description::verify_ssl%]"
         },
         "description": "Please choose a name for the calendar to be imported"
+      },
+      "auth": {
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "username": "The username for HTTP Basic Authentication.",
+          "password": "The password for HTTP Basic Authentication."
+        },
+        "description": "The calendar requires authentication."
       }
     }
   },

--- a/tests/components/remote_calendar/test_config_flow.py
+++ b/tests/components/remote_calendar/test_config_flow.py
@@ -6,7 +6,7 @@ import respx
 
 from homeassistant.components.remote_calendar.const import CONF_CALENDAR_NAME, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_URL, CONF_VERIFY_SSL
+from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -326,3 +326,249 @@ async def test_duplicate_url(
 
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
+
+
+@respx.mock
+async def test_form_unauthorized_basic_auth(
+    hass: HomeAssistant, ics_content: str
+) -> None:
+    """Test 401 with WWW-Authenticate: Basic triggers auth step and succeeds."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=401,
+            headers={"www-authenticate": 'Basic realm="test"'},
+        )
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_CALENDAR_NAME: CALENDAR_NAME,
+            CONF_URL: CALENDER_URL,
+            CONF_VERIFY_SSL: True,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "auth"
+
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=200,
+            text=ics_content,
+        )
+    )
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
+    )
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == CALENDAR_NAME
+    assert result3["data"] == {
+        CONF_CALENDAR_NAME: CALENDAR_NAME,
+        CONF_URL: CALENDER_URL,
+        CONF_VERIFY_SSL: True,
+        CONF_USERNAME: "user",
+        CONF_PASSWORD: "pass",
+    }
+
+
+@respx.mock
+async def test_form_auth_invalid_credentials(
+    hass: HomeAssistant, ics_content: str
+) -> None:
+    """Test wrong credentials in auth step shows invalid_auth error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=401,
+            headers={"www-authenticate": 'Basic realm="test"'},
+        )
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_CALENDAR_NAME: CALENDAR_NAME,
+            CONF_URL: CALENDER_URL,
+            CONF_VERIFY_SSL: True,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "auth"
+
+    # Wrong credentials - server still returns 401
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: "wrong",
+            CONF_PASSWORD: "wrong",
+        },
+    )
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["step_id"] == "auth"
+    assert result3["errors"] == {"base": "invalid_auth"}
+
+    # Correct credentials
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=200,
+            text=ics_content,
+        )
+    )
+    result4 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
+    )
+    assert result4["type"] is FlowResultType.CREATE_ENTRY
+    assert result4["title"] == CALENDAR_NAME
+
+
+@respx.mock
+async def test_form_auth_forbidden_aborts(hass: HomeAssistant) -> None:
+    """Test 403 in auth step aborts the flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=401,
+            headers={"www-authenticate": 'Basic realm="test"'},
+        )
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_CALENDAR_NAME: CALENDAR_NAME,
+            CONF_URL: CALENDER_URL,
+            CONF_VERIFY_SSL: True,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "auth"
+
+    respx.get(CALENDER_URL).mock(return_value=Response(status_code=403))
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
+    )
+    assert result3["type"] is FlowResultType.ABORT
+    assert result3["reason"] == "forbidden"
+
+
+@respx.mock
+async def test_form_auth_invalid_ics_aborts(hass: HomeAssistant) -> None:
+    """Test invalid ICS in auth step aborts the flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=401,
+            headers={"www-authenticate": 'Basic realm="test"'},
+        )
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_CALENDAR_NAME: CALENDAR_NAME,
+            CONF_URL: CALENDER_URL,
+            CONF_VERIFY_SSL: True,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "auth"
+
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=200,
+            text="not valid ics",
+        )
+    )
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
+    )
+    assert result3["type"] is FlowResultType.ABORT
+    assert result3["reason"] == "invalid_ics_file"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "base_error"),
+    [
+        (TimeoutException("Connection timed out"), "timeout_connect"),
+        (HTTPError("Connection failed"), "cannot_connect"),
+    ],
+)
+@respx.mock
+async def test_form_auth_connection_errors(
+    hass: HomeAssistant,
+    side_effect: Exception,
+    ics_content: str,
+    base_error: str,
+) -> None:
+    """Test connection errors in auth step show retryable errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=401,
+            headers={"www-authenticate": 'Basic realm="test"'},
+        )
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_CALENDAR_NAME: CALENDAR_NAME,
+            CONF_URL: CALENDER_URL,
+            CONF_VERIFY_SSL: True,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "auth"
+
+    # Connection error during auth
+    respx.get(CALENDER_URL).mock(side_effect=side_effect)
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
+    )
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["step_id"] == "auth"
+    assert result3["errors"] == {"base": base_error}
+
+    # Retry with success
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=200,
+            text=ics_content,
+        )
+    )
+    result4 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
+    )
+    assert result4["type"] is FlowResultType.CREATE_ENTRY

--- a/tests/components/remote_calendar/test_init.py
+++ b/tests/components/remote_calendar/test_init.py
@@ -4,12 +4,19 @@ from httpx import HTTPError, InvalidURL, Response, TimeoutException
 import pytest
 import respx
 
+from homeassistant.components.remote_calendar.const import CONF_CALENDAR_NAME, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_OFF
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_URL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    STATE_OFF,
+)
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
-from .conftest import CALENDER_URL, TEST_ENTITY
+from .conftest import CALENDAR_NAME, CALENDER_URL, TEST_ENTITY
 
 from tests.common import MockConfigEntry
 
@@ -85,3 +92,30 @@ async def test_calendar_parse_error(
     )
     await setup_integration(hass, config_entry)
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@respx.mock
+async def test_load_with_auth(hass: HomeAssistant, ics_content: str) -> None:
+    """Test loading a config entry with basic auth credentials."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_CALENDAR_NAME: CALENDAR_NAME,
+            CONF_URL: CALENDER_URL,
+            CONF_VERIFY_SSL: True,
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
+    )
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=200,
+            text=ics_content,
+        )
+    )
+    await setup_integration(hass, config_entry)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

No breaking changes.

## Proposed change

Adds HTTP Basic Authentication support to the Remote Calendar integration.

If a calendar URL returns 401 with a `WWW-Authenticate: Basic` header, the config flow prompts for credentials in a second step. Credentials are stored in the config entry and used for ongoing fetches.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43965
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

Thank you for contributing <3
