### PR TITLE
Fix roborock off peak electricity timer

### DIFF
--- a/homeassistant/components/roborock/time.py
+++ b/homeassistant/components/roborock/time.py
@@ -7,7 +7,7 @@ from datetime import time
 import logging
 from typing import Any
 
-from roborock.data import DnDTimer
+from roborock.data import DnDTimer, ValleyElectricityTimer
 from roborock.exceptions import RoborockException
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
@@ -80,13 +80,14 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
         key="off_peak_start",
         translation_key="off_peak_start",
         trait=lambda api: api.valley_electricity_timer,
-        update_value=lambda trait, desired_time: trait.update_value(
-            [
-                desired_time.hour,
-                desired_time.minute,
-                trait.end_hour,
-                trait.end_minute,
-            ]
+        update_value=lambda trait, desired_time: trait.set_timer(
+            ValleyElectricityTimer(
+                enabled=trait.enabled,
+                start_hour=desired_time.hour,
+                start_minute=desired_time.minute,
+                end_hour=trait.end_hour,
+                end_minute=trait.end_minute,
+            )
         ),
         get_value=lambda trait: datetime.time(
             hour=trait.start_hour, minute=trait.start_minute
@@ -98,13 +99,14 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
         key="off_peak_end",
         translation_key="off_peak_end",
         trait=lambda api: api.valley_electricity_timer,
-        update_value=lambda trait, desired_time: trait.update_value(
-            [
-                trait.start_hour,
-                trait.start_minute,
-                desired_time.hour,
-                desired_time.minute,
-            ]
+        update_value=lambda trait, desired_time: trait.set_timer(
+            ValleyElectricityTimer(
+                enabled=trait.enabled,
+                start_hour=trait.start_hour,
+                start_minute=trait.start_minute,
+                end_hour=desired_time.hour,
+                end_minute=desired_time.minute,
+            )
         ),
         get_value=lambda trait: datetime.time(
             hour=trait.end_hour, minute=trait.end_minute

--- a/tests/components/roborock/mock_data.py
+++ b/tests/components/roborock/mock_data.py
@@ -14,6 +14,7 @@ from roborock.data import (
     NetworkInfo,
     S7Status,
     UserData,
+    ValleyElectricityTimer,
 )
 from vacuum_map_parser_base.config.image_config import ImageConfig
 from vacuum_map_parser_base.map_data import ImageData
@@ -1065,6 +1066,16 @@ CONSUMABLE = Consumable.from_dict(
 DND_TIMER = DnDTimer.from_dict(
     {
         "start_hour": 22,
+        "start_minute": 0,
+        "end_hour": 7,
+        "end_minute": 0,
+        "enabled": 1,
+    }
+)
+
+VALLEY_ELECTRICITY_TIMER = ValleyElectricityTimer.from_dict(
+    {
+        "start_hour": 23,
         "start_minute": 0,
         "end_hour": 7,
         "end_minute": 0,

--- a/tests/components/roborock/test_time.py
+++ b/tests/components/roborock/test_time.py
@@ -1,10 +1,12 @@
 """Test Roborock Time platform."""
 
+from collections.abc import Callable
 from datetime import time
+from typing import Any
 
 import pytest
 import roborock
-from roborock.data import DnDTimer
+from roborock.data import DnDTimer, RoborockBaseTimer, ValleyElectricityTimer
 
 from homeassistant.components.time import SERVICE_SET_VALUE
 from homeassistant.const import Platform
@@ -22,20 +24,41 @@ def platforms() -> list[Platform]:
     return [Platform.TIME]
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
-    ("entity_id", "start_state", "expected_args", "end_state"),
+    ("entity_id", "start_state", "expected_call", "expected_args", "end_state"),
     [
         (
             "time.roborock_s7_maxv_do_not_disturb_begin",
             "22:00:00",
+            lambda x: x.v1_properties.dnd.set_dnd_timer,
             DnDTimer(start_hour=1, start_minute=1, end_hour=7, end_minute=0, enabled=1),
             "01:01:00",
         ),
         (
             "time.roborock_s7_maxv_do_not_disturb_end",
             "07:00:00",
+            lambda x: x.v1_properties.dnd.set_dnd_timer,
             DnDTimer(
                 start_hour=22, start_minute=0, end_hour=1, end_minute=1, enabled=1
+            ),
+            "01:01:00",
+        ),
+        (
+            "time.roborock_s7_maxv_off_peak_start",
+            "23:00:00",
+            lambda x: x.v1_properties.valley_electricity_timer.set_timer,
+            ValleyElectricityTimer(
+                start_hour=1, start_minute=1, end_hour=7, end_minute=0, enabled=1
+            ),
+            "01:01:00",
+        ),
+        (
+            "time.roborock_s7_maxv_off_peak_end",
+            "07:00:00",
+            lambda x: x.v1_properties.valley_electricity_timer.set_timer,
+            ValleyElectricityTimer(
+                start_hour=23, start_minute=0, end_hour=1, end_minute=1, enabled=1
             ),
             "01:01:00",
         ),
@@ -48,7 +71,8 @@ async def test_update_success(
     entity_id: str,
     start_state: str,
     end_state: str,
-    expected_args: DnDTimer,
+    expected_call: Callable[[FakeDevice], Any],
+    expected_args: RoborockBaseTimer,
 ) -> None:
     """Test turning switch entities on and off."""
     # Ensure that the entity exist, as these test can pass even if there is no entity.
@@ -64,10 +88,11 @@ async def test_update_success(
         target={"entity_id": entity_id},
     )
 
-    assert fake_vacuum.v1_properties.dnd.set_dnd_timer.call_count == 1
+    call = expected_call(fake_vacuum)
+    assert call.call_count == 1
     # Since we update the begin or end time separately: Verify that the args are built properly
     # by reading the existing value and only updating the relevant fields.
-    assert fake_vacuum.v1_properties.dnd.set_dnd_timer.call_args == ((expected_args,),)
+    assert call.call_args == ((expected_args,),)
 
     state = hass.states.get(entity_id)
     assert state is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix roborock off peak electricity timer time entities.

The existing code was calling the wrong API methods, which is defined here: https://github.com/Python-roborock/python-roborock/blob/main/roborock/devices/traits/v1/valley_electricity_timer.py -- this adds tests for the entities, sharing a fixture with the existing do not disturb time entities.






## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #158245
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
