### PR TITLE
Fix Philips TV channel logos not displaying in media browser

### DIFF
--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -253,6 +253,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
                     thumbnail=self.get_browse_image_url(
                         MediaType.CHANNEL,
                         f"{self._tv.channel_list_id}/{channel['ccid']}",
+                        media_image_id=None,
                     ),
                 )
                 for channel in self._tv.channels_current
@@ -296,6 +297,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
                         thumbnail=self.get_browse_image_url(
                             MediaType.CHANNEL,
                             f"{list_id}/{channel['ccid']}",
+                            media_image_id=None,
                         ),
                     )
                     for channel in favorites.get("channels", [])

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -250,6 +250,11 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
                     media_content_type=MediaType.CHANNEL,
                     can_play=True,
                     can_expand=False,
+                    thumbnail=self.get_browse_image_url(
+                        MediaType.CHANNEL,
+                        f"{self._tv.channel_list_id}/{channel['ccid']}",
+                        media_image_id=None,
+                    ),
                 )
                 for channel in self._tv.channels_current
             ]
@@ -289,6 +294,11 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
                         media_content_type=MediaType.CHANNEL,
                         can_play=True,
                         can_expand=False,
+                        thumbnail=self.get_browse_image_url(
+                            MediaType.CHANNEL,
+                            f"{list_id}/{channel['ccid']}",
+                            media_image_id=None,
+                        ),
                     )
                     for channel in favorites.get("channels", [])
                 ]
@@ -412,7 +422,9 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
             if media_content_type == MediaType.APP and media_content_id:
                 return await self._tv.getApplicationIcon(media_content_id)
             if media_content_type == MediaType.CHANNEL and media_content_id:
-                return await self._tv.getChannelLogo(media_content_id)
+                # Estrai solo il channel_id dalla stringa "list_id/ccid"
+                _, _, channel_id = media_content_id.partition("/")
+                return await self._tv.getChannelLogo(channel_id or media_content_id)
         except ConnectionFailure:
             _LOGGER.warning("Failed to fetch image")
         return None, None

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -252,7 +252,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
                     can_expand=False,
                     thumbnail=self.get_browse_image_url(
                         MediaType.CHANNEL,
-                        f"{self._tv.channel_list_id}/{channel['ccid']}",                        
+                        f"{self._tv.channel_list_id}/{channel['ccid']}",
                     ),
                 )
                 for channel in self._tv.channels_current
@@ -295,7 +295,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
                         can_expand=False,
                         thumbnail=self.get_browse_image_url(
                             MediaType.CHANNEL,
-                            f"{list_id}/{channel['ccid']}",                            
+                            f"{list_id}/{channel['ccid']}",
                         ),
                     )
                     for channel in favorites.get("channels", [])

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -253,7 +253,6 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
                     thumbnail=self.get_browse_image_url(
                         MediaType.CHANNEL,
                         f"{self._tv.channel_list_id}/{channel['ccid']}",
-                        media_image_id=None,
                     ),
                 )
                 for channel in self._tv.channels_current
@@ -297,7 +296,6 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
                         thumbnail=self.get_browse_image_url(
                             MediaType.CHANNEL,
                             f"{list_id}/{channel['ccid']}",
-                            media_image_id=None,
                         ),
                     )
                     for channel in favorites.get("channels", [])
@@ -422,8 +420,11 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
             if media_content_type == MediaType.APP and media_content_id:
                 return await self._tv.getApplicationIcon(media_content_id)
             if media_content_type == MediaType.CHANNEL and media_content_id:
-                _, _, channel_id = media_content_id.partition("/")
-                return await self._tv.getChannelLogo(channel_id or media_content_id)
+                list_id, _, channel_id = media_content_id.partition("/")
+                if not channel_id:
+                    channel_id = list_id
+                    list_id = "all"
+                return await self._tv.getChannelLogo(channel_id, list_id)
         except ConnectionFailure:
             _LOGGER.warning("Failed to fetch image")
         return None, None

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -252,8 +252,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
                     can_expand=False,
                     thumbnail=self.get_browse_image_url(
                         MediaType.CHANNEL,
-                        f"{self._tv.channel_list_id}/{channel['ccid']}",
-                        media_image_id=None,
+                        f"{self._tv.channel_list_id}/{channel['ccid']}",                        
                     ),
                 )
                 for channel in self._tv.channels_current
@@ -296,8 +295,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
                         can_expand=False,
                         thumbnail=self.get_browse_image_url(
                             MediaType.CHANNEL,
-                            f"{list_id}/{channel['ccid']}",
-                            media_image_id=None,
+                            f"{list_id}/{channel['ccid']}",                            
                         ),
                     )
                     for channel in favorites.get("channels", [])

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -421,8 +421,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
         try:
             if media_content_type == MediaType.APP and media_content_id:
                 return await self._tv.getApplicationIcon(media_content_id)
-            if media_content_type == MediaType.CHANNEL and media_content_id:
-                # Estrai solo il channel_id dalla stringa "list_id/ccid"
+            if media_content_type == MediaType.CHANNEL and media_content_id:                
                 _, _, channel_id = media_content_id.partition("/")
                 return await self._tv.getChannelLogo(channel_id or media_content_id)
         except ConnectionFailure:

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -421,7 +421,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
         try:
             if media_content_type == MediaType.APP and media_content_id:
                 return await self._tv.getApplicationIcon(media_content_id)
-            if media_content_type == MediaType.CHANNEL and media_content_id:                
+            if media_content_type == MediaType.CHANNEL and media_content_id:
                 _, _, channel_id = media_content_id.partition("/")
                 return await self._tv.getChannelLogo(channel_id or media_content_id)
         except ConnectionFailure:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No breaking change.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix channel logos not displaying in media browser for Philips TV integration.

The `thumbnail` parameter was missing from `BrowseMedia` objects for channels and favorites. Additionally, `async_get_browse_image` was passing the full `media_content_id` in format `list_id/ccid` (e.g., `all/1234`) to `getChannelLogo()`, which expects only the `ccid`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes issue #158966
- This PR is related to issue: #158966
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-hierarchical]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - aass file has been generated by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-hierarchical]: https://github.com/home-assistant/home-assistant.io