### PR TITLE
Migrate Blink component to use hardware_id instead of device_id

### DIFF
--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -64,6 +64,12 @@ async def async_migrate_entry(hass: HomeAssistant, entry: BlinkConfigEntry) -> b
     if entry.version == 2:
         await _reauth_flow_wrapper(hass, entry, data)
         return False
+    if entry.version == 3:
+        # Migrate device_id to hardware_id for blinkpy 0.25.x OAuth2 compatibility
+        if "device_id" in data:
+            data["hardware_id"] = data.pop("device_id")
+            hass.config_entries.async_update_entry(entry, data=data, version=4)
+        return True
     return True
 
 

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DEVICE_ID, DOMAIN
+from .const import DOMAIN, HARDWARE_ID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ async def _send_blink_2fa_pin(blink: Blink, pin: str | None) -> bool:
 class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a Blink config flow."""
 
-    VERSION = 3
+    VERSION = 4
 
     def __init__(self) -> None:
         """Initialize the blink flow."""
@@ -53,7 +53,7 @@ class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _handle_user_input(self, user_input: dict[str, Any]):
         """Handle user input."""
         self.auth = Auth(
-            {**user_input, "device_id": DEVICE_ID},
+            {**user_input, "hardware_id": HARDWARE_ID},
             no_prompt=True,
             session=async_get_clientsession(self.hass),
         )

--- a/homeassistant/components/blink/const.py
+++ b/homeassistant/components/blink/const.py
@@ -3,7 +3,7 @@
 from homeassistant.const import Platform
 
 DOMAIN = "blink"
-DEVICE_ID = "Home Assistant"
+HARDWARE_ID = "Home Assistant"
 
 CONF_MIGRATE = "migrate"
 CONF_CAMERA = "camera"

--- a/tests/components/blink/conftest.py
+++ b/tests/components/blink/conftest.py
@@ -85,7 +85,7 @@ def mock_config_fixture():
         data={
             CONF_USERNAME: "test_user",
             CONF_PASSWORD: "Password",
-            "device_id": "Home Assistant",
+            "hardware_id": "Home Assistant",
             "uid": "BlinkCamera_e1233333e2-0909-09cd-777a-123456789012",
             "token": "A_token",
             "unique_id": "an_email@email.com",
@@ -95,5 +95,5 @@ def mock_config_fixture():
             "account_id": 654321,
         },
         entry_id=str(uuid4()),
-        version=3,
+        version=4,
     )

--- a/tests/components/blink/snapshots/test_diagnostics.ambr
+++ b/tests/components/blink/snapshots/test_diagnostics.ambr
@@ -28,7 +28,7 @@
       'data': dict({
         'account_id': 654321,
         'client_id': 123456,
-        'device_id': 'Home Assistant',
+        'hardware_id': 'Home Assistant',
         'host': 'u034.immedia-semi.com',
         'password': '**REDACTED**',
         'region_id': 'u034',
@@ -52,7 +52,7 @@
       ]),
       'title': 'Mock Title',
       'unique_id': None,
-      'version': 3,
+      'version': 4,
     }),
   })
 # ---


### PR DESCRIPTION
## Proposed change

Updates Blink component configuration to use `hardware_id` for OAuth2 compatibility with blinkpy 0.25.x.

Introduces a migration path from version 3 to version 4 of the configuration entry to:
- Replace `device_id` with `hardware_id`
- Ensure compatibility with latest blinkpy library
- Maintain existing authentication and configuration data

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #158760
- Tested as custom component on real Home Assistant instance with blinkpy 0.25.x

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
