### PR TITLE
Add account selector to Anglian Water config flow

### DIFF
--- a/homeassistant/components/anglian_water/config_flow.py
+++ b/homeassistant/components/anglian_water/config_flow.py
@@ -30,14 +30,11 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): selector.TextSelector(
             selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
         ),
-        vol.Required(CONF_ACCOUNT_NUMBER): selector.TextSelector(),
     }
 )
 
 
-async def validate_credentials(
-    auth: MSOB2CAuth, account_number: str
-) -> str | MSOB2CAuth:
+async def validate_credentials(auth: MSOB2CAuth) -> str | MSOB2CAuth:
     """Validate the provided credentials."""
     try:
         await auth.send_login_request()
@@ -46,6 +43,33 @@ async def validate_credentials(
     except Exception:
         _LOGGER.exception("Unexpected exception")
         return "unknown"
+    return auth
+
+
+def humanize_account_data(account: dict) -> str:
+    """Convert an account data into a human-readable format."""
+    if account["address"]["company_name"]:
+        return f"{account['account_number']} - {account['address']['company_name']}"
+    if account["address"]["building_name"]:
+        return f"{account['account_number']} - {account['address']['building_name']}"
+    return f"{account['account_number']} - {account['address']['postcode']}"
+
+
+async def get_accounts(auth: MSOB2CAuth) -> list[selector.SelectOptionDict]:
+    """Retrieve the list of accounts associated with the authenticated user."""
+    _aw = AnglianWater(authenticator=auth)
+    accounts = await _aw.api.get_associated_accounts()
+    return [
+        selector.SelectOptionDict(
+            value=str(account["account_number"]),
+            label=humanize_account_data(account),
+        )
+        for account in accounts["result"]["active"]
+    ]
+
+
+async def validate_account(auth: MSOB2CAuth, account_number: str) -> str | MSOB2CAuth:
+    """Validate the provided account number."""
     _aw = AnglianWater(authenticator=auth)
     try:
         await _aw.validate_smart_meter(account_number)
@@ -57,36 +81,85 @@ async def validate_credentials(
 class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Anglian Water."""
 
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self.authenticator: MSOB2CAuth | None = None
+        self.accounts: list[selector.SelectOptionDict] = []
+        self.user_input: dict[str, Any] | None = None
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            validation_response = await validate_credentials(
-                MSOB2CAuth(
-                    username=user_input[CONF_USERNAME],
-                    password=user_input[CONF_PASSWORD],
-                    session=async_create_clientsession(
-                        self.hass,
-                        cookie_jar=CookieJar(quote_cookie=False),
-                    ),
+            self.authenticator = MSOB2CAuth(
+                username=user_input[CONF_USERNAME],
+                password=user_input[CONF_PASSWORD],
+                session=async_create_clientsession(
+                    self.hass,
+                    cookie_jar=CookieJar(quote_cookie=False),
                 ),
-                user_input[CONF_ACCOUNT_NUMBER],
             )
+            validation_response = await validate_credentials(self.authenticator)
             if isinstance(validation_response, str):
                 errors["base"] = validation_response
             else:
-                await self.async_set_unique_id(user_input[CONF_ACCOUNT_NUMBER])
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title=user_input[CONF_ACCOUNT_NUMBER],
-                    data={
-                        **user_input,
-                        CONF_ACCESS_TOKEN: validation_response.refresh_token,
-                    },
+                self.accounts = await get_accounts(self.authenticator)
+                if len(self.accounts) > 1:
+                    self.user_input = user_input
+                    return await self.async_step_select_account()
+                account_number = self.accounts[0]["value"]
+                self.user_input = user_input
+                return await self.async_step_complete(
+                    {
+                        CONF_ACCOUNT_NUMBER: account_number,
+                    }
                 )
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_select_account(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the account selection step."""
+        errors = {}
+        if user_input is not None:
+            validation_result = await validate_account(
+                self.authenticator,
+                user_input[CONF_ACCOUNT_NUMBER],
+            )
+            if isinstance(validation_result, str):
+                errors["base"] = validation_result
+            else:
+                return await self.async_step_complete(user_input)
+        return self.async_show_form(
+            step_id="select_account",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ACCOUNT_NUMBER): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=self.accounts,
+                            multiple=False,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_complete(self, user_input: dict[str, Any]) -> ConfigFlowResult:
+        """Handle the final configuration step."""
+        await self.async_set_unique_id(user_input[CONF_ACCOUNT_NUMBER])
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=user_input[CONF_ACCOUNT_NUMBER],
+            data={
+                **self.user_input,
+                CONF_ACCOUNT_NUMBER: user_input[CONF_ACCOUNT_NUMBER],
+                CONF_ACCESS_TOKEN: self.authenticator.refresh_token,
+            },
         )

--- a/homeassistant/components/anglian_water/strings.json
+++ b/homeassistant/components/anglian_water/strings.json
@@ -12,7 +12,7 @@
     "step": {
       "select_account": {
         "data": {
-          "account_number": "Billing Account Number"
+          "account_number": "Billing account number"
         },
         "data_description": {
           "account_number": "Select the billing account you wish to use."
@@ -21,12 +21,10 @@
       },
       "user": {
         "data": {
-          "account_number": "Billing Account Number",
           "password": "[%key:common::config_flow::data::password%]",
           "username": "[%key:common::config_flow::data::username%]"
         },
         "data_description": {
-          "account_number": "Your account number found on your latest bill.",
           "password": "Your password",
           "username": "Username or email used to log in to the Anglian Water website."
         },

--- a/homeassistant/components/anglian_water/strings.json
+++ b/homeassistant/components/anglian_water/strings.json
@@ -10,6 +10,15 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "select_account": {
+        "data": {
+          "account_number": "Billing Account Number"
+        },
+        "data_description": {
+          "account_number": "Select the billing account you wish to use."
+        },
+        "description": "Multiple active billing accounts were found with your credentials. Please select the account you wish to use. If this is unexpected, contact Anglian Water to confirm your active accounts."
+      },
       "user": {
         "data": {
           "account_number": "Billing Account Number",

--- a/tests/components/anglian_water/conftest.py
+++ b/tests/components/anglian_water/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for the Anglian Water tests."""
 
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyanglianwater.api import API
@@ -9,10 +9,11 @@ import pytest
 
 from homeassistant.components.anglian_water.const import CONF_ACCOUNT_NUMBER, DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from .const import ACCESS_TOKEN, ACCOUNT_NUMBER, PASSWORD, USERNAME
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 @pytest.fixture
@@ -63,9 +64,11 @@ def mock_anglian_water_authenticator() -> Generator[MagicMock]:
 
 
 @pytest.fixture
-def mock_anglian_water_client(
-    mock_smart_meter: SmartMeter, mock_anglian_water_authenticator: MagicMock
-) -> Generator[AsyncMock]:
+async def mock_anglian_water_client(
+    hass: HomeAssistant,
+    mock_smart_meter: SmartMeter,
+    mock_anglian_water_authenticator: MagicMock,
+) -> AsyncGenerator[AsyncMock]:
     """Mock a Anglian Water client."""
     # Create a mock instance with our meters and config first.
     with (
@@ -83,8 +86,10 @@ def mock_anglian_water_client(
         mock_client.updated_data_callbacks = []
         mock_client.validate_smart_meter.return_value = None
         mock_client.api = AsyncMock(spec=API)
-        mock_client.api.get_associated_accounts.return_value = load_json_object_fixture(
-            "multi_associated_accounts.json", DOMAIN
+        mock_client.api.get_associated_accounts.return_value = (
+            await async_load_json_object_fixture(
+                hass, "multi_associated_accounts.json", DOMAIN
+            )
         )
         yield mock_client
 

--- a/tests/components/anglian_water/conftest.py
+++ b/tests/components/anglian_water/conftest.py
@@ -3,6 +3,7 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from pyanglianwater.api import API
 from pyanglianwater.meter import SmartMeter
 import pytest
 
@@ -11,7 +12,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN, CONF_PASSWORD, CONF_USERNAME
 
 from .const import ACCESS_TOKEN, ACCOUNT_NUMBER, PASSWORD, USERNAME
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
@@ -81,6 +82,10 @@ def mock_anglian_water_client(
         mock_client.account_config = {"meter_type": "SmartMeter"}
         mock_client.updated_data_callbacks = []
         mock_client.validate_smart_meter.return_value = None
+        mock_client.api = AsyncMock(spec=API)
+        mock_client.api.get_associated_accounts.return_value = load_json_object_fixture(
+            "multi_associated_accounts.json", DOMAIN
+        )
         yield mock_client
 
 

--- a/tests/components/anglian_water/const.py
+++ b/tests/components/anglian_water/const.py
@@ -1,6 +1,6 @@
 """Constants for the Anglian Water test suite."""
 
-ACCOUNT_NUMBER = "12345678"
+ACCOUNT_NUMBER = "171266493"
 ACCESS_TOKEN = "valid_token"
 USERNAME = "hello@example.com"
 PASSWORD = "SecurePassword123"

--- a/tests/components/anglian_water/fixtures/multi_associated_accounts.json
+++ b/tests/components/anglian_water/fixtures/multi_associated_accounts.json
@@ -1,0 +1,65 @@
+{
+  "result": {
+    "property_count": 4,
+    "active": [
+      {
+        "business_partner_number": 906922831,
+        "account_number": 171266493,
+        "address": {
+          "company_name": "",
+          "building_name": "",
+          "sub_building_name": "",
+          "house_number": "10",
+          "street": "DOWNING STREET",
+          "locality": "",
+          "city": "LONDON",
+          "postcode": "SW1A 1AA"
+        }
+      },
+      {
+        "business_partner_number": 906922832,
+        "account_number": 171266494,
+        "address": {
+          "company_name": "",
+          "building_name": "Historic Building A",
+          "sub_building_name": "",
+          "house_number": "10",
+          "street": "DOWNING STREET",
+          "locality": "",
+          "city": "LONDON",
+          "postcode": "SW1A 1AA"
+        }
+      },
+      {
+        "business_partner_number": 906922832,
+        "account_number": 171266494,
+        "address": {
+          "company_name": "UK Government",
+          "building_name": "",
+          "sub_building_name": "",
+          "house_number": "10",
+          "street": "DOWNING STREET",
+          "locality": "",
+          "city": "LONDON",
+          "postcode": "SW1A 1AA"
+        }
+      }
+    ],
+    "inactive": [
+      {
+        "business_partner_number": 100000000,
+        "account_number": 171200000,
+        "address": {
+          "company_name": "",
+          "building_name": "Finance Office",
+          "sub_building_name": "Heritage Wing",
+          "house_number": "50",
+          "street": "DOWNING STREET",
+          "locality": "",
+          "city": "LONDON",
+          "postcode": "SW1A 1AA"
+        }
+      }
+    ]
+  }
+}

--- a/tests/components/anglian_water/fixtures/single_associated_accounts.json
+++ b/tests/components/anglian_water/fixtures/single_associated_accounts.json
@@ -1,0 +1,37 @@
+{
+  "result": {
+    "property_count": 1,
+    "active": [
+      {
+        "business_partner_number": 906922831,
+        "account_number": 171266493,
+        "address": {
+          "company_name": "",
+          "building_name": "",
+          "sub_building_name": "",
+          "house_number": "10",
+          "street": "DOWNING STREET",
+          "locality": "",
+          "city": "LONDON",
+          "postcode": "SW1A 1AA"
+        }
+      }
+    ],
+    "inactive": [
+      {
+        "business_partner_number": 100000000,
+        "account_number": 171200000,
+        "address": {
+          "company_name": "",
+          "building_name": "Finance Office",
+          "sub_building_name": "Heritage Wing",
+          "house_number": "50",
+          "street": "DOWNING STREET",
+          "locality": "",
+          "city": "LONDON",
+          "postcode": "SW1A 1AA"
+        }
+      }
+    ]
+  }
+}

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -21,13 +21,13 @@ from .const import ACCESS_TOKEN, ACCOUNT_NUMBER, PASSWORD, USERNAME
 from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
-async def test_full_flow(
+async def test_multiple_account_flow(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_anglian_water_authenticator: AsyncMock,
     mock_anglian_water_client: AsyncMock,
 ) -> None:
-    """Test a full and successful config flow."""
+    """Test the config flow when there are multiple accounts."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -68,7 +68,7 @@ async def test_single_account_flow(
     mock_anglian_water_authenticator: AsyncMock,
     mock_anglian_water_client: AsyncMock,
 ) -> None:
-    """Test a full and successful config flow with a single account."""
+    """Test the config flow when there is just a single account."""
     mock_anglian_water_client.api.get_associated_accounts.return_value = (
         await async_load_json_object_fixture(
             hass, "single_associated_accounts.json", DOMAIN

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .const import ACCESS_TOKEN, ACCOUNT_NUMBER, PASSWORD, USERNAME
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 async def test_full_flow(
@@ -40,7 +40,51 @@ async def test_full_flow(
         user_input={
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_account"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
             CONF_ACCOUNT_NUMBER: ACCOUNT_NUMBER,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == ACCOUNT_NUMBER
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_ACCESS_TOKEN] == ACCESS_TOKEN
+    assert result["data"][CONF_ACCOUNT_NUMBER] == ACCOUNT_NUMBER
+    assert result["result"].unique_id == ACCOUNT_NUMBER
+
+
+async def test_single_account_flow(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_anglian_water_authenticator: AsyncMock,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test a full and successful config flow with a single account."""
+    mock_anglian_water_client.api.get_associated_accounts.return_value = (
+        load_json_object_fixture("single_associated_accounts.json", DOMAIN)
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result is not None
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
         },
     )
 
@@ -75,6 +119,15 @@ async def test_already_configured(
         user_input={
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_account"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
             CONF_ACCOUNT_NUMBER: ACCOUNT_NUMBER,
         },
     )
@@ -109,7 +162,6 @@ async def test_auth_recover_exception(
         user_input={
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
-            CONF_ACCOUNT_NUMBER: ACCOUNT_NUMBER,
         },
     )
 
@@ -126,6 +178,15 @@ async def test_auth_recover_exception(
         user_input={
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_account"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
             CONF_ACCOUNT_NUMBER: ACCOUNT_NUMBER,
         },
     )
@@ -161,19 +222,28 @@ async def test_account_recover_exception(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
-    mock_anglian_water_client.validate_smart_meter.side_effect = exception_type
-
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    mock_anglian_water_client.validate_smart_meter.side_effect = exception_type
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_account"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
             CONF_ACCOUNT_NUMBER: ACCOUNT_NUMBER,
         },
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "select_account"
     assert result["errors"] == {"base": expected_error}
 
     # Now test we can recover
@@ -183,8 +253,6 @@ async def test_account_recover_exception(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
-            CONF_USERNAME: USERNAME,
-            CONF_PASSWORD: PASSWORD,
             CONF_ACCOUNT_NUMBER: ACCOUNT_NUMBER,
         },
     )

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .const import ACCESS_TOKEN, ACCOUNT_NUMBER, PASSWORD, USERNAME
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 async def test_full_flow(
@@ -70,7 +70,9 @@ async def test_single_account_flow(
 ) -> None:
     """Test a full and successful config flow with a single account."""
     mock_anglian_water_client.api.get_associated_accounts.return_value = (
-        load_json_object_fixture("single_associated_accounts.json", DOMAIN)
+        await async_load_json_object_fixture(
+            hass, "single_associated_accounts.json", DOMAIN
+        )
     )
 
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR implements a new account selector for the Anglian Water config flow following the discussion in #157939

This is a non-breaking change as `account_number` still only stores a single string value which is inline with what we had before. Existing config entries will be compatible as we always store the `account_number` anyway.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
