### PR TITLE
Bump aioaasuswrt to V2.0.0

### DIFF
--- a/homeassistant/components/asuswrt/bridge.py
+++ b/homeassistant/components/asuswrt/bridge.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable, Coroutine
-import functools
 import logging
 from typing import Any, NamedTuple
 
-from aioasuswrt.asuswrt import AsusWrt as AsusWrtLegacy
+from aioasuswrt import (
+    AsusWrt as AsusWrtLegacy,
+    AuthConfig,
+    ConnectionType,
+    Device,
+    Mode,
+    Settings,
+    connect_to_router as create_connection_aioasuswrt,
+)
 from aiohttp import ClientSession
 from asusrouter import AsusRouter, AsusRouterError
 from asusrouter.config import ARConfigKey
@@ -40,6 +46,7 @@ from .const import (
     DEFAULT_INTERFACE,
     KEY_METHOD,
     KEY_SENSORS,
+    MODE_ROUTER,
     PROTOCOL_HTTP,
     PROTOCOL_HTTPS,
     PROTOCOL_TELNET,
@@ -47,10 +54,9 @@ from .const import (
     SENSORS_LOAD_AVG,
     SENSORS_MEMORY,
     SENSORS_RATES,
-    SENSORS_TEMPERATURES_LEGACY,
     SENSORS_UPTIME,
 )
-from .helpers import clean_dict, translate_to_legacy
+from .helpers import clean_dict
 
 SENSORS_TYPE_BYTES = "sensors_bytes"
 SENSORS_TYPE_COUNT = "sensors_count"
@@ -71,51 +77,6 @@ class WrtDevice(NamedTuple):
 
 
 _LOGGER = logging.getLogger(__name__)
-
-type _FuncType[_T] = Callable[
-    [_T],
-    Awaitable[
-        list[str]
-        | tuple[float | None, float | None]
-        | list[float]
-        | dict[str, float | str | None]
-        | dict[str, float]
-    ],
-]
-type _ReturnFuncType[_T] = Callable[[_T], Coroutine[Any, Any, dict[str, Any]]]
-
-
-def handle_errors_and_zip[_AsusWrtBridgeT: AsusWrtBridge](
-    exceptions: type[Exception] | tuple[type[Exception], ...], keys: list[str] | None
-) -> Callable[[_FuncType[_AsusWrtBridgeT]], _ReturnFuncType[_AsusWrtBridgeT]]:
-    """Run library methods and zip results or manage exceptions."""
-
-    def _handle_errors_and_zip(
-        func: _FuncType[_AsusWrtBridgeT],
-    ) -> _ReturnFuncType[_AsusWrtBridgeT]:
-        """Run library methods and zip results or manage exceptions."""
-
-        @functools.wraps(func)
-        async def _wrapper(
-            self: _AsusWrtBridgeT,
-        ) -> dict[str, float | str | None] | dict[str, float]:
-            try:
-                data = await func(self)
-            except exceptions as exc:
-                raise UpdateFailed(exc) from exc
-
-            if keys is None:
-                if not isinstance(data, dict):
-                    raise UpdateFailed("Received invalid data type")
-                return data
-
-            if isinstance(data, dict):
-                return dict(zip(keys, list(data.values()), strict=False))
-            return dict(zip(keys, data, strict=False))
-
-        return _wrapper
-
-    return _handle_errors_and_zip
 
 
 class AsusWrtBridge(ABC):
@@ -221,17 +182,24 @@ class AsusWrtLegacyBridge(AsusWrtBridge):
         """Get the AsusWrtLegacy API."""
         opt = options or {}
 
-        return AsusWrtLegacy(
+        return create_connection_aioasuswrt(
             conf[CONF_HOST],
-            conf.get(CONF_PORT),
-            conf[CONF_PROTOCOL] == PROTOCOL_TELNET,
-            conf[CONF_USERNAME],
-            conf.get(CONF_PASSWORD, ""),
-            conf.get(CONF_SSH_KEY, ""),
-            conf[CONF_MODE],
-            opt.get(CONF_REQUIRE_IP, True),
-            interface=opt.get(CONF_INTERFACE, DEFAULT_INTERFACE),
-            dnsmasq=opt.get(CONF_DNSMASQ, DEFAULT_DNSMASQ),
+            AuthConfig(
+                username=conf.get(CONF_USERNAME),
+                password=conf.get(CONF_PASSWORD),
+                connection_type=ConnectionType.TELNET
+                if conf[CONF_PROTOCOL] == PROTOCOL_TELNET
+                else ConnectionType.SSH,
+                ssh_key=conf.get(CONF_SSH_KEY),
+                port=conf.get(CONF_PORT),
+                passphrase="",
+            ),
+            Settings(
+                mode=Mode.ROUTER if conf[CONF_MODE] == MODE_ROUTER else Mode.AP,
+                require_ip=opt.get(CONF_REQUIRE_IP, True),
+                wan_interface=opt.get(CONF_INTERFACE, DEFAULT_INTERFACE),
+                dnsmasq=opt.get(CONF_DNSMASQ, DEFAULT_DNSMASQ),
+            ),
         )
 
     @property
@@ -241,7 +209,7 @@ class AsusWrtLegacyBridge(AsusWrtBridge):
 
     async def async_connect(self) -> None:
         """Connect to the device."""
-        await self._api.connection.async_connect()
+        await self._api.connect()
 
         # get main router properties
         if self._label_mac is None:
@@ -253,27 +221,25 @@ class AsusWrtLegacyBridge(AsusWrtBridge):
 
     async def async_disconnect(self) -> None:
         """Disconnect to the device."""
-        await self._api.async_disconnect()
+        await self._api.disconnect()
 
     async def async_get_connected_devices(self) -> dict[str, WrtDevice]:
         """Get list of connected devices."""
-        api_devices = await self._api.async_get_connected_devices()
+        api_devices: dict[str, Device] = await self._api.get_connected_devices(
+            reachable=True
+        )
         return {
-            format_mac(mac): WrtDevice(dev.ip, dev.name, None)
+            format_mac(mac): WrtDevice(
+                dev.device_data.get("ip"),
+                dev.device_data.get("name"),
+                dev.interface.get("name"),
+            )
             for mac, dev in api_devices.items()
         }
 
-    async def _get_nvram_info(self, info_type: str) -> dict[str, Any]:
+    async def _get_nvram_info(self, info_type: str) -> dict[str, str] | None:
         """Get AsusWrt router info from nvram."""
-        info = {}
-        try:
-            info = await self._api.async_get_nvram(info_type)
-        except OSError as exc:
-            _LOGGER.warning(
-                "Error calling method async_get_nvram(%s): %s", info_type, exc
-            )
-
-        return info
+        return await self._api.get_nvram(info_type)
 
     async def _get_label_mac(self) -> None:
         """Get label mac information."""
@@ -318,30 +284,29 @@ class AsusWrtLegacyBridge(AsusWrtBridge):
             },
         }
 
-    async def _get_available_temperature_sensors(self) -> list[str]:
+    async def _get_available_temperature_sensors(self) -> dict[str, float] | None:
         """Check which temperature information is available on the router."""
-        availability = await self._api.async_find_temperature_commands()
-        return [SENSORS_TEMPERATURES_LEGACY[i] for i in range(3) if availability[i]]
+        return await self._api.get_temperature()
 
-    @handle_errors_and_zip((IndexError, OSError, ValueError), SENSORS_BYTES)
-    async def _get_bytes(self) -> tuple[float | None, float | None]:
+    async def _get_bytes(self) -> dict[str, int] | None:
         """Fetch byte information from the router."""
-        return await self._api.async_get_bytes_total()
+        items = await self._api.total_transfer()
+        return {f"sensor_{key}_bytes": value for key, value in items.items()}
 
-    @handle_errors_and_zip((IndexError, OSError, ValueError), SENSORS_RATES)
-    async def _get_rates(self) -> tuple[float, float]:
+    async def _get_rates(self) -> dict[str, int] | None:
         """Fetch rates information from the router."""
-        return await self._api.async_get_current_transfer_rates()
+        items = await self._api.get_current_transfer_rates()
+        if items:
+            return {f"sensor_{key}_rates": value for key, value in items.items()}
+        return None
 
-    @handle_errors_and_zip((IndexError, OSError, ValueError), SENSORS_LOAD_AVG)
-    async def _get_load_avg(self) -> list[float]:
+    async def _get_load_avg(self) -> dict[str, float] | None:
         """Fetch load average information from the router."""
-        return await self._api.async_get_loadavg()
+        return await self._api.get_loadavg()
 
-    @handle_errors_and_zip((OSError, ValueError), None)
-    async def _get_temperatures(self) -> dict[str, float]:
+    async def _get_temperatures(self) -> dict[str, float] | None:
         """Fetch temperatures information from the router."""
-        return await self._api.async_get_temperature()
+        return await self._api.get_temperature()
 
 
 class AsusWrtHttpBridge(AsusWrtBridge):
@@ -416,7 +381,7 @@ class AsusWrtHttpBridge(AsusWrtBridge):
         """
         try:
             raw = await self._api.async_get_data(datatype, force=force)
-            return translate_to_legacy(clean_dict(convert_to_ha_data(raw)))
+            return clean_dict(convert_to_ha_data(raw))
         except AsusRouterError as ex:
             raise UpdateFailed(ex) from ex
 
@@ -431,7 +396,7 @@ class AsusWrtHttpBridge(AsusWrtBridge):
             data = await self._api.async_get_data(datatype)
             # Get the list of sensors from the raw data
             # and translate in to the legacy format
-            sensors = translate_to_legacy(convert_to_ha_sensors(data, datatype))
+            sensors = convert_to_ha_sensors(data, datatype)
             _LOGGER.debug("Available `%s` sensors: %s", datatype.value, sensors)
         except AsusRouterError as ex:
             _LOGGER.warning(

--- a/homeassistant/components/asuswrt/helpers.py
+++ b/homeassistant/components/asuswrt/helpers.py
@@ -32,23 +32,3 @@ def clean_dict(raw: dict[str, Any]) -> dict[str, Any]:
     """
 
     return {k: v for k, v in raw.items() if v is not None or k.endswith("state")}
-
-
-def translate_to_legacy[T: (dict[str, Any], list[Any], None)](raw: T) -> T:
-    """Translate raw data to legacy format for dicts and lists."""
-
-    if raw is None:
-        return None
-
-    if isinstance(raw, dict):
-        return {TRANSLATION_MAP.get(k, k): v for k, v in raw.items()}
-
-    if isinstance(raw, list):
-        return [
-            TRANSLATION_MAP[item]
-            if isinstance(item, str) and item in TRANSLATION_MAP
-            else item
-            for item in raw
-        ]
-
-    return raw

--- a/homeassistant/components/asuswrt/manifest.json
+++ b/homeassistant/components/asuswrt/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["aioasuswrt", "asusrouter", "asyncssh"],
-  "requirements": ["aioasuswrt==1.5.2", "asusrouter==1.21.3"]
+  "requirements": ["aioasuswrt==2.0.6", "asusrouter==1.21.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -206,7 +206,7 @@ aioaquacell==0.2.0
 aioaseko==1.0.0
 
 # homeassistant.components.asuswrt
-aioasuswrt==1.5.2
+aioasuswrt==2.0.6
 
 # homeassistant.components.husqvarna_automower
 aioautomower==2.7.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -197,7 +197,7 @@ aioaquacell==0.2.0
 aioaseko==1.0.0
 
 # homeassistant.components.asuswrt
-aioasuswrt==1.5.2
+aioasuswrt==2.0.6
 
 # homeassistant.components.husqvarna_automower
 aioautomower==2.7.1

--- a/tests/components/asuswrt/common.py
+++ b/tests/components/asuswrt/common.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from aioasuswrt.asuswrt import Device as LegacyDevice
+from aioasuswrt.structure import Device, DeviceData, Interface
 from asusrouter.modules.client import ConnectionState
 
 from homeassistant.components.asuswrt.const import (
@@ -76,8 +76,12 @@ def make_client(mac, ip, name, node):
     return client
 
 
-def new_device(protocol, mac, ip, name, node=None):
+def new_device(protocol: str, mac: str, ip: str, name: str, node: str | None = None):
     """Return a new device for specific protocol."""
     if protocol in [PROTOCOL_HTTP, PROTOCOL_HTTPS]:
         return make_client(mac, ip, name, node)
-    return LegacyDevice(mac, ip, name)
+    return Device(
+        mac,
+        device_data=DeviceData(ip=ip, name=name, status=None, rssi=None),
+        interface=Interface(id=node, name=None, mac=None),
+    )

--- a/tests/components/asuswrt/conftest.py
+++ b/tests/components/asuswrt/conftest.py
@@ -81,14 +81,14 @@ def _mock_devices(protocol: str) -> dict[str, WrtDevice]:
     }
 
 
-@pytest.fixture
-def mock_devices() -> dict[str, WrtDevice]:
+@pytest.fixture(name="mock_devices_http")
+def mock_devices_http_fixture() -> dict[str, WrtDevice]:
     """Mock a list of AsusRouter client devices for HTTP backend."""
     return _mock_devices(PROTOCOL_HTTP)
 
 
-@pytest.fixture
-def mock_devices_legacy() -> dict[str, WrtDevice]:
+@pytest.fixture(name="mock_devices_legacy")
+def mock_devices_legacy_fixture() -> dict[str, WrtDevice]:
     """Mock a list of AsusRouter client devices for SSH backend."""
     return _mock_devices(PROTOCOL_SSH)
 
@@ -118,7 +118,7 @@ def mock_controller_connect_legacy(mock_devices_legacy):
 
 
 @pytest.fixture(name="connect_http")
-def mock_controller_connect_http(mock_devices):
+def mock_controller_connect_http(mock_devices_http):
     """Mock a successful connection with http library."""
     with patch(ASUSWRT_HTTP_LIB, spec_set=AsusRouter) as service_mock:
         instance = service_mock.return_value
@@ -138,7 +138,7 @@ def mock_controller_connect_http(mock_devices):
 
         # Data fetches via async_get_data
         instance.async_get_data.side_effect = lambda datatype, *args, **kwargs: {
-            AsusData.CLIENTS: mock_devices,
+            AsusData.CLIENTS: mock_devices_http,
             AsusData.NETWORK: MOCK_CURRENT_NETWORK,
             AsusData.SYSINFO: MOCK_LOAD_AVG,
             AsusData.TEMPERATURE: {

--- a/tests/components/asuswrt/conftest.py
+++ b/tests/components/asuswrt/conftest.py
@@ -10,20 +10,15 @@ from asusrouter.modules.data import AsusData
 from asusrouter.modules.identity import AsusDevice
 import pytest
 
-from .common import (
-    ASUSWRT_BASE,
-    HOST,
-    MOCK_MACS,
-    PROTOCOL_HTTP,
-    PROTOCOL_SSH,
-    ROUTER_MAC_ADDR,
-    new_device,
-)
+from homeassistant.components.asuswrt.bridge import WrtDevice
+from homeassistant.components.asuswrt.const import PROTOCOL_HTTP, PROTOCOL_SSH
+
+from .common import ASUSWRT_BASE, HOST, MOCK_MACS, ROUTER_MAC_ADDR, new_device
 
 ASUSWRT_HTTP_LIB = f"{ASUSWRT_BASE}.bridge.AsusRouter"
-ASUSWRT_LEGACY_LIB = f"{ASUSWRT_BASE}.bridge.AsusWrtLegacy"
+ASUSWRT_LEGACY_LIB = f"{ASUSWRT_BASE}.bridge.create_connection_aioasuswrt"
 
-MOCK_BYTES_TOTAL = 60000000000, 50000000000
+MOCK_BYTES_TOTAL = {"rx": 60000000000, "tx": 50000000000}
 MOCK_BYTES_TOTAL_HTTP = dict(enumerate(MOCK_BYTES_TOTAL))
 MOCK_CPU_USAGE = {
     "cpu1_usage": 0.1,
@@ -36,21 +31,19 @@ MOCK_CPU_USAGE = {
     "cpu8_usage": 0.8,
     "cpu_total_usage": 0.9,
 }
-MOCK_CURRENT_TRANSFER_RATES = 20000000, 10000000
+MOCK_CURRENT_TRANSFER_RATES = {"rx": 20000000, "tx": 10000000}
 MOCK_CURRENT_TRANSFER_RATES_HTTP = dict(enumerate(MOCK_CURRENT_TRANSFER_RATES))
 # Mock for AsusData.NETWORK return of both rates and total bytes
 MOCK_CURRENT_NETWORK = {
-    "sensor_rx_rates": MOCK_CURRENT_TRANSFER_RATES[0] * 8,  # AR works with bits
-    "sensor_tx_rates": MOCK_CURRENT_TRANSFER_RATES[1] * 8,  # AR works with bits
-    "sensor_rx_bytes": MOCK_BYTES_TOTAL[0],
-    "sensor_tx_bytes": MOCK_BYTES_TOTAL[1],
+    "sensor_rx_rates": MOCK_CURRENT_TRANSFER_RATES["rx"] * 8,  # AR works with bits
+    "sensor_tx_rates": MOCK_CURRENT_TRANSFER_RATES["tx"] * 8,  # AR works with bits
+    "sensor_rx_bytes": MOCK_BYTES_TOTAL["rx"],
+    "sensor_tx_bytes": MOCK_BYTES_TOTAL["tx"],
 }
-MOCK_LOAD_AVG_HTTP = {"load_avg_1": 1.1, "load_avg_5": 1.2, "load_avg_15": 1.3}
-MOCK_LOAD_AVG = list(MOCK_LOAD_AVG_HTTP.values())
-MOCK_SYSINFO = {
-    "sensor_load_avg1": MOCK_LOAD_AVG[0],
-    "sensor_load_avg5": MOCK_LOAD_AVG[1],
-    "sensor_load_avg15": MOCK_LOAD_AVG[2],
+MOCK_LOAD_AVG = {
+    "sensor_load_avg1": 1.1,
+    "sensor_load_avg5": 1.2,
+    "sensor_load_avg15": 1.3,
 }
 MOCK_MEMORY_USAGE = {
     "mem_usage_perc": 52.4,
@@ -58,7 +51,7 @@ MOCK_MEMORY_USAGE = {
     "mem_free": 393216,
     "mem_used": 655360,
 }
-MOCK_TEMPERATURES = {"2.4GHz": 40.2, "5.0GHz": 0, "CPU": 71.2}
+MOCK_TEMPERATURES = {"2.4GHz": 40.2, "5.0GHz": 62, "CPU": 71.2}
 MOCK_TEMPERATURES_HTTP = {**MOCK_TEMPERATURES, "5.0GHz_2": 40.3, "6.0GHz": 40.4}
 MOCK_UPTIME = {"last_boot": "2024-08-02T00:47:00+00:00", "uptime": 1625927}
 MOCK_BOOTTIME = {
@@ -76,79 +69,56 @@ def mock_controller_patch_setup_entry():
         yield setup_entry_mock
 
 
-@pytest.fixture(name="mock_devices_legacy")
-def mock_devices_legacy_fixture():
-    """Mock a list of devices."""
-    return {
-        MOCK_MACS[0]: new_device(PROTOCOL_SSH, MOCK_MACS[0], "192.168.1.2", "Test"),
-        MOCK_MACS[1]: new_device(PROTOCOL_SSH, MOCK_MACS[1], "192.168.1.3", "TestTwo"),
-    }
-
-
-@pytest.fixture(name="mock_devices_http")
-def mock_devices_http_fixture():
-    """Mock a list of AsusRouter client devices for HTTP backend."""
+def _mock_devices(protocol: str) -> dict[str, WrtDevice]:
+    """Mock devices."""
     return {
         MOCK_MACS[0]: new_device(
-            PROTOCOL_HTTP, MOCK_MACS[0], "192.168.1.2", "Test", "node1"
+            protocol, MOCK_MACS[0], "192.168.1.2", "Test", "node1"
         ),
         MOCK_MACS[1]: new_device(
-            PROTOCOL_HTTP, MOCK_MACS[1], "192.168.1.3", "TestTwo", "node2"
+            protocol, MOCK_MACS[1], "192.168.1.3", "TestTwo", "node2"
         ),
     }
 
 
-@pytest.fixture(name="mock_available_temps")
-def mock_available_temps_fixture():
-    """Mock a list of available temperature sensors."""
-    return [True, False, True]
+@pytest.fixture
+def mock_devices() -> dict[str, WrtDevice]:
+    """Mock a list of AsusRouter client devices for HTTP backend."""
+    return _mock_devices(PROTOCOL_HTTP)
+
+
+@pytest.fixture
+def mock_devices_legacy() -> dict[str, WrtDevice]:
+    """Mock a list of AsusRouter client devices for SSH backend."""
+    return _mock_devices(PROTOCOL_SSH)
 
 
 @pytest.fixture(name="connect_legacy")
-def mock_controller_connect_legacy(mock_devices_legacy, mock_available_temps):
+def mock_controller_connect_legacy(mock_devices_legacy):
     """Mock a successful connection with legacy library."""
-    with patch(ASUSWRT_LEGACY_LIB, spec=AsusWrtLegacy) as service_mock:
-        service_mock.return_value.connection = Mock(spec=TelnetConnection)
+    with patch(ASUSWRT_LEGACY_LIB, autospec=AsusWrtLegacy) as service_mock:
+        service_mock.return_value._connection = Mock(spec=TelnetConnection)
         service_mock.return_value.is_connected = True
-        service_mock.return_value.async_get_nvram.return_value = {
+        service_mock.return_value.get_nvram.return_value = {
             "label_mac": ROUTER_MAC_ADDR,
             "model": "abcd",
             "firmver": "efg",
             "buildno": "123",
         }
-        service_mock.return_value.async_get_connected_devices.return_value = (
+        service_mock.return_value.get_connected_devices.return_value = (
             mock_devices_legacy
         )
-        service_mock.return_value.async_get_bytes_total.return_value = MOCK_BYTES_TOTAL
-        service_mock.return_value.async_get_current_transfer_rates.return_value = (
+        service_mock.return_value.total_transfer.return_value = MOCK_BYTES_TOTAL
+        service_mock.return_value.get_current_transfer_rates.return_value = (
             MOCK_CURRENT_TRANSFER_RATES
         )
-        service_mock.return_value.async_get_loadavg.return_value = MOCK_LOAD_AVG
-        service_mock.return_value.async_get_temperature.return_value = MOCK_TEMPERATURES
-        service_mock.return_value.async_find_temperature_commands.return_value = (
-            mock_available_temps
-        )
+        service_mock.return_value.get_loadavg.return_value = MOCK_LOAD_AVG
+        service_mock.return_value.get_temperature.return_value = MOCK_TEMPERATURES
         yield service_mock
 
 
-@pytest.fixture(name="connect_legacy_sens_fail")
-def mock_controller_connect_legacy_sens_fail(connect_legacy):
-    """Mock a successful connection using legacy library with sensors fail."""
-    connect_legacy.return_value.async_get_nvram.side_effect = OSError
-    connect_legacy.return_value.async_get_connected_devices.side_effect = OSError
-    connect_legacy.return_value.async_get_bytes_total.side_effect = OSError
-    connect_legacy.return_value.async_get_current_transfer_rates.side_effect = OSError
-    connect_legacy.return_value.async_get_loadavg.side_effect = OSError
-    connect_legacy.return_value.async_get_temperature.side_effect = OSError
-    connect_legacy.return_value.async_find_temperature_commands.return_value = [
-        True,
-        True,
-        True,
-    ]
-
-
 @pytest.fixture(name="connect_http")
-def mock_controller_connect_http(mock_devices_http):
+def mock_controller_connect_http(mock_devices):
     """Mock a successful connection with http library."""
     with patch(ASUSWRT_HTTP_LIB, spec_set=AsusRouter) as service_mock:
         instance = service_mock.return_value
@@ -168,9 +138,9 @@ def mock_controller_connect_http(mock_devices_http):
 
         # Data fetches via async_get_data
         instance.async_get_data.side_effect = lambda datatype, *args, **kwargs: {
-            AsusData.CLIENTS: mock_devices_http,
+            AsusData.CLIENTS: mock_devices,
             AsusData.NETWORK: MOCK_CURRENT_NETWORK,
-            AsusData.SYSINFO: MOCK_SYSINFO,
+            AsusData.SYSINFO: MOCK_LOAD_AVG,
             AsusData.TEMPERATURE: {
                 k: v for k, v in MOCK_TEMPERATURES_HTTP.items() if k != "5.0GHz"
             },
@@ -232,7 +202,7 @@ def mock_controller_connect_http_sens_detect():
         if datatype == AsusData.CPU:
             return list(MOCK_CPU_USAGE)
         if datatype == AsusData.SYSINFO:
-            return list(MOCK_SYSINFO)
+            return list(MOCK_LOAD_AVG)
         return []
 
     with patch(

--- a/tests/components/asuswrt/test_config_flow.py
+++ b/tests/components/asuswrt/test_config_flow.py
@@ -94,7 +94,7 @@ async def test_user_legacy(
     assert flow_result["type"] is FlowResultType.FORM
     assert flow_result["step_id"] == "user"
 
-    connect_legacy.return_value.async_get_nvram.return_value = unique_id
+    connect_legacy.return_value.get_nvram.return_value = unique_id
 
     # test with all provided
     legacy_result = await hass.config_entries.flow.async_configure(
@@ -258,7 +258,7 @@ async def test_abort_invalid_unique_id(hass: HomeAssistant, connect_legacy) -> N
         unique_id=ROUTER_MAC_ADDR,
     ).add_to_hass(hass)
 
-    connect_legacy.return_value.async_get_nvram.return_value = {}
+    connect_legacy.return_value.get_nvram.return_value = {}
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -287,7 +287,7 @@ async def test_on_connect_legacy_failed(
     )
 
     connect_legacy.return_value.is_connected = False
-    connect_legacy.return_value.connection.async_connect.side_effect = side_effect
+    connect_legacy.return_value.connect.side_effect = side_effect
 
     # go to legacy form
     result = await hass.config_entries.flow.async_configure(

--- a/tests/components/asuswrt/test_helpers.py
+++ b/tests/components/asuswrt/test_helpers.py
@@ -1,10 +1,6 @@
 """Tests for AsusWRT helpers."""
 
-from typing import Any
-
-import pytest
-
-from homeassistant.components.asuswrt.helpers import clean_dict, translate_to_legacy
+from homeassistant.components.asuswrt.helpers import clean_dict
 
 DICT_TO_CLEAN = {
     "key1": "value1",
@@ -66,30 +62,3 @@ def test_clean_dict() -> None:
     """Test clean_dict method."""
 
     assert clean_dict(DICT_TO_CLEAN) == DICT_CLEAN
-
-
-@pytest.mark.parametrize(
-    ("input", "expected"),
-    [
-        # Case set 0: None as input -> None on output
-        (None, None),
-        # Case set 1: Dict structure should stay intact or translated
-        ({"key1": "value1", "key2": None}, {"key1": "value1", "key2": None}),
-        (TRANSLATE_0_INPUT, TRANSLATE_0_OUTPUT),
-        (TRANSLATE_1_INPUT, TRANSLATE_1_OUTPUT),
-        ({}, {}),
-        # Case set 2: List structure should stay intact or translated
-        (["key1", "key2"], ["key1", "key2"]),
-        (TRANSLATE_2_INPUT, TRANSLATE_2_OUTPUT),
-        (TRANSLATE_3_INPUT, TRANSLATE_3_OUTPUT),
-        ([], []),
-        # Case set 3: Anything else should be simply returned
-        (123, 123),
-        ("string", "string"),
-        (3.1415926535, 3.1415926535),
-    ],
-)
-def test_translate(input: Any, expected: Any) -> None:
-    """Test translate method."""
-
-    assert translate_to_legacy(input) == expected

--- a/tests/components/asuswrt/test_init.py
+++ b/tests/components/asuswrt/test_init.py
@@ -26,5 +26,5 @@ async def test_disconnect_on_stop(hass: HomeAssistant, connect_legacy) -> None:
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
 
-    assert connect_legacy.return_value.async_disconnect.await_count == 1
+    assert connect_legacy.return_value.disconnect.await_count == 1
     assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -212,13 +212,15 @@ async def test_sensors_legacy(
 async def test_sensors_http(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
-    mock_devices,
+    mock_devices_http,
     entry_unique_id,
     connect_http,
     create_device_registry_devices,
 ) -> None:
     """Test creating AsusWRT default sensors and tracker with http protocol."""
-    await _test_sensors(hass, freezer, mock_devices, CONFIG_DATA_HTTP, entry_unique_id)
+    await _test_sensors(
+        hass, freezer, mock_devices_http, CONFIG_DATA_HTTP, entry_unique_id
+    )
 
 
 async def _test_loadavg_sensors(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This bumps `aioasuswrt` to 2.0.4. As this is a major update the structure of the lib was altered quite a lot. This means that a bigger rewrite where done in hass to use `aioasustwrt 2.0.+`.

The test situation in asuswrt is beyond bad IMO, and this also goes for the integration code of the two libraries to some extent. Some of the tests that I touched in this PR are redundant and only test functionality of the lib which is already covered in the tests for the lib (there are a ton more problems but that is IMO the biggest one).

I wanted to bring this in slowly by first annotate and strictly type the integration, but that showed to be a hard endeavor unfortunately so I'll do a full on PR and we can discuss the items one by one instead (or not, that is always an option 🤣).

The 2.0.4 version of `aioasuswrt` is measured to reduce startup time ~20% but will draw a bit more memory for now (its planned to be optimized in my next iteration).

### Notable changes:
* An actually working version of total_transfer 
    - still a best effort estimate but in my trials so far it actually seem to work
    - IMO its a bad thing to put these values in a underlying lib, I think that the libs should always ONLY provide "now"-data. But I got into the discussion about "breaking changes" and did not want to argue.
* The list of connected devices got a huge overhaul and with that it also got thoroughly tested.
* The dreadful decorator in `bridge.py` is now removed.
    - I want to align the asuswrt-libs and try to remove as much code as possible in hass.
    - The decorator "hides" some problems that should not be hidden! 
      The outcome of hiding them is more or less "Why does nothing work but the log is empty"
      Lets remove such obscurities and actually solve the problem instead of using ducktape 😄!

[CHANGELOG](https://github.com/kennedyshead/aioasuswrt/blob/master/CHANGELOG.txt) for `aioasuswrt 2.0.4`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
