### PR TITLE
Deprecate implicit Wake-On-LAN in Samsung TV integration

### DIFF
--- a/homeassistant/components/samsungtv/entity.py
+++ b/homeassistant/components/samsungtv/entity.py
@@ -99,7 +99,7 @@ class SamsungTVEntity(CoordinatorEntity[SamsungTVDataUpdateCoordinator], Entity)
                 DOMAIN,
                 DEPRECATED_IMPLICIT_WAKE_ON_LAN.format(self._mac),
                 is_fixable=False,
-                breaks_in_ha_version="2026.7.0",
+                breaks_in_ha_version="2026.8.0",
                 severity=ir.IssueSeverity.WARNING,
                 translation_key="deprecated_implicit_wake_on_lan",
                 translation_placeholders={

--- a/homeassistant/components/samsungtv/entity.py
+++ b/homeassistant/components/samsungtv/entity.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_MODEL,
 )
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.trigger import PluggableAction
@@ -23,6 +23,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import CONF_MANUFACTURER, DOMAIN, LOGGER
 from .coordinator import SamsungTVDataUpdateCoordinator
 from .triggers.turn_on import async_get_turn_on_trigger
+
+DEPRECATED_IMPLICIT_WAKE_ON_LAN = "deprecated_implicit_wake_on_lan_{}"
 
 
 class SamsungTVEntity(CoordinatorEntity[SamsungTVDataUpdateCoordinator], Entity):
@@ -92,9 +94,18 @@ class SamsungTVEntity(CoordinatorEntity[SamsungTVDataUpdateCoordinator], Entity)
             LOGGER.debug("Attempting to turn on %s via automation", self.entity_id)
             await self._turn_on_action.async_run(self.hass, self._context)
         elif self._mac:
-            LOGGER.debug(
-                "Attempting to turn on %s via Wake-On-Lan",
-                self.entity_id,
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                DEPRECATED_IMPLICIT_WAKE_ON_LAN.format(self._mac),
+                is_fixable=False,
+                breaks_in_ha_version="2026.7.0",
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="deprecated_implicit_wake_on_lan",
+                translation_placeholders={
+                    "mac_address": self._mac,
+                    "wol_documentation_url": "https://www.home-assistant.io/integrations/wake_on_lan/",
+                },
             )
             await self.hass.async_add_executor_job(self._wake_on_lan)
         else:

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -97,7 +97,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
         self._attr_supported_features = SUPPORT_SAMSUNGTV
         if self._mac:
-            # Deprecated: Implicit Wake-On-LAN, will be removed in 2026.7.0
+            # Deprecated: Implicit Wake-On-LAN, will be removed in 2026.8.0
             # Triggers have not yet been registered so this is adjusted in the property
             self._attr_supported_features |= MediaPlayerEntityFeature.TURN_ON
         if self._ssdp_rendering_control_location:

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -97,7 +97,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
         self._attr_supported_features = SUPPORT_SAMSUNGTV
         if self._mac:
-            # (deprecated) add turn-on if mac is available
+            # Deprecated: Implicit Wake-On-LAN, will be removed in 2026.7.0
             # Triggers have not yet been registered so this is adjusted in the property
             self._attr_supported_features |= MediaPlayerEntityFeature.TURN_ON
         if self._ssdp_rendering_control_location:

--- a/homeassistant/components/samsungtv/strings.json
+++ b/homeassistant/components/samsungtv/strings.json
@@ -80,5 +80,11 @@
     "unhandled_trigger_type": {
       "message": "Unhandled trigger type {trigger_type}."
     }
+  },
+  "issues": {
+    "deprecated_implicit_wake_on_lan": {
+      "description": "Implicit Wake-On-LAN is deprecated and will be removed in a future version of Home Assistant. Please create an explicit Wake-On-LAN automation to turn on your TV, targeting MAC address `{mac_address}`.\n\nFor more information, see the [Wake-On-LAN documentation]({wol_documentation_url}).",
+      "title": "Implicit Wake-On-LAN is deprecated"
+    }
   }
 }


### PR DESCRIPTION
When a Samsung TV has a MAC address configured but no turn_on automation, the integration was silently using Wake-On-LAN to turn on the device. This implicit behavior is now deprecated and will be removed in 2025.6.0.

A repair issue is now created prompting users to create an explicit Wake-On-LAN automation targeting the device's MAC address.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
