### PR TITLE
Add helper to test service action description placeholders are set

### DIFF
--- a/tests/components/kitchen_sink/test_init.py
+++ b/tests/components/kitchen_sink/test_init.py
@@ -24,6 +24,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
+from tests.common import async_check_service_description_placeholders
 from tests.components.recorder.common import async_wait_recording_done
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
@@ -353,9 +354,7 @@ async def test_issues_created(
     }
 
 
-async def test_service(
-    hass: HomeAssistant,
-) -> None:
+async def test_service(hass: HomeAssistant) -> None:
     """Test we can call the service."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -372,6 +371,9 @@ async def test_service(
         {"field_1": 1, "field_2": "auto", "field_3": 1, "field_4": "forwards"},
         blocking=True,
     )
+
+    await async_check_service_description_placeholders(hass, DOMAIN, "test_service_1")
+    await async_check_service_description_placeholders(hass, DOMAIN)
 
 
 @pytest.fixture

--- a/tests/components/knx/test_services.py
+++ b/tests/components/knx/test_services.py
@@ -13,7 +13,10 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .conftest import KNXTestKit
 
-from tests.common import async_capture_events
+from tests.common import (
+    async_capture_events,
+    async_check_service_description_placeholders,
+)
 
 
 @pytest.mark.parametrize(
@@ -298,3 +301,11 @@ async def test_service_setup_failed(hass: HomeAssistant, knx: KNXTestKit) -> Non
         )
     assert exc_info.value.translation_domain == DOMAIN
     assert exc_info.value.translation_key == "integration_not_loaded"
+
+
+async def test_service_desciption_placeholders(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test `knx.read` service."""
+    await knx.setup_integration()
+    await async_check_service_description_placeholders(hass, "knx")

--- a/tests/components/lametric/test_services.py
+++ b/tests/components/lametric/test_services.py
@@ -30,6 +30,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
+from tests.common import async_check_service_description_placeholders
+
 pytestmark = pytest.mark.usefixtures("init_integration")
 
 
@@ -208,3 +210,9 @@ async def test_service_message(
         )
 
     assert len(mock_lametric.notify.mock_calls) == 3
+
+
+@pytest.mark.usefixtures("mock_lametric")
+async def test_service_description_placeholders(hass: HomeAssistant) -> None:
+    """Test the LaMetric service description placeholders."""
+    await async_check_service_description_placeholders(hass, DOMAIN)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This asserts if any description placeholders set in service action translation strings have corresponding place holders set when they were registered.
As test was added for `lametric`, `kitchen_sink` and `knx`.

Related to https://github.com/home-assistant/core/pull/154224

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
