### PR TITLE
Skip check for onboarding done in Music Assistant integration

### DIFF
--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -163,9 +163,6 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             LOGGER.exception("Unexpected exception during add-on discovery")
             return self.async_abort(reason="unknown")
 
-        if not server_info.onboard_done:
-            return self.async_abort(reason="server_not_ready")
-
         # We trust the token from hassio discovery and validate it during setup
         self.token = discovery_info.config["auth_token"]
 
@@ -225,11 +222,6 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
             if server_info.homeassistant_addon:
                 LOGGER.debug("Ignoring add-on server in zeroconf discovery")
                 return self.async_abort(reason="already_discovered_addon")
-
-            # Ignore servers that have not completed onboarding yet
-            if not server_info.onboard_done:
-                LOGGER.debug("Ignoring server that hasn't completed onboarding")
-                return self.async_abort(reason="server_not_ready")
 
         self.url = server_info.base_url
         self.server_info = server_info

--- a/tests/components/music_assistant/test_config_flow.py
+++ b/tests/components/music_assistant/test_config_flow.py
@@ -544,28 +544,6 @@ async def test_hassio_flow_errors(
     assert result["reason"] == error_reason
 
 
-async def test_hassio_flow_server_not_ready(
-    hass: HomeAssistant,
-    mock_get_server_info: AsyncMock,
-) -> None:
-    """Test hassio discovery flow when server onboarding is not complete."""
-    server_info = ServerInfoMessage.from_json(
-        await async_load_fixture(hass, "server_info_message.json", DOMAIN)
-    )
-    server_info.onboard_done = False
-    mock_get_server_info.return_value = server_info
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_HASSIO},
-        data=HASSIO_DATA,
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "server_not_ready"
-
-
 async def test_zeroconf_addon_server_ignored(
     hass: HomeAssistant,
     mock_get_server_info: AsyncMock,
@@ -587,27 +565,6 @@ async def test_zeroconf_addon_server_ignored(
     assert result["reason"] == "already_discovered_addon"
 
 
-async def test_zeroconf_server_not_ready_ignored(
-    hass: HomeAssistant,
-    mock_get_server_info: AsyncMock,
-) -> None:
-    """Test zeroconf discovery ignores servers that haven't completed onboarding."""
-    not_ready_zeroconf_data = deepcopy(ZEROCONF_DATA)
-    not_ready_zeroconf_data.properties["onboard_done"] = (
-        "False"  # Zeroconf properties are strings
-    )
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=not_ready_zeroconf_data,
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "server_not_ready"
-
-
 async def test_zeroconf_old_schema_addon_not_ignored(
     hass: HomeAssistant,
     mock_get_server_info: AsyncMock,
@@ -627,33 +584,6 @@ async def test_zeroconf_old_schema_addon_not_ignored(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=old_schema_addon_data,
-    )
-    await hass.async_block_till_done()
-
-    # Should proceed to discovery_confirm, not abort
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "discovery_confirm"
-
-
-async def test_zeroconf_old_schema_not_ready_not_ignored(
-    hass: HomeAssistant,
-    mock_get_server_info: AsyncMock,
-) -> None:
-    """Test zeroconf discovery does NOT ignore not-ready servers with old schema version."""
-    old_schema_not_ready_data = deepcopy(ZEROCONF_DATA)
-    old_schema_version = AUTH_SCHEMA_VERSION - 1
-    old_schema_not_ready_data.properties["schema_version"] = str(old_schema_version)
-    old_schema_not_ready_data.properties["min_supported_schema_version"] = str(
-        old_schema_version
-    )
-    old_schema_not_ready_data.properties["onboard_done"] = (
-        "False"  # Zeroconf properties are strings
-    )
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=old_schema_not_ready_data,
     )
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change

We are currently ignoring servers that are not yet onboarded but this actually is not needed and causes more harm than good and user confusion. 

- For the hassio discovery flow, the integration can simply already connect to the internal websocket (and this way existing automations etc will just keep working in case of a server migrated to schema 28)
- In case of a direct connection, the oauth flow will redirect to the onboarding/setup wizard, the user completes setup and the oauth flow continues, all in one go.

So this PR removed the "onboard_done" check to solve the user confusion reported during beta testing.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
