### PR TITLE
Fix flaky camera stream teardown

### DIFF
--- a/tests/components/camera/conftest.py
+++ b/tests/components/camera/conftest.py
@@ -155,6 +155,8 @@ def mock_create_stream_fixture() -> Generator[Mock]:
     mock_stream.add_provider = Mock()
     mock_stream.start = AsyncMock()
     mock_stream.endpoint_url = Mock(return_value="http://home.assistant/playlist.m3u8")
+    mock_stream.set_update_callback = Mock()
+    mock_stream.available = True
     with patch(
         "homeassistant.components.camera.create_stream",
         return_value=mock_stream,

--- a/tests/components/camera/conftest.py
+++ b/tests/components/camera/conftest.py
@@ -148,6 +148,20 @@ def mock_stream_source_fixture() -> Generator[AsyncMock]:
         yield mock_stream_source
 
 
+@pytest.fixture(name="mock_create_stream")
+def mock_create_stream_fixture() -> Generator[Mock]:
+    """Fixture to mock create_stream and prevent real stream threads."""
+    mock_stream = Mock()
+    mock_stream.add_provider = Mock()
+    mock_stream.start = AsyncMock()
+    mock_stream.endpoint_url = Mock(return_value="http://home.assistant/playlist.m3u8")
+    with patch(
+        "homeassistant.components.camera.create_stream",
+        return_value=mock_stream,
+    ):
+        yield mock_stream
+
+
 @pytest.fixture
 async def mock_test_webrtc_cameras(hass: HomeAssistant) -> None:
     """Initialize test WebRTC cameras with native RTC support."""

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -352,7 +352,10 @@ async def test_websocket_camera_stream(
     await async_setup_component(hass, "camera", {})
 
     with (
-        patch("homeassistant.components.camera.create_stream") as mock_create_stream,
+        patch(
+            "homeassistant.components.camera.create_stream",
+            return_value=mock_stream,
+        ),
         patch(
             "homeassistant.components.demo.camera.DemoCamera.stream_source",
             return_value="http://example.com",
@@ -371,7 +374,7 @@ async def test_websocket_camera_stream(
         msg = await client.receive_json()
 
         # Assert WebSocket response
-        assert mock_create_stream.called
+        assert mock_stream.endpoint_url.called
         assert msg["id"] == 6
         assert msg["type"] == TYPE_RESULT
         assert msg["success"]

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -344,7 +344,7 @@ async def test_websocket_stream_no_source(
     assert not msg["success"]
 
 
-@pytest.mark.usefixtures("mock_camera", "mock_stream", "mock_create_stream")
+@pytest.mark.usefixtures("mock_camera", "mock_stream")
 async def test_websocket_camera_stream(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_create_stream: Mock
 ) -> None:
@@ -498,7 +498,7 @@ async def test_play_stream_service_no_source(hass: HomeAssistant) -> None:
         )
 
 
-@pytest.mark.usefixtures("mock_camera", "mock_stream", "mock_create_stream")
+@pytest.mark.usefixtures("mock_camera", "mock_stream")
 async def test_handle_play_stream_service(
     hass: HomeAssistant, mock_create_stream: Mock
 ) -> None:

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -351,6 +351,10 @@ async def test_websocket_camera_stream(
     """Test camera/stream websocket command."""
     await async_setup_component(hass, "camera", {})
 
+    mock_stream = Mock()
+    mock_stream.endpoint_url.return_value = "http://home.assistant/playlist.m3u8"
+    mock_stream.start = AsyncMock()
+
     with (
         patch(
             "homeassistant.components.camera.create_stream",
@@ -361,11 +365,6 @@ async def test_websocket_camera_stream(
             return_value="http://example.com",
         ),
     ):
-        mock_stream = Mock()
-        mock_stream.endpoint_url.return_value = "http://home.assistant/playlist.m3u8"
-        mock_stream.start = AsyncMock()
-        mock_create_stream.return_value = mock_stream
-
         # Request playlist through WebSocket
         client = await hass_ws_client(hass)
         await client.send_json(


### PR DESCRIPTION
Mock create_stream instead of Stream.endpoint_url to prevent real stream objects from being created during the test. This fixes a flaky test failure where the test would fail with "errors while tearing down" because the stream worker thread wasn't being properly cleaned up when the test patches exited.

This failed in https://github.com/home-assistant/core/actions/runs/20080972481/job/57608219715?pr=158279

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
