### PR TITLE
Bump python-overseerr to 0.8.0

### DIFF
--- a/homeassistant/components/overseerr/manifest.json
+++ b/homeassistant/components/overseerr/manifest.json
@@ -9,5 +9,5 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["python-overseerr==0.7.1"]
+  "requirements": ["python-overseerr==0.8.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2548,7 +2548,7 @@ python-opensky==1.0.1
 python-otbr-api==2.7.0
 
 # homeassistant.components.overseerr
-python-overseerr==0.7.1
+python-overseerr==0.8.0
 
 # homeassistant.components.picnic
 python-picnic-api2==1.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2132,7 +2132,7 @@ python-opensky==1.0.1
 python-otbr-api==2.7.0
 
 # homeassistant.components.overseerr
-python-overseerr==0.7.1
+python-overseerr==0.8.0
 
 # homeassistant.components.picnic
 python-picnic-api2==1.3.1


### PR DESCRIPTION
## Proposed change

Bump python-overseerr dependency from 0.7.1 to 0.8.0.

This version adds issue management API methods (get_issue_count, get_issues, create_issue, update_issue, delete_issue) that will be used by #158888.

**Library changelog:** https://github.com/joostlek/python-overseerr/compare/v0.7.1...v0.8.0

## Type of change

<!--
What type of change does your PR introduce to Home Assistant?
NOTE: Please, check only 1! box!
If your PR requires multiple boxes to be checked, you'll most likely need to
split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
Details are important, and help maintainers processing your PR.
Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: #158888
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42494

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look
for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works (N/A for dependency bump).

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] (N/A - no user-facing changes in this PR)

If the code communicates with devices, web services, or third-party tools:

- [x] New or updated dependencies have been added to `requirements_all.txt`. Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
Thank you for contributing <3

Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist
[perfect-pr]: https://developers.home-assistant.io/docs/review-process#perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io

## Diff

```diff
--- a/homeassistant/components/overseerr/manifest.json
+++ b/homeassistant/components/overseerr/manifest.json
@@ -9,5 +9,5 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["python-overseerr==0.7.1"]
+  "requirements": ["python-overseerr==0.8.0"]
 }
```