### PR TITLE
Bump HueBLE to 2.1.0

### DIFF
--- a/homeassistant/components/hue_ble/__init__.py
+++ b/homeassistant/components/hue_ble/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from HueBLE import HueBleLight
+from HueBLE import ConnectionError, HueBleError, HueBleLight
 
 from homeassistant.components.bluetooth import (
     async_ble_device_from_address,
@@ -40,12 +40,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: HueBLEConfigEntry) -> bo
 
     try:
         await light.connect()
-    except Exception as e:
-        raise ConfigEntryNotReady("Device found but unable to connect.") from e
-
-    try:
         await light.poll_state()
-    except Exception as e:
+    except ConnectionError as e:
+        raise ConfigEntryNotReady("Device found but unable to connect.") from e
+    except HueBleError as e:
         raise ConfigEntryNotReady(
             "Device found and connected but unable to poll values from it."
         ) from e

--- a/homeassistant/components/hue_ble/__init__.py
+++ b/homeassistant/components/hue_ble/__init__.py
@@ -38,8 +38,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: HueBLEConfigEntry) -> bo
 
     light = HueBleLight(ble_device)
 
-    if not await light.connect() or not await light.poll_state():
-        raise ConfigEntryNotReady("Device found but unable to connect.")
+    try:
+        await light.connect()
+        await light.poll_state()
+    except Exception as e:
+        raise ConfigEntryNotReady("Device found but unable to connect.") from e
 
     entry.runtime_data = light
 

--- a/homeassistant/components/hue_ble/__init__.py
+++ b/homeassistant/components/hue_ble/__init__.py
@@ -40,9 +40,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: HueBLEConfigEntry) -> bo
 
     try:
         await light.connect()
-        await light.poll_state()
     except Exception as e:
         raise ConfigEntryNotReady("Device found but unable to connect.") from e
+
+    try:
+        await light.poll_state()
+    except Exception as e:
+        raise ConfigEntryNotReady(
+            "Device found and connected but unable to poll values from it."
+        ) from e
 
     entry.runtime_data = light
 

--- a/homeassistant/components/hue_ble/config_flow.py
+++ b/homeassistant/components/hue_ble/config_flow.py
@@ -59,10 +59,7 @@ async def validate_input(hass: HomeAssistant, address: str) -> Error | None:
         except HomeAssistantError:
             return Error.NOT_SUPPORTED
 
-        _, errors = await light.poll_state()
-        if len(errors) != 0:
-            _LOGGER.warning("Errors raised when connecting to light: %s", errors)
-            return Error.CANNOT_CONNECT
+        await light.poll_state()
 
     except Exception:
         _LOGGER.exception("Unexpected error validating light connection")

--- a/homeassistant/components/hue_ble/config_flow.py
+++ b/homeassistant/components/hue_ble/config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 
-from .const import DOMAIN, URL_PAIRING_MODE
+from .const import DOMAIN, URL_FACTORY_RESET, URL_PAIRING_MODE
 from .light import get_available_color_modes
 
 _LOGGER = logging.getLogger(__name__)
@@ -126,6 +126,7 @@ class HueBleConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_NAME: self._discovery_info.name,
                 CONF_MAC: self._discovery_info.address,
                 "url_pairing_mode": URL_PAIRING_MODE,
+                "url_factory_reset": URL_FACTORY_RESET,
             },
         )
 

--- a/homeassistant/components/hue_ble/const.py
+++ b/homeassistant/components/hue_ble/const.py
@@ -2,3 +2,4 @@
 
 DOMAIN = "hue_ble"
 URL_PAIRING_MODE = "https://www.home-assistant.io/integrations/hue_ble#initial-setup"
+URL_FACTORY_RESET = "https://www.philips-hue.com/en-gb/support/article/how-to-factory-reset-philips-hue-lights/000004"

--- a/homeassistant/components/hue_ble/light.py
+++ b/homeassistant/components/hue_ble/light.py
@@ -113,7 +113,7 @@ class HueBLELight(LightEntity):
 
     async def async_update(self) -> None:
         """Fetch latest state from light and make available via properties."""
-        await self._api.poll_state(run_callbacks=True)
+        await self._api.poll_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Set properties then turn the light on."""

--- a/homeassistant/components/hue_ble/manifest.json
+++ b/homeassistant/components/hue_ble/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_push",
   "loggers": ["bleak", "HueBLE"],
   "quality_scale": "bronze",
-  "requirements": ["HueBLE==2.0.0"]
+  "requirements": ["HueBLE==2.1.0"]
 }

--- a/homeassistant/components/hue_ble/manifest.json
+++ b/homeassistant/components/hue_ble/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_push",
   "loggers": ["bleak", "HueBLE"],
   "quality_scale": "bronze",
-  "requirements": ["HueBLE==1.0.8"]
+  "requirements": ["HueBLE==2.0.0"]
 }

--- a/homeassistant/components/hue_ble/strings.json
+++ b/homeassistant/components/hue_ble/strings.json
@@ -14,7 +14,7 @@
     },
     "step": {
       "confirm": {
-        "description": "Do you want to set up {name} ({mac})?. Make sure the light is [made discoverable to voice assistants]({url_pairing_mode})."
+        "description": "Do you want to set up {name} ({mac})?. Make sure the light is [made discoverable to voice assistants]({url_pairing_mode}) or has been [factory reset]({url_factory_reset})."
       }
     }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -22,7 +22,7 @@ HAP-python==5.0.0
 HATasmota==0.10.1
 
 # homeassistant.components.hue_ble
-HueBLE==2.0.0
+HueBLE==2.1.0
 
 # homeassistant.components.mastodon
 Mastodon.py==2.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -22,7 +22,7 @@ HAP-python==5.0.0
 HATasmota==0.10.1
 
 # homeassistant.components.hue_ble
-HueBLE==1.0.8
+HueBLE==2.0.0
 
 # homeassistant.components.mastodon
 Mastodon.py==2.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -22,7 +22,7 @@ HAP-python==5.0.0
 HATasmota==0.10.1
 
 # homeassistant.components.hue_ble
-HueBLE==2.0.0
+HueBLE==2.1.0
 
 # homeassistant.components.mastodon
 Mastodon.py==2.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -22,7 +22,7 @@ HAP-python==5.0.0
 HATasmota==0.10.1
 
 # homeassistant.components.hue_ble
-HueBLE==1.0.8
+HueBLE==2.0.0
 
 # homeassistant.components.mastodon
 Mastodon.py==2.1.2

--- a/tests/components/hue_ble/test_config_flow.py
+++ b/tests/components/hue_ble/test_config_flow.py
@@ -2,11 +2,16 @@
 
 from unittest.mock import AsyncMock, PropertyMock, patch
 
+from HueBLE import ConnectionError, HueBleError, PairingError
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.hue_ble.config_flow import Error
-from homeassistant.components.hue_ble.const import DOMAIN, URL_PAIRING_MODE
+from homeassistant.components.hue_ble.const import (
+    DOMAIN,
+    URL_FACTORY_RESET,
+    URL_PAIRING_MODE,
+)
 from homeassistant.config_entries import SOURCE_BLUETOOTH
 from homeassistant.const import CONF_MAC, CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -18,22 +23,13 @@ from . import HUE_BLE_SERVICE_INFO, TEST_DEVICE_MAC, TEST_DEVICE_NAME
 from tests.common import MockConfigEntry
 from tests.components.bluetooth import BLEDevice, generate_ble_device
 
+AUTH_ERROR = ConnectionError()
+AUTH_ERROR.__cause__ = PairingError()
 
-@pytest.mark.parametrize(
-    ("mock_authenticated"),
-    [
-        (True,),
-        (None),
-    ],
-    ids=[
-        "normal",
-        "unknown_auth",
-    ],
-)
+
 async def test_bluetooth_form(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_authenticated: bool | None,
 ) -> None:
     """Test bluetooth discovery form."""
 
@@ -48,6 +44,7 @@ async def test_bluetooth_form(
         CONF_NAME: TEST_DEVICE_NAME,
         CONF_MAC: TEST_DEVICE_MAC,
         "url_pairing_mode": URL_PAIRING_MODE,
+        "url_factory_reset": URL_FACTORY_RESET,
     }
 
     with (
@@ -66,16 +63,6 @@ async def test_bluetooth_form(
         patch(
             "homeassistant.components.hue_ble.config_flow.HueBleLight.poll_state",
             side_effect=[True],
-        ),
-        patch(
-            "homeassistant.components.hue_ble.config_flow.HueBleLight.connected",
-            new_callable=PropertyMock,
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.hue_ble.config_flow.HueBleLight.authenticated",
-            new_callable=PropertyMock,
-            return_value=mock_authenticated,
         ),
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -96,8 +83,6 @@ async def test_bluetooth_form(
         "mock_return_device",
         "mock_scanner_count",
         "mock_connect",
-        "mock_authenticated",
-        "mock_connected",
         "mock_support_on_off",
         "mock_poll_state",
         "error",
@@ -106,71 +91,57 @@ async def test_bluetooth_form(
         (
             None,
             0,
+            None,
             True,
-            True,
-            True,
-            True,
-            True,
+            None,
             Error.NO_SCANNERS,
         ),
         (
             None,
             1,
+            None,
             True,
-            True,
-            True,
-            True,
-            True,
+            None,
             Error.NOT_FOUND,
         ),
         (
             generate_ble_device(TEST_DEVICE_NAME, TEST_DEVICE_MAC),
             1,
+            AUTH_ERROR,
             True,
-            False,
-            True,
-            True,
-            True,
+            None,
             Error.INVALID_AUTH,
         ),
         (
             generate_ble_device(TEST_DEVICE_NAME, TEST_DEVICE_MAC),
             1,
+            ConnectionError,
             True,
-            True,
-            False,
-            True,
-            True,
+            None,
             Error.CANNOT_CONNECT,
         ),
         (
             generate_ble_device(TEST_DEVICE_NAME, TEST_DEVICE_MAC),
             1,
-            True,
-            True,
-            True,
+            None,
             False,
-            True,
+            None,
             Error.NOT_SUPPORTED,
         ),
         (
             generate_ble_device(TEST_DEVICE_NAME, TEST_DEVICE_MAC),
             1,
+            None,
             True,
-            True,
-            True,
-            True,
-            Exception,
+            HueBleError,
             Error.UNKNOWN,
         ),
         (
             generate_ble_device(TEST_DEVICE_NAME, TEST_DEVICE_MAC),
             1,
-            Exception,
+            HueBleError,
             None,
-            True,
-            True,
-            Exception,
+            None,
             Error.UNKNOWN,
         ),
     ],
@@ -189,11 +160,9 @@ async def test_bluetooth_form_exception(
     mock_setup_entry: AsyncMock,
     mock_return_device: BLEDevice | None,
     mock_scanner_count: int,
-    mock_connect: Exception | bool,
-    mock_authenticated: bool | None,
-    mock_connected: bool,
+    mock_connect: Exception | None,
     mock_support_on_off: bool,
-    mock_poll_state: Exception | bool,
+    mock_poll_state: Exception | None,
     error: Error,
 ) -> None:
     """Test bluetooth discovery form with errors."""
@@ -228,16 +197,6 @@ async def test_bluetooth_form_exception(
             "homeassistant.components.hue_ble.config_flow.HueBleLight.poll_state",
             side_effect=[mock_poll_state],
         ),
-        patch(
-            "homeassistant.components.hue_ble.config_flow.HueBleLight.connected",
-            new_callable=PropertyMock,
-            return_value=mock_connected,
-        ),
-        patch(
-            "homeassistant.components.hue_ble.config_flow.HueBleLight.authenticated",
-            new_callable=PropertyMock,
-            return_value=mock_authenticated,
-        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -263,16 +222,6 @@ async def test_bluetooth_form_exception(
         patch(
             "homeassistant.components.hue_ble.config_flow.HueBleLight.poll_state",
             side_effect=[True],
-        ),
-        patch(
-            "homeassistant.components.hue_ble.config_flow.HueBleLight.connected",
-            new_callable=PropertyMock,
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.hue_ble.config_flow.HueBleLight.authenticated",
-            new_callable=PropertyMock,
-            return_value=True,
         ),
     ):
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/hue_ble/test_config_flow.py
+++ b/tests/components/hue_ble/test_config_flow.py
@@ -65,7 +65,7 @@ async def test_bluetooth_form(
         ),
         patch(
             "homeassistant.components.hue_ble.config_flow.HueBleLight.poll_state",
-            side_effect=[(True, [])],
+            side_effect=[True],
         ),
         patch(
             "homeassistant.components.hue_ble.config_flow.HueBleLight.connected",
@@ -110,7 +110,7 @@ async def test_bluetooth_form(
             True,
             True,
             True,
-            (True, []),
+            True,
             Error.NO_SCANNERS,
         ),
         (
@@ -120,7 +120,7 @@ async def test_bluetooth_form(
             True,
             True,
             True,
-            (True, []),
+            True,
             Error.NOT_FOUND,
         ),
         (
@@ -130,7 +130,7 @@ async def test_bluetooth_form(
             False,
             True,
             True,
-            (True, []),
+            True,
             Error.INVALID_AUTH,
         ),
         (
@@ -140,7 +140,7 @@ async def test_bluetooth_form(
             True,
             False,
             True,
-            (True, []),
+            True,
             Error.CANNOT_CONNECT,
         ),
         (
@@ -150,7 +150,7 @@ async def test_bluetooth_form(
             True,
             True,
             False,
-            (True, []),
+            True,
             Error.NOT_SUPPORTED,
         ),
         (
@@ -160,8 +160,8 @@ async def test_bluetooth_form(
             True,
             True,
             True,
-            (True, ["ERROR!"]),
-            Error.CANNOT_CONNECT,
+            Exception,
+            Error.UNKNOWN,
         ),
         (
             generate_ble_device(TEST_DEVICE_NAME, TEST_DEVICE_MAC),
@@ -170,7 +170,7 @@ async def test_bluetooth_form(
             None,
             True,
             True,
-            (True, []),
+            Exception,
             Error.UNKNOWN,
         ),
     ],
@@ -193,7 +193,7 @@ async def test_bluetooth_form_exception(
     mock_authenticated: bool | None,
     mock_connected: bool,
     mock_support_on_off: bool,
-    mock_poll_state: Exception | tuple[bool, list[Exception]],
+    mock_poll_state: Exception | bool,
     error: Error,
 ) -> None:
     """Test bluetooth discovery form with errors."""
@@ -262,7 +262,7 @@ async def test_bluetooth_form_exception(
         ),
         patch(
             "homeassistant.components.hue_ble.config_flow.HueBleLight.poll_state",
-            side_effect=[(True, [])],
+            side_effect=[True],
         ),
         patch(
             "homeassistant.components.hue_ble.config_flow.HueBleLight.connected",

--- a/tests/components/hue_ble/test_init.py
+++ b/tests/components/hue_ble/test_init.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from bleak.backends.device import BLEDevice
+from HueBLE import ConnectionError, HueBleError
 import pytest
 
 from homeassistant.components.hue_ble.const import DOMAIN
@@ -43,15 +44,15 @@ from tests.components.bluetooth import generate_ble_device
             generate_ble_device(TEST_DEVICE_MAC, TEST_DEVICE_NAME),
             2,
             False,
-            Exception,
+            ConnectionError,
             "Device found but unable to connect.",
         ),
         (
             generate_ble_device(TEST_DEVICE_MAC, TEST_DEVICE_NAME),
             2,
             True,
-            Exception,
-            "Device found but unable to connect.",
+            HueBleError,
+            "Device found and connected but unable to poll values from it.",
         ),
     ],
     ids=["no_device", "no_scanners", "error_connect", "error_poll"],

--- a/tests/components/hue_ble/test_init.py
+++ b/tests/components/hue_ble/test_init.py
@@ -29,28 +29,28 @@ from tests.components.bluetooth import generate_ble_device
             None,
             2,
             True,
-            True,
+            None,
             "The light was not found.",
         ),
         (
             None,
             0,
             True,
-            True,
+            None,
             "No Bluetooth scanners are available to search for the light.",
         ),
         (
             generate_ble_device(TEST_DEVICE_MAC, TEST_DEVICE_NAME),
             2,
             False,
-            True,
+            Exception,
             "Device found but unable to connect.",
         ),
         (
             generate_ble_device(TEST_DEVICE_MAC, TEST_DEVICE_NAME),
             2,
             True,
-            False,
+            Exception,
             "Device found but unable to connect.",
         ),
     ],
@@ -61,8 +61,8 @@ async def test_setup_error(
     caplog: pytest.LogCaptureFixture,
     ble_device: BLEDevice | None,
     scanner_count: int,
-    connect_result: bool,
-    poll_state_result: bool,
+    connect_result: Exception | None,
+    poll_state_result: Exception | None,
     message: str,
 ) -> None:
     """Test that ConfigEntryNotReady is raised if there is an error condition."""
@@ -80,11 +80,11 @@ async def test_setup_error(
         ),
         patch(
             "homeassistant.components.hue_ble.HueBleLight.connect",
-            return_value=connect_result,
+            side_effect=[connect_result],
         ),
         patch(
             "homeassistant.components.hue_ble.HueBleLight.poll_state",
-            return_value=poll_state_result,
+            side_effect=[poll_state_result],
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, {}) is True
@@ -111,11 +111,11 @@ async def test_setup(
         ),
         patch(
             "homeassistant.components.hue_ble.HueBleLight.connect",
-            return_value=True,
+            return_value=None,
         ),
         patch(
             "homeassistant.components.hue_ble.HueBleLight.poll_state",
-            return_value=True,
+            return_value=None,
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, {}) is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This updates the hue_ble component to work with the latest version of HueBLE. Quite a few issues have been raised and the existing logging functionality in the library was not quite as good as I thought it was, so I updated the underlying library with better logging and also made some changes which should improve compadability with other lights. 

#158157
#158030

[Library diff](https://github.com/flip-dots/HueBLE/compare/v1.0.8...v2.1.0)
[Library changelog](https://hueble.readthedocs.io/en/latest/history.html#id1)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue:  #158157 #158030

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
