### PR TITLE
Fix Tesla update showing scheduled updates as installing

### DIFF
--- a/homeassistant/components/tesla_fleet/update.py
+++ b/homeassistant/components/tesla_fleet/update.py
@@ -88,13 +88,9 @@ class TeslaFleetUpdateEntity(TeslaFleetVehicleEntity, UpdateEntity):
             # Remove build from version
             self._attr_installed_version = self._attr_installed_version.split(" ")[0]
 
-        # Latest Version
-        if self._value in (
-            AVAILABLE,
-            SCHEDULED,
-            INSTALLING,
-            DOWNLOADING,
-            WIFI_WAIT,
+        # Latest Version - hide update if scheduled far in the future
+        if self._value in (AVAILABLE, INSTALLING, DOWNLOADING, WIFI_WAIT) or (
+            self._value == SCHEDULED and self._is_scheduled_soon()
         ):
             self._attr_latest_version = self.coordinator.data[
                 "vehicle_state_software_update_version"

--- a/homeassistant/components/tesla_fleet/update.py
+++ b/homeassistant/components/tesla_fleet/update.py
@@ -102,13 +102,23 @@ class TeslaFleetUpdateEntity(TeslaFleetVehicleEntity, UpdateEntity):
             self._attr_latest_version = self._attr_installed_version
 
         # In Progress
-        if self._value in (
-            SCHEDULED,
-            INSTALLING,
-        ):
+        if self._value == INSTALLING:
             self._attr_in_progress = True
             if install_perc := self.get("vehicle_state_software_update_install_perc"):
                 self._attr_update_percentage = install_perc
         else:
             self._attr_in_progress = False
             self._attr_update_percentage = None
+
+        # Release Summary - show when update is scheduled
+        if self._value == SCHEDULED:
+            self._attr_release_summary = "Update scheduled"
+        else:
+            self._attr_release_summary = None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        """Return extra state attributes."""
+        if self._value:
+            return {"update_status": self._value}
+        return None

--- a/homeassistant/components/tesla_fleet/update.py
+++ b/homeassistant/components/tesla_fleet/update.py
@@ -73,12 +73,9 @@ class TeslaFleetUpdateEntity(TeslaFleetVehicleEntity, UpdateEntity):
     def _async_update_attrs(self) -> None:
         """Update the attributes of the entity."""
 
-        # Supported Features
-        if self.scoped and self._value in (
-            AVAILABLE,
-            SCHEDULED,
-        ):
-            # Only allow install when an update has been fully downloaded
+        # Supported Features - only show install button if update is available
+        # but not already scheduled
+        if self.scoped and self._value == AVAILABLE:
             self._attr_supported_features = (
                 UpdateEntityFeature.PROGRESS | UpdateEntityFeature.INSTALL
             )

--- a/homeassistant/components/tesla_fleet/update.py
+++ b/homeassistant/components/tesla_fleet/update.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from tesla_fleet_api.const import Scope
@@ -23,6 +24,9 @@ WIFI_WAIT = "downloading_wifi_wait"
 SCHEDULED = "scheduled"
 
 PARALLEL_UPDATES = 0
+
+# Show scheduled update as installing if within this many seconds
+SCHEDULED_THRESHOLD_SECONDS = 120
 
 
 async def async_setup_entry(
@@ -101,24 +105,24 @@ class TeslaFleetUpdateEntity(TeslaFleetVehicleEntity, UpdateEntity):
         else:
             self._attr_latest_version = self._attr_installed_version
 
-        # In Progress
+        # In Progress - only show as installing if actually installing or
+        # scheduled to start within 2 minutes
         if self._value == INSTALLING:
             self._attr_in_progress = True
             if install_perc := self.get("vehicle_state_software_update_install_perc"):
                 self._attr_update_percentage = install_perc
+        elif self._value == SCHEDULED and self._is_scheduled_soon():
+            self._attr_in_progress = True
+            self._attr_update_percentage = None
         else:
             self._attr_in_progress = False
             self._attr_update_percentage = None
 
-        # Release Summary - show when update is scheduled
-        if self._value == SCHEDULED:
-            self._attr_release_summary = "Update scheduled"
-        else:
-            self._attr_release_summary = None
-
-    @property
-    def extra_state_attributes(self) -> dict[str, str] | None:
-        """Return extra state attributes."""
-        if self._value:
-            return {"update_status": self._value}
-        return None
+    def _is_scheduled_soon(self) -> bool:
+        """Check if a scheduled update is within the threshold to start."""
+        scheduled_time_ms = self.get("vehicle_state_software_update_scheduled_time_ms")
+        if scheduled_time_ms is None:
+            return False
+        # Convert milliseconds to seconds and compare to current time
+        scheduled_time_sec = scheduled_time_ms / 1000
+        return scheduled_time_sec - time.time() < SCHEDULED_THRESHOLD_SECONDS

--- a/tests/components/tesla_fleet/snapshots/test_update.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_update.ambr
@@ -50,7 +50,6 @@
       'supported_features': <UpdateEntityFeature: 5>,
       'title': None,
       'update_percentage': None,
-      'update_status': 'available',
     }),
     'context': <ANY>,
     'entity_id': 'update.test_update',

--- a/tests/components/tesla_fleet/snapshots/test_update.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_update.ambr
@@ -50,6 +50,7 @@
       'supported_features': <UpdateEntityFeature: 5>,
       'title': None,
       'update_percentage': None,
+      'update_status': 'available',
     }),
     'context': <ANY>,
     'entity_id': 'update.test_update',


### PR DESCRIPTION
When a Tesla software update is scheduled for later (e.g., tonight), the update entity was incorrectly showing as "Installing" because the SCHEDULED status was being treated the same as INSTALLING.

This change:
1. Makes in_progress only true when the status is INSTALLING
2. Adds an update_status attribute to show the actual API status (available, scheduled, installing, downloading, etc.)
3. Shows "Update scheduled" in the release_summary when scheduled, making it visible in the update card UI

Users can now clearly see when an update is scheduled vs installing.

In my current HA I see this when I have scheduled the update:

<img width="555" height="278" alt="image" src="https://github.com/user-attachments/assets/67b34926-547c-4db7-af53-32e9ba4cc4c8" />


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
