### PR TITLE
Improve Roborock exception logging behavior for Zeo/Dyad devices

### DIFF
--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -394,7 +394,14 @@ class RoborockWashingMachineUpdateCoordinator(
     async def _async_update_data(
         self,
     ) -> dict[RoborockZeoProtocol, StateType]:
-        return await self.api.query_values(self.request_protocols)
+        try:
+            return await self.api.query_values(self.request_protocols)
+        except RoborockException as ex:
+            _LOGGER.debug("Failed to update washing machine data: %s", ex)
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_data_fail",
+            ) from ex
 
 
 class RoborockWetDryVacUpdateCoordinator(
@@ -425,4 +432,11 @@ class RoborockWetDryVacUpdateCoordinator(
     async def _async_update_data(
         self,
     ) -> dict[RoborockDyadDataProtocol, StateType]:
-        return await self.api.query_values(self.request_protocols)
+        try:
+            return await self.api.query_values(self.request_protocols)
+        except RoborockException as ex:
+            _LOGGER.debug("Failed to update wet dry vac data: %s", ex)
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_data_fail",
+            ) from ex

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -353,7 +353,6 @@ async def test_zeo_device_fails_setup(
     assert mock_roborock_entry.state is ConfigEntryState.LOADED
 
     # The current behavior is that we do not add the Zeo device if it fails to setup
-    await hass.async_block_till_done()
     found_devices = device_registry.devices.get_devices_for_config_entry_id(
         mock_roborock_entry.entry_id
     )
@@ -389,7 +388,6 @@ async def test_dyad_device_fails_setup(
     assert mock_roborock_entry.state is ConfigEntryState.LOADED
 
     # The current behavior is that we do not add the Zeo device if it fails to setup
-    await hass.async_block_till_done()
     found_devices = device_registry.devices.get_devices_for_config_entry_id(
         mock_roborock_entry.entry_id
     )

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -333,15 +333,6 @@ async def test_cloud_api_repair(
     assert len(issue_registry.issues) == 0
 
 
-EXPECTED_DEVICES = {
-    "Roborock S7 MaxV",
-    "Roborock S7 MaxV Dock",
-    "Roborock S7 2",
-    "Roborock S7 2 Dock",
-    "Dyad Pro",
-}
-
-
 @pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
 async def test_zeo_device_fails_setup(
     hass: HomeAssistant,

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -10,6 +10,7 @@ from roborock import (
     RoborockInvalidUserAgreement,
     RoborockNoUserAgreement,
 )
+from roborock.exceptions import RoborockException
 
 from homeassistant.components.roborock.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -330,3 +331,82 @@ async def test_cloud_api_repair(
     await hass.async_block_till_done()
 
     assert len(issue_registry.issues) == 0
+
+
+EXPECTED_DEVICES = {
+    "Roborock S7 MaxV",
+    "Roborock S7 MaxV Dock",
+    "Roborock S7 2",
+    "Roborock S7 2 Dock",
+    "Dyad Pro",
+}
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
+async def test_zeo_device_fails_setup(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Simulate an error while setting up a zeo device."""
+    # We have a single zeo device in the test setup. Find it then set it to fail.
+    zeo_device = next(
+        (device for device in fake_devices if device.zeo is not None),
+        None,
+    )
+    assert zeo_device is not None
+    zeo_device.zeo.query_values.side_effect = RoborockException("Simulated Zeo failure")
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    assert mock_roborock_entry.state is ConfigEntryState.LOADED
+
+    # The current behavior is that we do not add the Zeo device if it fails to setup
+    await hass.async_block_till_done()
+    found_devices = device_registry.devices.get_devices_for_config_entry_id(
+        mock_roborock_entry.entry_id
+    )
+    assert {device.name for device in found_devices} == {
+        "Roborock S7 MaxV",
+        "Roborock S7 MaxV Dock",
+        "Roborock S7 2",
+        "Roborock S7 2 Dock",
+        "Dyad Pro",
+        # Zeo device is missing
+    }
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
+async def test_dyad_device_fails_setup(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Simulate an error while setting up a dyad device."""
+    # We have a single dyad device in the test setup. Find it then set it to fail.
+    dyad_device = next(
+        (device for device in fake_devices if device.dyad is not None),
+        None,
+    )
+    assert dyad_device is not None
+    dyad_device.dyad.query_values.side_effect = RoborockException(
+        "Simulated Dyad failure"
+    )
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    assert mock_roborock_entry.state is ConfigEntryState.LOADED
+
+    # The current behavior is that we do not add the Zeo device if it fails to setup
+    await hass.async_block_till_done()
+    found_devices = device_registry.devices.get_devices_for_config_entry_id(
+        mock_roborock_entry.entry_id
+    )
+    assert {device.name for device in found_devices} == {
+        "Roborock S7 MaxV",
+        "Roborock S7 MaxV Dock",
+        "Roborock S7 2",
+        "Roborock S7 2 Dock",
+        # Dyad device is missing
+        "Zeo One",
+    }

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -387,7 +387,7 @@ async def test_dyad_device_fails_setup(
     await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
     assert mock_roborock_entry.state is ConfigEntryState.LOADED
 
-    # The current behavior is that we do not add the Zeo device if it fails to setup
+    # The current behavior is that we do not add the Dyad device if it fails to setup
     found_devices = device_registry.devices.get_devices_for_config_entry_id(
         mock_roborock_entry.entry_id
     )


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update the coordinator to  catch the integration library specific exceptions and raise UpdateFailed to reduce exceptions in the log message

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #
- This PR is related to issue: #158294
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
