### PR TITLE
Handle Transmission integration startup error when the server is not available

### DIFF
--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -39,7 +39,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
         self,
         hass: HomeAssistant,
         entry: TransmissionConfigEntry,
-        api: transmission_rpc.Client,
+        api: transmission_rpc.Client | None,
     ) -> None:
         """Initialize the Transmission RPC API."""
         self.api = api
@@ -69,10 +69,14 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
     async def _async_update_data(self) -> SessionStats:
         """Update transmission data."""
+        if self.api is None:
+            raise UpdateFailed("Transmission client not available")
         return await self.hass.async_add_executor_job(self.update)
 
     def update(self) -> SessionStats:
         """Get the latest data from Transmission instance."""
+        if self.api is None:
+            raise UpdateFailed("Transmission client not available")
         try:
             data = self.api.session_stats()
             self.torrents = self.api.get_torrents()
@@ -88,6 +92,8 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
     def init_torrent_list(self) -> None:
         """Initialize torrent lists."""
+        if self.api is None:
+            return
         self.torrents = self.api.get_torrents()
         self._completed_torrents = [
             torrent for torrent in self.torrents if torrent.status == "seeding"
@@ -157,19 +163,21 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
     def start_torrents(self) -> None:
         """Start all torrents."""
-        if not self.torrents:
+        if self.api is None or not self.torrents:
             return
         self.api.start_all()
 
     def stop_torrents(self) -> None:
         """Stop all active torrents."""
-        if not self.torrents:
+        if self.api is None or not self.torrents:
             return
         torrent_ids: list[int | str] = [torrent.id for torrent in self.torrents]
         self.api.stop_torrent(torrent_ids)
 
     def set_alt_speed_enabled(self, is_enabled: bool) -> None:
         """Set the alternative speed flag."""
+        if self.api is None:
+            return
         self.api.set_session(alt_speed_enabled=is_enabled)
 
     def get_alt_speed_enabled(self) -> bool | None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This modification makes the HA server startup seamless, and does not fail the integration when the Transmission server is not reachable. Its connected entities remain unavailable until the Transmission is online.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #158251
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
