### PR TITLE
ADD NOAA Tides Sensor attributes

### DIFF
--- a/homeassistant/components/noaa_tides/sensor.py
+++ b/homeassistant/components/noaa_tides/sensor.py
@@ -128,6 +128,7 @@ class NOAATidesAndCurrentsSensor(SensorEntity):
             # convert to local time for display, matching existing attributes
             local_next = dt_util.as_local(api_time)
             attr["next_tide_event_time"] = local_next.strftime("%Y-%m-%dT%H:%M")
+            attr["next_tide_event_height"] = self.data["predicted_wl"][0]
 
             # minutes until next tide event, based on now in the same timezone
             delta = (local_next - dt_util.now()).total_seconds() / 60

--- a/homeassistant/components/noaa_tides/sensor.py
+++ b/homeassistant/components/noaa_tides/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util.unit_system import METRIC_SYSTEM
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTRIBUTION,
@@ -120,6 +121,18 @@ class NOAATidesAndCurrentsSensor(SensorEntity):
         attr: dict[str, Any] = {}
         if self.data is None:
             return attr
+
+        # Index 0 is the next tide event (the same event in native_value)
+        api_time = self.data["time_stamp"][0]
+        if api_time is not None:
+            # convert to local time for display, matching existing attributes
+            local_next = dt_util.as_local(api_time)
+            attr["next_tide_event_time"] = local_next.strftime("%Y-%m-%dT%H:%M")
+
+            # minutes until next tide event, based on now in the same timezone
+            delta = (local_next - dt_util.now()).total_seconds() / 60
+            attr["minutes_until_next_tide_event"] = int(delta)
+
         if self.data["hi_lo"][1] == "H":
             attr["high_tide_time"] = self.data["time_stamp"][1].strftime(
                 "%Y-%m-%dT%H:%M"


### PR DESCRIPTION
Add next_tide_event_time and minutes_until_next_tide_event attributes to NOAA Tides sensor

This PR adds two new attributes to the NOAA Tides integration:

next_tide_event_time
ISO-formatted local timestamp for the next tide event (the same event described by the sensor’s native value).

minutes_until_next_tide_event
Number of minutes until the next tide event, based on local time. Useful for automations that need to notify shortly before a tide event.

These attributes do not modify existing behavior
and are fully backwards-compatible.

No configuration changes required.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I need an event when a tide change occurs, and this makes it super easy. It also makes
rendering the date/time of the next tide event a lot easier.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42399
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
