### PR TITLE
Fix Backblaze B2 timeout issues during backup uploads

### DIFF
--- a/homeassistant/components/backblaze_b2/__init__.py
+++ b/homeassistant/components/backblaze_b2/__init__.py
@@ -6,13 +6,15 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from b2sdk.v2 import B2Api, Bucket, InMemoryAccountInfo, exception
+from b2sdk.v2 import Bucket, exception
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.event import async_track_time_interval
 
+# Import from b2_client to ensure timeout configuration is applied
+from .b2_client import B2Api, InMemoryAccountInfo
 from .const import (
     BACKBLAZE_REALM,
     CONF_APPLICATION_KEY,
@@ -72,7 +74,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: BackblazeConfigEntry) ->
             translation_domain=DOMAIN,
             translation_key="invalid_bucket_name",
         ) from err
-    except exception.ConnectionReset as err:
+    except (
+        exception.B2ConnectionError,
+        exception.B2RequestTimeout,
+        exception.ConnectionReset,
+    ) as err:
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="cannot_connect",

--- a/homeassistant/components/backblaze_b2/b2_client.py
+++ b/homeassistant/components/backblaze_b2/b2_client.py
@@ -1,0 +1,39 @@
+"""Backblaze B2 client with extended timeouts.
+
+The b2sdk library uses class-level timeout attributes. To avoid modifying
+global library state, we subclass the relevant classes to provide extended
+timeouts suitable for backup operations involving large files.
+"""
+
+from b2sdk.v2 import B2Api as BaseB2Api, InMemoryAccountInfo
+from b2sdk.v2.b2http import B2Http as BaseB2Http
+from b2sdk.v2.session import B2Session as BaseB2Session
+
+# Extended timeouts for Home Assistant backup operations
+# Default CONNECTION_TIMEOUT is 46 seconds, which can be too short for slow connections
+CONNECTION_TIMEOUT = 120  # 2 minutes
+
+# Default TIMEOUT_FOR_UPLOAD is 128 seconds, which is too short for large backups
+TIMEOUT_FOR_UPLOAD = 43200  # 12 hours
+
+
+class B2Http(BaseB2Http):  # type: ignore[misc]
+    """B2Http with extended timeouts for backup operations."""
+
+    CONNECTION_TIMEOUT = CONNECTION_TIMEOUT
+    TIMEOUT_FOR_UPLOAD = TIMEOUT_FOR_UPLOAD
+
+
+class B2Session(BaseB2Session):  # type: ignore[misc]
+    """B2Session using custom B2Http with extended timeouts."""
+
+    B2HTTP_CLASS = B2Http
+
+
+class B2Api(BaseB2Api):  # type: ignore[misc]
+    """B2Api using custom session with extended timeouts."""
+
+    SESSION_CLASS = B2Session
+
+
+__all__ = ["B2Api", "InMemoryAccountInfo"]

--- a/homeassistant/components/backblaze_b2/manifest.json
+++ b/homeassistant/components/backblaze_b2/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "loggers": ["b2sdk"],
   "quality_scale": "bronze",
-  "requirements": ["b2sdk==2.8.1"]
+  "requirements": ["b2sdk==2.10.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -609,7 +609,7 @@ azure-servicebus==7.10.0
 azure-storage-blob==12.24.0
 
 # homeassistant.components.backblaze_b2
-b2sdk==2.8.1
+b2sdk==2.10.1
 
 # homeassistant.components.holiday
 babel==2.15.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -558,7 +558,7 @@ azure-kusto-ingest==4.5.1
 azure-storage-blob==12.24.0
 
 # homeassistant.components.backblaze_b2
-b2sdk==2.8.1
+b2sdk==2.10.1
 
 # homeassistant.components.holiday
 babel==2.15.0

--- a/tests/components/backblaze_b2/conftest.py
+++ b/tests/components/backblaze_b2/conftest.py
@@ -51,7 +51,13 @@ def b2_fixture():
 
     with (
         patch("b2sdk.v2.B2Api", return_value=sim) as mock_client,
+        patch(
+            "homeassistant.components.backblaze_b2.b2_client.B2Api", return_value=sim
+        ),
         patch("homeassistant.components.backblaze_b2.B2Api", return_value=sim),
+        patch(
+            "homeassistant.components.backblaze_b2.config_flow.B2Api", return_value=sim
+        ),
         patch.object(
             RawSimulator,
             "get_bucket_by_name",

--- a/tests/components/backblaze_b2/test_config_flow.py
+++ b/tests/components/backblaze_b2/test_config_flow.py
@@ -158,6 +158,26 @@ async def test_already_configured(
         ),
         ("invalid_prefix", {"mock_prefix": "test/"}, "invalid_prefix", "prefix"),
         (
+            "connection_error",
+            {
+                "patch": "b2sdk.v2.RawSimulator.authorize_account",
+                "exception": exception.B2ConnectionError,
+                "args": ["Connection error"],
+            },
+            "cannot_connect",
+            "base",
+        ),
+        (
+            "timeout_error",
+            {
+                "patch": "b2sdk.v2.RawSimulator.authorize_account",
+                "exception": exception.B2RequestTimeout,
+                "args": ["Request timed out"],
+            },
+            "cannot_connect",
+            "base",
+        ),
+        (
             "unknown_error",
             {
                 "patch": "b2sdk.v2.RawSimulator.authorize_account",


### PR DESCRIPTION
## Proposed change

Fixes timeout issues when using Backblaze B2 for backups on slow connections or with large files.

The b2sdk library uses class-level timeout attributes that are too short for backup operations:
- Connection timeout (46s) is insufficient for slow SSL handshakes
- Upload timeout (128s) causes watchdog kills on large backups

This PR subclasses B2Http, B2Session, and B2Api to extend timeouts without modifying global library state:
- Connection timeout: 46s → 120s
- Upload timeout: 128s → 12 hours

Also adds exception handling for `B2ConnectionError`, `B2RequestTimeout`, and `ConnectionReset`.

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #158217, fixes #158198
- Link to b2sdk changelog: https://github.com/Backblaze/b2-sdk-python/blob/master/CHANGELOG.md (2.8.1 → 2.10.1)

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/