### PR TITLE
Add new Mealie meal plan types to calendar and services

### DIFF
--- a/homeassistant/components/mealie/__init__.py
+++ b/homeassistant/components/mealie/__init__.py
@@ -94,7 +94,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: MealieConfigEntry) -> bo
     await statistics_coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = MealieData(
-        client, mealplan_coordinator, shoppinglist_coordinator, statistics_coordinator
+        client,
+        version,
+        mealplan_coordinator,
+        shoppinglist_coordinator,
+        statistics_coordinator,
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/mealie/calendar.py
+++ b/homeassistant/components/mealie/calendar.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from aiomealie import Mealplan, MealplanEntryType
+from awesomeversion import AwesomeVersion
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.core import HomeAssistant
@@ -15,13 +16,6 @@ from .entity import MealieEntity
 
 PARALLEL_UPDATES = 0
 
-SUPPORTED_MEALPLAN_ENTRY_TYPES = [
-    MealplanEntryType.BREAKFAST,
-    MealplanEntryType.DINNER,
-    MealplanEntryType.LUNCH,
-    MealplanEntryType.SIDE,
-]
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -30,10 +24,24 @@ async def async_setup_entry(
 ) -> None:
     """Set up the calendar platform for entity."""
     coordinator = entry.runtime_data.mealplan_coordinator
+    version = entry.runtime_data.version
+
+    supported_mealplan_entry_types: list[MealplanEntryType]
+    if version.valid and version < AwesomeVersion("v3.7.0"):
+        # Prior to Mealie 3.7.0, only these mealplan entry types were supported
+        supported_mealplan_entry_types = [
+            MealplanEntryType.BREAKFAST,
+            MealplanEntryType.DINNER,
+            MealplanEntryType.LUNCH,
+            MealplanEntryType.SIDE,
+        ]
+    else:
+        # For Mealie 3.7.0 and newer and nightlies, add all current mealplan entry types
+        supported_mealplan_entry_types = list(MealplanEntryType)
 
     async_add_entities(
         MealieMealplanCalendarEntity(coordinator, entry_type)
-        for entry_type in SUPPORTED_MEALPLAN_ENTRY_TYPES
+        for entry_type in supported_mealplan_entry_types
     )
 
 

--- a/homeassistant/components/mealie/coordinator.py
+++ b/homeassistant/components/mealie/coordinator.py
@@ -16,6 +16,7 @@ from aiomealie import (
     ShoppingList,
     Statistics,
 )
+from awesomeversion import AwesomeVersion
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -33,6 +34,7 @@ class MealieData:
     """Mealie data type."""
 
     client: MealieClient
+    version: AwesomeVersion
     mealplan_coordinator: MealieMealplanCoordinator
     shoppinglist_coordinator: MealieShoppingListCoordinator
     statistics_coordinator: MealieStatisticsCoordinator

--- a/homeassistant/components/mealie/services.py
+++ b/homeassistant/components/mealie/services.py
@@ -10,6 +10,7 @@ from aiomealie import (
     MealieValidationError,
     MealplanEntryType,
 )
+from awesomeversion import AwesomeVersion
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntryState
@@ -127,6 +128,20 @@ def _async_get_entry(call: ServiceCall) -> MealieConfigEntry:
     return cast(MealieConfigEntry, entry)
 
 
+def _valid_mealplan_type(version: AwesomeVersion, entry_type: str) -> bool:
+    """Validate mealplan entry type."""
+    if version.valid and version < AwesomeVersion("v3.7.0"):
+        # Prior to Mealie 3.7.0, only these mealplan entry types were supported
+        return entry_type in {
+            MealplanEntryType.BREAKFAST.value,
+            MealplanEntryType.DINNER.value,
+            MealplanEntryType.LUNCH.value,
+            MealplanEntryType.SIDE.value,
+        }
+    # For Mealie 3.7.0 and newer and nightlies, all current mealplan entry types are valid
+    return entry_type in list(MealplanEntryType)
+
+
 async def _async_get_mealplan(call: ServiceCall) -> ServiceResponse:
     """Get the mealplan for a specific range."""
     entry = _async_get_entry(call)
@@ -219,6 +234,14 @@ async def _async_set_random_mealplan(call: ServiceCall) -> ServiceResponse:
     mealplan_date = call.data[ATTR_DATE]
     entry_type = MealplanEntryType(call.data[ATTR_ENTRY_TYPE])
     client = entry.runtime_data.client
+
+    if not _valid_mealplan_type(entry.runtime_data.version, entry_type.value):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_mealplan_entry_type",
+            translation_placeholders={"mealplan_type": entry_type.value},
+        )
+
     try:
         mealplan = await client.random_mealplan(mealplan_date, entry_type)
     except MealieConnectionError as err:
@@ -237,6 +260,14 @@ async def _async_set_mealplan(call: ServiceCall) -> ServiceResponse:
     mealplan_date = call.data[ATTR_DATE]
     entry_type = MealplanEntryType(call.data[ATTR_ENTRY_TYPE])
     client = entry.runtime_data.client
+
+    if not _valid_mealplan_type(entry.runtime_data.version, entry_type.value):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_mealplan_entry_type",
+            translation_placeholders={"mealplan_type": entry_type.value},
+        )
+
     try:
         mealplan = await client.set_mealplan(
             mealplan_date,

--- a/homeassistant/components/mealie/services.yaml
+++ b/homeassistant/components/mealie/services.yaml
@@ -78,6 +78,9 @@ set_random_mealplan:
             - lunch
             - dinner
             - side
+            - dessert
+            - snack
+            - drink
           translation_key: mealplan_entry_type
 
 set_mealplan:
@@ -98,6 +101,9 @@ set_mealplan:
             - lunch
             - dinner
             - side
+            - dessert
+            - snack
+            - drink
           translation_key: mealplan_entry_type
     recipe_id:
       selector:

--- a/homeassistant/components/mealie/strings.json
+++ b/homeassistant/components/mealie/strings.json
@@ -135,6 +135,9 @@
     "integration_not_found": {
       "message": "Integration \"{target}\" not found in registry."
     },
+    "invalid_mealplan_entry_type": {
+      "message": "Entry type {mealplan_type} is not valid for this Mealie version."
+    },
     "item_not_found_error": {
       "message": "Item {shopping_list_item} not found."
     },
@@ -170,9 +173,12 @@
     "mealplan_entry_type": {
       "options": {
         "breakfast": "[%key:component::mealie::entity::calendar::breakfast::name%]",
+        "dessert": "[%key:component::mealie::entity::calendar::dessert::name%]",
         "dinner": "[%key:component::mealie::entity::calendar::dinner::name%]",
+        "drink": "[%key:component::mealie::entity::calendar::drink::name%]",
         "lunch": "[%key:component::mealie::entity::calendar::lunch::name%]",
-        "side": "[%key:component::mealie::entity::calendar::side::name%]"
+        "side": "[%key:component::mealie::entity::calendar::side::name%]",
+        "snack": "[%key:component::mealie::entity::calendar::snack::name%]"
       }
     }
   },

--- a/homeassistant/components/mealie/strings.json
+++ b/homeassistant/components/mealie/strings.json
@@ -71,14 +71,23 @@
       "breakfast": {
         "name": "Breakfast"
       },
+      "dessert": {
+        "name": "Dessert"
+      },
       "dinner": {
         "name": "Dinner"
+      },
+      "drink": {
+        "name": "Drink"
       },
       "lunch": {
         "name": "Lunch"
       },
       "side": {
         "name": "Side"
+      },
+      "snack": {
+        "name": "Snack"
       }
     },
     "sensor": {

--- a/tests/components/mealie/fixtures/about.json
+++ b/tests/components/mealie/fixtures/about.json
@@ -1,3 +1,3 @@
 {
-  "version": "v2.0.0"
+  "version": "v3.7.0"
 }

--- a/tests/components/mealie/snapshots/test_calendar.ambr
+++ b/tests/components/mealie/snapshots/test_calendar.ambr
@@ -6,28 +6,28 @@
       'name': 'Mealie Breakfast',
     }),
     dict({
+      'entity_id': 'calendar.mealie_dessert',
+      'name': 'Mealie Dessert',
+    }),
+    dict({
       'entity_id': 'calendar.mealie_dinner',
       'name': 'Mealie Dinner',
+    }),
+    dict({
+      'entity_id': 'calendar.mealie_drink',
+      'name': 'Mealie Drink',
     }),
     dict({
       'entity_id': 'calendar.mealie_lunch',
       'name': 'Mealie Lunch',
     }),
     dict({
-      'entity_id': 'calendar.mealie_none',
-      'name': 'Mealie None',
-    }),
-    dict({
-      'entity_id': 'calendar.mealie_none_2',
-      'name': 'Mealie None',
-    }),
-    dict({
-      'entity_id': 'calendar.mealie_none_3',
-      'name': 'Mealie None',
-    }),
-    dict({
       'entity_id': 'calendar.mealie_side',
       'name': 'Mealie Side',
+    }),
+    dict({
+      'entity_id': 'calendar.mealie_snack',
+      'name': 'Mealie Snack',
     }),
   ])
 # ---
@@ -187,6 +187,60 @@
     'state': 'off',
   })
 # ---
+# name: test_entities[calendar.mealie_dessert-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'calendar',
+    'entity_category': None,
+    'entity_id': 'calendar.mealie_dessert',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Dessert',
+    'platform': 'mealie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dessert',
+    'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_dessert',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[calendar.mealie_dessert-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'all_day': True,
+      'description': 'Delicious Greek turkey meatballs with lemon orzo, tender veggies, and a creamy feta yogurt sauce. These healthy baked Greek turkey meatballs are filled with tons of wonderful herbs and make the perfect protein-packed weeknight meal!',
+      'end_time': '2024-01-24 00:00:00',
+      'friendly_name': 'Mealie Dessert',
+      'location': '',
+      'message': 'Greek Turkey Meatballs with Lemon Orzo & Creamy Feta Yogurt Sauce',
+      'start_time': '2024-01-23 00:00:00',
+    }),
+    'context': <ANY>,
+    'entity_id': 'calendar.mealie_dessert',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_entities[calendar.mealie_dinner-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -235,6 +289,60 @@
     }),
     'context': <ANY>,
     'entity_id': 'calendar.mealie_dinner',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[calendar.mealie_drink-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'calendar',
+    'entity_category': None,
+    'entity_id': 'calendar.mealie_drink',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Drink',
+    'platform': 'mealie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'drink',
+    'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_drink',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[calendar.mealie_drink-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'all_day': True,
+      'description': 'Einfacher Nudelauflauf mit Brokkoli, Sahnesauce und extra Käse. Dieses vegetarische 5 Zutaten Rezept ist super schnell gemacht und SO gut!',
+      'end_time': '2024-01-23 00:00:00',
+      'friendly_name': 'Mealie Drink',
+      'location': '',
+      'message': 'Einfacher Nudelauflauf mit Brokkoli',
+      'start_time': '2024-01-22 00:00:00',
+    }),
+    'context': <ANY>,
+    'entity_id': 'calendar.mealie_drink',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -295,168 +403,6 @@
     'state': 'off',
   })
 # ---
-# name: test_entities[calendar.mealie_none-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'calendar',
-    'entity_category': None,
-    'entity_id': 'calendar.mealie_none',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'mealie',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'snack',
-    'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_snack',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_entities[calendar.mealie_none-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'all_day': True,
-      'description': 'Avis aux nostalgiques des années 1980, la mousse de saumon est de retour dans une présentation adaptée au goût du jour. On utilise une technique sans faille : un saumon frais cuit au micro-ondes et mélangé au robot avec du fromage à la crème et de la crème sure. On obtient ainsi une texture onctueuse à tartiner, qui n’a rien à envier aux préparations gélatineuses d’antan !',
-      'end_time': '2024-01-23 00:00:00',
-      'friendly_name': 'Mealie None',
-      'location': '',
-      'message': 'Mousse de saumon',
-      'start_time': '2024-01-22 00:00:00',
-    }),
-    'context': <ANY>,
-    'entity_id': 'calendar.mealie_none',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_entities[calendar.mealie_none_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'calendar',
-    'entity_category': None,
-    'entity_id': 'calendar.mealie_none_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'mealie',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'drink',
-    'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_drink',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_entities[calendar.mealie_none_2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'all_day': True,
-      'description': 'Einfacher Nudelauflauf mit Brokkoli, Sahnesauce und extra Käse. Dieses vegetarische 5 Zutaten Rezept ist super schnell gemacht und SO gut!',
-      'end_time': '2024-01-23 00:00:00',
-      'friendly_name': 'Mealie None',
-      'location': '',
-      'message': 'Einfacher Nudelauflauf mit Brokkoli',
-      'start_time': '2024-01-22 00:00:00',
-    }),
-    'context': <ANY>,
-    'entity_id': 'calendar.mealie_none_2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_entities[calendar.mealie_none_3-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'calendar',
-    'entity_category': None,
-    'entity_id': 'calendar.mealie_none_3',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'mealie',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'dessert',
-    'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_dessert',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_entities[calendar.mealie_none_3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'all_day': True,
-      'description': 'Delicious Greek turkey meatballs with lemon orzo, tender veggies, and a creamy feta yogurt sauce. These healthy baked Greek turkey meatballs are filled with tons of wonderful herbs and make the perfect protein-packed weeknight meal!',
-      'end_time': '2024-01-24 00:00:00',
-      'friendly_name': 'Mealie None',
-      'location': '',
-      'message': 'Greek Turkey Meatballs with Lemon Orzo & Creamy Feta Yogurt Sauce',
-      'start_time': '2024-01-23 00:00:00',
-    }),
-    'context': <ANY>,
-    'entity_id': 'calendar.mealie_none_3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_entities[calendar.mealie_side-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -505,6 +451,60 @@
     }),
     'context': <ANY>,
     'entity_id': 'calendar.mealie_side',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[calendar.mealie_snack-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'calendar',
+    'entity_category': None,
+    'entity_id': 'calendar.mealie_snack',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Snack',
+    'platform': 'mealie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'snack',
+    'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_snack',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[calendar.mealie_snack-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'all_day': True,
+      'description': 'Avis aux nostalgiques des années 1980, la mousse de saumon est de retour dans une présentation adaptée au goût du jour. On utilise une technique sans faille : un saumon frais cuit au micro-ondes et mélangé au robot avec du fromage à la crème et de la crème sure. On obtient ainsi une texture onctueuse à tartiner, qui n’a rien à envier aux préparations gélatineuses d’antan !',
+      'end_time': '2024-01-23 00:00:00',
+      'friendly_name': 'Mealie Snack',
+      'location': '',
+      'message': 'Mousse de saumon',
+      'start_time': '2024-01-22 00:00:00',
+    }),
+    'context': <ANY>,
+    'entity_id': 'calendar.mealie_snack',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/mealie/snapshots/test_calendar.ambr
+++ b/tests/components/mealie/snapshots/test_calendar.ambr
@@ -14,6 +14,18 @@
       'name': 'Mealie Lunch',
     }),
     dict({
+      'entity_id': 'calendar.mealie_none',
+      'name': 'Mealie None',
+    }),
+    dict({
+      'entity_id': 'calendar.mealie_none_2',
+      'name': 'Mealie None',
+    }),
+    dict({
+      'entity_id': 'calendar.mealie_none_3',
+      'name': 'Mealie None',
+    }),
+    dict({
       'entity_id': 'calendar.mealie_side',
       'name': 'Mealie Side',
     }),
@@ -277,6 +289,168 @@
     }),
     'context': <ANY>,
     'entity_id': 'calendar.mealie_lunch',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[calendar.mealie_none-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'calendar',
+    'entity_category': None,
+    'entity_id': 'calendar.mealie_none',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'mealie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'snack',
+    'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_snack',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[calendar.mealie_none-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'all_day': True,
+      'description': 'Avis aux nostalgiques des années 1980, la mousse de saumon est de retour dans une présentation adaptée au goût du jour. On utilise une technique sans faille : un saumon frais cuit au micro-ondes et mélangé au robot avec du fromage à la crème et de la crème sure. On obtient ainsi une texture onctueuse à tartiner, qui n’a rien à envier aux préparations gélatineuses d’antan !',
+      'end_time': '2024-01-23 00:00:00',
+      'friendly_name': 'Mealie None',
+      'location': '',
+      'message': 'Mousse de saumon',
+      'start_time': '2024-01-22 00:00:00',
+    }),
+    'context': <ANY>,
+    'entity_id': 'calendar.mealie_none',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[calendar.mealie_none_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'calendar',
+    'entity_category': None,
+    'entity_id': 'calendar.mealie_none_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'mealie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'drink',
+    'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_drink',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[calendar.mealie_none_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'all_day': True,
+      'description': 'Einfacher Nudelauflauf mit Brokkoli, Sahnesauce und extra Käse. Dieses vegetarische 5 Zutaten Rezept ist super schnell gemacht und SO gut!',
+      'end_time': '2024-01-23 00:00:00',
+      'friendly_name': 'Mealie None',
+      'location': '',
+      'message': 'Einfacher Nudelauflauf mit Brokkoli',
+      'start_time': '2024-01-22 00:00:00',
+    }),
+    'context': <ANY>,
+    'entity_id': 'calendar.mealie_none_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[calendar.mealie_none_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'calendar',
+    'entity_category': None,
+    'entity_id': 'calendar.mealie_none_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'mealie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dessert',
+    'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_dessert',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[calendar.mealie_none_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'all_day': True,
+      'description': 'Delicious Greek turkey meatballs with lemon orzo, tender veggies, and a creamy feta yogurt sauce. These healthy baked Greek turkey meatballs are filled with tons of wonderful herbs and make the perfect protein-packed weeknight meal!',
+      'end_time': '2024-01-24 00:00:00',
+      'friendly_name': 'Mealie None',
+      'location': '',
+      'message': 'Greek Turkey Meatballs with Lemon Orzo & Creamy Feta Yogurt Sauce',
+      'start_time': '2024-01-23 00:00:00',
+    }),
+    'context': <ANY>,
+    'entity_id': 'calendar.mealie_none_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/mealie/snapshots/test_diagnostics.ambr
+++ b/tests/components/mealie/snapshots/test_diagnostics.ambr
@@ -2,7 +2,7 @@
 # name: test_entry_diagnostics
   dict({
     'about': dict({
-      'version': 'v2.0.0',
+      'version': 'v3.7.0',
     }),
     'mealplans': dict({
       'breakfast': list([

--- a/tests/components/mealie/snapshots/test_init.ambr
+++ b/tests/components/mealie/snapshots/test_init.ambr
@@ -26,7 +26,7 @@
     'name_by_user': None,
     'primary_config_entry': <ANY>,
     'serial_number': None,
-    'sw_version': 'v2.0.0',
+    'sw_version': 'v3.7.0',
     'via_device_id': None,
   })
 # ---

--- a/tests/components/mealie/snapshots/test_services.ambr
+++ b/tests/components/mealie/snapshots/test_services.ambr
@@ -2408,7 +2408,7 @@
     }),
   })
 # ---
-# name: test_service_set_mealplan[v3.6.0-lunch-payload4-kwargs4-False]
+# name: test_service_set_mealplan[payload0-kwargs0]
   dict({
     'mealplan': dict({
       'description': None,
@@ -2438,7 +2438,7 @@
     }),
   })
 # ---
-# name: test_service_set_mealplan[v3.7.0-dessert-payload1-kwargs1-False]
+# name: test_service_set_mealplan[payload1-kwargs1]
   dict({
     'mealplan': dict({
       'description': None,
@@ -2468,7 +2468,7 @@
     }),
   })
 # ---
-# name: test_service_set_mealplan[v3.7.0-lunch-payload0-kwargs0-False]
+# name: test_service_set_mealplan[payload2-kwargs2]
   dict({
     'mealplan': dict({
       'description': None,
@@ -2498,127 +2498,7 @@
     }),
   })
 # ---
-# name: test_service_set_mealplan[v3.7.0-lunch-payload2-kwargs2-False]
-  dict({
-    'mealplan': dict({
-      'description': None,
-      'entry_type': <MealplanEntryType.DINNER: 'dinner'>,
-      'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
-      'household_id': None,
-      'mealplan_date': datetime.date(2024, 1, 22),
-      'mealplan_id': 230,
-      'recipe': dict({
-        'description': "Een traybake is eigenlijk altijd een goed idee. Deze zoete aardappel curry traybake dus ook. Waarom? Omdat je alleen maar wat groenten - en in dit geval kip - op een bakplaat (traybake dus) legt, hier wat kruiden aan toevoegt en deze in de oven schuift. Ideaal dus als je geen zin hebt om lang in de keuken te staan. Maar gewoon lekker op de bank wil ploffen om te wachten tot de oven klaar is. Joe! That\\'s what we like. Deze zoete aardappel curry traybake bevat behalve zoete aardappel en curry ook kikkererwten, kippendijfilet en bloemkoolroosjes. Je gebruikt yoghurt en limoen als een soort dressing. En je serveert deze heerlijke traybake met naanbrood. Je kunt natuurljk ook voor deze traybake met chipolataworstjes gaan. Wil je graag meer ovengerechten? Dan moet je eigenlijk even kijken naar onze Ovenbijbel. Onmisbaar in je keuken! We willen je deze zoete aardappelstamppot met prei ook niet onthouden. Megalekker bordje comfortfood als je \\'t ons vraagt.",
-        'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
-        'household_id': None,
-        'image': 'AiIo',
-        'name': 'Zoete aardappel curry traybake',
-        'original_url': 'https://chickslovefood.com/recept/zoete-aardappel-curry-traybake/',
-        'perform_time': None,
-        'prep_time': None,
-        'rating': None,
-        'recipe_id': 'c5f00a93-71a2-4e48-900f-d9ad0bb9de93',
-        'recipe_yield': '2 servings',
-        'slug': 'zoete-aardappel-curry-traybake',
-        'total_time': '40 Minutes',
-        'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
-      }),
-      'title': None,
-      'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
-    }),
-  })
-# ---
-# name: test_service_set_mealplan[v3.7.0-lunch-payload3-kwargs3-False]
-  dict({
-    'mealplan': dict({
-      'description': None,
-      'entry_type': <MealplanEntryType.DINNER: 'dinner'>,
-      'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
-      'household_id': None,
-      'mealplan_date': datetime.date(2024, 1, 22),
-      'mealplan_id': 230,
-      'recipe': dict({
-        'description': "Een traybake is eigenlijk altijd een goed idee. Deze zoete aardappel curry traybake dus ook. Waarom? Omdat je alleen maar wat groenten - en in dit geval kip - op een bakplaat (traybake dus) legt, hier wat kruiden aan toevoegt en deze in de oven schuift. Ideaal dus als je geen zin hebt om lang in de keuken te staan. Maar gewoon lekker op de bank wil ploffen om te wachten tot de oven klaar is. Joe! That\\'s what we like. Deze zoete aardappel curry traybake bevat behalve zoete aardappel en curry ook kikkererwten, kippendijfilet en bloemkoolroosjes. Je gebruikt yoghurt en limoen als een soort dressing. En je serveert deze heerlijke traybake met naanbrood. Je kunt natuurljk ook voor deze traybake met chipolataworstjes gaan. Wil je graag meer ovengerechten? Dan moet je eigenlijk even kijken naar onze Ovenbijbel. Onmisbaar in je keuken! We willen je deze zoete aardappelstamppot met prei ook niet onthouden. Megalekker bordje comfortfood als je \\'t ons vraagt.",
-        'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
-        'household_id': None,
-        'image': 'AiIo',
-        'name': 'Zoete aardappel curry traybake',
-        'original_url': 'https://chickslovefood.com/recept/zoete-aardappel-curry-traybake/',
-        'perform_time': None,
-        'prep_time': None,
-        'rating': None,
-        'recipe_id': 'c5f00a93-71a2-4e48-900f-d9ad0bb9de93',
-        'recipe_yield': '2 servings',
-        'slug': 'zoete-aardappel-curry-traybake',
-        'total_time': '40 Minutes',
-        'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
-      }),
-      'title': None,
-      'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
-    }),
-  })
-# ---
-# name: test_service_set_random_mealplan[v3.6.0-lunch-False]
-  dict({
-    'mealplan': dict({
-      'description': None,
-      'entry_type': <MealplanEntryType.DINNER: 'dinner'>,
-      'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
-      'household_id': None,
-      'mealplan_date': datetime.date(2024, 1, 22),
-      'mealplan_id': 230,
-      'recipe': dict({
-        'description': "Een traybake is eigenlijk altijd een goed idee. Deze zoete aardappel curry traybake dus ook. Waarom? Omdat je alleen maar wat groenten - en in dit geval kip - op een bakplaat (traybake dus) legt, hier wat kruiden aan toevoegt en deze in de oven schuift. Ideaal dus als je geen zin hebt om lang in de keuken te staan. Maar gewoon lekker op de bank wil ploffen om te wachten tot de oven klaar is. Joe! That\\'s what we like. Deze zoete aardappel curry traybake bevat behalve zoete aardappel en curry ook kikkererwten, kippendijfilet en bloemkoolroosjes. Je gebruikt yoghurt en limoen als een soort dressing. En je serveert deze heerlijke traybake met naanbrood. Je kunt natuurljk ook voor deze traybake met chipolataworstjes gaan. Wil je graag meer ovengerechten? Dan moet je eigenlijk even kijken naar onze Ovenbijbel. Onmisbaar in je keuken! We willen je deze zoete aardappelstamppot met prei ook niet onthouden. Megalekker bordje comfortfood als je \\'t ons vraagt.",
-        'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
-        'household_id': None,
-        'image': 'AiIo',
-        'name': 'Zoete aardappel curry traybake',
-        'original_url': 'https://chickslovefood.com/recept/zoete-aardappel-curry-traybake/',
-        'perform_time': None,
-        'prep_time': None,
-        'rating': None,
-        'recipe_id': 'c5f00a93-71a2-4e48-900f-d9ad0bb9de93',
-        'recipe_yield': '2 servings',
-        'slug': 'zoete-aardappel-curry-traybake',
-        'total_time': '40 Minutes',
-        'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
-      }),
-      'title': None,
-      'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
-    }),
-  })
-# ---
-# name: test_service_set_random_mealplan[v3.7.0-dessert-False]
-  dict({
-    'mealplan': dict({
-      'description': None,
-      'entry_type': <MealplanEntryType.DINNER: 'dinner'>,
-      'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
-      'household_id': None,
-      'mealplan_date': datetime.date(2024, 1, 22),
-      'mealplan_id': 230,
-      'recipe': dict({
-        'description': "Een traybake is eigenlijk altijd een goed idee. Deze zoete aardappel curry traybake dus ook. Waarom? Omdat je alleen maar wat groenten - en in dit geval kip - op een bakplaat (traybake dus) legt, hier wat kruiden aan toevoegt en deze in de oven schuift. Ideaal dus als je geen zin hebt om lang in de keuken te staan. Maar gewoon lekker op de bank wil ploffen om te wachten tot de oven klaar is. Joe! That\\'s what we like. Deze zoete aardappel curry traybake bevat behalve zoete aardappel en curry ook kikkererwten, kippendijfilet en bloemkoolroosjes. Je gebruikt yoghurt en limoen als een soort dressing. En je serveert deze heerlijke traybake met naanbrood. Je kunt natuurljk ook voor deze traybake met chipolataworstjes gaan. Wil je graag meer ovengerechten? Dan moet je eigenlijk even kijken naar onze Ovenbijbel. Onmisbaar in je keuken! We willen je deze zoete aardappelstamppot met prei ook niet onthouden. Megalekker bordje comfortfood als je \\'t ons vraagt.",
-        'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
-        'household_id': None,
-        'image': 'AiIo',
-        'name': 'Zoete aardappel curry traybake',
-        'original_url': 'https://chickslovefood.com/recept/zoete-aardappel-curry-traybake/',
-        'perform_time': None,
-        'prep_time': None,
-        'rating': None,
-        'recipe_id': 'c5f00a93-71a2-4e48-900f-d9ad0bb9de93',
-        'recipe_yield': '2 servings',
-        'slug': 'zoete-aardappel-curry-traybake',
-        'total_time': '40 Minutes',
-        'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
-      }),
-      'title': None,
-      'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
-    }),
-  })
-# ---
-# name: test_service_set_random_mealplan[v3.7.0-lunch-False]
+# name: test_service_set_random_mealplan
   dict({
     'mealplan': dict({
       'description': None,

--- a/tests/components/mealie/snapshots/test_services.ambr
+++ b/tests/components/mealie/snapshots/test_services.ambr
@@ -2408,7 +2408,7 @@
     }),
   })
 # ---
-# name: test_service_set_mealplan[payload0-kwargs0]
+# name: test_service_set_mealplan[v3.6.0-lunch-payload4-kwargs4-False]
   dict({
     'mealplan': dict({
       'description': None,
@@ -2438,7 +2438,7 @@
     }),
   })
 # ---
-# name: test_service_set_mealplan[payload1-kwargs1]
+# name: test_service_set_mealplan[v3.7.0-dessert-payload1-kwargs1-False]
   dict({
     'mealplan': dict({
       'description': None,
@@ -2468,7 +2468,7 @@
     }),
   })
 # ---
-# name: test_service_set_mealplan[payload2-kwargs2]
+# name: test_service_set_mealplan[v3.7.0-lunch-payload0-kwargs0-False]
   dict({
     'mealplan': dict({
       'description': None,
@@ -2498,7 +2498,127 @@
     }),
   })
 # ---
-# name: test_service_set_random_mealplan
+# name: test_service_set_mealplan[v3.7.0-lunch-payload2-kwargs2-False]
+  dict({
+    'mealplan': dict({
+      'description': None,
+      'entry_type': <MealplanEntryType.DINNER: 'dinner'>,
+      'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
+      'household_id': None,
+      'mealplan_date': datetime.date(2024, 1, 22),
+      'mealplan_id': 230,
+      'recipe': dict({
+        'description': "Een traybake is eigenlijk altijd een goed idee. Deze zoete aardappel curry traybake dus ook. Waarom? Omdat je alleen maar wat groenten - en in dit geval kip - op een bakplaat (traybake dus) legt, hier wat kruiden aan toevoegt en deze in de oven schuift. Ideaal dus als je geen zin hebt om lang in de keuken te staan. Maar gewoon lekker op de bank wil ploffen om te wachten tot de oven klaar is. Joe! That\\'s what we like. Deze zoete aardappel curry traybake bevat behalve zoete aardappel en curry ook kikkererwten, kippendijfilet en bloemkoolroosjes. Je gebruikt yoghurt en limoen als een soort dressing. En je serveert deze heerlijke traybake met naanbrood. Je kunt natuurljk ook voor deze traybake met chipolataworstjes gaan. Wil je graag meer ovengerechten? Dan moet je eigenlijk even kijken naar onze Ovenbijbel. Onmisbaar in je keuken! We willen je deze zoete aardappelstamppot met prei ook niet onthouden. Megalekker bordje comfortfood als je \\'t ons vraagt.",
+        'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
+        'household_id': None,
+        'image': 'AiIo',
+        'name': 'Zoete aardappel curry traybake',
+        'original_url': 'https://chickslovefood.com/recept/zoete-aardappel-curry-traybake/',
+        'perform_time': None,
+        'prep_time': None,
+        'rating': None,
+        'recipe_id': 'c5f00a93-71a2-4e48-900f-d9ad0bb9de93',
+        'recipe_yield': '2 servings',
+        'slug': 'zoete-aardappel-curry-traybake',
+        'total_time': '40 Minutes',
+        'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
+      }),
+      'title': None,
+      'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
+    }),
+  })
+# ---
+# name: test_service_set_mealplan[v3.7.0-lunch-payload3-kwargs3-False]
+  dict({
+    'mealplan': dict({
+      'description': None,
+      'entry_type': <MealplanEntryType.DINNER: 'dinner'>,
+      'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
+      'household_id': None,
+      'mealplan_date': datetime.date(2024, 1, 22),
+      'mealplan_id': 230,
+      'recipe': dict({
+        'description': "Een traybake is eigenlijk altijd een goed idee. Deze zoete aardappel curry traybake dus ook. Waarom? Omdat je alleen maar wat groenten - en in dit geval kip - op een bakplaat (traybake dus) legt, hier wat kruiden aan toevoegt en deze in de oven schuift. Ideaal dus als je geen zin hebt om lang in de keuken te staan. Maar gewoon lekker op de bank wil ploffen om te wachten tot de oven klaar is. Joe! That\\'s what we like. Deze zoete aardappel curry traybake bevat behalve zoete aardappel en curry ook kikkererwten, kippendijfilet en bloemkoolroosjes. Je gebruikt yoghurt en limoen als een soort dressing. En je serveert deze heerlijke traybake met naanbrood. Je kunt natuurljk ook voor deze traybake met chipolataworstjes gaan. Wil je graag meer ovengerechten? Dan moet je eigenlijk even kijken naar onze Ovenbijbel. Onmisbaar in je keuken! We willen je deze zoete aardappelstamppot met prei ook niet onthouden. Megalekker bordje comfortfood als je \\'t ons vraagt.",
+        'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
+        'household_id': None,
+        'image': 'AiIo',
+        'name': 'Zoete aardappel curry traybake',
+        'original_url': 'https://chickslovefood.com/recept/zoete-aardappel-curry-traybake/',
+        'perform_time': None,
+        'prep_time': None,
+        'rating': None,
+        'recipe_id': 'c5f00a93-71a2-4e48-900f-d9ad0bb9de93',
+        'recipe_yield': '2 servings',
+        'slug': 'zoete-aardappel-curry-traybake',
+        'total_time': '40 Minutes',
+        'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
+      }),
+      'title': None,
+      'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
+    }),
+  })
+# ---
+# name: test_service_set_random_mealplan[v3.6.0-lunch-False]
+  dict({
+    'mealplan': dict({
+      'description': None,
+      'entry_type': <MealplanEntryType.DINNER: 'dinner'>,
+      'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
+      'household_id': None,
+      'mealplan_date': datetime.date(2024, 1, 22),
+      'mealplan_id': 230,
+      'recipe': dict({
+        'description': "Een traybake is eigenlijk altijd een goed idee. Deze zoete aardappel curry traybake dus ook. Waarom? Omdat je alleen maar wat groenten - en in dit geval kip - op een bakplaat (traybake dus) legt, hier wat kruiden aan toevoegt en deze in de oven schuift. Ideaal dus als je geen zin hebt om lang in de keuken te staan. Maar gewoon lekker op de bank wil ploffen om te wachten tot de oven klaar is. Joe! That\\'s what we like. Deze zoete aardappel curry traybake bevat behalve zoete aardappel en curry ook kikkererwten, kippendijfilet en bloemkoolroosjes. Je gebruikt yoghurt en limoen als een soort dressing. En je serveert deze heerlijke traybake met naanbrood. Je kunt natuurljk ook voor deze traybake met chipolataworstjes gaan. Wil je graag meer ovengerechten? Dan moet je eigenlijk even kijken naar onze Ovenbijbel. Onmisbaar in je keuken! We willen je deze zoete aardappelstamppot met prei ook niet onthouden. Megalekker bordje comfortfood als je \\'t ons vraagt.",
+        'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
+        'household_id': None,
+        'image': 'AiIo',
+        'name': 'Zoete aardappel curry traybake',
+        'original_url': 'https://chickslovefood.com/recept/zoete-aardappel-curry-traybake/',
+        'perform_time': None,
+        'prep_time': None,
+        'rating': None,
+        'recipe_id': 'c5f00a93-71a2-4e48-900f-d9ad0bb9de93',
+        'recipe_yield': '2 servings',
+        'slug': 'zoete-aardappel-curry-traybake',
+        'total_time': '40 Minutes',
+        'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
+      }),
+      'title': None,
+      'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
+    }),
+  })
+# ---
+# name: test_service_set_random_mealplan[v3.7.0-dessert-False]
+  dict({
+    'mealplan': dict({
+      'description': None,
+      'entry_type': <MealplanEntryType.DINNER: 'dinner'>,
+      'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
+      'household_id': None,
+      'mealplan_date': datetime.date(2024, 1, 22),
+      'mealplan_id': 230,
+      'recipe': dict({
+        'description': "Een traybake is eigenlijk altijd een goed idee. Deze zoete aardappel curry traybake dus ook. Waarom? Omdat je alleen maar wat groenten - en in dit geval kip - op een bakplaat (traybake dus) legt, hier wat kruiden aan toevoegt en deze in de oven schuift. Ideaal dus als je geen zin hebt om lang in de keuken te staan. Maar gewoon lekker op de bank wil ploffen om te wachten tot de oven klaar is. Joe! That\\'s what we like. Deze zoete aardappel curry traybake bevat behalve zoete aardappel en curry ook kikkererwten, kippendijfilet en bloemkoolroosjes. Je gebruikt yoghurt en limoen als een soort dressing. En je serveert deze heerlijke traybake met naanbrood. Je kunt natuurljk ook voor deze traybake met chipolataworstjes gaan. Wil je graag meer ovengerechten? Dan moet je eigenlijk even kijken naar onze Ovenbijbel. Onmisbaar in je keuken! We willen je deze zoete aardappelstamppot met prei ook niet onthouden. Megalekker bordje comfortfood als je \\'t ons vraagt.",
+        'group_id': '0bf60b2e-ca89-42a9-94d4-8f67ca72b157',
+        'household_id': None,
+        'image': 'AiIo',
+        'name': 'Zoete aardappel curry traybake',
+        'original_url': 'https://chickslovefood.com/recept/zoete-aardappel-curry-traybake/',
+        'perform_time': None,
+        'prep_time': None,
+        'rating': None,
+        'recipe_id': 'c5f00a93-71a2-4e48-900f-d9ad0bb9de93',
+        'recipe_yield': '2 servings',
+        'slug': 'zoete-aardappel-curry-traybake',
+        'total_time': '40 Minutes',
+        'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
+      }),
+      'title': None,
+      'user_id': '1ce8b5fe-04e8-4b80-aab1-d92c94685c6d',
+    }),
+  })
+# ---
+# name: test_service_set_random_mealplan[v3.7.0-lunch-False]
   dict({
     'mealplan': dict({
       'description': None,

--- a/tests/components/mealie/test_calendar.py
+++ b/tests/components/mealie/test_calendar.py
@@ -4,7 +4,7 @@ from datetime import date
 from http import HTTPStatus
 from unittest.mock import AsyncMock, patch
 
-from aiomealie import MealplanResponse
+from aiomealie import About, MealplanResponse
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import STATE_OFF, Platform
@@ -85,3 +85,25 @@ async def test_api_events(
     assert response.status == HTTPStatus.OK
     events = await response.json()
     assert events == snapshot
+
+
+async def test_legacy_calendars(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that only legacy calendars are created for Mealie versions prior to 3.7.0."""
+
+    mock_mealie_client.get_about.return_value = About(version="v3.6.0")
+
+    with patch("homeassistant.components.mealie.PLATFORMS", [Platform.CALENDAR]):
+        await setup_integration(hass, mock_config_entry)
+
+    assert entity_registry.async_get("calendar.mealie_dessert") is None
+    assert entity_registry.async_get("calendar.mealie_drink") is None
+    assert entity_registry.async_get("calendar.mealie_snack") is None
+    assert entity_registry.async_get("calendar.mealie_breakfast") is not None
+    assert entity_registry.async_get("calendar.mealie_lunch") is not None
+    assert entity_registry.async_get("calendar.mealie_dinner") is not None
+    assert entity_registry.async_get("calendar.mealie_side") is not None

--- a/tests/components/mealie/test_services.py
+++ b/tests/components/mealie/test_services.py
@@ -4,6 +4,7 @@ from datetime import date
 from unittest.mock import AsyncMock
 
 from aiomealie import (
+    About,
     MealieConnectionError,
     MealieNotFoundError,
     MealieValidationError,
@@ -229,70 +230,124 @@ async def test_service_import_recipe(
     )
 
 
+@pytest.mark.parametrize(
+    ("version", "entry_type", "should_fail"),
+    [
+        ("v3.7.0", "lunch", False),  # Valid: legacy type on new version
+        ("v3.7.0", "dessert", False),  # Valid: new type on new version
+        ("v3.6.0", "lunch", False),  # Valid: legacy type on old version
+        ("v3.6.0", "dessert", True),  # Invalid: new type on old version
+    ],
+)
 async def test_service_set_random_mealplan(
     hass: HomeAssistant,
     mock_mealie_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
+    version: str,
+    entry_type: str,
+    should_fail: bool,
 ) -> None:
-    """Test the set_random_mealplan service."""
+    """Test the set_random_mealplan service with version validation."""
+    mock_mealie_client.get_about.return_value = About(version=version)
 
     await setup_integration(hass, mock_config_entry)
 
-    response = await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_RANDOM_MEALPLAN,
-        {
-            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
-            ATTR_DATE: "2023-10-21",
-            ATTR_ENTRY_TYPE: "lunch",
-        },
-        blocking=True,
-        return_response=True,
-    )
-    assert response == snapshot
-    mock_mealie_client.random_mealplan.assert_called_with(
-        date(2023, 10, 21), MealplanEntryType.LUNCH
-    )
+    if should_fail:
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_SET_RANDOM_MEALPLAN,
+                {
+                    ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+                    ATTR_DATE: "2023-10-21",
+                    ATTR_ENTRY_TYPE: entry_type,
+                },
+                blocking=True,
+                return_response=True,
+            )
+        mock_mealie_client.random_mealplan.assert_not_called()
+    else:
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_RANDOM_MEALPLAN,
+            {
+                ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+                ATTR_DATE: "2023-10-21",
+                ATTR_ENTRY_TYPE: entry_type,
+            },
+            blocking=True,
+            return_response=True,
+        )
+        assert response == snapshot
+        mock_mealie_client.random_mealplan.assert_called_with(
+            date(2023, 10, 21), MealplanEntryType[entry_type.upper()]
+        )
 
-    mock_mealie_client.random_mealplan.reset_mock()
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_RANDOM_MEALPLAN,
-        {
-            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
-            ATTR_DATE: "2023-10-21",
-            ATTR_ENTRY_TYPE: "lunch",
-        },
-        blocking=True,
-        return_response=False,
-    )
-    mock_mealie_client.random_mealplan.assert_called_with(
-        date(2023, 10, 21), MealplanEntryType.LUNCH
-    )
+        mock_mealie_client.random_mealplan.reset_mock()
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_RANDOM_MEALPLAN,
+            {
+                ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+                ATTR_DATE: "2023-10-21",
+                ATTR_ENTRY_TYPE: entry_type,
+            },
+            blocking=True,
+            return_response=False,
+        )
+        mock_mealie_client.random_mealplan.assert_called_with(
+            date(2023, 10, 21), MealplanEntryType[entry_type.upper()]
+        )
 
 
 @pytest.mark.parametrize(
-    ("payload", "kwargs"),
+    ("version", "entry_type", "payload", "kwargs", "should_fail"),
     [
+        # Valid cases on new version
         (
-            {
-                ATTR_RECIPE_ID: "recipe_id",
-            },
+            "v3.7.0",
+            "lunch",
+            {ATTR_RECIPE_ID: "recipe_id"},
             {"recipe_id": "recipe_id", "note_title": None, "note_text": None},
+            False,
         ),
         (
-            {
-                ATTR_NOTE_TITLE: "Note Title",
-                ATTR_NOTE_TEXT: "Note Text",
-            },
+            "v3.7.0",
+            "dessert",
+            {ATTR_RECIPE_ID: "recipe_id"},
+            {"recipe_id": "recipe_id", "note_title": None, "note_text": None},
+            False,
+        ),
+        (
+            "v3.7.0",
+            "lunch",
+            {ATTR_NOTE_TITLE: "Note Title", ATTR_NOTE_TEXT: "Note Text"},
             {"recipe_id": None, "note_title": "Note Title", "note_text": "Note Text"},
+            False,
         ),
         (
-            {
-                ATTR_NOTE_TITLE: "Note Title",
-            },
+            "v3.7.0",
+            "lunch",
+            {ATTR_NOTE_TITLE: "Note Title"},
             {"recipe_id": None, "note_title": "Note Title", "note_text": None},
+            False,
+        ),
+        # Valid cases on old version (legacy types)
+        (
+            "v3.6.0",
+            "lunch",
+            {ATTR_RECIPE_ID: "recipe_id"},
+            {"recipe_id": "recipe_id", "note_title": None, "note_text": None},
+            False,
+        ),
+        # Invalid cases on old version (new types)
+        (
+            "v3.6.0",
+            "dessert",
+            {ATTR_RECIPE_ID: "recipe_id"},
+            {"recipe_id": "recipe_id", "note_title": None, "note_text": None},
+            True,
         ),
     ],
 )
@@ -301,46 +356,67 @@ async def test_service_set_mealplan(
     mock_mealie_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
+    version: str,
+    entry_type: str,
     payload: dict[str, str],
     kwargs: dict[str, str],
+    should_fail: bool,
 ) -> None:
-    """Test the set_mealplan service."""
+    """Test the set_mealplan service with version validation."""
+    mock_mealie_client.get_about.return_value = About(version=version)
 
     await setup_integration(hass, mock_config_entry)
 
-    response = await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_MEALPLAN,
-        {
-            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
-            ATTR_DATE: "2023-10-21",
-            ATTR_ENTRY_TYPE: "lunch",
-        }
-        | payload,
-        blocking=True,
-        return_response=True,
-    )
-    assert response == snapshot
-    mock_mealie_client.set_mealplan.assert_called_with(
-        date(2023, 10, 21), MealplanEntryType.LUNCH, **kwargs
-    )
+    if should_fail:
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_SET_MEALPLAN,
+                {
+                    ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+                    ATTR_DATE: "2023-10-21",
+                    ATTR_ENTRY_TYPE: entry_type,
+                }
+                | payload,
+                blocking=True,
+                return_response=True,
+            )
+        mock_mealie_client.set_mealplan.assert_not_called()
+    else:
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_MEALPLAN,
+            {
+                ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+                ATTR_DATE: "2023-10-21",
+                ATTR_ENTRY_TYPE: entry_type,
+            }
+            | payload,
+            blocking=True,
+            return_response=True,
+        )
+        assert response == snapshot
+        mock_mealie_client.set_mealplan.assert_called_with(
+            date(2023, 10, 21), MealplanEntryType[entry_type.upper()], **kwargs
+        )
 
-    mock_mealie_client.random_mealplan.reset_mock()
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_MEALPLAN,
-        {
-            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
-            ATTR_DATE: "2023-10-21",
-            ATTR_ENTRY_TYPE: "lunch",
-        }
-        | payload,
-        blocking=True,
-        return_response=False,
-    )
-    mock_mealie_client.set_mealplan.assert_called_with(
-        date(2023, 10, 21), MealplanEntryType.LUNCH, **kwargs
-    )
+        # Test call without return_response
+        mock_mealie_client.set_mealplan.reset_mock()
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_MEALPLAN,
+            {
+                ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+                ATTR_DATE: "2023-10-21",
+                ATTR_ENTRY_TYPE: entry_type,
+            }
+            | payload,
+            blocking=True,
+            return_response=False,
+        )
+        mock_mealie_client.set_mealplan.assert_called_with(
+            date(2023, 10, 21), MealplanEntryType[entry_type.upper()], **kwargs
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mealie 3.7 introduced new meal plan types.  This PR adds support for these with backward compatibility with older versions.

Calendar - checks the Mealie version and only creates calendar entities supported by the version.

Services - Adds the meal plan types to the two services that add meals, with a version check and a service validation error being raised if trying to use the new meal plan types with older versions.

Mealie has nightly versions, which are un-versioned, we already have a warning that nightly is not supported and assume that they are running the latest version if this is the case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42562
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
