### PR TITLE
Revert "Pin pycares to 4.11.0"

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -223,6 +223,3 @@ gql<4.0.0
 
 # Pin pytest-rerunfailures to prevent accidental breaks
 pytest-rerunfailures==16.0.1
-
-# pycares 5.x is not yet compatible with aiodns
-pycares==4.11.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -214,9 +214,6 @@ gql<4.0.0
 
 # Pin pytest-rerunfailures to prevent accidental breaks
 pytest-rerunfailures==16.0.1
-
-# pycares 5.x is not yet compatible with aiodns
-pycares==4.11.0
 """
 
 GENERATED_MESSAGE = (


### PR DESCRIPTION
Reverts home-assistant/core#158695

Suggested in https://github.com/home-assistant/core/pull/159073#issuecomment-3654823109
https://github.com/home-assistant/core/pull/159073 bumps aiodns, which itself constrains `pycares>=4.9.0,<5` so this is not needed anymore 