### PR TITLE
Suppress roborock failures under some unavailability threshold

### DIFF
--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -170,7 +170,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState]):
             await self.properties_api.home.discover_home()
             await self.properties_api.home.refresh()
         except RoborockException as ex:
-            raise UpdateFailed(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="map_failure",
             ) from ex
@@ -243,8 +243,10 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState]):
             > IMAGE_CACHE_INTERVAL
         ) or self.last_update_state != new_status.state_name:
             self._last_home_update_attempt = dt_util.utcnow()
-            # Will raise UpdateFailed on failure
-            await self.update_map()
+            try:
+                await self.update_map()
+            except HomeAssistantError as err:
+                _LOGGER.debug("Failed to update map: %s", err)
 
         if self.properties_api.status.in_cleaning:
             if self._device.is_local_connected:

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -43,6 +43,12 @@ from .models import DeviceState
 
 SCAN_INTERVAL = timedelta(seconds=30)
 
+# Roborock devices have a known issue where they go offline for a short period
+# around 3AM local time for ~1 minute and reset both the local connection
+# and MQTT connection. To avoid log spam, we will avoid failures refreshing
+# data until this duration has passed.
+MIN_UNAVAILABLE_DURATION = timedelta(minutes=2)
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -102,6 +108,9 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState]):
         # Keep track of last attempt to refresh maps/rooms to know when to try again.
         self._last_home_update_attempt: datetime
         self.last_home_update: datetime | None = None
+        # Tracks the last successful update to control when we report failure
+        # to the base class. This is reset on successful data update.
+        self._last_update_success_time: datetime | None = None
 
     @cached_property
     def dock_device_info(self) -> DeviceInfo:
@@ -161,7 +170,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState]):
             await self.properties_api.home.discover_home()
             await self.properties_api.home.refresh()
         except RoborockException as ex:
-            raise HomeAssistantError(
+            raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="map_failure",
             ) from ex
@@ -169,7 +178,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState]):
             self.last_home_update = dt_util.utcnow()
 
     async def _verify_api(self) -> None:
-        """Verify that the api is reachable. If it is not, switch clients."""
+        """Verify that the api is reachable."""
         if self._device.is_connected:
             if self._device.is_local_connected:
                 async_delete_issue(
@@ -217,26 +226,25 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState]):
         try:
             # Update device props and standard api information
             await self._update_device_prop()
+        except UpdateFailed:
+            if self._should_suppress_update_failure():
+                _LOGGER.debug(
+                    "Suppressing update failure until unavailable duration passed"
+                )
+                return self.data
+            raise
 
-            # If the vacuum is currently cleaning and it has been IMAGE_CACHE_INTERVAL
-            # since the last map update, you can update the map.
-            new_status = self.properties_api.status
-            if (
-                new_status.in_cleaning
-                and (dt_util.utcnow() - self._last_home_update_attempt)
-                > IMAGE_CACHE_INTERVAL
-            ) or self.last_update_state != new_status.state_name:
-                self._last_home_update_attempt = dt_util.utcnow()
-                try:
-                    await self.update_map()
-                except HomeAssistantError as err:
-                    _LOGGER.debug("Failed to update map: %s", err)
-        except RoborockException as ex:
-            _LOGGER.debug("Failed to update data: %s", ex)
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="update_data_fail",
-            ) from ex
+        # If the vacuum is currently cleaning and it has been IMAGE_CACHE_INTERVAL
+        # since the last map update, you can update the map.
+        new_status = self.properties_api.status
+        if (
+            new_status.in_cleaning
+            and (dt_util.utcnow() - self._last_home_update_attempt)
+            > IMAGE_CACHE_INTERVAL
+        ) or self.last_update_state != new_status.state_name:
+            self._last_home_update_attempt = dt_util.utcnow()
+            # Will raise UpdateFailed on failure
+            await self.update_map()
 
         if self.properties_api.status.in_cleaning:
             if self._device.is_local_connected:
@@ -248,12 +256,31 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState]):
         else:
             self.update_interval = V1_CLOUD_NOT_CLEANING_INTERVAL
         self.last_update_state = self.properties_api.status.state_name
+        self._last_update_success_time = dt_util.utcnow()
+        _LOGGER.debug("Data update successful %s", self._last_update_success_time)
         return DeviceState(
             status=self.properties_api.status,
             dnd_timer=self.properties_api.dnd,
             consumable=self.properties_api.consumables,
             clean_summary=self.properties_api.clean_summary,
         )
+
+    def _should_suppress_update_failure(self) -> bool:
+        """Determine if we should suppress update failure reporting.
+
+        We suppress reporting update failures until a minimum duration has
+        passed since the last successful update. This is used to avoid reporting
+        the device as unavailable for short periods, a known issue.
+
+        The intent is to apply to routine background state refreshes and not
+        other failures such as the first update or map updates.
+        """
+        if self._last_update_success_time is None:
+            # Never had a successful update, do not suppress
+            return False
+        failure_duration = dt_util.utcnow() - self._last_update_success_time
+        _LOGGER.debug("Update failure duration: %s", failure_duration)
+        return failure_duration < MIN_UNAVAILABLE_DURATION
 
     async def get_routines(self) -> list[HomeDataScene]:
         """Get routines."""

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -45,7 +45,7 @@ SCAN_INTERVAL = timedelta(seconds=30)
 
 # Roborock devices have a known issue where they go offline for a short period
 # around 3AM local time for ~1 minute and reset both the local connection
-# and MQTT connection. To avoid log spam, we will avoid failures refreshing
+# and MQTT connection. To avoid log spam, we will avoid reporting failures refreshing
 # data until this duration has passed.
 MIN_UNAVAILABLE_DURATION = timedelta(minutes=2)
 

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -1,19 +1,26 @@
 """Test for Roborock init."""
 
+import datetime
 import pathlib
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from roborock import (
     RoborockInvalidCredentials,
     RoborockInvalidUserAgreement,
     RoborockNoUserAgreement,
 )
+from roborock.exceptions import RoborockException
 
+from homeassistant.components.homeassistant import (
+    DOMAIN as HA_DOMAIN,
+    SERVICE_UPDATE_ENTITY,
+)
 from homeassistant.components.roborock.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceRegistry
@@ -22,7 +29,7 @@ from homeassistant.setup import async_setup_component
 from .conftest import FakeDevice
 from .mock_data import ROBOROCK_RRUID, USER_EMAIL
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.typing import ClientSessionGenerator
 
 
@@ -292,6 +299,72 @@ async def test_migrate_config_entry_unique_id(
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.unique_id == ROBOROCK_RRUID
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
+async def test_update_unavailability_threshold(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    setup_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test that a small number of updates failures are suppressed before marking a device unavailable."""
+    await async_setup_component(hass, HA_DOMAIN, {})
+    assert setup_entry.state is ConfigEntryState.LOADED
+
+    # We pick an arbitrary sensor to test for availability
+    sensor_entity_id = "sensor.roborock_s7_maxv_battery"
+    expected_state = "100"
+    state = hass.states.get(sensor_entity_id)
+    assert state is not None
+    assert state.state == expected_state
+
+    # Simulate a few update failures below the threshold
+    assert fake_vacuum.v1_properties is not None
+    fake_vacuum.v1_properties.status.refresh.side_effect = RoborockException(
+        "Simulated update failure"
+    )
+
+    # Move forward in time less than the threshold
+    freezer.tick(datetime.timedelta(seconds=90))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Force a coordinator refresh.
+    await hass.services.async_call(
+        HA_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: sensor_entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Verify that the entity is still available
+    state = hass.states.get(sensor_entity_id)
+    assert state is not None
+    assert state.state == expected_state
+
+    # Move forward in time to exceed the threshold
+    freezer.tick(datetime.timedelta(minutes=3))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Verify that the entity is now unavailable
+    state = hass.states.get(sensor_entity_id)
+    assert state is not None
+    assert state.state == "unavailable"
+
+    # Now restore normal update behavior and refresh.
+    fake_vacuum.v1_properties.status.refresh.side_effect = None
+
+    freezer.tick(datetime.timedelta(seconds=45))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Verify that the entity recovers and is available again
+    state = hass.states.get(sensor_entity_id)
+    assert state is not None
+    assert state.state == expected_state
 
 
 async def test_cloud_api_repair(

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -308,7 +308,7 @@ async def test_update_unavailability_threshold(
     setup_entry: MockConfigEntry,
     fake_vacuum: FakeDevice,
 ) -> None:
-    """Test that a small number of updates failures are suppressed before marking a device unavailable."""
+    """Test that a small number of update failures are suppressed before marking a device unavailable."""
     await async_setup_component(hass, HA_DOMAIN, {})
     assert setup_entry.state is ConfigEntryState.LOADED
 


### PR DESCRIPTION
We aggressively refresh roborock devices local channel (every 30 seconds) and there is a known issue where devices go unavailable around 3am every day for a period of ~1 minute which causes log spam during a non-critical background refresh. We instead will suppress refresh failures until a minimum unavailability threshold has passed.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Suppress roborock failures under some unavailability threshold to handle the 3am unavailability issue.

Other members: Very happy to have review/approval, but I would request you let me merge this myself. Also, I would like to target this for 2025.1.x, and not a patch release since it is a long standing issue. 
 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #98013
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
