### PR TITLE
Update pynintendoparental to 2.0.0

### DIFF
--- a/homeassistant/components/nintendo_parental_controls/__init__.py
+++ b/homeassistant/components/nintendo_parental_controls/__init__.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from pynintendoparental import Authenticator
-from pynintendoparental.exceptions import (
+from pynintendoauth.exceptions import (
     InvalidOAuthConfigurationException,
     InvalidSessionTokenException,
 )
+from pynintendoparental import Authenticator
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -39,13 +39,12 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: NintendoParentalControlsConfigEntry
 ) -> bool:
     """Set up Nintendo Switch parental controls from a config entry."""
+    nintendo_auth = Authenticator(
+        session_token=entry.data[CONF_SESSION_TOKEN],
+        client_session=async_get_clientsession(hass),
+    )
     try:
-        nintendo_auth = await Authenticator.complete_login(
-            auth=None,
-            response_token=entry.data[CONF_SESSION_TOKEN],
-            is_session_token=True,
-            client_session=async_get_clientsession(hass),
-        )
+        await nintendo_auth.async_complete_login(use_session_token=True)
     except (InvalidSessionTokenException, InvalidOAuthConfigurationException) as err:
         raise ConfigEntryAuthFailed(
             translation_domain=DOMAIN,

--- a/homeassistant/components/nintendo_parental_controls/coordinator.py
+++ b/homeassistant/components/nintendo_parental_controls/coordinator.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
+from pynintendoauth.exceptions import InvalidOAuthConfigurationException
 from pynintendoparental import Authenticator, NintendoParental
-from pynintendoparental.exceptions import (
-    InvalidOAuthConfigurationException,
-    NoDevicesFoundException,
-)
+from pynintendoparental.exceptions import NoDevicesFoundException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/nintendo_parental_controls/manifest.json
+++ b/homeassistant/components/nintendo_parental_controls/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["pynintendoparental"],
   "quality_scale": "bronze",
-  "requirements": ["pynintendoparental==1.1.3"]
+  "requirements": ["pynintendoparental==2.0.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2229,7 +2229,7 @@ pynetio==0.1.9.1
 pynina==0.3.6
 
 # homeassistant.components.nintendo_parental_controls
-pynintendoparental==1.1.3
+pynintendoparental==2.0.0
 
 # homeassistant.components.nobo_hub
 pynobo==1.8.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1876,7 +1876,7 @@ pynetgear==0.10.10
 pynina==0.3.6
 
 # homeassistant.components.nintendo_parental_controls
-pynintendoparental==1.1.3
+pynintendoparental==2.0.0
 
 # homeassistant.components.nobo_hub
 pynobo==1.8.1

--- a/tests/components/nintendo_parental_controls/test_config_flow.py
+++ b/tests/components/nintendo_parental_controls/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock
 
-from pynintendoparental.exceptions import HttpException, InvalidSessionTokenException
+from pynintendoauth.exceptions import HttpException, InvalidSessionTokenException
 
 from homeassistant import config_entries
 from homeassistant.components.nintendo_parental_controls.const import (
@@ -82,7 +82,7 @@ async def test_invalid_auth(
     assert "link" in result["description_placeholders"]
 
     # Simulate invalid authentication by raising an exception
-    mock_nintendo_authenticator.complete_login.side_effect = (
+    mock_nintendo_authenticator.async_complete_login.side_effect = (
         InvalidSessionTokenException(status_code=401, message="Test")
     )
 
@@ -95,7 +95,7 @@ async def test_invalid_auth(
     assert result["errors"] == {"base": "invalid_auth"}
 
     # Now ensure that the flow can be recovered
-    mock_nintendo_authenticator.complete_login.side_effect = None
+    mock_nintendo_authenticator.async_complete_login.side_effect = None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_API_TOKEN: API_TOKEN}
@@ -121,7 +121,7 @@ async def test_missing_devices(
     assert result["step_id"] == "user"
     assert "link" in result["description_placeholders"]
 
-    mock_nintendo_authenticator.complete_login.side_effect = None
+    mock_nintendo_authenticator.async_complete_login.side_effect = None
 
     mock_nintendo_api.async_get_account_devices.side_effect = HttpException(
         status_code=404, message="TEST"
@@ -149,7 +149,7 @@ async def test_cannot_connect(
     assert result["step_id"] == "user"
     assert "link" in result["description_placeholders"]
 
-    mock_nintendo_authenticator.complete_login.side_effect = None
+    mock_nintendo_authenticator.async_complete_login.side_effect = None
 
     mock_nintendo_api.async_get_account_devices.side_effect = HttpException(
         status_code=500, message="TEST"
@@ -209,7 +209,7 @@ async def test_reauthentication_fail(
     assert result["errors"] == {}
 
     # Simulate invalid authentication by raising an exception
-    mock_nintendo_authenticator.complete_login.side_effect = (
+    mock_nintendo_authenticator.async_complete_login.side_effect = (
         InvalidSessionTokenException(status_code=401, message="Test")
     )
 
@@ -222,7 +222,7 @@ async def test_reauthentication_fail(
     assert result["errors"] == {"base": "invalid_auth"}
 
     # Now ensure that the flow can be recovered
-    mock_nintendo_authenticator.complete_login.side_effect = None
+    mock_nintendo_authenticator.async_complete_login.side_effect = None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_API_TOKEN: API_TOKEN}

--- a/tests/components/nintendo_parental_controls/test_coordinator.py
+++ b/tests/components/nintendo_parental_controls/test_coordinator.py
@@ -2,10 +2,8 @@
 
 from unittest.mock import AsyncMock
 
-from pynintendoparental.exceptions import (
-    InvalidOAuthConfigurationException,
-    NoDevicesFoundException,
-)
+from pynintendoauth.exceptions import InvalidOAuthConfigurationException
+from pynintendoparental.exceptions import NoDevicesFoundException
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant

--- a/tests/components/nintendo_parental_controls/test_init.py
+++ b/tests/components/nintendo_parental_controls/test_init.py
@@ -14,10 +14,11 @@ from tests.common import MockConfigEntry
 async def test_invalid_authentication(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_failed_nintendo_authenticator: AsyncMock,
+    mock_nintendo_authenticator: AsyncMock,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test handling of invalid authentication."""
+    mock_nintendo_authenticator.async_complete_login.side_effect = ValueError
     await setup_integration(hass, mock_config_entry)
 
     # Ensure no entities are created


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As above, in this version all of the authentication related code has been split out into a pynintendoauth library to make it easier to maintain (especially as there could be a Nintendo Switch Online integration on the way which will rely on the same auth code) hence the major version bump.

This new dependency is included in the library configuration as a compatible release (https://peps.python.org/pep-0440/#compatible-release).

That being said this is the only change in this version. A summary of the changes (courtesy of Gemini) is available here https://github.com/pantherale0/pynintendoparental/pull/54#issuecomment-3486849987

You will see a number of methods have been renamed (eg `get_session_token` is now just `session_token` and `complete_login` is no longer a class method and instead a standard async function called `async_complete_login`).

This has been fully tested locally.

Release: https://github.com/pantherale0/pynintendoparental/releases/tag/2.0.0
Diff: https://github.com/pantherale0/pynintendoparental/compare/1.1.3...2.0.0

Related lib https://github.com/pantherale0/pynintendoauth:

Release: https://github.com/pantherale0/pynintendoauth/releases/tag/1.0.0
Diff: Not available

Required to complete #155786 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
