### PR TITLE
Fix Sonos speaker async_offline assertion failure

### DIFF
--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -690,7 +690,8 @@ class SonosSpeaker:
 
     async def async_offline(self) -> None:
         """Handle removal of speaker when unavailable."""
-        assert self._subscription_lock is not None
+        if not self._subscription_lock:
+            self._subscription_lock = asyncio.Lock()
         async with self._subscription_lock:
             await self._async_offline()
 

--- a/tests/components/sonos/test_speaker.py
+++ b/tests/components/sonos/test_speaker.py
@@ -208,9 +208,11 @@ async def test_async_offline_without_subscription_lock(
     # so this creates a speaker in discovered without _subscription_lock being created.
     # Using PropertyMock to only affect this specific test's soco instance.
     with patch.object(
-        type(soco), "play_mode", new_callable=lambda: property(
+        type(soco),
+        "play_mode",
+        new_callable=lambda: property(
             fget=lambda self: (_ for _ in ()).throw(SoCoException("Connection failed"))
-        )
+        ),
     ):
         config_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/sonos/test_speaker.py
+++ b/tests/components/sonos/test_speaker.py
@@ -210,9 +210,9 @@ async def test_async_offline_without_subscription_lock(
     ):
         config_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
         # Unload should succeed without AssertionError even though
         # _subscription_lock was never created
         assert await hass.config_entries.async_unload(config_entry.entry_id)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/sonos/test_speaker.py
+++ b/tests/components/sonos/test_speaker.py
@@ -198,14 +198,15 @@ async def test_async_offline_without_subscription_lock(
 ) -> None:
     """Test unloading entry works when subscription lock was never created.
 
-    This can happen when a speaker is discovered but async_subscribe()
+    This can happen when a speaker is discovered but async_setup()
     was never called (e.g., no activity detected before shutdown).
     The integration should handle this gracefully during unload.
     """
-    # Patch async_subscribe to do nothing, simulating the scenario where
-    # the speaker is discovered but no activity triggers subscription setup
+    # Patch async_setup to do nothing, simulating the scenario where
+    # the speaker is discovered but async_setup() never completes
+    # (which would normally call async_subscribe and create the lock)
     with patch(
-        "homeassistant.components.sonos.speaker.SonosSpeaker.async_subscribe",
+        "homeassistant.components.sonos.speaker.SonosSpeaker.async_setup",
         new_callable=AsyncMock,
     ):
         config_entry.add_to_hass(hass)


### PR DESCRIPTION
Handle the case where async_offline() is called before async_subscribe() has been invoked, which would leave _subscription_lock as None. This can happen during shutdown when a speaker was discovered but no activity was detected yet. Instead of asserting, create the lock if it doesn't exist, matching the existing pattern in async_subscribe().

Failed in: https://github.com/home-assistant/core/actions/runs/20151776328/job/57846433236

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Root cause: In SonosSpeaker:

* _subscription_lock is initialized as None in __init__ (line 133)
* The lock is only created when async_subscribe() is called (lines 374-375)
* async_offline() asserts the lock is not None
* During shutdown, async_offline() is called on all discovered speakers, including those that never had async_subscribe() called (e.g., speakers discovered but with no activity detected yet)
* Fix (homeassistant/components/sonos/speaker.py:691-695): Instead of asserting, create the lock if it doesn't exist - matching the existing pattern in async_subscribe():




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
