### PR TITLE
Remove doorbell binary sensor, use event entity instead

### DIFF
--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -383,13 +383,6 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
 
 EVENT_SENSORS: tuple[ProtectBinaryEventEntityDescription, ...] = (
     ProtectBinaryEventEntityDescription(
-        key="doorbell",
-        translation_key="doorbell",
-        device_class=BinarySensorDeviceClass.OCCUPANCY,
-        ufp_required_field="feature_flags.is_doorbell",
-        ufp_event_obj="last_ring_event",
-    ),
-    ProtectBinaryEventEntityDescription(
         key="motion",
         device_class=BinarySensorDeviceClass.MOTION,
         ufp_enabled="is_motion_detection_on",

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -12,7 +12,7 @@ from uiprotect.data import Camera, Chime
 from uiprotect.exceptions import ClientError
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.event import EventDeviceClass
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_NAME, Platform
 from homeassistant.core import (
     HomeAssistant,
@@ -227,16 +227,15 @@ async def set_chime_paired_doorbells(call: ServiceCall) -> None:
     )
     doorbell_ids: set[str] = set()
     for camera_id in doorbell_refs.referenced | doorbell_refs.indirectly_referenced:
-        doorbell_sensor = entity_registry.async_get(camera_id)
-        assert doorbell_sensor is not None
+        doorbell_entity = entity_registry.async_get(camera_id)
+        assert doorbell_entity is not None
         if (
-            doorbell_sensor.platform != DOMAIN
-            or doorbell_sensor.domain != Platform.BINARY_SENSOR
-            or doorbell_sensor.original_device_class
-            != BinarySensorDeviceClass.OCCUPANCY
+            doorbell_entity.platform != DOMAIN
+            or doorbell_entity.domain != Platform.EVENT
+            or doorbell_entity.original_device_class != EventDeviceClass.DOORBELL
         ):
             continue
-        doorbell_mac = _async_unique_id_to_mac(doorbell_sensor.unique_id)
+        doorbell_mac = _async_unique_id_to_mac(doorbell_entity.unique_id)
         camera = instance.bootstrap.get_device_from_mac(doorbell_mac)
         assert camera is not None
         doorbell_ids.add(camera.id)

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -64,11 +64,11 @@ async def test_binary_sensor_camera_remove(
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 9, 6)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 8, 5)
     await remove_entities(hass, ufp, [doorbell, unadopted_camera])
     assert_entity_counts(hass, Platform.BINARY_SENSOR, 0, 0)
     await adopt_devices(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 9, 6)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 8, 5)
 
 
 async def test_binary_sensor_light_remove(
@@ -136,8 +136,9 @@ async def test_binary_sensor_setup_camera_all(
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 9, 6)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 8, 5)
 
+    # Motion (EVENT_SENSORS[0])
     description = EVENT_SENSORS[0]
     unique_id, entity_id = await ids_from_device_description(
         hass, Platform.BINARY_SENSOR, doorbell, description
@@ -152,7 +153,7 @@ async def test_binary_sensor_setup_camera_all(
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
-    # Is Dark
+    # Is Dark (CAMERA_SENSORS[0])
     description = CAMERA_SENSORS[0]
     unique_id, entity_id = await ids_from_device_description(
         hass, Platform.BINARY_SENSOR, doorbell, description
@@ -167,8 +168,8 @@ async def test_binary_sensor_setup_camera_all(
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
-    # Motion
-    description = EVENT_SENSORS[1]
+    # Person detected (EVENT_SENSORS[2])
+    description = EVENT_SENSORS[2]
     unique_id, entity_id = await ids_from_device_description(
         hass, Platform.BINARY_SENSOR, doorbell, description
     )
@@ -176,11 +177,6 @@ async def test_binary_sensor_setup_camera_all(
     entity = entity_registry.async_get(entity_id)
     assert entity
     assert entity.unique_id == unique_id
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_OFF
-    assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
 
 async def test_binary_sensor_setup_camera_none(
@@ -286,10 +282,10 @@ async def test_binary_sensor_update_motion(
     """Test binary_sensor motion entity."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 15, 12)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 14, 11)
 
     _, entity_id = await ids_from_device_description(
-        hass, Platform.BINARY_SENSOR, doorbell, EVENT_SENSORS[1]
+        hass, Platform.BINARY_SENSOR, doorbell, EVENT_SENSORS[0]
     )
 
     event = Event(
@@ -447,12 +443,12 @@ async def test_binary_sensor_package_detected(
     """Test binary_sensor package detection entity."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 15, 15)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 14, 14)
 
     doorbell.smart_detect_settings.object_types.append(SmartDetectObjectType.PACKAGE)
 
     _, entity_id = await ids_from_device_description(
-        hass, Platform.BINARY_SENSOR, doorbell, EVENT_SENSORS[6]
+        hass, Platform.BINARY_SENSOR, doorbell, EVENT_SENSORS[5]
     )
 
     event = Event(
@@ -588,12 +584,12 @@ async def test_binary_sensor_person_detected(
     """Test binary_sensor person detected detection entity."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 15, 15)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 14, 14)
 
     doorbell.smart_detect_settings.object_types.append(SmartDetectObjectType.PERSON)
 
     _, entity_id = await ids_from_device_description(
-        hass, Platform.BINARY_SENSOR, doorbell, EVENT_SENSORS[3]
+        hass, Platform.BINARY_SENSOR, doorbell, EVENT_SENSORS[2]
     )
 
     events = async_capture_events(hass, EVENT_STATE_CHANGED)

--- a/tests/components/unifiprotect/test_recorder.py
+++ b/tests/components/unifiprotect/test_recorder.py
@@ -36,7 +36,7 @@ async def test_exclude_attributes(
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
 
     _, entity_id = await ids_from_device_description(
-        hass, Platform.BINARY_SENSOR, doorbell, EVENT_SENSORS[1]
+        hass, Platform.BINARY_SENSOR, doorbell, EVENT_SENSORS[0]
     )
 
     event = Event(

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -187,7 +187,7 @@ async def test_set_chime_paired_doorbells(
     await init_entry(hass, ufp, [camera1, camera2, chime])
 
     chime_entry = entity_registry.async_get("button.test_chime_play_chime")
-    camera_entry = entity_registry.async_get("binary_sensor.test_camera_2_doorbell")
+    camera_entry = entity_registry.async_get("event.test_camera_2_doorbell")
     assert chime_entry is not None
     assert camera_entry is not None
 
@@ -197,7 +197,7 @@ async def test_set_chime_paired_doorbells(
         {
             ATTR_DEVICE_ID: chime_entry.device_id,
             "doorbells": {
-                ATTR_ENTITY_ID: ["binary_sensor.test_camera_1_doorbell"],
+                ATTR_ENTITY_ID: ["event.test_camera_1_doorbell"],
                 ATTR_DEVICE_ID: [camera_entry.device_id],
             },
         },
@@ -222,7 +222,7 @@ async def test_remove_privacy_zone_no_zone(
 
     await init_entry(hass, ufp, [doorbell])
 
-    camera_entry = entity_registry.async_get("binary_sensor.test_camera_doorbell")
+    camera_entry = entity_registry.async_get("binary_sensor.test_camera_is_dark")
 
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
@@ -249,7 +249,7 @@ async def test_remove_privacy_zone(
 
     await init_entry(hass, ufp, [doorbell])
 
-    camera_entry = entity_registry.async_get("binary_sensor.test_camera_doorbell")
+    camera_entry = entity_registry.async_get("binary_sensor.test_camera_is_dark")
 
     await hass.services.async_call(
         DOMAIN,
@@ -286,7 +286,7 @@ async def get_user_keyring_info(
 
     await init_entry(hass, ufp, [doorbell])
 
-    camera_entry = entity_registry.async_get("binary_sensor.test_camera_doorbell")
+    camera_entry = entity_registry.async_get("binary_sensor.test_camera_is_dark")
 
     response = await hass.services.async_call(
         DOMAIN,
@@ -330,7 +330,7 @@ async def test_get_user_keyring_info_no_users(
 
     await init_entry(hass, ufp, [doorbell])
 
-    camera_entry = entity_registry.async_get("binary_sensor.test_camera_doorbell")
+    camera_entry = entity_registry.async_get("binary_sensor.test_camera_is_dark")
 
     with pytest.raises(
         HomeAssistantError, match="No users found, please check Protect permissions"


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The doorbell binary sensor with OCCUPANCY device class was redundant since the doorbell event entity already exists with the correct DOORBELL device class.

Updated set_chime_paired_doorbells service to look for event entities with EventDeviceClass.DOORBELL instead of binary sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
