### PR TITLE
Fix Ring WebRTC stream incompatible SDP direction

### DIFF
--- a/tests/components/ring/test_camera.py
+++ b/tests/components/ring/test_camera.py
@@ -487,7 +487,10 @@ async def test_camera_webrtc(
             "m=video 9 UDP/TLS/RTP/SAVPF 96\r\na=sendonly\r\n",
         ),
         # SDP without direction attributes should be unchanged
-        ("v=0\r\nm=video 9 UDP/TLS/RTP/SAVPF 96\r\n", "v=0\r\nm=video 9 UDP/TLS/RTP/SAVPF 96\r\n"),
+        (
+            "v=0\r\nm=video 9 UDP/TLS/RTP/SAVPF 96\r\n",
+            "v=0\r\nm=video 9 UDP/TLS/RTP/SAVPF 96\r\n",
+        ),
     ],
     ids=[
         "recvonly_to_sendonly",


### PR DESCRIPTION
## Summary

Ring's cloud may return SDP answers with direction attributes (`recvonly`, `sendrecv`) that are incompatible with the browser's offer. Newer browsers (Chrome 143+, Firefox) enforce stricter SDP validation and reject these malformed answers with "Failed to set remote answer sdp: Incompatible send direction".

For a camera live stream where Ring sends video/audio to the client, the answer direction should be `sendonly`. This change fixes the SDP direction attributes before passing the answer to the browser.

This is basically inlining https://github.com/python-ring-doorbell/python-ring-doorbell/pull/497

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

Fixes #158118

## Test plan

- Added unit tests for the `_fix_sdp_direction` function covering all direction attribute cases
- Added integration test verifying the WebRTC answer SDP is correctly fixed
- All 19 Ring camera tests pass

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass with `pytest tests/components/ring/test_camera.py`
- [x] There is no commented out code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)