### PR TITLE
`async_select_source` now tries to fetch device list if source isn't …

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -42,17 +42,17 @@ from .entity import SpotifyEntity
 _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_SPOTIFY = (
-        MediaPlayerEntityFeature.BROWSE_MEDIA
-        | MediaPlayerEntityFeature.NEXT_TRACK
-        | MediaPlayerEntityFeature.PAUSE
-        | MediaPlayerEntityFeature.PLAY
-        | MediaPlayerEntityFeature.PLAY_MEDIA
-        | MediaPlayerEntityFeature.PREVIOUS_TRACK
-        | MediaPlayerEntityFeature.REPEAT_SET
-        | MediaPlayerEntityFeature.SEEK
-        | MediaPlayerEntityFeature.SELECT_SOURCE
-        | MediaPlayerEntityFeature.SHUFFLE_SET
-        | MediaPlayerEntityFeature.VOLUME_SET
+    MediaPlayerEntityFeature.BROWSE_MEDIA
+    | MediaPlayerEntityFeature.NEXT_TRACK
+    | MediaPlayerEntityFeature.PAUSE
+    | MediaPlayerEntityFeature.PLAY
+    | MediaPlayerEntityFeature.PLAY_MEDIA
+    | MediaPlayerEntityFeature.PREVIOUS_TRACK
+    | MediaPlayerEntityFeature.REPEAT_SET
+    | MediaPlayerEntityFeature.SEEK
+    | MediaPlayerEntityFeature.SELECT_SOURCE
+    | MediaPlayerEntityFeature.SHUFFLE_SET
+    | MediaPlayerEntityFeature.VOLUME_SET
 )
 
 REPEAT_MODE_MAPPING_TO_HA = {
@@ -68,9 +68,9 @@ AFTER_REQUEST_SLEEP = 1
 
 
 async def async_setup_entry(
-        hass: HomeAssistant,
-        entry: SpotifyConfigEntry,
-        async_add_entities: AddConfigEntryEntitiesCallback,
+    hass: HomeAssistant,
+    entry: SpotifyConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Spotify based on a config entry."""
     data = entry.runtime_data
@@ -83,7 +83,7 @@ async def async_setup_entry(
 
 
 def ensure_item[_R](
-        func: Callable[[SpotifyMediaPlayer, Item], _R],
+    func: Callable[[SpotifyMediaPlayer, Item], _R],
 ) -> Callable[[SpotifyMediaPlayer], _R | None]:
     """Ensure that the currently playing item is available."""
 
@@ -96,7 +96,7 @@ def ensure_item[_R](
 
 
 def async_refresh_after[_T: SpotifyEntity, **_P](
-        func: Callable[Concatenate[_T, _P], Awaitable[None]],
+    func: Callable[Concatenate[_T, _P], Awaitable[None]],
 ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
     """Define a wrapper to yield and refresh after."""
 
@@ -116,9 +116,9 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
     _attr_translation_key = "spotify"
 
     def __init__(
-            self,
-            coordinator: SpotifyCoordinator,
-            device_coordinator: DataUpdateCoordinator[list[Device]],
+        self,
+        coordinator: SpotifyCoordinator,
+        device_coordinator: DataUpdateCoordinator[list[Device]],
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
@@ -314,7 +314,7 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
 
     @async_refresh_after
     async def async_play_media(
-            self, media_type: MediaType | str, media_id: str, **kwargs: Any
+        self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
         """Play media."""
         media_type = media_type.removeprefix(MEDIA_PLAYER_PREFIX)
@@ -394,9 +394,9 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
         await self.coordinator.client.set_repeat(REPEAT_MODE_MAPPING_TO_SPOTIFY[repeat])
 
     async def async_browse_media(
-            self,
-            media_content_type: MediaType | str | None = None,
-            media_content_id: str | None = None,
+        self,
+        media_content_type: MediaType | str | None = None,
+        media_content_id: str | None = None,
     ) -> BrowseMedia:
         """Implement the websocket media browsing helper."""
 

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -42,17 +42,17 @@ from .entity import SpotifyEntity
 _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_SPOTIFY = (
-    MediaPlayerEntityFeature.BROWSE_MEDIA
-    | MediaPlayerEntityFeature.NEXT_TRACK
-    | MediaPlayerEntityFeature.PAUSE
-    | MediaPlayerEntityFeature.PLAY
-    | MediaPlayerEntityFeature.PLAY_MEDIA
-    | MediaPlayerEntityFeature.PREVIOUS_TRACK
-    | MediaPlayerEntityFeature.REPEAT_SET
-    | MediaPlayerEntityFeature.SEEK
-    | MediaPlayerEntityFeature.SELECT_SOURCE
-    | MediaPlayerEntityFeature.SHUFFLE_SET
-    | MediaPlayerEntityFeature.VOLUME_SET
+        MediaPlayerEntityFeature.BROWSE_MEDIA
+        | MediaPlayerEntityFeature.NEXT_TRACK
+        | MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.PLAY
+        | MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.PREVIOUS_TRACK
+        | MediaPlayerEntityFeature.REPEAT_SET
+        | MediaPlayerEntityFeature.SEEK
+        | MediaPlayerEntityFeature.SELECT_SOURCE
+        | MediaPlayerEntityFeature.SHUFFLE_SET
+        | MediaPlayerEntityFeature.VOLUME_SET
 )
 
 REPEAT_MODE_MAPPING_TO_HA = {
@@ -68,9 +68,9 @@ AFTER_REQUEST_SLEEP = 1
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: SpotifyConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+        hass: HomeAssistant,
+        entry: SpotifyConfigEntry,
+        async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Spotify based on a config entry."""
     data = entry.runtime_data
@@ -83,7 +83,7 @@ async def async_setup_entry(
 
 
 def ensure_item[_R](
-    func: Callable[[SpotifyMediaPlayer, Item], _R],
+        func: Callable[[SpotifyMediaPlayer, Item], _R],
 ) -> Callable[[SpotifyMediaPlayer], _R | None]:
     """Ensure that the currently playing item is available."""
 
@@ -96,7 +96,7 @@ def ensure_item[_R](
 
 
 def async_refresh_after[_T: SpotifyEntity, **_P](
-    func: Callable[Concatenate[_T, _P], Awaitable[None]],
+        func: Callable[Concatenate[_T, _P], Awaitable[None]],
 ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
     """Define a wrapper to yield and refresh after."""
 
@@ -116,9 +116,9 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
     _attr_translation_key = "spotify"
 
     def __init__(
-        self,
-        coordinator: SpotifyCoordinator,
-        device_coordinator: DataUpdateCoordinator[list[Device]],
+            self,
+            coordinator: SpotifyCoordinator,
+            device_coordinator: DataUpdateCoordinator[list[Device]],
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
@@ -314,7 +314,7 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
 
     @async_refresh_after
     async def async_play_media(
-        self, media_type: MediaType | str, media_id: str, **kwargs: Any
+            self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
         """Play media."""
         media_type = media_type.removeprefix(MEDIA_PLAYER_PREFIX)
@@ -359,12 +359,27 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
     @async_refresh_after
     async def async_select_source(self, source: str) -> None:
         """Select playback device."""
-        for device in self.devices.data:
-            if device.name == source:
-                if TYPE_CHECKING:
-                    assert device.device_id is not None
-                await self.coordinator.client.transfer_playback(device.device_id)
-                return
+
+        def _find_device():
+            for device in self.devices.data:
+                if device.name == source:
+                    return device
+            return None
+
+        device = _find_device()
+
+        if device is None:
+            await self.devices.async_refresh()
+
+        device = _find_device()
+
+        if device is None:
+            return
+
+        if TYPE_CHECKING:
+            assert device.device_id is not None
+
+        await self.coordinator.client.transfer_playback(device.device_id)
 
     @async_refresh_after
     async def async_set_shuffle(self, shuffle: bool) -> None:
@@ -379,9 +394,9 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
         await self.coordinator.client.set_repeat(REPEAT_MODE_MAPPING_TO_SPOTIFY[repeat])
 
     async def async_browse_media(
-        self,
-        media_content_type: MediaType | str | None = None,
-        media_content_id: str | None = None,
+            self,
+            media_content_type: MediaType | str | None = None,
+            media_content_id: str | None = None,
     ) -> BrowseMedia:
         """Implement the websocket media browsing helper."""
 


### PR DESCRIPTION
…in the list of devices yet

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
