### PR TITLE
Bump python-smarttub to 0.0.46

### DIFF
--- a/homeassistant/components/smarttub/manifest.json
+++ b/homeassistant/components/smarttub/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/smarttub",
   "iot_class": "cloud_polling",
   "loggers": ["smarttub"],
-  "requirements": ["python-smarttub==0.0.45"]
+  "requirements": ["python-smarttub==0.0.46"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2578,7 +2578,7 @@ python-ripple-api==0.0.3
 python-roborock==3.12.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.45
+python-smarttub==0.0.46
 
 # homeassistant.components.snoo
 python-snoo==0.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2159,7 +2159,7 @@ python-rabbitair==0.0.8
 python-roborock==3.12.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.45
+python-smarttub==0.0.46
 
 # homeassistant.components.snoo
 python-snoo==0.8.3


### PR DESCRIPTION
## Proposed change

Bump python-smarttub to 0.0.46 to fix authentication for new SmartTub accounts.

SmartTub migrated new user accounts from Auth0 to their own IDP endpoint, breaking authentication. This library update:

- Uses new `/idp/signin` endpoint instead of Auth0
- Parses new token response format
- Re-authenticates on token expiry (no refresh endpoint available in new IDP)

### Changelog

https://github.com/mdz/python-smarttub/compare/v0.0.45...v0.0.46

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Fixes #156317
- Library PR: https://github.com/mdz/python-smarttub/pull/66

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user facing or API exposed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-hierarchies]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
  - Updated version: `python-smarttub==0.0.46`

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist
[docs-hierarchies]: https://developers.home-assistant.io/docs/documentation/create-page
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest
[perfect-pr]: https://developers.home-assistant.io/docs/review-process#creating-the-perfect-pr