### PR TITLE
Improve Tuya action validation

### DIFF
--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -86,6 +86,10 @@ class DPCodeTypeInformationWrapper[T: TypeInformation](DPCodeWrapper):
             device.status.get(self.dpcode), device
         )
 
+    def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
+        """Convert a Home Assistant value back to a raw device value."""
+        return self.type_information.process_value_back(value)
+
     @classmethod
     def find_dpcode(
         cls,
@@ -105,44 +109,15 @@ class DPCodeTypeInformationWrapper[T: TypeInformation](DPCodeWrapper):
 
 
 class DPCodeBooleanWrapper(DPCodeTypeInformationWrapper[BooleanTypeInformation]):
-    """Simple wrapper for boolean values.
-
-    Supports True/False only.
-    """
+    """Simple wrapper for BooleanTypeInformation values."""
 
     _DPTYPE = BooleanTypeInformation
-
-    def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: Any
-    ) -> Any | None:
-        """Convert a Home Assistant value back to a raw device value."""
-        if value in (True, False):
-            return value
-        # Currently only called with boolean values
-        # Safety net in case of future changes
-        raise ValueError(f"Invalid boolean value `{value}`")
-
-
-class DPCodeJsonWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
-    """Wrapper to extract information from a JSON value."""
-
-    _DPTYPE = JsonTypeInformation
 
 
 class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
     """Simple wrapper for EnumTypeInformation values."""
 
     _DPTYPE = EnumTypeInformation
-
-    def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
-        """Convert a Home Assistant value back to a raw device value."""
-        if value in self.type_information.range:
-            return value
-        # Guarded by select option validation
-        # Safety net in case of future changes
-        raise ValueError(
-            f"Enum value `{value}` out of range: {self.type_information.range}"
-        )
 
 
 class DPCodeIntegerWrapper(DPCodeTypeInformationWrapper[IntegerTypeInformation]):
@@ -155,27 +130,21 @@ class DPCodeIntegerWrapper(DPCodeTypeInformationWrapper[IntegerTypeInformation])
         super().__init__(dpcode, type_information)
         self.native_unit = type_information.unit
 
-    def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
-        """Convert a Home Assistant value back to a raw device value."""
-        new_value = round(value * (10**self.type_information.scale))
-        if self.type_information.min <= new_value <= self.type_information.max:
-            return new_value
-        # Guarded by number validation
-        # Safety net in case of future changes
-        raise ValueError(
-            f"Value `{new_value}` (converted from `{value}`) out of range:"
-            f" ({self.type_information.min}-{self.type_information.max})"
-        )
+
+class DPCodeJsonWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
+    """Simple wrapper for JsonTypeInformation values."""
+
+    _DPTYPE = JsonTypeInformation
 
 
 class DPCodeRawWrapper(DPCodeTypeInformationWrapper[RawTypeInformation]):
-    """Wrapper to extract information from a RAW/binary value."""
+    """Simple wrapper for RawTypeInformation values."""
 
     _DPTYPE = RawTypeInformation
 
 
 class DPCodeStringWrapper(DPCodeTypeInformationWrapper[StringTypeInformation]):
-    """Wrapper to extract information from a STRING value."""
+    """Simple wrapper for StringTypeInformation values."""
 
     _DPTYPE = StringTypeInformation
 

--- a/homeassistant/components/tuya/type_information.py
+++ b/homeassistant/components/tuya/type_information.py
@@ -243,6 +243,10 @@ class IntegerTypeInformation(TypeInformation[float]):
         """Scale a value."""
         return value / (10**self.scale)
 
+    def scale_value_back(self, value: float) -> int:
+        """Return raw value for scaled."""
+        return round(value * (10**self.scale))
+
     def remap_value_to(
         self,
         value: float,

--- a/homeassistant/components/tuya/type_information.py
+++ b/homeassistant/components/tuya/type_information.py
@@ -290,11 +290,11 @@ class IntegerTypeInformation(TypeInformation[float]):
                 )
 
             return None
-        return raw_value / (10**self.scale)
+        return self.scale_value(raw_value)
 
     def process_value_back(self, value: float) -> int:
         """Convert a Home Assistant value back to a raw device value."""
-        new_value = round(value * (10**self.scale))
+        new_value = self.scale_value_back(value)
         if self.min <= new_value <= self.max:
             return new_value
         # Guarded by number validation

--- a/homeassistant/components/tuya/type_information.py
+++ b/homeassistant/components/tuya/type_information.py
@@ -290,11 +290,11 @@ class IntegerTypeInformation(TypeInformation[float]):
                 )
 
             return None
-        return self.scale_value(raw_value)
+        return raw_value / (10**self.scale)
 
     def process_value_back(self, value: float) -> int:
         """Convert a Home Assistant value back to a raw device value."""
-        new_value = self.scale_value_back(value)
+        new_value = round(value * (10**self.scale))
         if self.min <= new_value <= self.max:
             return new_value
         # Guarded by number validation

--- a/homeassistant/components/tuya/type_information.py
+++ b/homeassistant/components/tuya/type_information.py
@@ -243,10 +243,6 @@ class IntegerTypeInformation(TypeInformation[float]):
         """Scale a value."""
         return value / (10**self.scale)
 
-    def scale_value_back(self, value: float) -> int:
-        """Return raw value for scaled."""
-        return round(value * (10**self.scale))
-
     def remap_value_to(
         self,
         value: float,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #157968
- Move HA->Tuya action validation from wrapper classes to type information classes
  - the default should be to use the `TypeInformation` method
  - wrapper classes can override the default implementation if they do not want to use the default `TypeInformation` method
- Drop unused `scale_value_back`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
