### PR TITLE
Assign unique IDs to IoTaWatt output sensors

### DIFF
--- a/homeassistant/components/iotawatt/sensor.py
+++ b/homeassistant/components/iotawatt/sensor.py
@@ -165,9 +165,17 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
 
         self._key = key
         data = self._sensor_data
-        if data.getType() == "Input":
+        sensor_type = data.getType()
+        if sensor_type == "Input":
             self._attr_unique_id = (
                 f"{data.hub_mac_address}-input-{data.getChannel()}-{data.getUnit()}"
+            )
+        else:
+            sensor_type_suffix = (
+                sensor_type.lower() if isinstance(sensor_type, str) else "sensor"
+            )
+            self._attr_unique_id = (
+                f"{data.hub_mac_address}-{sensor_type_suffix}-{self._key}"
             )
         self.entity_description = entity_description
 

--- a/tests/components/iotawatt/test_sensor.py
+++ b/tests/components/iotawatt/test_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     UnitOfPower,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from . import INPUT_SENSOR, OUTPUT_SENSOR
@@ -52,6 +53,11 @@ async def test_sensor_type_input(
     assert state.attributes["channel"] == "1"
     assert state.attributes["type"] == "Input"
 
+    registry = er.async_get(hass)
+    entry = registry.async_get("sensor.my_sensor")
+    assert entry is not None
+    assert entry.unique_id == "mock-mac-input-1-Watts"
+
     mock_iotawatt.getSensors.return_value["sensors"].pop("my_sensor_key")
     freezer.tick(timedelta(seconds=30))
     async_fire_time_changed(hass)
@@ -80,6 +86,11 @@ async def test_sensor_type_output(
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfEnergy.WATT_HOUR
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENERGY
     assert state.attributes["type"] == "Output"
+
+    registry = er.async_get(hass)
+    entry = registry.async_get("sensor.my_watthour_sensor")
+    assert entry is not None
+    assert entry.unique_id == "mock-mac-output-my_watthour_sensor_key"
 
     mock_iotawatt.getSensors.return_value["sensors"].pop("my_watthour_sensor_key")
     freezer.tick(timedelta(seconds=30))


### PR DESCRIPTION
## Proposed change
Assign stable unique IDs to every IoTaWatt sensor. Input sensors continue using channel/unit identifiers, while output sensors now build their IDs from the hub MAC, lower-cased sensor type, and sensor key. 

Tests now assert the expected unique IDs for both sensor types to prevent regressions.


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
