### PR TITLE
Bump pyanglianwater to 3.0.0

### DIFF
--- a/homeassistant/components/anglian_water/__init__.py
+++ b/homeassistant/components/anglian_water/__init__.py
@@ -39,7 +39,6 @@ async def async_setup_entry(
             cookie_jar=CookieJar(quote_cookie=False),
         ),
         refresh_token=entry.data[CONF_ACCESS_TOKEN],
-        account_number=entry.data[CONF_ACCOUNT_NUMBER],
     )
     try:
         await auth.send_refresh_request()
@@ -49,7 +48,7 @@ async def async_setup_entry(
     _aw = AnglianWater(authenticator=auth)
 
     try:
-        await _aw.validate_smart_meter()
+        await _aw.validate_smart_meter(entry.data[CONF_ACCOUNT_NUMBER])
     except SmartMeterUnavailableError as err:
         raise ConfigEntryError(
             translation_domain=DOMAIN, translation_key="smart_meter_unavailable"

--- a/homeassistant/components/anglian_water/coordinator.py
+++ b/homeassistant/components/anglian_water/coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .const import CONF_ACCOUNT_NUMBER, DOMAIN
 
 type AnglianWaterConfigEntry = ConfigEntry[AnglianWaterUpdateCoordinator]
 
@@ -44,6 +44,6 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
     async def _async_update_data(self) -> None:
         """Update data from Anglian Water's API."""
         try:
-            return await self.api.update()
+            return await self.api.update(self.config_entry.data[CONF_ACCOUNT_NUMBER])
         except (ExpiredAccessTokenError, UnknownEndpointError) as err:
             raise UpdateFailed from err

--- a/homeassistant/components/anglian_water/manifest.json
+++ b/homeassistant/components/anglian_water/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["pyanglianwater"],
   "quality_scale": "bronze",
-  "requirements": ["pyanglianwater==2.1.0"]
+  "requirements": ["pyanglianwater==3.0.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1889,7 +1889,7 @@ pyairobotrest==0.1.0
 pyairvisual==2023.08.1
 
 # homeassistant.components.anglian_water
-pyanglianwater==2.1.0
+pyanglianwater==3.0.0
 
 # homeassistant.components.aprilaire
 pyaprilaire==0.9.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1608,7 +1608,7 @@ pyairobotrest==0.1.0
 pyairvisual==2023.08.1
 
 # homeassistant.components.anglian_water
-pyanglianwater==2.1.0
+pyanglianwater==3.0.0
 
 # homeassistant.components.aprilaire
 pyaprilaire==0.9.1

--- a/tests/components/anglian_water/conftest.py
+++ b/tests/components/anglian_water/conftest.py
@@ -54,7 +54,6 @@ def mock_anglian_water_authenticator() -> Generator[MagicMock]:
         ),
     ):
         mock_instance = mock_auth_class.return_value
-        mock_instance.account_number = ACCOUNT_NUMBER
         mock_instance.access_token = ACCESS_TOKEN
         mock_instance.refresh_token = ACCESS_TOKEN
         mock_instance.send_login_request.return_value = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As part of the previous PR for Anglian Water we agreed to follow up with a PR to introduce select options in the ConfigFlow.

This PR is for the initial work for this and bumps pyanglianwater to 3.0.0. The account_number is no longer a "set once property on init" and instead all API calls require the account number to be passed through hence the major version bump from 2.2.0 to 3.0.0.

The code changes that have been made are required for this bump to work successfully. This does not break existing installations as we collect the account number on all configurations anyway.

Release: https://github.com/pantherale0/pyanglianwater/releases/tag/3.0.0
Diff: https://github.com/pantherale0/pyanglianwater/compare/2.2.0...3.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
