### PR TITLE
Add packet loss sensor to Ping integration

### DIFF
--- a/homeassistant/components/ping/helpers.py
+++ b/homeassistant/components/ping/helpers.py
@@ -64,10 +64,11 @@ class PingDataICMPLib(PingData):
             return
 
         _LOGGER.debug(
-            "async_ping returned: reachable=%s sent=%i received=%s",
+            "async_ping returned: reachable=%s sent=%i received=%s loss=%s",
             data.is_alive,
             data.packets_sent,
             data.packets_received,
+            data.packet_loss * 100,
         )
 
         self.is_alive = data.is_alive
@@ -80,6 +81,7 @@ class PingDataICMPLib(PingData):
             "max": data.max_rtt,
             "avg": data.avg_rtt,
             "jitter": data.jitter,
+            "loss": data.packet_loss * 100,
         }
 
 

--- a/homeassistant/components/ping/icons.json
+++ b/homeassistant/components/ping/icons.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "sensor": {
+      "loss": {
+        "default": "mdi:information-outline"
+      }
+    }
+  }
+}

--- a/homeassistant/components/ping/icons.json
+++ b/homeassistant/components/ping/icons.json
@@ -2,7 +2,7 @@
   "entity": {
     "sensor": {
       "loss": {
-        "default": "mdi:information-outline"
+        "default": "mdi:alert-circle-outline"
       }
     }
   }

--- a/homeassistant/components/ping/sensor.py
+++ b/homeassistant/components/ping/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -81,6 +81,16 @@ SENSORS: tuple[PingSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda result: result.data.get("jitter"),
         has_fn=lambda result: "jitter" in result.data,
+    ),
+    PingSensorEntityDescription(
+        key="loss",
+        translation_key="loss",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda result: result.data.get("loss"),
+        has_fn=lambda result: "loss" in result.data,
     ),
 )
 

--- a/homeassistant/components/ping/strings.json
+++ b/homeassistant/components/ping/strings.json
@@ -22,6 +22,9 @@
       "jitter": {
         "name": "Jitter"
       },
+      "loss": {
+        "name": "Packet loss"
+      },
       "round_trip_time_avg": {
         "name": "Round-trip time average"
       },

--- a/tests/components/ping/snapshots/test_sensor.ambr
+++ b/tests/components/ping/snapshots/test_sensor.ambr
@@ -54,6 +54,57 @@
     'state': '3.5',
   })
 # ---
+# name: test_setup_and_update[packet_loss]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.10_10_10_10_packet_loss',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Packet loss',
+    'platform': 'ping',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'loss',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_setup_and_update[packet_loss].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '10.10.10.10 Packet loss',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.10_10_10_10_packet_loss',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_setup_and_update[round_trip_time_average]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/ping/test_sensor.py
+++ b/tests/components/ping/test_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.helpers import entity_registry as er
         "round_trip_time_mean_deviation",  # should be None in the snapshot
         "round_trip_time_minimum",
         "jitter",
+        "packet_loss",
     ],
 )
 async def test_setup_and_update(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This add an additional sensor to the `ping` integration to show the packet loss. This only works, when the `icmplib` is used (_which should be the case for all docker based installations, so all official supported ones_)

<img width="659" height="584" alt="image" src="https://github.com/user-attachments/assets/85b5e1d8-45f1-4d90-978d-11efbd0b1549" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42182
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
