### PR TITLE
Replace access token authentication with OAuth2 in Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -67,7 +67,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
     """Set up Teslemetry config."""
 
-    access_token = entry.data["token"]["access_token"]
     session = async_get_clientsession(hass)
     oauth_session = OAuth2Session(hass, entry, TeslemetryImplementation(hass))
 

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Callable
 import time
-from typing import Any, Final
+from typing import Final
 
 from aiohttp import ClientResponseError
 from tesla_fleet_api.const import Scope
@@ -315,7 +315,7 @@ async def async_migrate_entry(
 
 async def _migrate_token_to_oauth(
     hass: HomeAssistant, access_token: str
-) -> dict[str, Any]:
+) -> dict[str, str]:
     """Migrate legacy access token to OAuth format using Teslemetry migrate endpoint."""
     session = async_get_clientsession(hass)
 

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -75,10 +75,24 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+def temporary_fix(hass: HomeAssistant, entry: TeslemetryConfigEntry):
+    """TEMPORARY: Handle existing entries that don't have auth_implementation."""
+    # This is needed to migrate beta users to the new OAuth credential system.
+    # Remove this block before merging to main.
+    if "auth_implementation" not in entry.data:
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, "auth_implementation": DOMAIN},
+        )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
     """Set up Teslemetry config."""
 
     session = async_get_clientsession(hass)
+
+    temporary_fix(hass, entry)
+
     implementation = await async_get_config_entry_implementation(hass, entry)
     oauth_session = OAuth2Session(hass, entry, implementation)
 

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -71,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
     session = async_get_clientsession(hass)
     oauth_session = OAuth2Session(hass, entry, TeslemetryImplementation(hass))
 
-    async def _refresh_hook() -> str:
+    async def _get_access_token() -> str:
         try:
             await oauth_session.async_ensure_token_valid()
         except ClientResponseError as e:
@@ -84,8 +84,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
     # Create API connection
     teslemetry = Teslemetry(
         session=session,
-        access_token=access_token,
-        refresh_hook=_refresh_hook,
+        access_token=_get_access_token,
     )
     try:
         calls = await asyncio.gather(
@@ -141,7 +140,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             if not stream:
                 stream = TeslemetryStream(
                     session,
-                    access_token,
+                    _get_access_token,
                     server=f"{region.lower()}.teslemetry.com",
                     parse_timestamp=True,
                     manual=True,

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -74,23 +74,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-def temporary_fix(hass: HomeAssistant, entry: TeslemetryConfigEntry):
-    """TEMPORARY: Handle existing entries that don't have auth_implementation."""
-    # This is needed to migrate beta users to the new OAuth credential system.
-    # Remove this block before merging to main.
-    if "auth_implementation" not in entry.data:
-        hass.config_entries.async_update_entry(
-            entry,
-            data={**entry.data, "auth_implementation": DOMAIN},
-        )
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
     """Set up Teslemetry config."""
 
     session = async_get_clientsession(hass)
-
-    temporary_fix(hass, entry)
 
     implementation = await async_get_config_entry_implementation(hass, entry)
     oauth_session = OAuth2Session(hass, entry, implementation)

--- a/homeassistant/components/teslemetry/application_credentials.py
+++ b/homeassistant/components/teslemetry/application_credentials.py
@@ -1,0 +1,16 @@
+"""Application Credentials platform the Teslemetry integration."""
+
+from homeassistant.components.application_credentials import ClientCredential
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow
+
+from .oauth import TeslemetryImplementation
+
+
+async def async_get_auth_implementation(
+    hass: HomeAssistant, auth_domain: str, credential: ClientCredential
+) -> config_entry_oauth2_flow.AbstractOAuth2Implementation:
+    """Return auth implementation."""
+    return TeslemetryImplementation(
+        hass,
+    )

--- a/homeassistant/components/teslemetry/application_credentials.py
+++ b/homeassistant/components/teslemetry/application_credentials.py
@@ -1,10 +1,22 @@
 """Application Credentials platform the Teslemetry integration."""
 
-from homeassistant.components.application_credentials import ClientCredential
+from homeassistant.components.application_credentials import (
+    AuthorizationServer,
+    ClientCredential,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
+from .const import AUTHORIZE_URL, TOKEN_URL
 from .oauth import TeslemetryImplementation
+
+
+async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationServer:
+    """Return authorization server."""
+    return AuthorizationServer(
+        authorize_url=AUTHORIZE_URL,
+        token_url=TOKEN_URL,
+    )
 
 
 async def async_get_auth_implementation(
@@ -13,4 +25,6 @@ async def async_get_auth_implementation(
     """Return auth implementation."""
     return TeslemetryImplementation(
         hass,
+        auth_domain,
+        credential.client_id,
     )

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -14,12 +14,15 @@ from tesla_fleet_api.exceptions import (
 )
 from tesla_fleet_api.teslemetry import Teslemetry
 
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, LOGGER
-from .oauth import TeslemetryImplementation
+from .const import CLIENT_ID, DOMAIN, LOGGER
 
 
 class OAuth2FlowHandler(
@@ -35,7 +38,6 @@ class OAuth2FlowHandler(
         super().__init__()
         self.data: dict[str, Any] = {}
         self.uid: str | None = None
-        self._oauth_impl: TeslemetryImplementation | None = None
 
     @property
     def logger(self) -> logging.Logger:
@@ -46,9 +48,11 @@ class OAuth2FlowHandler(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow start."""
-        self._oauth_impl = TeslemetryImplementation(self.hass)
-        self.async_register_implementation(self.hass, self._oauth_impl)
-
+        await async_import_client_credential(
+            self.hass,
+            DOMAIN,
+            ClientCredential(CLIENT_ID, "", name="Teslemetry"),
+        )
         return await super().async_step_user()
 
     async def async_oauth_create_entry(
@@ -104,8 +108,11 @@ class OAuth2FlowHandler(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle reauth on failure."""
-        self._oauth_impl = TeslemetryImplementation(self.hass)
-        self.async_register_implementation(self.hass, self._oauth_impl)
+        await async_import_client_credential(
+            self.hass,
+            DOMAIN,
+            ClientCredential(CLIENT_ID, "", name="Teslemetry"),
+        )
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -108,11 +108,6 @@ class OAuth2FlowHandler(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle reauth on failure."""
-        await async_import_client_credential(
-            self.hass,
-            DOMAIN,
-            ClientCredential(CLIENT_ID, "", name="Teslemetry"),
-        )
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import logging
 from typing import Any
 
 from aiohttp import ClientConnectionError
@@ -12,67 +13,92 @@ from tesla_fleet_api.exceptions import (
     TeslaFleetError,
 )
 from tesla_fleet_api.teslemetry import Teslemetry
-import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
+from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, LOGGER
-
-TESLEMETRY_SCHEMA = vol.Schema({vol.Required(CONF_ACCESS_TOKEN): str})
-DESCRIPTION_PLACEHOLDERS = {
-    "name": "Teslemetry",
-    "short_url": "teslemetry.com/console",
-    "url": "[teslemetry.com/console](https://teslemetry.com/console)",
-}
+from .oauth import TeslemetryImplementation
 
 
-class TeslemetryConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Config Teslemetry API connection."""
+class OAuth2FlowHandler(
+    config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN
+):
+    """Config flow to handle Teslemetry OAuth2 authentication."""
 
-    VERSION = 1
-    MINOR_VERSION = 2
+    DOMAIN = DOMAIN
 
-    async def async_auth(self, user_input: Mapping[str, Any]) -> dict[str, str]:
-        """Reusable Auth Helper."""
+    def __init__(self) -> None:
+        """Initialize config flow."""
+        super().__init__()
+        self.data: dict[str, Any] = {}
+        self.uid: str | None = None
+
+    @property
+    def logger(self) -> logging.Logger:
+        """Return logger."""
+        return LOGGER
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a flow start."""
+        self.async_register_implementation(
+            self.hass,
+            TeslemetryImplementation(self.hass),
+        )
+
+        return await super().async_step_user()
+
+    async def async_oauth_create_entry(
+        self,
+        data: dict[str, Any],
+    ) -> ConfigFlowResult:
+        """Handle OAuth completion and create config entry."""
+        self.data = data
+
+        # Test the connection with the OAuth token
+        errors = await self.async_test_connection(data)
+        if errors:
+            return self.async_abort(reason="oauth_error")
+
+        await self.async_set_unique_id(self.uid)
+        if self.source == SOURCE_REAUTH:
+            self._abort_if_unique_id_mismatch(reason="reauth_account_mismatch")
+            return self.async_update_reload_and_abort(
+                self._get_reauth_entry(), data=data
+            )
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title="Teslemetry",
+            data=data,
+        )
+
+    async def async_test_connection(self, token_data: dict[str, Any]) -> dict[str, str]:
+        """Test the connection with OAuth token."""
+        access_token = token_data["token"]["access_token"]
+
         teslemetry = Teslemetry(
             session=async_get_clientsession(self.hass),
-            access_token=user_input[CONF_ACCESS_TOKEN],
+            access_token=access_token,
         )
+
         try:
             metadata = await teslemetry.metadata()
         except InvalidToken:
-            return {CONF_ACCESS_TOKEN: "invalid_access_token"}
+            return {"base": "invalid_access_token"}
         except SubscriptionRequired:
             return {"base": "subscription_required"}
         except ClientConnectionError:
             return {"base": "cannot_connect"}
         except TeslaFleetError as e:
-            LOGGER.error(e)
+            LOGGER.error("Teslemetry API error: %s", e)
             return {"base": "unknown"}
 
-        await self.async_set_unique_id(metadata["uid"])
+        self.uid = metadata["uid"]
         return {}
-
-    async def async_step_user(
-        self, user_input: Mapping[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Get configuration from the user."""
-        errors: dict[str, str] = {}
-        if user_input and not (errors := await self.async_auth(user_input)):
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(
-                title="Teslemetry",
-                data=user_input,
-            )
-
-        return self.async_show_form(
-            step_id="user",
-            data_schema=TESLEMETRY_SCHEMA,
-            description_placeholders=DESCRIPTION_PLACEHOLDERS,
-            errors=errors,
-        )
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
@@ -81,21 +107,12 @@ class TeslemetryConfigFlow(ConfigFlow, domain=DOMAIN):
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
-        self, user_input: Mapping[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle users reauth credentials."""
-
-        errors: dict[str, str] = {}
-
-        if user_input and not (errors := await self.async_auth(user_input)):
-            return self.async_update_reload_and_abort(
-                self._get_reauth_entry(),
-                data=user_input,
+        """Confirm reauth dialog."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                description_placeholders={"name": "Teslemetry"},
             )
-
-        return self.async_show_form(
-            step_id="reauth_confirm",
-            description_placeholders=DESCRIPTION_PLACEHOLDERS,
-            data_schema=TESLEMETRY_SCHEMA,
-            errors=errors,
-        )
+        return await super().async_step_user()

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, LOGGER, TOKEN_URLS
+from .const import DOMAIN, LOGGER
 from .oauth import TeslemetryImplementation
 
 
@@ -49,34 +49,6 @@ class OAuth2FlowHandler(
         self.async_register_implementation(self.hass, self._oauth_impl)
 
         return await super().async_step_user()
-
-    async def async_step_auth(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle OAuth2 authorization step with region capture."""
-        if user_input is not None:
-            # Check if region parameter is present in the callback
-            if "region" not in user_input:
-                return self.async_abort(reason="missing_region")
-
-            region = user_input["region"]
-            if region not in TOKEN_URLS:
-                return self.async_abort(reason="invalid_region")
-
-            # Set region on the OAuth implementation
-            if self._oauth_impl and hasattr(self._oauth_impl, "set_region"):
-                try:
-                    self._oauth_impl.set_region(region)
-                except ValueError:
-                    return self.async_abort(reason="invalid_region")
-
-            # Store region in external data for later use
-            self.external_data = user_input
-            next_step = "authorize_rejected" if "error" in user_input else "creation"
-            return self.async_external_step_done(next_step_id=next_step)
-
-        # Continue with standard auth flow
-        return await super().async_step_auth(user_input)
 
     async def async_oauth_create_entry(
         self,

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -28,6 +28,7 @@ class OAuth2FlowHandler(
     """Config flow to handle Teslemetry OAuth2 authentication."""
 
     DOMAIN = DOMAIN
+    VERSION = 2
 
     def __init__(self) -> None:
         """Initialize config flow."""

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -103,6 +103,8 @@ class OAuth2FlowHandler(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle reauth on failure."""
+        self._oauth_impl = TeslemetryImplementation(self.hass)
+        self.async_register_implementation(self.hass, self._oauth_impl)
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
@@ -114,4 +116,5 @@ class OAuth2FlowHandler(
                 step_id="reauth_confirm",
                 description_placeholders={"name": "Teslemetry"},
             )
+
         return await super().async_step_user()

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -9,6 +9,12 @@ AUTHORIZE_URL = "https://teslemetry.com/connect"
 TOKEN_URL = "https://api.teslemetry.com/oauth/token"
 CLIENT_ID = "homeassistant"
 
+# Regional token URLs
+TOKEN_URLS = {
+    "NA": "https://na.teslemetry.com/oauth/token",  # North America
+    "EU": "https://eu.teslemetry.eu/oauth/token",  # Europe
+}
+
 DOMAIN = "teslemetry"
 
 LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -5,19 +5,14 @@ from __future__ import annotations
 from enum import StrEnum
 import logging
 
-AUTHORIZE_URL = "https://teslemetry.com/connect"
-TOKEN_URL = "https://api.teslemetry.com/oauth/token"
-CLIENT_ID = "homeassistant"
-
-# Regional token URLs
-TOKEN_URLS = {
-    "NA": "https://na.teslemetry.com/oauth/token",  # North America
-    "EU": "https://eu.teslemetry.eu/oauth/token",  # Europe
-}
-
 DOMAIN = "teslemetry"
 
 LOGGER = logging.getLogger(__package__)
+
+# OAuth
+AUTHORIZE_URL = "https://teslemetry.com/connect"
+TOKEN_URL = "https://api.teslemetry.com/oauth/token"
+CLIENT_ID = "homeassistant"
 
 ENERGY_HISTORY_FIELDS = [
     "solar_energy_exported",

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from enum import StrEnum
 import logging
 
+AUTHORIZE_URL = "https://teslemetry.com/connect"
+TOKEN_URL = "https://api.teslemetry.com/oauth/token"
+CLIENT_ID = "homeassistant"
+
 DOMAIN = "teslemetry"
 
 LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -3,6 +3,7 @@
   "name": "Teslemetry",
   "codeowners": ["@Bre77"],
   "config_flow": true,
+  "dependencies": ["application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/teslemetry",
   "integration_type": "hub",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/teslemetry/oauth.py
+++ b/homeassistant/components/teslemetry/oauth.py
@@ -1,5 +1,7 @@
 """Provide oauth implementations for the Teslemetry integration."""
 
+from __future__ import annotations
+
 import base64
 import hashlib
 import secrets
@@ -8,24 +10,22 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .const import AUTHORIZE_URL, CLIENT_ID, DOMAIN, TOKEN_URL
+from .const import AUTHORIZE_URL, CLIENT_ID, DOMAIN, TOKEN_URL, TOKEN_URLS
 
 
 class TeslemetryImplementation(config_entry_oauth2_flow.LocalOAuth2Implementation):
-    """Tesla Fleet API open source Oauth2 implementation."""
-
-    code_verifier: str
-    code_challenge: str
+    """Tesla Fleet API OAuth2 implementation with region support."""
 
     def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize open source Oauth2 implementation."""
-
+        """Initialize OAuth2 implementation."""
         # Setup PKCE
         self.code_verifier = secrets.token_urlsafe(32)
         hashed_verifier = hashlib.sha256(self.code_verifier.encode()).digest()
         self.code_challenge = (
             base64.urlsafe_b64encode(hashed_verifier).decode().replace("=", "")
         )
+
+        # Use placeholder token URL - will be updated based on region
         super().__init__(
             hass,
             DOMAIN,
@@ -34,6 +34,9 @@ class TeslemetryImplementation(config_entry_oauth2_flow.LocalOAuth2Implementatio
             AUTHORIZE_URL,
             TOKEN_URL,
         )
+
+        # Store region for token requests
+        self._region: str | None = None
 
     @property
     def name(self) -> str:
@@ -44,33 +47,28 @@ class TeslemetryImplementation(config_entry_oauth2_flow.LocalOAuth2Implementatio
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {
-            "code_challenge": self.code_challenge,  # PKCE
+            "code_challenge": self.code_challenge,
         }
 
     @property
     def extra_token_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the token request."""
-        # print("extra_token_data", self.hass.config.location_name)
         return {
             "name": self.hass.config.location_name,
         }
 
     @property
-    def extra_token_resolve_data(self) -> dict:
+    def extra_token_resolve_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the token resolve request."""
-        # print("extra_token_resolve_data", self.hass.config.location_name)
         return {
             "name": self.hass.config.location_name,
+            "code_verifier": self.code_verifier,
         }
 
-    async def async_resolve_external_data(self, external_data: Any) -> dict:
-        """Resolve the authorization code to tokens."""
-        return await self._token_request(
-            {
-                "grant_type": "authorization_code",
-                "client_id": CLIENT_ID,
-                "code": external_data["code"],
-                "redirect_uri": external_data["state"]["redirect_uri"],
-                "code_verifier": self.code_verifier,  # PKCE
-            }
-        )
+    def set_region(self, region: str) -> None:
+        """Set the region and update token URL."""
+        if region not in TOKEN_URLS:
+            raise ValueError(
+                f"Invalid region '{region}'. Must be one of: {', '.join(TOKEN_URLS.keys())}"
+            )
+        self.token_url = TOKEN_URLS[region]

--- a/homeassistant/components/teslemetry/oauth.py
+++ b/homeassistant/components/teslemetry/oauth.py
@@ -10,11 +10,11 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .const import AUTHORIZE_URL, CLIENT_ID, DOMAIN, TOKEN_URL, TOKEN_URLS
+from .const import AUTHORIZE_URL, CLIENT_ID, DOMAIN, TOKEN_URL
 
 
 class TeslemetryImplementation(config_entry_oauth2_flow.LocalOAuth2Implementation):
-    """Tesla Fleet API OAuth2 implementation with region support."""
+    """Teslemetry OAuth2 implementation."""
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize OAuth2 implementation."""
@@ -25,7 +25,6 @@ class TeslemetryImplementation(config_entry_oauth2_flow.LocalOAuth2Implementatio
             base64.urlsafe_b64encode(hashed_verifier).decode().replace("=", "")
         )
 
-        # Use placeholder token URL - will be updated based on region
         super().__init__(
             hass,
             DOMAIN,
@@ -34,9 +33,6 @@ class TeslemetryImplementation(config_entry_oauth2_flow.LocalOAuth2Implementatio
             AUTHORIZE_URL,
             TOKEN_URL,
         )
-
-        # Store region for token requests
-        self._region: str | None = None
 
     @property
     def name(self) -> str:
@@ -47,14 +43,8 @@ class TeslemetryImplementation(config_entry_oauth2_flow.LocalOAuth2Implementatio
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {
-            "code_challenge": self.code_challenge,
-        }
-
-    @property
-    def extra_token_data(self) -> dict[str, Any]:
-        """Extra data that needs to be appended to the token request."""
-        return {
             "name": self.hass.config.location_name,
+            "code_challenge": self.code_challenge,
         }
 
     @property
@@ -64,11 +54,3 @@ class TeslemetryImplementation(config_entry_oauth2_flow.LocalOAuth2Implementatio
             "name": self.hass.config.location_name,
             "code_verifier": self.code_verifier,
         }
-
-    def set_region(self, region: str) -> None:
-        """Set the region and update token URL."""
-        if region not in TOKEN_URLS:
-            raise ValueError(
-                f"Invalid region '{region}'. Must be one of: {', '.join(TOKEN_URLS.keys())}"
-            )
-        self.token_url = TOKEN_URLS[region]

--- a/homeassistant/components/teslemetry/oauth.py
+++ b/homeassistant/components/teslemetry/oauth.py
@@ -1,0 +1,76 @@
+"""Provide oauth implementations for the Teslemetry integration."""
+
+import base64
+import hashlib
+import secrets
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow
+
+from .const import AUTHORIZE_URL, CLIENT_ID, DOMAIN, TOKEN_URL
+
+
+class TeslemetryImplementation(config_entry_oauth2_flow.LocalOAuth2Implementation):
+    """Tesla Fleet API open source Oauth2 implementation."""
+
+    code_verifier: str
+    code_challenge: str
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize open source Oauth2 implementation."""
+
+        # Setup PKCE
+        self.code_verifier = secrets.token_urlsafe(32)
+        hashed_verifier = hashlib.sha256(self.code_verifier.encode()).digest()
+        self.code_challenge = (
+            base64.urlsafe_b64encode(hashed_verifier).decode().replace("=", "")
+        )
+        super().__init__(
+            hass,
+            DOMAIN,
+            CLIENT_ID,
+            "",
+            AUTHORIZE_URL,
+            TOKEN_URL,
+        )
+
+    @property
+    def name(self) -> str:
+        """Name of the implementation."""
+        return "Teslemetry OAuth2"
+
+    @property
+    def extra_authorize_data(self) -> dict[str, Any]:
+        """Extra data that needs to be appended to the authorize url."""
+        return {
+            "code_challenge": self.code_challenge,  # PKCE
+        }
+
+    @property
+    def extra_token_data(self) -> dict[str, Any]:
+        """Extra data that needs to be appended to the token request."""
+        # print("extra_token_data", self.hass.config.location_name)
+        return {
+            "name": self.hass.config.location_name,
+        }
+
+    @property
+    def extra_token_resolve_data(self) -> dict:
+        """Extra data that needs to be appended to the token resolve request."""
+        # print("extra_token_resolve_data", self.hass.config.location_name)
+        return {
+            "name": self.hass.config.location_name,
+        }
+
+    async def async_resolve_external_data(self, external_data: Any) -> dict:
+        """Resolve the authorization code to tokens."""
+        return await self._token_request(
+            {
+                "grant_type": "authorization_code",
+                "client_id": CLIENT_ID,
+                "code": external_data["code"],
+                "redirect_uri": external_data["state"]["redirect_uri"],
+                "code_verifier": self.code_verifier,  # PKCE
+            }
+        )

--- a/homeassistant/components/teslemetry/oauth.py
+++ b/homeassistant/components/teslemetry/oauth.py
@@ -7,7 +7,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .const import AUTHORIZE_URL, CLIENT_ID, DOMAIN, TOKEN_URL
+from .const import AUTHORIZE_URL, TOKEN_URL
 
 
 class TeslemetryImplementation(
@@ -15,13 +15,13 @@ class TeslemetryImplementation(
 ):
     """Teslemetry OAuth2 implementation."""
 
-    def __init__(self, hass: HomeAssistant) -> None:
+    def __init__(self, hass: HomeAssistant, domain: str, client_id: str) -> None:
         """Initialize OAuth2 implementation."""
 
         super().__init__(
             hass,
-            DOMAIN,
-            CLIENT_ID,
+            domain,
+            client_id,
             AUTHORIZE_URL,
             TOKEN_URL,
         )

--- a/homeassistant/components/teslemetry/oauth.py
+++ b/homeassistant/components/teslemetry/oauth.py
@@ -37,6 +37,7 @@ class TeslemetryImplementation(
         data: dict = {
             "name": self.hass.config.location_name,
         }
+        data.update(super().extra_authorize_data)
         return data
 
     @property

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -39,17 +39,8 @@
     },
     "step": {
       "reauth_confirm": {
-        "data": {
-          "access_token": "[%key:common::config_flow::data::access_token%]"
-        },
-        "description": "The {name} integration needs to re-authenticate your account, please enter an access token from {url}",
+        "description": "The {name} integration needs to re-authenticate your account",
         "title": "[%key:common::config_flow::title::reauth%]"
-      },
-      "user": {
-        "data": {
-          "access_token": "[%key:common::config_flow::data::access_token%]"
-        },
-        "description": "Enter an access token from {url}."
       }
     }
   },

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -28,6 +28,10 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
       "reauth_account_mismatch": "The reauthentication account does not match the original account",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -28,6 +28,8 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "invalid_region": "Invalid region parameter. Must be either 'NA' or 'EU'",
+      "missing_region": "Region parameter is required but missing from authorization response",
       "reauth_account_mismatch": "The reauthentication account does not match the original account",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -28,8 +28,6 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "invalid_region": "Invalid region parameter. Must be either 'NA' or 'EU'",
-      "missing_region": "Region parameter is required but missing from authorization response",
       "reauth_account_mismatch": "The reauthentication account does not match the original account",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },

--- a/homeassistant/generated/application_credentials.py
+++ b/homeassistant/generated/application_credentials.py
@@ -38,6 +38,7 @@ APPLICATION_CREDENTIALS = [
     "smartthings",
     "spotify",
     "tesla_fleet",
+    "teslemetry",
     "twitch",
     "volvo",
     "watts",

--- a/tests/components/teslemetry/__init__.py
+++ b/tests/components/teslemetry/__init__.py
@@ -21,6 +21,7 @@ def mock_config_entry() -> MockConfigEntry:
         version=2,
         unique_id="abc-123",
         data={
+            "auth_implementation": DOMAIN,
             "token": {
                 "access_token": "test_access_token",
                 "refresh_token": "test_refresh_token",

--- a/tests/components/teslemetry/__init__.py
+++ b/tests/components/teslemetry/__init__.py
@@ -13,10 +13,8 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry
 
 
-def mock_config_entry(expires_at: int | None = None) -> MockConfigEntry:
+def mock_config_entry() -> MockConfigEntry:
     """Create a mock config entry."""
-    if expires_at is None:
-        expires_at = int(time.time()) + 3600
 
     return MockConfigEntry(
         domain=DOMAIN,
@@ -26,7 +24,7 @@ def mock_config_entry(expires_at: int | None = None) -> MockConfigEntry:
             "token": {
                 "access_token": "test_access_token",
                 "refresh_token": "test_refresh_token",
-                "expires_at": expires_at,
+                "expires_at": int(time.time()) + 3600,
             },
         },
     )
@@ -35,11 +33,10 @@ def mock_config_entry(expires_at: int | None = None) -> MockConfigEntry:
 async def setup_platform(
     hass: HomeAssistant,
     platforms: list[Platform] | None = None,
-    expires_at: int | None = None,
 ) -> MockConfigEntry:
     """Set up the Teslemetry platform."""
 
-    mock_entry = mock_config_entry(expires_at)
+    mock_entry = mock_config_entry()
     mock_entry.add_to_hass(hass)
 
     if platforms is None:

--- a/tests/components/teslemetry/__init__.py
+++ b/tests/components/teslemetry/__init__.py
@@ -13,17 +13,12 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry
 
 
-async def setup_platform(
-    hass: HomeAssistant,
-    platforms: list[Platform] | None = None,
-    expires_at: int | None = None,
-) -> MockConfigEntry:
-    """Set up the Teslemetry platform."""
-
+def mock_config_entry(expires_at: int | None = None) -> MockConfigEntry:
+    """Create a mock config entry."""
     if expires_at is None:
         expires_at = int(time.time()) + 3600
 
-    mock_entry = MockConfigEntry(
+    return MockConfigEntry(
         domain=DOMAIN,
         version=2,
         unique_id="abc-123",
@@ -35,6 +30,19 @@ async def setup_platform(
             },
         },
     )
+
+
+async def setup_platform(
+    hass: HomeAssistant,
+    platforms: list[Platform] | None = None,
+    expires_at: int | None = None,
+) -> MockConfigEntry:
+    """Set up the Teslemetry platform."""
+
+    if expires_at is None:
+        expires_at = int(time.time()) + 3600
+
+    mock_entry = mock_config_entry(expires_at)
     mock_entry.add_to_hass(hass)
 
     if platforms is None:

--- a/tests/components/teslemetry/__init__.py
+++ b/tests/components/teslemetry/__init__.py
@@ -39,9 +39,6 @@ async def setup_platform(
 ) -> MockConfigEntry:
     """Set up the Teslemetry platform."""
 
-    if expires_at is None:
-        expires_at = int(time.time()) + 3600
-
     mock_entry = mock_config_entry(expires_at)
     mock_entry.add_to_hass(hass)
 

--- a/tests/components/teslemetry/__init__.py
+++ b/tests/components/teslemetry/__init__.py
@@ -1,5 +1,6 @@
 """Tests for the Teslemetry integration."""
 
+import time
 from unittest.mock import patch
 
 from syrupy.assertion import SnapshotAssertion
@@ -9,18 +10,30 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .const import CONFIG
-
 from tests.common import MockConfigEntry
 
 
 async def setup_platform(
-    hass: HomeAssistant, platforms: list[Platform] | None = None
+    hass: HomeAssistant,
+    platforms: list[Platform] | None = None,
+    expires_at: int | None = None,
 ) -> MockConfigEntry:
     """Set up the Teslemetry platform."""
 
+    if expires_at is None:
+        expires_at = int(time.time()) + 3600
+
     mock_entry = MockConfigEntry(
-        domain=DOMAIN, data=CONFIG, minor_version=2, unique_id="abc-123"
+        domain=DOMAIN,
+        version=2,
+        unique_id="abc-123",
+        data={
+            "token": {
+                "access_token": "test_access_token",
+                "refresh_token": "test_refresh_token",
+                "expires_at": expires_at,
+            },
+        },
     )
     mock_entry.add_to_hass(hass)
 

--- a/tests/components/teslemetry/conftest.py
+++ b/tests/components/teslemetry/conftest.py
@@ -22,8 +22,8 @@ from .const import (
 )
 
 
-@pytest.fixture(autouse=False)
-def mock_async_setup_entry():
+@pytest.fixture
+def mock_setup_entry():
     """Mock Teslemetry async_setup_entry method."""
     with patch(
         "homeassistant.components.teslemetry.async_setup_entry", return_value=True

--- a/tests/components/teslemetry/conftest.py
+++ b/tests/components/teslemetry/conftest.py
@@ -1,10 +1,9 @@
-"""Fixtures for Teslemetry."""
+"""Test fixtures for Teslemetry component."""
 
 from __future__ import annotations
 
 from collections.abc import Generator
 from copy import deepcopy
-import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -21,12 +20,6 @@ from .const import (
     VEHICLE_DATA,
     WAKE_UP_ONLINE,
 )
-
-
-@pytest.fixture(name="expires_at")
-def mock_expires_at() -> float:
-    """Fixture to set the oauth token expiration time."""
-    return time.time() + 3600
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/teslemetry/conftest.py
+++ b/tests/components/teslemetry/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from copy import deepcopy
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -20,6 +21,12 @@ from .const import (
     VEHICLE_DATA,
     WAKE_UP_ONLINE,
 )
+
+
+@pytest.fixture(name="expires_at")
+def mock_expires_at() -> float:
+    """Fixture to set the oauth token expiration time."""
+    return time.time() + 3600
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/teslemetry/conftest.py
+++ b/tests/components/teslemetry/conftest.py
@@ -22,6 +22,15 @@ from .const import (
 )
 
 
+@pytest.fixture(autouse=False)
+def mock_async_setup_entry():
+    """Mock Teslemetry async_setup_entry method."""
+    with patch(
+        "homeassistant.components.teslemetry.async_setup_entry", return_value=True
+    ) as mock_async_setup_entry:
+        yield mock_async_setup_entry
+
+
 @pytest.fixture(autouse=True)
 def mock_metadata():
     """Mock Tesla Fleet Api metadata method."""

--- a/tests/components/teslemetry/const.py
+++ b/tests/components/teslemetry/const.py
@@ -5,7 +5,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 
 from tests.common import load_json_object_fixture
 
-UNIQUE_ID = "uid"
+UNIQUE_ID = "abc-123"
 CONFIG_V1 = {CONF_ACCESS_TOKEN: "abc-123"}
 
 WAKE_UP_ONLINE = {"response": {"state": TeslemetryState.ONLINE}, "error": None}
@@ -38,7 +38,7 @@ COMMAND_ERRORS = (COMMAND_REASON, COMMAND_NOREASON, COMMAND_ERROR, COMMAND_NOERR
 RESPONSE_OK = {"response": {}, "error": None}
 
 METADATA = {
-    "uid": "abc-123",
+    "uid": UNIQUE_ID,
     "region": "NA",
     "scopes": [
         "openid",
@@ -64,7 +64,7 @@ METADATA = {
     },
 }
 METADATA_LEGACY = {
-    "uid": "abc-123",
+    "uid": UNIQUE_ID,
     "region": "NA",
     "scopes": [
         "openid",
@@ -90,7 +90,7 @@ METADATA_LEGACY = {
     },
 }
 METADATA_NOSCOPE = {
-    "uid": "abc-123",
+    "uid": UNIQUE_ID,
     "region": "NA",
     "scopes": ["openid", "offline_access", "vehicle_device_data"],
     "vehicles": {

--- a/tests/components/teslemetry/const.py
+++ b/tests/components/teslemetry/const.py
@@ -5,7 +5,8 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 
 from tests.common import load_json_object_fixture
 
-CONFIG = {CONF_ACCESS_TOKEN: "1234567890"}
+UNIQUE_ID = "uid"
+CONFIG_V1 = {CONF_ACCESS_TOKEN: "abc-123"}
 
 WAKE_UP_ONLINE = {"response": {"state": TeslemetryState.ONLINE}, "error": None}
 WAKE_UP_ASLEEP = {"response": {"state": TeslemetryState.ASLEEP}, "error": None}

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -156,8 +156,7 @@ async def test_reauth_account_mismatch(
 
     result = await old_entry.start_reauth_flow(hass)
 
-    flows = hass.config_entries.flow.async_progress()
-    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -1,190 +1,226 @@
 """Test the Teslemetry config flow."""
 
 from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlparse
 
-from aiohttp import ClientConnectionError
 import pytest
-from tesla_fleet_api.exceptions import (
-    InvalidToken,
-    SubscriptionRequired,
-    TeslaFleetError,
-)
+from tesla_fleet_api.exceptions import TeslaFleetError
 
-from homeassistant import config_entries
-from homeassistant.components.teslemetry.const import DOMAIN
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.components.teslemetry.const import (
+    AUTHORIZE_URL,
+    CLIENT_ID,
+    DOMAIN,
+    TOKEN_URL,
+)
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import config_entry_oauth2_flow
 
-from .const import CONFIG, METADATA
+from .const import CONFIG_V1, METADATA, UNIQUE_ID
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
-BAD_CONFIG = {CONF_ACCESS_TOKEN: "bad_access_token"}
+REDIRECT = "https://example.com/auth/external/callback"
 
 
-async def test_form(
+async def test_oauth_flow(
     hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test we get the form."""
 
-    result1 = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result1["type"] is FlowResultType.FORM
-    assert not result1["errors"]
 
-    with patch(
-        "homeassistant.components.teslemetry.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result1["flow_id"],
-            CONFIG,
-        )
-        await hass.async_block_till_done()
-        assert len(mock_setup_entry.mock_calls) == 1
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["data"] == CONFIG
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    assert result["url"].startswith(AUTHORIZE_URL)
+    parsed_url = urlparse(result["url"])
+    parsed_query = parse_qs(parsed_url.query)
+    assert parsed_query["response_type"][0] == "code"
+    assert parsed_query["client_id"][0] == CLIENT_ID
+    assert parsed_query["redirect_uri"][0] == REDIRECT
+    assert parsed_query["state"][0] == state
+    assert parsed_query["code_challenge"][0]
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "test_refresh_token",
+            "access_token": "test_access_token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    # Complete OAuth
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.parametrize(
-    ("side_effect", "error"),
-    [
-        (InvalidToken, {CONF_ACCESS_TOKEN: "invalid_access_token"}),
-        (SubscriptionRequired, {"base": "subscription_required"}),
-        (ClientConnectionError, {"base": "cannot_connect"}),
-        (TeslaFleetError, {"base": "unknown"}),
-    ],
-)
-async def test_form_errors(
+async def test_reauth(
     hass: HomeAssistant,
-    side_effect: TeslaFleetError,
-    error: dict[str, str],
-    mock_metadata: AsyncMock,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
-    """Test errors are handled."""
-
-    result1 = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    mock_metadata.side_effect = side_effect
-    result2 = await hass.config_entries.flow.async_configure(
-        result1["flow_id"],
-        CONFIG,
-    )
-
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == error
-
-    # Complete the flow
-    mock_metadata.side_effect = None
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
-        CONFIG,
-    )
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-
-
-async def test_reauth(hass: HomeAssistant, mock_metadata: AsyncMock) -> None:
     """Test reauth flow."""
 
-    mock_entry = MockConfigEntry(
-        domain=DOMAIN, data=BAD_CONFIG, minor_version=2, unique_id="abc-123"
-    )
-    mock_entry.add_to_hass(hass)
-
-    result1 = await mock_entry.start_reauth_flow(hass)
-
-    assert result1["type"] is FlowResultType.FORM
-    assert result1["step_id"] == "reauth_confirm"
-    assert not result1["errors"]
-
-    with patch(
-        "homeassistant.components.teslemetry.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result1["flow_id"],
-            CONFIG,
-        )
-        await hass.async_block_till_done()
-        assert len(mock_setup_entry.mock_calls) == 1
-        assert len(mock_metadata.mock_calls) == 1
-
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "reauth_successful"
-    assert mock_entry.data == CONFIG
-
-
-@pytest.mark.parametrize(
-    ("side_effect", "error"),
-    [
-        (InvalidToken, {CONF_ACCESS_TOKEN: "invalid_access_token"}),
-        (SubscriptionRequired, {"base": "subscription_required"}),
-        (ClientConnectionError, {"base": "cannot_connect"}),
-        (TeslaFleetError, {"base": "unknown"}),
-    ],
-)
-async def test_reauth_errors(
-    hass: HomeAssistant,
-    mock_metadata: AsyncMock,
-    side_effect: TeslaFleetError,
-    error: dict[str, str],
-) -> None:
-    """Test reauth flows that fail."""
-
-    # Start the reauth
-    mock_entry = MockConfigEntry(
-        domain=DOMAIN, data=BAD_CONFIG, minor_version=2, unique_id="abc-123"
-    )
+    mock_entry = MockConfigEntry(domain=DOMAIN, data={}, version=2, unique_id=UNIQUE_ID)
     mock_entry.add_to_hass(hass)
 
     result = await mock_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
 
-    mock_metadata.side_effect = side_effect
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        BAD_CONFIG,
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
     )
-    await hass.async_block_till_done()
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == error
-
-    # Complete the flow
-    mock_metadata.side_effect = None
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
-        CONFIG,
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "test_refresh_token",
+            "access_token": "test_access_token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
     )
-    assert "errors" not in result3
-    assert result3["type"] is FlowResultType.ABORT
-    assert result3["reason"] == "reauth_successful"
-    assert mock_entry.data == CONFIG
+
+    with patch(
+        "homeassistant.components.teslemetry.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
 
 
-async def test_unique_id_abort(
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_reauth_account_mismatch(
     hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
 ) -> None:
-    """Test duplicate unique ID in config."""
+    """Test Tesla Fleet reauthentication with different account."""
+    old_entry = MockConfigEntry(domain=DOMAIN, unique_id="baduid", version=1, data={})
+    old_entry.add_to_hass(hass)
 
-    result1 = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}, data=CONFIG
+    result = await old_entry.start_reauth_flow(hass)
+
+    flows = hass.config_entries.flow.async_progress()
+    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
     )
-    assert result1["type"] is FlowResultType.CREATE_ENTRY
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
 
-    # Setup a duplicate
-    result2 = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}, data=CONFIG
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
     )
-    assert result2["type"] is FlowResultType.ABORT
+
+    with patch(
+        "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_account_mismatch"
 
 
-async def test_migrate_from_1_1(hass: HomeAssistant, mock_metadata: AsyncMock) -> None:
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_duplicate_unique_id_abort(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
+) -> None:
+    """Test duplicate unique ID aborts flow."""
+    # Create existing entry
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=UNIQUE_ID,
+        version=1,
+        data={},
+    )
+    existing_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    # Complete OAuth - should abort due to duplicate unique_id
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_migrate_from_v1(hass: HomeAssistant, mock_metadata: AsyncMock) -> None:
     """Test config migration."""
 
     mock_entry = MockConfigEntry(
@@ -192,7 +228,7 @@ async def test_migrate_from_1_1(hass: HomeAssistant, mock_metadata: AsyncMock) -
         version=1,
         minor_version=1,
         unique_id=None,
-        data=CONFIG,
+        data=CONFIG_V1,
     )
 
     mock_entry.add_to_hass(hass)
@@ -205,7 +241,7 @@ async def test_migrate_from_1_1(hass: HomeAssistant, mock_metadata: AsyncMock) -
     assert entry.unique_id == METADATA["uid"]
 
 
-async def test_migrate_error_from_1_1(
+async def test_migrate_error_from_v1(
     hass: HomeAssistant, mock_metadata: AsyncMock
 ) -> None:
     """Test config migration handles errors."""
@@ -217,7 +253,7 @@ async def test_migrate_error_from_1_1(
         version=1,
         minor_version=1,
         unique_id=None,
-        data=CONFIG,
+        data=CONFIG_V1,
     )
 
     mock_entry.add_to_hass(hass)
@@ -240,7 +276,7 @@ async def test_migrate_error_from_future(
         version=2,
         minor_version=1,
         unique_id="abc-123",
-        data=CONFIG,
+        data=CONFIG_V1,
     )
 
     mock_entry.add_to_hass(hass)

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -38,12 +38,6 @@ async def test_oauth_flow(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    if result["type"] is FlowResultType.FORM:
-        assert result["step_id"] == "pick_implementation"
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"implementation": DOMAIN}
-        )
-
     assert result["type"] is FlowResultType.EXTERNAL_STEP
 
     state = config_entry_oauth2_flow._encode_jwt(

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -230,65 +230,6 @@ async def test_duplicate_unique_id_abort(
     assert result["reason"] == "already_configured"
 
 
-async def test_migrate_from_v1(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    mock_metadata: AsyncMock,
-) -> None:
-    """Test config migration."""
-
-    aioclient_mock.post(
-        TOKEN_URL,
-        json={
-            "refresh_token": "test_refresh_token",
-            "access_token": "test_access_token",
-            "type": "Bearer",
-            "expires_in": 60,
-        },
-    )
-
-    mock_entry = MockConfigEntry(
-        domain=DOMAIN,
-        version=1,
-        minor_version=1,
-        unique_id=UNIQUE_ID,
-        data=CONFIG_V1,
-    )
-
-    mock_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-
-    entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
-    assert entry.version == 2
-    assert entry.minor_version == 1
-    assert entry.unique_id == UNIQUE_ID
-
-
-async def test_migrate_error_from_v1(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-) -> None:
-    """Test config migration handles errors."""
-
-    aioclient_mock.post(TOKEN_URL, status=400)
-
-    mock_entry = MockConfigEntry(
-        domain=DOMAIN,
-        version=1,
-        minor_version=1,
-        unique_id=None,
-        data=CONFIG_V1,
-    )
-
-    mock_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-
-    entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
-    assert entry.state is ConfigEntryState.MIGRATION_ERROR
-
-
 @pytest.mark.usefixtures("current_request_with_host")
 @pytest.mark.parametrize(
     "exception",

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -323,16 +323,15 @@ async def test_migrate_from_version_1_success(hass: HomeAssistant) -> None:
             CLIENT_ID, CONFIG_V1[CONF_ACCESS_TOKEN], hass.config.location_name
         )
 
-    entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
-    assert entry is not None
-    assert entry.version == 2
+    assert mock_entry is not None
+    assert mock_entry.version == 2
     # Verify data was converted to OAuth format
-    assert "token" in entry.data
-    assert entry.data["token"]["access_token"] == "migrated_token"
-    assert entry.data["token"]["refresh_token"] == "migrated_refresh_token"
+    assert "token" in mock_entry.data
+    assert mock_entry.data["token"]["access_token"] == "migrated_token"
+    assert mock_entry.data["token"]["refresh_token"] == "migrated_refresh_token"
     # Verify auth_implementation was added for OAuth2 flow compatibility
-    assert entry.data["auth_implementation"] == DOMAIN
-    assert entry.state is ConfigEntryState.LOADED
+    assert mock_entry.data["auth_implementation"] == DOMAIN
+    assert mock_entry.state is ConfigEntryState.LOADED
 
 
 async def test_migrate_from_version_1_token_endpoint_error(hass: HomeAssistant) -> None:

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -328,6 +328,8 @@ async def test_migrate_from_version_1_success(hass: HomeAssistant) -> None:
     assert "token" in entry.data
     assert entry.data["token"]["access_token"] == "migrated_token"
     assert entry.data["token"]["refresh_token"] == "migrated_refresh_token"
+    # Verify auth_implementation was added for OAuth2 flow compatibility
+    assert entry.data["auth_implementation"] == DOMAIN
     assert entry.state is ConfigEntryState.LOADED
 
 
@@ -364,13 +366,14 @@ async def test_migrate_from_version_1_token_endpoint_error(hass: HomeAssistant) 
 async def test_migrate_version_2_no_migration_needed(hass: HomeAssistant) -> None:
     """Test that version 2 entries don't need migration."""
     oauth_config = {
+        "auth_implementation": DOMAIN,
         "token": {
             "access_token": "existing_oauth_token",
             "token_type": "Bearer",
             "refresh_token": "existing_refresh_token",
             "expires_in": 3600,
             "expires_at": 1234567890,
-        }
+        },
     }
 
     mock_entry = MockConfigEntry(

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -1,7 +1,9 @@
 """Test the Teslemetry init."""
 
-from unittest.mock import AsyncMock, patch
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from aiohttp import ClientResponseError
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -16,6 +18,7 @@ from homeassistant.components.teslemetry.coordinator import VEHICLE_INTERVAL
 from homeassistant.components.teslemetry.models import TeslemetryData
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -26,7 +29,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from . import setup_platform
-from .const import PRODUCTS_MODERN, VEHICLE_DATA_ALT
+from .const import CONFIG_V1, PRODUCTS_MODERN, UNIQUE_ID, VEHICLE_DATA_ALT
+
+from tests.common import MockConfigEntry
 
 ERRORS = [
     (InvalidToken, ConfigEntryState.SETUP_ERROR),
@@ -127,9 +132,11 @@ async def test_vehicle_stream(
     mock_add_listener.assert_called()
 
     state = hass.states.get("binary_sensor.test_status")
+    assert state is not None
     assert state.state == STATE_UNKNOWN
 
     state = hass.states.get("binary_sensor.test_user_present")
+    assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
     mock_add_listener.send(
@@ -143,9 +150,11 @@ async def test_vehicle_stream(
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test_status")
+    assert state is not None
     assert state.state == STATE_ON
 
     state = hass.states.get("binary_sensor.test_user_present")
+    assert state is not None
     assert state.state == STATE_ON
 
     mock_add_listener.send(
@@ -158,6 +167,7 @@ async def test_vehicle_stream(
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test_status")
+    assert state is not None
     assert state.state == STATE_OFF
 
 
@@ -279,3 +289,137 @@ async def test_device_retention_during_reload(
     # Since the products data didn't change, we should have the same devices
     assert post_count == pre_count
     assert post_identifiers == original_identifiers
+
+
+async def test_migrate_from_version_1_success(hass: HomeAssistant) -> None:
+    """Test successful config migration from version 1."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        unique_id=UNIQUE_ID,
+        data=CONFIG_V1,
+    )
+
+    # Mock the migrate token endpoint response
+    with patch(
+        "homeassistant.components.teslemetry._migrate_token_to_oauth"
+    ) as mock_migrate:
+        mock_migrate.return_value = {
+            "token": {
+                "access_token": "migrated_token",
+                "token_type": "Bearer",
+                "refresh_token": "migrated_refresh_token",
+                "expires_in": 3600,
+                "expires_at": time.time() + 3600,
+            }
+        }
+
+        mock_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Verify migration function was called with the correct token
+        mock_migrate.assert_called_once_with(hass, CONFIG_V1[CONF_ACCESS_TOKEN])
+
+    entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
+    assert entry is not None
+    assert entry.version == 2
+    # Verify data was converted to OAuth format
+    assert "token" in entry.data
+    assert entry.data["token"]["access_token"] == "migrated_token"
+    assert entry.data["token"]["refresh_token"] == "migrated_refresh_token"
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_migrate_from_version_1_token_endpoint_error(hass: HomeAssistant) -> None:
+    """Test config migration handles token endpoint errors."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        unique_id=UNIQUE_ID,
+        data=CONFIG_V1,
+    )
+
+    # Mock the migrate token endpoint to raise an HTTP error
+    with patch(
+        "homeassistant.components.teslemetry._migrate_token_to_oauth"
+    ) as mock_migrate:
+        mock_migrate.side_effect = ClientResponseError(
+            request_info=MagicMock(), history=(), status=400
+        )
+
+        mock_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Verify migration function was called
+        mock_migrate.assert_called_once_with(hass, CONFIG_V1[CONF_ACCESS_TOKEN])
+
+    entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
+    assert entry is not None
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR
+    assert entry.version == 1  # Version should remain unchanged on migration failure
+
+
+async def test_migrate_version_2_no_migration_needed(hass: HomeAssistant) -> None:
+    """Test that version 2 entries don't need migration."""
+    oauth_config = {
+        "token": {
+            "access_token": "existing_oauth_token",
+            "token_type": "Bearer",
+            "refresh_token": "existing_refresh_token",
+            "expires_in": 3600,
+            "expires_at": 1234567890,
+        }
+    }
+
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,  # Already current version
+        unique_id=UNIQUE_ID,
+        data=oauth_config,
+    )
+
+    # Should not call the migrate endpoint since already version 2
+    with patch(
+        "homeassistant.components.teslemetry._migrate_token_to_oauth"
+    ) as mock_migrate:
+        mock_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Migration should not be called
+        mock_migrate.assert_not_called()
+
+    entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
+    assert entry is not None
+    assert entry.version == 2
+    # Verify data was not modified
+    assert entry.data == oauth_config
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_migrate_from_future_version_fails(hass: HomeAssistant) -> None:
+    """Test migration fails for future versions."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,  # Future version
+        unique_id=UNIQUE_ID,
+        data={
+            "token": {
+                "access_token": "future_token",
+                "token_type": "Bearer",
+                "refresh_token": "future_refresh_token",
+                "expires_in": 3600,
+            }
+        },
+    )
+
+    mock_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
+    assert entry is not None
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR
+    assert entry.version == 3  # Version should remain unchanged


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Teslemetry will no longer use the provided access token, and instead will be automatically migrated to an OAuth registration. You can manage your application registrations on the Teslemetry Console.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Teslemetry Config Flow is now version 2, and is a PKRE OAuth2 implementation using a hardcoded client ID and no client secret. This removes the need for the user to copy and paste an access token (which surprisingly was causing friction), and now uses a simple OAuth2 flow.

Needs https://github.com/home-assistant/core/pull/159056 and https://github.com/home-assistant/core/pull/159048 which have been rebased into this PR so that its functional.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42551
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
