### PR TITLE
Fix Matter Door Lock Operating Mode select entity

### DIFF
--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -184,8 +184,14 @@ class MatterModeSelectEntity(MatterAttributeSelectEntity):
 
 
 class MatterDoorLockOperatingModeSelectEntity(MatterAttributeSelectEntity):
-    """Representation of a Door Lock Operating Mode select entity."""
+    """Representation of a Door Lock Operating Mode select entity.
 
+    This entity dynamically filters available operating modes based on the device's
+    `SupportedOperatingModes` bitmap attribute. In this bitmap, bit=0 indicates a
+    supported mode and bit=1 indicates unsupported (inverted from typical bitmap conventions).
+    If the bitmap is unavailable, only mandatory modes are included. The mapping from
+    bitmap bits to operating mode values is defined by the Matter specification.
+    """
     entity_description: MatterMapSelectEntityDescription
 
     @callback

--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -207,16 +207,17 @@ class MatterDoorLockOperatingModeSelectEntity(MatterAttributeSelectEntity):
         # NOTE: The Matter spec inverts the usual meaning: bit=0 means supported,
         # bit=1 means not supported, undefined bits must be 1. Mandatory modes are
         # bits 0 (Normal) and 3 (NoRemoteLockUnlock).
-        supported_modes = [
+        num_mode_bits = supported_modes_bitmap.bit_length()
+        supported_mode_values = [
             bit_position
-            for bit_position in range(5)  # Operating modes are bits 0-4
+            for bit_position in range(num_mode_bits)
             if not supported_modes_bitmap & (1 << bit_position)
         ]
 
         # Map supported mode values to their string representations
         self._attr_options = [
             mapped_value
-            for mode_value in supported_modes
+            for mode_value in supported_mode_values
             if (mapped_value := self.entity_description.device_to_ha(mode_value))
         ]
 

--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -192,6 +192,7 @@ class MatterDoorLockOperatingModeSelectEntity(MatterAttributeSelectEntity):
     If the bitmap is unavailable, only mandatory modes are included. The mapping from
     bitmap bits to operating mode values is defined by the Matter specification.
     """
+
     entity_description: MatterMapSelectEntityDescription
 
     @callback
@@ -206,18 +207,11 @@ class MatterDoorLockOperatingModeSelectEntity(MatterAttributeSelectEntity):
         # NOTE: The Matter spec inverts the usual meaning: bit=0 means supported,
         # bit=1 means not supported, undefined bits must be 1. Mandatory modes are
         # bits 0 (Normal) and 3 (NoRemoteLockUnlock).
-        if supported_modes_bitmap is not None:
-            supported_modes = [
-                bit_position
-                for bit_position in range(5)  # Operating modes are bits 0-4
-                if not supported_modes_bitmap & (1 << bit_position)
-            ]
-            # Fall back to mandatory modes if the bitmap yields no supported entries
-            if not supported_modes:
-                supported_modes = [0, 3]
-        else:
-            # If bitmap not available, include all mandatory modes
-            supported_modes = [0, 3]
+        supported_modes = [
+            bit_position
+            for bit_position in range(5)  # Operating modes are bits 0-4
+            if not supported_modes_bitmap & (1 << bit_position)
+        ]
 
         # Map supported mode values to their string representations
         self._attr_options = [

--- a/tests/components/matter/snapshots/test_select.ambr
+++ b/tests/components/matter/snapshots/test_select.ambr
@@ -3658,7 +3658,6 @@
       'options': list([
         'normal',
         'vacation',
-        'privacy',
         'no_remote_lock_unlock',
         'passage',
       ]),
@@ -3699,7 +3698,6 @@
       'options': list([
         'normal',
         'vacation',
-        'privacy',
         'no_remote_lock_unlock',
         'passage',
       ]),

--- a/tests/components/matter/snapshots/test_select.ambr
+++ b/tests/components/matter/snapshots/test_select.ambr
@@ -241,10 +241,7 @@
     'capabilities': dict({
       'options': list([
         'normal',
-        'vacation',
-        'privacy',
         'no_remote_lock_unlock',
-        'passage',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -282,10 +279,7 @@
       'friendly_name': 'Aqara Smart Lock U200 Operating mode',
       'options': list([
         'normal',
-        'vacation',
-        'privacy',
         'no_remote_lock_unlock',
-        'passage',
       ]),
     }),
     'context': <ANY>,
@@ -684,10 +678,7 @@
     'capabilities': dict({
       'options': list([
         'normal',
-        'vacation',
-        'privacy',
         'no_remote_lock_unlock',
-        'passage',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -725,10 +716,7 @@
       'friendly_name': 'Mock Door Lock Operating mode',
       'options': list([
         'normal',
-        'vacation',
-        'privacy',
         'no_remote_lock_unlock',
-        'passage',
       ]),
     }),
     'context': <ANY>,
@@ -869,10 +857,7 @@
     'capabilities': dict({
       'options': list([
         'normal',
-        'vacation',
-        'privacy',
         'no_remote_lock_unlock',
-        'passage',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -910,10 +895,7 @@
       'friendly_name': 'Mock Door Lock with unbolt Operating mode',
       'options': list([
         'normal',
-        'vacation',
-        'privacy',
         'no_remote_lock_unlock',
-        'passage',
       ]),
     }),
     'context': <ANY>,
@@ -2454,10 +2436,7 @@
     'capabilities': dict({
       'options': list([
         'normal',
-        'vacation',
-        'privacy',
         'no_remote_lock_unlock',
-        'passage',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -2495,10 +2474,7 @@
       'friendly_name': 'Mock Lock Operating mode',
       'options': list([
         'normal',
-        'vacation',
-        'privacy',
         'no_remote_lock_unlock',
-        'passage',
       ]),
     }),
     'context': <ANY>,
@@ -3657,9 +3633,8 @@
     'capabilities': dict({
       'options': list([
         'normal',
-        'vacation',
+        'privacy',
         'no_remote_lock_unlock',
-        'passage',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -3697,9 +3672,8 @@
       'friendly_name': 'Secuyou Smart Lock Operating mode',
       'options': list([
         'normal',
-        'vacation',
+        'privacy',
         'no_remote_lock_unlock',
-        'passage',
       ]),
     }),
     'context': <ANY>,

--- a/tests/components/matter/test_select.py
+++ b/tests/components/matter/test_select.py
@@ -329,6 +329,8 @@ async def test_door_lock_operating_mode_select(
         "privacy",
         "no_remote_lock_unlock",
     }
+    # Verify that the initial state is part of the allowed options
+    assert state.state in state.attributes["options"]
 
     # Dynamically obtain ids instead of hardcoding
     door_lock_cluster_id = clusters.DoorLock.Attributes.OperatingMode.cluster_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Problem:** The Door Lock Operating Mode selector was including all 5 operating modes unconditionally, but the Matter specification uses a bitmap attribute (`SupportedOperatingModes`) to indicate which modes a device actually supports.

**Solution:** Created a specialized `MatterDoorLockOperatingModeSelectEntity` class that:

1. **Reads the bitmap**: Retrieves the `SupportedOperatingModes` bitmap from the device
2. **Extracts enabled bits**: Converts the bitmap to bit positions (0-4, representing the 5 operating modes)
3. **Filters options dynamically**: Only includes modes that the device supports
4. **Maintains translation support**: Uses the full `DOOR_LOCK_OPERATING_MODE_MAP` for all possible translations

**Key Features:**
- ✅ Respects Matter bitmap specification
- ✅ Dynamically updates available modes based on device capabilities
- ✅ Full translation support for all 5 operating modes (Normal, Vacation, Privacy, NoRemoteLockUnlock, Passage)
- ✅ Handles enum to string conversion for user selection
- ✅ Writes correct enum values when options are selected

**SupportedOperatingModes Attribute**

- This attribute SHALL contain a bitmap with all operating bits of the OperatingMode attribute supported by the lock.
- A bit position set to zero SHALL indicate that the mode is supported. A bit position set to one SHALL indicate that the mode is not supported.
- Any bit that is not yet defined in OperatingModesBitmap SHALL be set to 1.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #158447
- This PR is related to issue: #158447
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
