### PR TITLE
Fix flaky laundrify coordinator test

### DIFF
--- a/tests/components/laundrify/conftest.py
+++ b/tests/components/laundrify/conftest.py
@@ -33,7 +33,9 @@ def laundrify_sensor_fixture() -> LaundrifyDevice:
 
 @pytest.fixture(name="laundrify_config_entry")
 async def laundrify_setup_config_entry(
-    hass: HomeAssistant, access_token: str = VALID_ACCESS_TOKEN
+    hass: HomeAssistant,
+    laundrify_api_mock,
+    access_token: str = VALID_ACCESS_TOKEN,
 ) -> MockConfigEntry:
     """Create laundrify entry in Home Assistant."""
     entry = MockConfigEntry(

--- a/tests/components/laundrify/test_coordinator.py
+++ b/tests/components/laundrify/test_coordinator.py
@@ -21,9 +21,7 @@ def get_coord_entity(
 ) -> State | None:
     """Get the coordinated energy sensor entity."""
     unique_id = f"{mock_device.id}_{SensorDeviceClass.ENERGY}"
-    entity_entry = entity_registry.async_get_entity_id(
-        "sensor", DOMAIN, unique_id
-    )
+    entity_entry = entity_registry.async_get_entity_id("sensor", DOMAIN, unique_id)
     if entity_entry is None:
         return None
     return hass.states.get(entity_entry)

--- a/tests/components/laundrify/test_coordinator.py
+++ b/tests/components/laundrify/test_coordinator.py
@@ -5,20 +5,21 @@ from datetime import timedelta
 from freezegun.api import FrozenDateTimeFactory
 from laundrify_aio import exceptions
 
-from homeassistant.components.laundrify.const import DEFAULT_POLL_INTERVAL
+from homeassistant.components.laundrify.const import DEFAULT_POLL_INTERVAL, DOMAIN
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_fire_time_changed
 
-# The energy sensor entity_id based on the device name "Demo Waschmaschine"
-# from fixtures/machines.json. It gets "_2" suffix as it's registered after
-# the power sensor which takes the base name.
-ENERGY_SENSOR_ENTITY_ID = "sensor.demo_waschmaschine_2"
+# Device ID from fixtures/machines.json
+DEVICE_ID = "14"
 
 
 async def test_coordinator_update_success(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     laundrify_config_entry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -27,13 +28,17 @@ async def test_coordinator_update_success(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get(ENERGY_SENSOR_ENTITY_ID)
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{DEVICE_ID}_{SensorDeviceClass.ENERGY}"
+    )
+    state = hass.states.get(entity_id)
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
 
 
 async def test_coordinator_update_unauthorized(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     laundrify_config_entry,
     laundrify_api_mock,
     freezer: FrozenDateTimeFactory,
@@ -45,13 +50,17 @@ async def test_coordinator_update_unauthorized(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get(ENERGY_SENSOR_ENTITY_ID)
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{DEVICE_ID}_{SensorDeviceClass.ENERGY}"
+    )
+    state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
 
 async def test_coordinator_update_connection_failed(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     laundrify_config_entry,
     laundrify_api_mock,
     freezer: FrozenDateTimeFactory,
@@ -63,6 +72,9 @@ async def test_coordinator_update_connection_failed(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get(ENERGY_SENSOR_ENTITY_ID)
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{DEVICE_ID}_{SensorDeviceClass.ENERGY}"
+    )
+    state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE

--- a/tests/components/laundrify/test_coordinator.py
+++ b/tests/components/laundrify/test_coordinator.py
@@ -5,22 +5,33 @@ from datetime import timedelta
 from freezegun.api import FrozenDateTimeFactory
 from laundrify_aio import LaundrifyDevice, exceptions
 
-from homeassistant.components.laundrify.const import DEFAULT_POLL_INTERVAL
+from homeassistant.components.laundrify.const import DEFAULT_POLL_INTERVAL, DOMAIN
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, State
-from homeassistant.util import slugify
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_fire_time_changed
 
 
-def get_coord_entity(hass: HomeAssistant, mock_device: LaundrifyDevice) -> State:
+def get_coord_entity(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_device: LaundrifyDevice,
+) -> State | None:
     """Get the coordinated energy sensor entity."""
-    device_slug = slugify(mock_device.name, separator="_")
-    return hass.states.get(f"sensor.{device_slug}_energy")
+    unique_id = f"{mock_device.id}_{SensorDeviceClass.ENERGY}"
+    entity_entry = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, unique_id
+    )
+    if entity_entry is None:
+        return None
+    return hass.states.get(entity_entry)
 
 
 async def test_coordinator_update_success(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     laundrify_config_entry,
     mock_device: LaundrifyDevice,
     freezer: FrozenDateTimeFactory,
@@ -30,12 +41,14 @@ async def test_coordinator_update_success(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    coord_entity = get_coord_entity(hass, mock_device)
+    coord_entity = get_coord_entity(hass, entity_registry, mock_device)
+    assert coord_entity is not None
     assert coord_entity.state != STATE_UNAVAILABLE
 
 
 async def test_coordinator_update_unauthorized(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     laundrify_config_entry,
     laundrify_api_mock,
     mock_device: LaundrifyDevice,
@@ -48,12 +61,14 @@ async def test_coordinator_update_unauthorized(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    coord_entity = get_coord_entity(hass, mock_device)
+    coord_entity = get_coord_entity(hass, entity_registry, mock_device)
+    assert coord_entity is not None
     assert coord_entity.state == STATE_UNAVAILABLE
 
 
 async def test_coordinator_update_connection_failed(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     laundrify_config_entry,
     laundrify_api_mock,
     mock_device: LaundrifyDevice,
@@ -66,5 +81,6 @@ async def test_coordinator_update_connection_failed(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    coord_entity = get_coord_entity(hass, mock_device)
+    coord_entity = get_coord_entity(hass, entity_registry, mock_device)
+    assert coord_entity is not None
     assert coord_entity.state == STATE_UNAVAILABLE


### PR DESCRIPTION
The test was failing intermittently due to two issues:

1. Fixture ordering: The `laundrify_config_entry` fixture didn't explicitly depend on `laundrify_api_mock`, causing potential race conditions where the config entry might be set up before the API patches were applied.

2. Incorrect entity lookup: The `get_coord_entity` helper was constructing the entity_id using slugify on the device name and appending "_energy". Changed to look up the entity by its unique_id via the entity registry instead.

This failed in https://github.com/home-assistant/core/actions/runs/20065867549/job/57554963670

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
