### PR TITLE
Allow to wait for start of script execution

### DIFF
--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -71,6 +71,7 @@ from .const import (
     ATTR_LAST_ACTION,
     ATTR_LAST_TRIGGERED,
     ATTR_VARIABLES,
+    ATTR_WAIT_FOR_START,
     CONF_FIELDS,
     CONF_TRACE,
     DOMAIN,
@@ -83,7 +84,10 @@ from .trace import trace_script
 
 SCRIPT_SERVICE_SCHEMA = vol.Schema(dict)
 SCRIPT_TURN_ONOFF_SCHEMA = make_entity_service_schema(
-    {vol.Optional(ATTR_VARIABLES): {str: cv.match_all}}
+    {
+        vol.Optional(ATTR_VARIABLES): {str: cv.match_all},
+        vol.Optional(ATTR_WAIT_FOR_START): cv.boolean,
+    }
 )
 RELOAD_SERVICE_SCHEMA = vol.Schema({})
 
@@ -242,11 +246,22 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def turn_on_service(service: ServiceCall) -> None:
         """Call a service to turn script on."""
         variables = service.data.get(ATTR_VARIABLES)
+        wait_for_start = service.data.get(ATTR_WAIT_FOR_START, False)
         script_entities = await component.async_extract_from_service(service)
-        for script_entity in script_entities:
-            await script_entity.async_turn_on(
-                variables=variables, context=service.context, wait=False
+        if not script_entities:
+            return
+
+        await asyncio.gather(
+            *(
+                script_entity.async_turn_on(
+                    variables=variables,
+                    context=service.context,
+                    wait=False,
+                    wait_for_start=wait_for_start,
+                )
+                for script_entity in script_entities
             )
+        )
 
     async def turn_off_service(service: ServiceCall) -> None:
         """Cancel a script."""
@@ -664,10 +679,15 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
         variables: dict[str, Any] | None = kwargs.get("variables")
         context: Context = kwargs["context"]
         wait: bool = kwargs.get("wait", True)
-        await self._async_start_run(variables, context, wait)
+        wait_for_start: bool = kwargs.get("wait_for_start", False)
+        await self._async_start_run(variables, context, wait, wait_for_start)
 
     async def _async_start_run(
-        self, variables: dict[str, Any] | None, context: Context, wait: bool
+        self,
+        variables: dict[str, Any] | None,
+        context: Context,
+        wait: bool,
+        wait_for_start: bool = False,
     ) -> ServiceResponse:
         """Start the run of a script."""
         self.async_set_context(context)
@@ -676,7 +696,6 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
             {ATTR_NAME: self.script.name, ATTR_ENTITY_ID: self.entity_id},
             context=context,
         )
-        coro = self._async_run(variables, context)
         if wait:
             # If we are executing in parallel, we need to copy the script stack so
             # that if this script is called in parallel, it will not be seen in the
@@ -687,7 +706,7 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
             if script_stack := script_stack_cv.get():
                 script_stack_cv.set(script_stack.copy())
 
-            script_result = await coro
+            script_result = await self._async_run(variables, context)
             return script_result.service_response if script_result else None
 
         # Caller does not want to wait for called script to finish so let script run in
@@ -696,14 +715,25 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
         script_stack_cv.set([])
 
         self._changed.clear()
-        self.hass.async_create_task(coro, eager_start=True)
+        started_event = asyncio.Event() if wait_for_start else None
+
+        self.hass.async_create_task(
+            self._async_run(variables, context, started_event=started_event),
+            eager_start=True,
+        )
         # Wait for first state change so we can guarantee that
         # it is written to the State Machine before we return.
-        await self._changed.wait()
+        if started_event:
+            await started_event.wait()
+        else:
+            await self._changed.wait()
         return None
 
     async def _async_run(
-        self, variables: dict[str, Any] | None, context: Context
+        self,
+        variables: dict[str, Any] | None,
+        context: Context,
+        started_event: asyncio.Event | None = None,
     ) -> ScriptRunResult | None:
         with trace_script(
             self.hass,
@@ -720,7 +750,9 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
                 if state := self.hass.states.get(self.entity_id):
                     this = state.as_dict()
                 script_vars = {"this": this, **(variables or {})}
-                return await self.script.async_run(script_vars, context)
+                return await self.script.async_run(
+                    script_vars, context, started_event=started_event
+                )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Stop running the script.

--- a/homeassistant/components/script/const.py
+++ b/homeassistant/components/script/const.py
@@ -7,6 +7,7 @@ DOMAIN = "script"
 ATTR_LAST_ACTION = "last_action"
 ATTR_LAST_TRIGGERED = "last_triggered"
 ATTR_VARIABLES = "variables"
+ATTR_WAIT_FOR_START = "wait_for_start"
 
 CONF_ADVANCED = "advanced"
 CONF_EXAMPLE = "example"

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -413,12 +413,14 @@ class _ScriptRun:
         variables: ScriptRunVariables,
         context: Context | None,
         log_exceptions: bool,
+        started_event: asyncio.Event | None = None,
     ) -> None:
         self._hass = hass
         self._script = script
         self._variables = variables
         self._context = context
         self._log_exceptions = log_exceptions
+        self._started_event = started_event
         self._step = -1
         self._started = False
         self._stop = hass.loop.create_future()
@@ -444,6 +446,9 @@ class _ScriptRun:
     async def async_run(self) -> ScriptRunResult | None:
         """Run script."""
         self._started = True
+        if self._started_event:
+            self._started_event.set()
+
         # Push the script to the script execution stack
         if (script_stack := script_stack_cv.get()) is None:
             script_stack = []
@@ -1735,6 +1740,7 @@ class Script:
         run_variables: _VarsType | None = None,
         context: Context | None = None,
         started_action: Callable[..., Any] | None = None,
+        started_event: asyncio.Event | None = None,
     ) -> ScriptRunResult | None:
         """Run script."""
         if context is None:
@@ -1811,7 +1817,14 @@ class Script:
             cls = _ScriptRun
         else:
             cls = _QueuedScriptRun
-        run = cls(self._hass, self, variables, context, self._log_exceptions)
+        run = cls(
+            self._hass,
+            self,
+            variables,
+            context,
+            self._log_exceptions,
+            started_event=started_event,
+        )
         has_existing_runs = bool(self._runs)
         self._runs.append(run)
         if self.script_mode == SCRIPT_MODE_RESTART and has_existing_runs:

--- a/tests/components/script/test_wait_for_start.py
+++ b/tests/components/script/test_wait_for_start.py
@@ -1,4 +1,4 @@
-"""The tests for the Script component wait_for_queue feature."""
+"""The tests for the Script component wait_for_start feature."""
 
 import asyncio
 import contextlib

--- a/tests/components/script/test_wait_for_start.py
+++ b/tests/components/script/test_wait_for_start.py
@@ -1,0 +1,320 @@
+"""The tests for the Script component wait_for_queue feature."""
+
+import asyncio
+import contextlib
+
+from homeassistant.components.script import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import async_mock_service
+
+
+async def test_wait_for_start(hass: HomeAssistant) -> None:
+    """Test wait_for_start."""
+    calls = async_mock_service(hass, "test", "script")
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "test_script": {
+                    "mode": "queued",
+                    "max": 2,
+                    "sequence": [
+                        {"action": "test.script", "data": {"value": "start"}},
+                        {"wait_template": "{{ is_state('input_boolean.wait', 'on') }}"},
+                        {
+                            "service": "input_boolean.turn_off",
+                            "entity_id": "input_boolean.wait",
+                        },
+                        {"action": "test.script", "data": {"value": "end"}},
+                    ],
+                }
+            }
+        },
+    )
+
+    assert await async_setup_component(
+        hass, "input_boolean", {"input_boolean": {"wait": {}}}
+    )
+
+    # Start the first run (background)
+    hass.async_create_task(
+        hass.services.async_call(
+            DOMAIN, "turn_on", {ATTR_ENTITY_ID: "script.test_script"}
+        )
+    )
+
+    # Wait for it to start
+    await asyncio.sleep(0.1)
+    assert len(calls) == 1
+    assert calls[0].data["value"] == "start"
+
+    # Start the second run with wait_for_start=True
+    # This should block until the first run finishes
+    task = hass.async_create_task(
+        hass.services.async_call(
+            DOMAIN,
+            "turn_on",
+            {ATTR_ENTITY_ID: "script.test_script", "wait_for_start": True},
+            blocking=True,
+        )
+    )
+
+    # It should not be done yet because first run is still running
+    await asyncio.sleep(0.1)
+    assert not task.done()
+
+    # Finish the first run
+    hass.states.async_set("input_boolean.wait", "on")
+    # We can't use async_block_till_done here because 'task' is tracked and it is blocked,
+    # so async_block_till_done would wait for it forever (or until timeout).
+    # We just need to let the event loop run so the state change is processed.
+    await asyncio.sleep(0.1)
+
+    # Now the first run should have finished (and turned off input_boolean).
+    # The second run should have started.
+    # The task (turn_on call) should be done.
+    assert task.done()
+
+    # And the second run should have started
+    # calls: start1, end1, start2
+    assert len(calls) >= 3
+    assert calls[2].data["value"] == "start"
+
+    # But the second run should NOT be finished yet (it waits for template, which is off now)
+    # So we shouldn't see end2
+    assert len(calls) == 3
+
+    # Now finish the second run
+    hass.states.async_set("input_boolean.wait", "on")
+    await hass.async_block_till_done()
+
+    assert len(calls) == 4
+    assert calls[3].data["value"] == "end"
+
+
+async def test_wait_for_start_single_mode(hass: HomeAssistant) -> None:
+    """Test wait_for_start with single mode (no queue)."""
+    calls = async_mock_service(hass, "test", "script")
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "test_script": {
+                    "mode": "single",
+                    "sequence": [
+                        {"action": "test.script", "data": {"value": "run"}},
+                    ],
+                }
+            }
+        },
+    )
+
+    # Start the run with wait_for_start=True
+    # It should return immediately as there is no queue
+    await hass.services.async_call(
+        DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: "script.test_script", "wait_for_start": True},
+        blocking=True,
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data["value"] == "run"
+
+
+async def test_wait_for_start_cancellation(hass: HomeAssistant) -> None:
+    """Test cancelling wait_for_start does not cancel the script."""
+    calls = async_mock_service(hass, "test", "script")
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "test_script": {
+                    "mode": "queued",
+                    "max": 2,
+                    "sequence": [
+                        {"action": "test.script", "data": {"value": "start"}},
+                        {"wait_template": "{{ is_state('input_boolean.wait', 'on') }}"},
+                        {"action": "test.script", "data": {"value": "end"}},
+                    ],
+                }
+            }
+        },
+    )
+
+    assert await async_setup_component(
+        hass, "input_boolean", {"input_boolean": {"wait": {}}}
+    )
+
+    # Start the first run (background)
+    hass.async_create_task(
+        hass.services.async_call(
+            DOMAIN, "turn_on", {ATTR_ENTITY_ID: "script.test_script"}
+        )
+    )
+
+    # Wait for it to start
+    await asyncio.sleep(0.1)
+    assert len(calls) == 1
+
+    # Start the second run with wait_for_start=True
+    task = hass.async_create_task(
+        hass.services.async_call(
+            DOMAIN,
+            "turn_on",
+            {ATTR_ENTITY_ID: "script.test_script", "wait_for_start": True},
+            blocking=True,
+        )
+    )
+
+    # It should be blocked
+    await asyncio.sleep(0.1)
+    assert not task.done()
+
+    # Cancel the waiting task
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    # Finish the first run
+    hass.states.async_set("input_boolean.wait", "on")
+    await hass.async_block_till_done()
+
+    # The second run should still have executed because the script was queued
+    # before the task was cancelled. Both runs complete:
+    # calls: start1, end1, start2, end2
+    assert len(calls) == 4
+    assert calls[2].data["value"] == "start"
+    assert calls[3].data["value"] == "end"
+
+
+async def test_wait_for_start_multiple_scripts(hass: HomeAssistant) -> None:
+    """Test wait_for_start with multiple scripts."""
+    calls = async_mock_service(hass, "test", "script")
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "test_script_1": {
+                    "mode": "queued",
+                    "max": 2,
+                    "sequence": [
+                        {"action": "test.script", "data": {"value": "start_1"}},
+                        {
+                            "wait_template": "{{ is_state('input_boolean.wait_1', 'on') }}"
+                        },
+                        {
+                            "service": "input_boolean.turn_off",
+                            "entity_id": "input_boolean.wait_1",
+                        },
+                        {"action": "test.script", "data": {"value": "end_1"}},
+                    ],
+                },
+                "test_script_2": {
+                    "mode": "queued",
+                    "max": 2,
+                    "sequence": [
+                        {"action": "test.script", "data": {"value": "start_2"}},
+                        {
+                            "wait_template": "{{ is_state('input_boolean.wait_2', 'on') }}"
+                        },
+                        {
+                            "service": "input_boolean.turn_off",
+                            "entity_id": "input_boolean.wait_2",
+                        },
+                        {"action": "test.script", "data": {"value": "end_2"}},
+                    ],
+                },
+            }
+        },
+    )
+
+    assert await async_setup_component(
+        hass,
+        "input_boolean",
+        {"input_boolean": {"wait_1": {}, "wait_2": {}}},
+    )
+
+    # Start the first run for both scripts (background)
+    hass.async_create_task(
+        hass.services.async_call(
+            DOMAIN, "turn_on", {ATTR_ENTITY_ID: "script.test_script_1"}
+        )
+    )
+    hass.async_create_task(
+        hass.services.async_call(
+            DOMAIN, "turn_on", {ATTR_ENTITY_ID: "script.test_script_2"}
+        )
+    )
+
+    # Wait for them to start
+    await asyncio.sleep(0.1)
+    assert len(calls) == 2
+    call_values = {c.data["value"] for c in calls}
+    assert call_values == {"start_1", "start_2"}
+    calls.clear()
+
+    # Start the second run for both scripts with wait_for_start=True
+    # This should block until both first runs finish
+    task = hass.async_create_task(
+        hass.services.async_call(
+            DOMAIN,
+            "turn_on",
+            {
+                ATTR_ENTITY_ID: ["script.test_script_1", "script.test_script_2"],
+                "wait_for_start": True,
+            },
+            blocking=True,
+        )
+    )
+
+    # It should be blocked
+    await asyncio.sleep(0.1)
+    assert not task.done()
+
+    # Verify both scripts have 2 runs (1 running, 1 queued)
+    # This confirms that both scripts were queued simultaneously
+    state_1 = hass.states.get("script.test_script_1")
+    assert state_1 is not None
+    assert state_1.attributes["current"] == 2
+
+    state_2 = hass.states.get("script.test_script_2")
+    assert state_2 is not None
+    assert state_2.attributes["current"] == 2
+
+    # Finish the first run of script 1
+    hass.states.async_set("input_boolean.wait_1", "on")
+    await asyncio.sleep(0.1)
+
+    # Script 1 second run should have started
+    assert len(calls) == 2
+    call_values = {c.data["value"] for c in calls}
+    assert call_values == {"end_1", "start_1"}
+    calls.clear()
+
+    # But the task should still be blocked because script 2 hasn't started its second run
+    assert not task.done()
+
+    # Finish the first run of script 2
+    hass.states.async_set("input_boolean.wait_2", "on")
+    await asyncio.sleep(0.1)
+
+    # Script 2 second run should have started
+    assert len(calls) == 2
+    call_values = {c.data["value"] for c in calls}
+    assert call_values == {"end_2", "start_2"}
+
+    # Now the task should be done
+    assert task.done()
+    await task


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a new optional parameter `wait_for_start` (boolean, default `false`) to the `script.turn_on` action.

When set to `true`, the action call will wait until the script execution actually begins. This is particularly useful for scripts with `mode: queued`, as it allows the caller to wait until the script has acquired the execution lock and started running, rather than returning immediately after the script is queued.

When multiple scripts are targeted, they are all queued simultaneously, and if `wait_for_start: true` is used, the service will wait for *all* targeted scripts to start before returning.

> [!NOTE]
> I have intentionally not added `wait_for_start` in [`services.yaml`](./homeassistant/components/script/services.yaml) as I consider this an advanced parameter, and also considering that not even `variables` is included there.
>
> Please let me know if that doesn't seem right.

### Example use case

<details>
  <summary>Click here to show</summary>

I have a fan that can be controlled through RF commands. It has some limitations:

1. It cannot process more than one command per second
2. When it's inverting the direction, it doesn't accept any command.

This feature allows me to handle this more cleanly:

```yaml
# scripts.yaml

desk_fan_send_command:
  alias: Send command to desk fan
  icon: mdi:remote
  mode: queued
  max: 20
  fields:
    command:
      name: Command
      description: The command to send
      required: true
      selector:
        text:
  sequence:
  - action: remote.send_command
    data:
      entity_id: remote.desk
      device: desk_fan
      command: "{{ command }}"
  - delay:
      seconds: >-
        {% if command == 'direction' and is_state('fan.desk', 'on') %}
          25
        {% else %}
          1
        {% endif %}
```

```yaml
# configuration.yaml

template:
  - fan:
    - name: Desk
      default_entity_id: fan.desk
      unique_id: 3a55e2aa-6e11-4f5f-98dc-74163f713c03
      turn_on:
        service: script.turn_on
        data:
          entity_id: script.desk_fan_send_command
          variables:
            command: on_off
          wait_for_start: true
      turn_off:
        service: script.turn_on
        data:
          entity_id: script.desk_fan_send_command
          variables:
            command: on_off
          wait_for_start: true
      set_direction:
        service: script.turn_on
        data:
          entity_id: script.desk_fan_send_command
          variables:
            command: direction
          wait_for_start: true
```

The workaround without this feature is to create two separate scripts:

```yaml
# scripts.yaml

desk_fan_send_command:
  alias: Send command to desk fan
  icon: mdi:remote
  mode: queued
  max: 20
  fields:
    command:
      name: Command
      description: The command to send
      required: true
      selector:
        text:
  sequence:
  - wait_template: "{{ is_state('script.desk_fan_send_command_busy', 'off') }}"
  - action: script.turn_on
    data:
      entity_id: script.desk_fan_send_command_busy
      variables:
        command: "{{ command }}"

desk_fan_send_command_busy:
  alias: Send command to desk fan (busy)
  icon: mdi:remote
  mode: single
  fields:
    command:
      name: Command
      description: The command to send
      required: true
      selector:
        text:
  sequence:
  - action: remote.send_command
    data:
      entity_id: remote.desk
      device: desk_fan
      command: "{{ command }}"
  - delay:
      seconds: >-
        {% if command == 'direction' and is_state('fan.desk', 'on') %}
          25
        {% else %}
          1
        {% endif %}
```

</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
