### PR TITLE
Add expire_after configuration option to template sensors and sensors

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -125,6 +125,8 @@ PLATFORM_SCHEMA = BINARY_SENSOR_PLATFORM_SCHEMA.extend(
     }
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_platform(
     hass: HomeAssistant,
@@ -308,6 +310,15 @@ class TriggerBinarySensorEntity(TriggerEntity, AbstractTemplateBinarySensor):
         if self._expire_after is not None and self._expire_after > 0:
             self._expired = True
         self._expiration_trigger: CALLBACK_TYPE | None = None
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove expire triggers."""
+        if self._expiration_trigger:
+            _LOGGER.debug("Clean up expire after trigger for %s", self.entity_id)
+            self._expiration_trigger()
+            self._expiration_trigger = None
+            self._expired = False
+        await TriggerEntity.async_will_remove_from_hass(self)
 
     async def async_added_to_hass(self) -> None:
         """Restore last state."""

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -68,6 +68,7 @@ DEFAULT_NAME = "Template Binary Sensor"
 CONF_DELAY_ON = "delay_on"
 CONF_DELAY_OFF = "delay_off"
 CONF_AUTO_OFF = "auto_off"
+CONF_EXPIRE_AFTER = "expire_after"
 
 LEGACY_FIELDS = {
     CONF_FRIENDLY_NAME_TEMPLATE: CONF_NAME,
@@ -82,6 +83,7 @@ BINARY_SENSOR_COMMON_SCHEMA = vol.Schema(
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
         vol.Required(CONF_STATE): cv.template,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+        vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
     }
 )
 
@@ -301,6 +303,12 @@ class TriggerBinarySensorEntity(TriggerEntity, AbstractTemplateBinarySensor):
         self._auto_off_cancel: CALLBACK_TYPE | None = None
         self._auto_off_time: datetime | None = None
 
+        self._expire_after: int | None = config.get(CONF_EXPIRE_AFTER)
+        self._expired: bool = False
+        if self._expire_after is not None and self._expire_after > 0:
+            self._expired = True
+        self._expiration_trigger: CALLBACK_TYPE | None = None
+
     async def async_added_to_hass(self) -> None:
         """Restore last state."""
         await super().async_added_to_hass()
@@ -436,6 +444,36 @@ class TriggerBinarySensorEntity(TriggerEntity, AbstractTemplateBinarySensor):
         if (restored_last_extra_data := await self.async_get_last_extra_data()) is None:
             return None
         return AutoOffExtraStoredData.from_dict(restored_last_extra_data.as_dict())
+
+    @callback
+    def _process_data(self) -> None:
+        """Process new data."""
+        super()._process_data()
+
+        if self._expire_after is not None and self._expire_after > 0:
+            self._expired = False
+
+            if self._expiration_trigger:
+                self._expiration_trigger()
+
+            self._expiration_trigger = async_call_later(
+                self.hass, self._expire_after, self._value_is_expired
+            )
+
+    @callback
+    def _value_is_expired(self, *_: datetime) -> None:
+        """Triggered when value is expired."""
+        self._expiration_trigger = None
+        self._expired = True
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Return true if the device is available and value has not expired."""
+        # mypy doesn't know about fget: https://github.com/python/mypy/issues/6185
+        return TriggerEntity.available.fget(self) and (  # type: ignore[attr-defined]
+            not self._expired
+        )
 
 
 @dataclass

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -308,6 +308,15 @@ class TriggerSensorEntity(TriggerEntity, AbstractTemplateSensor):
             self._expired = True
         self._expiration_trigger: CALLBACK_TYPE | None = None
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove expire triggers."""
+        if self._expiration_trigger:
+            _LOGGER.debug("Clean up expire after trigger for %s", self.entity_id)
+            self._expiration_trigger()
+            self._expiration_trigger = None
+            self._expired = False
+        await TriggerEntity.async_will_remove_from_hass(self)
+
     async def async_added_to_hass(self) -> None:
         """Restore last state."""
         await super().async_added_to_hass()

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -40,13 +40,14 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
@@ -65,6 +66,8 @@ from .schemas import (
 )
 from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
+
+CONF_EXPIRE_AFTER = "expire_after"
 
 DEFAULT_NAME = "Template Sensor"
 
@@ -93,6 +96,7 @@ SENSOR_COMMON_SCHEMA = vol.Schema(
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
         vol.Optional(CONF_STATE_CLASS): STATE_CLASSES_SCHEMA,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+        vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
     }
 )
 
@@ -298,6 +302,12 @@ class TriggerSensorEntity(TriggerEntity, AbstractTemplateSensor):
             else:
                 self._to_render_simple.append(ATTR_LAST_RESET)
 
+        self._expire_after: int | None = config.get(CONF_EXPIRE_AFTER)
+        self._expired: bool = False
+        if self._expire_after is not None and self._expire_after > 0:
+            self._expired = True
+        self._expiration_trigger: CALLBACK_TYPE | None = None
+
     async def async_added_to_hass(self) -> None:
         """Restore last state."""
         await super().async_added_to_hass()
@@ -317,9 +327,34 @@ class TriggerSensorEntity(TriggerEntity, AbstractTemplateSensor):
         """Process new data."""
         super()._process_data()
 
+        if self._expire_after is not None and self._expire_after > 0:
+            self._expired = False
+
+            if self._expiration_trigger:
+                self._expiration_trigger()
+
+            self._expiration_trigger = async_call_later(
+                self.hass, self._expire_after, self._value_is_expired
+            )
+
         # Update last_reset
         if (last_reset := self._rendered.get(ATTR_LAST_RESET)) is not None:
             self._update_last_reset(last_reset)
 
         rendered = self._rendered.get(CONF_STATE)
         self._handle_state(rendered)
+
+    @callback
+    def _value_is_expired(self, *_: datetime) -> None:
+        """Triggered when value is expired."""
+        self._expiration_trigger = None
+        self._expired = True
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Return true if the device is available and value has not expired."""
+        # mypy doesn't know about fget: https://github.com/python/mypy/issues/6185
+        return TriggerEntity.available.fget(self) and (  # type: ignore[attr-defined]
+            not self._expired
+        )

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -1763,7 +1763,7 @@ async def test_flow_preview(
 )
 @pytest.mark.usefixtures("start_ha")
 async def test_trigger_expire_after(hass: HomeAssistant) -> None:
-    """Test conditional trigger entity works."""
+    """Test trigger binary sensor with expire_after configuration."""
     state = hass.states.get("binary_sensor.enough_name")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 from unittest.mock import Mock, patch
 
+from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -25,6 +26,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.helpers.restore_state import STORAGE_KEY as RESTORE_STATE_KEY
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import dt as dt_util
 
 from .conftest import (
     ConfigurationStyle,
@@ -1735,3 +1737,104 @@ async def test_flow_preview(
         {"name": "My template", "state": "{{ 'on' }}"},
     )
     assert state["state"] == "on"
+
+
+@pytest.mark.parametrize(("count", "domain"), [(1, template.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "template": [
+                {
+                    "unique_id": "listening-test-event",
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "binary_sensor": [
+                        {
+                            "name": "Enough Name",
+                            "unique_id": "enough-id",
+                            "state": "{{ trigger.event.data.val }}",
+                            "expire_after": 4,
+                        }
+                    ],
+                },
+            ],
+        },
+    ],
+)
+@pytest.mark.usefixtures("start_ha")
+async def test_trigger_expire_after(hass: HomeAssistant) -> None:
+    """Test conditional trigger entity works."""
+    state = hass.states.get("binary_sensor.enough_name")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    hass.bus.async_fire("test_event", {"val": False})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.enough_name")
+    assert state.state == "off"
+
+    realnow = dt_util.utcnow()
+    now = datetime(realnow.year + 1, 1, 1, 1, tzinfo=dt_util.UTC)
+    with freeze_time(now) as freezer:
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        hass.bus.async_fire("test_event", {"val": True})
+        await hass.async_block_till_done()
+
+        # Value was set correctly.
+        state = hass.states.get("binary_sensor.enough_name")
+        assert state.state == "on"
+
+        # Time jump +3s
+        now += timedelta(seconds=3)
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+        # Value is not yet expired
+        state = hass.states.get("binary_sensor.enough_name")
+        assert state.state == "on"
+
+        # Next message resets timer
+        now += timedelta(seconds=0.5)
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        hass.bus.async_fire("test_event", {"val": False})
+        await hass.async_block_till_done()
+
+        # Value was updated correctly.
+        state = hass.states.get("binary_sensor.enough_name")
+        assert state.state == "off"
+
+        # Time jump +3s
+        now += timedelta(seconds=3)
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+        # Value is not yet expired
+        state = hass.states.get("binary_sensor.enough_name")
+        assert state.state == "off"
+
+        # Time jump +2s
+        now += timedelta(seconds=2)
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+        # Value is expired now
+        state = hass.states.get("binary_sensor.enough_name")
+        assert state.state == STATE_UNAVAILABLE
+
+        # Send the last message again
+        # Time jump 0.5s
+        now += timedelta(seconds=0.5)
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        hass.bus.async_fire("test_event", {"val": True})
+        await hass.async_block_till_done()
+
+        # Value was updated correctly.
+        state = hass.states.get("binary_sensor.enough_name")
+        assert state.state == "on"

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -4,6 +4,7 @@ from asyncio import Event
 from datetime import datetime, timedelta
 from unittest.mock import ANY, patch
 
+from freezegun import freeze_time
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -2512,3 +2513,104 @@ async def test_flow_preview(
     )
 
     assert state["state"] == "0.0"
+
+
+@pytest.mark.parametrize(("count", "domain"), [(1, template.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "template": [
+                {
+                    "unique_id": "listening-test-event",
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "sensor": [
+                        {
+                            "name": "Enough Name",
+                            "unique_id": "enough-id",
+                            "state": "{{ trigger.event.data.val }}",
+                            "expire_after": 4,
+                        }
+                    ],
+                },
+            ],
+        },
+    ],
+)
+@pytest.mark.usefixtures("start_ha")
+async def test_trigger_expire_after(hass: HomeAssistant) -> None:
+    """Test conditional trigger entity works."""
+    state = hass.states.get("sensor.enough_name")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    hass.bus.async_fire("test_event", {"val": 42})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.enough_name")
+    assert state.state == "42"
+
+    realnow = dt_util.utcnow()
+    now = datetime(realnow.year + 1, 1, 1, 1, tzinfo=dt_util.UTC)
+    with freeze_time(now) as freezer:
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        hass.bus.async_fire("test_event", {"val": 100})
+        await hass.async_block_till_done()
+
+        # Value was set correctly.
+        state = hass.states.get("sensor.enough_name")
+        assert state.state == "100"
+
+        # Time jump +3s
+        now += timedelta(seconds=3)
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+        # Value is not yet expired
+        state = hass.states.get("sensor.enough_name")
+        assert state.state == "100"
+
+        # Next message resets timer
+        now += timedelta(seconds=0.5)
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        hass.bus.async_fire("test_event", {"val": 101})
+        await hass.async_block_till_done()
+
+        # Value was updated correctly.
+        state = hass.states.get("sensor.enough_name")
+        assert state.state == "101"
+
+        # Time jump +3s
+        now += timedelta(seconds=3)
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+        # Value is not yet expired
+        state = hass.states.get("sensor.enough_name")
+        assert state.state == "101"
+
+        # Time jump +2s
+        now += timedelta(seconds=2)
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+        # Value is expired now
+        state = hass.states.get("sensor.enough_name")
+        assert state.state == STATE_UNAVAILABLE
+
+        # Send the last message again
+        # Time jump 0.5s
+        now += timedelta(seconds=0.5)
+        freezer.move_to(now)
+        async_fire_time_changed(hass, now)
+        hass.bus.async_fire("test_event", {"val": 101})
+        await hass.async_block_till_done()
+
+        # Value was updated correctly.
+        state = hass.states.get("sensor.enough_name")
+        assert state.state == "101"

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -2539,7 +2539,7 @@ async def test_flow_preview(
 )
 @pytest.mark.usefixtures("start_ha")
 async def test_trigger_expire_after(hass: HomeAssistant) -> None:
-    """Test conditional trigger entity works."""
+    """Test trigger binary sensor with expire_after configuration."""
     state = hass.states.get("sensor.enough_name")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Inspired from mqtt integration, this PR adds an "expire_after" configuration option to trigger sensors/binary sensors of template integration, that sets the sensor to unavailable if no value is received in configured time


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42552
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
