### PR TITLE
tplink_omada: added actions block/unblock, similar to reconnect

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -29,7 +29,6 @@ PLATFORMS: list[Platform] = [
     Platform.UPDATE,
 ]
 
-
 type OmadaConfigEntry = ConfigEntry[OmadaSiteController]
 
 
@@ -68,7 +67,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 
         await site_client.reconnect_client(mac)
 
+    async def handle_block_client(call: ServiceCall) -> None:
+        """Handle the service action call."""
+        mac: str | None = call.data.get("mac")
+        if not mac:
+            return
+
+        await site_client.block_client(mac)
+
+    async def handle_unblock_client(call: ServiceCall) -> None:
+        """Handle the service action call."""
+        mac: str | None = call.data.get("mac")
+        if not mac:
+            return
+
+        await site_client.unblock_client(mac)
+
     hass.services.async_register(DOMAIN, "reconnect_client", handle_reconnect_client)
+    hass.services.async_register(DOMAIN, "block_client", handle_block_client)
+    hass.services.async_register(DOMAIN, "unblock_client", handle_unblock_client)
 
     _remove_old_devices(hass, entry, controller.devices_coordinator.data)
 
@@ -83,6 +100,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bo
     if not hass.config_entries.async_loaded_entries(DOMAIN):
         # This is the last loaded instance of Omada, deregister any services
         hass.services.async_remove(DOMAIN, "reconnect_client")
+        hass.services.async_remove(DOMAIN, "block_client")
+        hass.services.async_remove(DOMAIN, "unblock_client")
 
     return unload_ok
 

--- a/homeassistant/components/tplink_omada/icons.json
+++ b/homeassistant/components/tplink_omada/icons.json
@@ -31,6 +31,12 @@
   "services": {
     "reconnect_client": {
       "service": "mdi:sync"
+    },
+    "block_client": {
+      "service": "mdi:link-off"
+    },
+    "unblock_client": {
+      "service": "mdi:link"
     }
   }
 }

--- a/homeassistant/components/tplink_omada/services.yaml
+++ b/homeassistant/components/tplink_omada/services.yaml
@@ -5,3 +5,17 @@ reconnect_client:
       example: "01-23-45-67-89-AB"
       selector:
         text:
+block_client:
+  fields:
+    mac:
+      required: true
+      example: "01-23-45-67-89-AB"
+      selector:
+        text:
+unblock_client:
+  fields:
+    mac:
+      required: true
+      example: "01-23-45-67-89-AB"
+      selector:
+        text:

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -98,6 +98,26 @@
         }
       },
       "name": "Reconnect wireless client"
+    },
+    "block_client": {
+      "description": "Block wireless client from Omada network.",
+      "fields": {
+        "mac": {
+          "description": "MAC address of the device.",
+          "name": "MAC address"
+        }
+      },
+      "name": "Block wireless client"
+    },
+    "unblock_client": {
+      "description": "Unblock wireless client from Omada network.",
+      "fields": {
+        "mac": {
+          "description": "MAC address of the device.",
+          "name": "MAC address"
+        }
+      },
+      "name": "Unblock wireless client"
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The tplink_omada component had 1 action: reconnect (force wireless clients to reconnect).
With this I added 2 additional actions, to block and unblock wireless clients.
The dependency in use supports this already, see https://github.com/MarkGodwin/tplink-omada-api/blob/003bdda5f89ac308a7cf957173a2b432502a50c6/src/tplink_omada_client/omadasiteclient.py#L164 .

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
