### PR TITLE
Deprecate doorbell binary sensor in unifiprotect

### DIFF
--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -388,6 +388,9 @@ EVENT_SENSORS: tuple[ProtectBinaryEventEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.OCCUPANCY,
         ufp_required_field="feature_flags.is_doorbell",
         ufp_event_obj="last_ring_event",
+        # Deprecated in 2026.1, scheduled for removal in 2026.2
+        # Use event.doorbell entity instead
+        entity_registry_enabled_default=False,
     ),
     ProtectBinaryEventEntityDescription(
         key="motion",

--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -111,6 +111,10 @@ async def async_migrate_data(
     async_deprecate_hdr(hass, entry)
     _LOGGER.debug("Completed Migrate: async_deprecate_hdr")
 
+    _LOGGER.debug("Start Migrate: async_deprecate_doorbell_binary_sensor")
+    async_deprecate_doorbell_binary_sensor(hass, entry)
+    _LOGGER.debug("Completed Migrate: async_deprecate_doorbell_binary_sensor")
+
 
 @callback
 def async_deprecate_hdr(hass: HomeAssistant, entry: UFPConfigEntry) -> None:
@@ -127,4 +131,30 @@ def async_deprecate_hdr(hass: HomeAssistant, entry: UFPConfigEntry) -> None:
         entry,
         "2024.10.0",
         {"hdr_switch": {"id": "hdr_mode", "platform": Platform.SWITCH}},
+    )
+
+
+@callback
+def async_deprecate_doorbell_binary_sensor(
+    hass: HomeAssistant, entry: UFPConfigEntry
+) -> None:
+    """Check for usages of doorbell binary sensor and raise repair if it is used.
+
+    The doorbell binary sensor was using the wrong device class (occupancy) since it
+    represents an event, not a state. It has been replaced with a doorbell event entity
+    which properly represents doorbell ring events.
+
+    Added in 2026.1.0
+    """
+
+    create_repair_if_used(
+        hass,
+        entry,
+        "2026.2.0",
+        {
+            "doorbell_binary_sensor": {
+                "id": "doorbell",
+                "platform": Platform.BINARY_SENSOR,
+            }
+        },
     )

--- a/homeassistant/components/unifiprotect/services.yaml
+++ b/homeassistant/components/unifiprotect/services.yaml
@@ -32,14 +32,14 @@ set_chime_paired_doorbells:
           entity:
             device_class: unifiprotect__chime_button
     doorbells:
-      example: "binary_sensor.front_doorbell_doorbell"
+      example: "event.front_doorbell_doorbell"
       required: false
       selector:
         target:
           entity:
             integration: unifiprotect
-            domain: binary_sensor
-            device_class: occupancy
+            domain: event
+            device_class: doorbell
 remove_privacy_zone:
   fields:
     device_id:

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -638,6 +638,10 @@
       },
       "title": "Ubiquiti Cloud Users are not Supported"
     },
+    "deprecate_doorbell_binary_sensor": {
+      "description": "The doorbell binary sensor has been replaced with a doorbell event entity. The binary sensor was using an incorrect device class (occupancy) since doorbell rings are events, not states.\n\nPlease update your automations to use the corresponding doorbell event entity instead. The event entity will fire a `ring` event when the doorbell is pressed.\n\nBelow are the detected automations or scripts that use one or more of the deprecated entities:\n{items}\nThe above list may be incomplete and it does not include any template usages inside of dashboards. Please update any templates, automations or scripts accordingly.",
+      "title": "Doorbell binary sensor deprecated"
+    },
     "deprecate_hdr_switch": {
       "description": "UniFi Protect v3 added a new state for HDR (auto). As a result, the HDR Mode switch has been replaced with an HDR Mode select, and it is deprecated.\n\nBelow are the detected automations or scripts that use one or more of the deprecated entities:\n{items}\nThe above list may be incomplete and it does not include any template usages inside of dashboards. Please update any templates, automations or scripts accordingly.",
       "title": "HDR Mode switch deprecated"

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -64,11 +64,11 @@ async def test_binary_sensor_camera_remove(
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 9, 6)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 9, 5)
     await remove_entities(hass, ufp, [doorbell, unadopted_camera])
     assert_entity_counts(hass, Platform.BINARY_SENSOR, 0, 0)
     await adopt_devices(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 9, 6)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 9, 5)
 
 
 async def test_binary_sensor_light_remove(
@@ -136,21 +136,7 @@ async def test_binary_sensor_setup_camera_all(
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 9, 6)
-
-    description = EVENT_SENSORS[0]
-    unique_id, entity_id = await ids_from_device_description(
-        hass, Platform.BINARY_SENSOR, doorbell, description
-    )
-
-    entity = entity_registry.async_get(entity_id)
-    assert entity
-    assert entity.unique_id == unique_id
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_OFF
-    assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 9, 5)
 
     # Is Dark
     description = CAMERA_SENSORS[0]
@@ -286,7 +272,7 @@ async def test_binary_sensor_update_motion(
     """Test binary_sensor motion entity."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.BINARY_SENSOR, 15, 12)
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 15, 11)
 
     _, entity_id = await ids_from_device_description(
         hass, Platform.BINARY_SENSOR, doorbell, EVENT_SENSORS[1]


### PR DESCRIPTION
- Disable doorbell binary sensor by default for new installs
- Add deprecation repair issue for existing users
- Update set_chime_paired_doorbells service to prefer event entity
- Maintain backwards compatibility with legacy binary sensor
- Deprecation: 2026.1, Removal: 2026.2

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
