### PR TITLE
Add option to enable offline mode to lamarzocco

### DIFF
--- a/homeassistant/components/lamarzocco/__init__.py
+++ b/homeassistant/components/lamarzocco/__init__.py
@@ -33,7 +33,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import CONF_INSTALLATION_KEY, CONF_USE_BLUETOOTH, DOMAIN
+from .const import CONF_INSTALLATION_KEY, CONF_OFFLINE_MODE, CONF_USE_BLUETOOTH, DOMAIN
 from .coordinator import (
     LaMarzoccoBluetoothUpdateCoordinator,
     LaMarzoccoConfigEntry,
@@ -118,44 +118,50 @@ async def async_setup_entry(hass: HomeAssistant, entry: LaMarzoccoConfigEntry) -
                 _LOGGER.info(
                     "Bluetooth device not found during lamarzocco setup, continuing with cloud only"
                 )
-    try:
-        settings = await cloud_client.get_thing_settings(serial)
-    except AuthFail as ex:
-        raise ConfigEntryAuthFailed(
-            translation_domain=DOMAIN, translation_key="authentication_failed"
-        ) from ex
-    except (RequestNotSuccessful, TimeoutError) as ex:
-        _LOGGER.debug(ex, exc_info=True)
-        if not bluetooth_client:
-            raise ConfigEntryNotReady(
-                translation_domain=DOMAIN, translation_key="api_error"
-            ) from ex
-        _LOGGER.debug("Cloud failed, continuing with Bluetooth only", exc_info=True)
-    else:
-        gateway_version = version.parse(
-            settings.firmwares[FirmwareType.GATEWAY].build_version
-        )
 
-        if gateway_version < version.parse("v5.0.9"):
-            # incompatible gateway firmware, create an issue
-            ir.async_create_issue(
-                hass,
-                DOMAIN,
-                "unsupported_gateway_firmware",
-                is_fixable=False,
-                severity=ir.IssueSeverity.ERROR,
-                translation_key="unsupported_gateway_firmware",
-                translation_placeholders={"gateway_version": str(gateway_version)},
+    async def _get_thing_settings() -> None:
+        """Get thing settings from cloud to verify details and get BLE token."""
+        try:
+            settings = await cloud_client.get_thing_settings(serial)
+        except AuthFail as ex:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN, translation_key="authentication_failed"
+            ) from ex
+        except (RequestNotSuccessful, TimeoutError) as ex:
+            _LOGGER.debug(ex, exc_info=True)
+            if not bluetooth_client:
+                raise ConfigEntryNotReady(
+                    translation_domain=DOMAIN, translation_key="api_error"
+                ) from ex
+            _LOGGER.debug("Cloud failed, continuing with Bluetooth only", exc_info=True)
+        else:
+            gateway_version = version.parse(
+                settings.firmwares[FirmwareType.GATEWAY].build_version
             )
-        # Update BLE Token if exists
-        if settings.ble_auth_token:
-            hass.config_entries.async_update_entry(
-                entry,
-                data={
-                    **entry.data,
-                    CONF_TOKEN: settings.ble_auth_token,
-                },
-            )
+
+            if gateway_version < version.parse("v5.0.9"):
+                # incompatible gateway firmware, create an issue
+                ir.async_create_issue(
+                    hass,
+                    DOMAIN,
+                    "unsupported_gateway_firmware",
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.ERROR,
+                    translation_key="unsupported_gateway_firmware",
+                    translation_placeholders={"gateway_version": str(gateway_version)},
+                )
+            # Update BLE Token if exists
+            if settings.ble_auth_token:
+                hass.config_entries.async_update_entry(
+                    entry,
+                    data={
+                        **entry.data,
+                        CONF_TOKEN: settings.ble_auth_token,
+                    },
+                )
+
+    if not (local_mode := entry.options.get(CONF_OFFLINE_MODE, False)):
+        await _get_thing_settings()
 
     device = LaMarzoccoMachine(
         serial_number=entry.unique_id,
@@ -170,12 +176,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: LaMarzoccoConfigEntry) -
         LaMarzoccoStatisticsUpdateCoordinator(hass, entry, device),
     )
 
-    await asyncio.gather(
-        coordinators.config_coordinator.async_config_entry_first_refresh(),
-        coordinators.settings_coordinator.async_config_entry_first_refresh(),
-        coordinators.schedule_coordinator.async_config_entry_first_refresh(),
-        coordinators.statistics_coordinator.async_config_entry_first_refresh(),
-    )
+    if not local_mode:
+        await asyncio.gather(
+            coordinators.config_coordinator.async_config_entry_first_refresh(),
+            coordinators.settings_coordinator.async_config_entry_first_refresh(),
+            coordinators.schedule_coordinator.async_config_entry_first_refresh(),
+            coordinators.statistics_coordinator.async_config_entry_first_refresh(),
+        )
 
     # bt coordinator only if bluetooth client is available
     # and after the initial refresh of the config coordinator

--- a/homeassistant/components/lamarzocco/__init__.py
+++ b/homeassistant/components/lamarzocco/__init__.py
@@ -184,6 +184,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: LaMarzoccoConfigEntry) -
             coordinators.statistics_coordinator.async_config_entry_first_refresh(),
         )
 
+    if local_mode and not bluetooth_client:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN, translation_key="bluetooth_required_offline"
+        )
+
     # bt coordinator only if bluetooth client is available
     # and after the initial refresh of the config coordinator
     # to fetch only if the others failed

--- a/homeassistant/components/lamarzocco/config_flow.py
+++ b/homeassistant/components/lamarzocco/config_flow.py
@@ -47,7 +47,7 @@ from homeassistant.helpers.selector import (
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from . import create_client_session
-from .const import CONF_INSTALLATION_KEY, CONF_USE_BLUETOOTH, DOMAIN
+from .const import CONF_INSTALLATION_KEY, CONF_OFFLINE_MODE, CONF_USE_BLUETOOTH, DOMAIN
 from .coordinator import LaMarzoccoConfigEntry
 
 CONF_MACHINE = "machine"
@@ -387,6 +387,10 @@ class LmOptionsFlowHandler(OptionsFlowWithReload):
                 vol.Optional(
                     CONF_USE_BLUETOOTH,
                     default=self.config_entry.options.get(CONF_USE_BLUETOOTH, True),
+                ): cv.boolean,
+                vol.Optional(
+                    CONF_OFFLINE_MODE,
+                    default=self.config_entry.options.get(CONF_OFFLINE_MODE, False),
                 ): cv.boolean,
             }
         )

--- a/homeassistant/components/lamarzocco/config_flow.py
+++ b/homeassistant/components/lamarzocco/config_flow.py
@@ -379,9 +379,15 @@ class LmOptionsFlowHandler(OptionsFlowWithReload):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the options for the custom component."""
-        if user_input:
-            return self.async_create_entry(title="", data=user_input)
+        errors: dict[str, str] = {}
 
+        if user_input:
+            if user_input.get(CONF_OFFLINE_MODE) and not user_input.get(
+                CONF_USE_BLUETOOTH
+            ):
+                errors[CONF_USE_BLUETOOTH] = "bluetooth_required_offline"
+            else:
+                return self.async_create_entry(title="", data=user_input)
         options_schema = vol.Schema(
             {
                 vol.Optional(
@@ -398,4 +404,5 @@ class LmOptionsFlowHandler(OptionsFlowWithReload):
         return self.async_show_form(
             step_id="init",
             data_schema=options_schema,
+            errors=errors,
         )

--- a/homeassistant/components/lamarzocco/const.py
+++ b/homeassistant/components/lamarzocco/const.py
@@ -6,3 +6,4 @@ DOMAIN: Final = "lamarzocco"
 
 CONF_USE_BLUETOOTH: Final = "use_bluetooth"
 CONF_INSTALLATION_KEY: Final = "installation_key"
+CONF_OFFLINE_MODE: Final = "offline_mode"

--- a/homeassistant/components/lamarzocco/coordinator.py
+++ b/homeassistant/components/lamarzocco/coordinator.py
@@ -62,7 +62,9 @@ class LaMarzoccoUpdateCoordinator(DataUpdateCoordinator[None]):
     ) -> None:
         """Initialize coordinator."""
         update_interval = self._default_update_interval
-        if not self._ignore_offline_mode and entry.options.get(CONF_OFFLINE_MODE):
+        if not self._ignore_offline_mode and entry.options.get(
+            CONF_OFFLINE_MODE, False
+        ):
             update_interval = None
         super().__init__(
             hass,

--- a/homeassistant/components/lamarzocco/coordinator.py
+++ b/homeassistant/components/lamarzocco/coordinator.py
@@ -50,6 +50,7 @@ class LaMarzoccoUpdateCoordinator(DataUpdateCoordinator[None]):
     """Base class for La Marzocco coordinators."""
 
     _default_update_interval: timedelta | None = SCAN_INTERVAL
+    _ignore_offline_mode = False
     config_entry: LaMarzoccoConfigEntry
     update_success = False
 
@@ -61,7 +62,7 @@ class LaMarzoccoUpdateCoordinator(DataUpdateCoordinator[None]):
     ) -> None:
         """Initialize coordinator."""
         update_interval = self._default_update_interval
-        if entry.options.get(CONF_OFFLINE_MODE):
+        if not self._ignore_offline_mode and entry.options.get(CONF_OFFLINE_MODE):
             update_interval = None
         super().__init__(
             hass,
@@ -217,16 +218,7 @@ class LaMarzoccoStatisticsUpdateCoordinator(LaMarzoccoUpdateCoordinator):
 class LaMarzoccoBluetoothUpdateCoordinator(LaMarzoccoUpdateCoordinator):
     """Class to handle fetching data from the La Marzocco Bluetooth API centrally."""
 
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        entry: LaMarzoccoConfigEntry,
-        device: LaMarzoccoMachine,
-    ) -> None:
-        """Initialize coordinator."""
-        super().__init__(hass, entry, device)
-        # Always use default interval for Bluetooth, even in offline mode
-        self.update_interval = self._default_update_interval
+    _ignore_offline_mode = True
 
     async def _internal_async_setup(self) -> None:
         """Initial setup for Bluetooth coordinator."""

--- a/homeassistant/components/lamarzocco/strings.json
+++ b/homeassistant/components/lamarzocco/strings.json
@@ -226,9 +226,11 @@
     "step": {
       "init": {
         "data": {
+          "offline_mode": "Offline Mode",
           "use_bluetooth": "Use Bluetooth"
         },
         "data_description": {
+          "offline_mode": "Enable offline mode to operate without internet connectivity through Bluetooth. Only local features will be available. Requires Bluetooth to be enabled.",
           "use_bluetooth": "Should the integration try to use Bluetooth to control the machine?"
         }
       }

--- a/homeassistant/components/lamarzocco/strings.json
+++ b/homeassistant/components/lamarzocco/strings.json
@@ -197,6 +197,9 @@
     "bluetooth_connection_failed": {
       "message": "Error while connecting to machine via Bluetooth"
     },
+    "bluetooth_required_offline": {
+      "message": "Bluetooth is required when offline mode is enabled, but no Bluetooth device was found"
+    },
     "button_error": {
       "message": "Error while executing button {key}"
     },
@@ -223,6 +226,9 @@
     }
   },
   "options": {
+    "error": {
+      "bluetooth_required_offline": "Bluetooth is required when offline mode is enabled."
+    },
     "step": {
       "init": {
         "data": {

--- a/tests/components/lamarzocco/test_bluetooth.py
+++ b/tests/components/lamarzocco/test_bluetooth.py
@@ -10,7 +10,7 @@ from pylamarzocco.exceptions import BluetoothConnectionFailed, RequestNotSuccess
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.lamarzocco.const import DOMAIN
+from homeassistant.components.lamarzocco.const import CONF_OFFLINE_MODE, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
@@ -297,6 +297,71 @@ async def test_setup_through_bluetooth_only(
     assert device == snapshot(
         name=f"device_bluetooth_{mock_lamarzocco_bluetooth.serial_number}"
     )
+
+
+async def test_manual_offline_mode_no_bluetooth_device(
+    hass: HomeAssistant,
+    mock_lamarzocco: MagicMock,
+    mock_config_entry_bluetooth: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test manual offline mode with no Bluetooth device found."""
+
+    mock_config_entry_bluetooth.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry_bluetooth, options={CONF_OFFLINE_MODE: True}
+    )
+    await hass.config_entries.async_setup(mock_config_entry_bluetooth.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry_bluetooth.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_manual_offline_mode(
+    hass: HomeAssistant,
+    mock_lamarzocco: MagicMock,
+    mock_config_entry_bluetooth: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    mock_ble_device_from_address: MagicMock,
+) -> None:
+    """Test the manual offline mode."""
+
+    mock_config_entry_bluetooth.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry_bluetooth, options={CONF_OFFLINE_MODE: True}
+    )
+    await hass.config_entries.async_setup(mock_config_entry_bluetooth.entry_id)
+    await hass.async_block_till_done()
+
+    main_switch = f"switch.{mock_lamarzocco.serial_number}"
+    state = hass.states.get(main_switch)
+    assert state
+    assert state.state == STATE_ON
+
+    # Simulate Bluetooth update changing machine mode to standby
+    mock_lamarzocco.dashboard.config[
+        WidgetType.CM_MACHINE_STATUS
+    ].mode = MachineMode.STANDBY
+
+    # Trigger Bluetooth coordinator update
+    freezer.tick(timedelta(seconds=61))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Verify entity state was updated
+    state = hass.states.get(main_switch)
+    assert state
+    assert state.state == STATE_OFF
+
+    # verify other entities are unavailable
+    sample_entities = (
+        f"binary_sensor.{mock_lamarzocco.serial_number}_backflush_active",
+        f"update.{mock_lamarzocco.serial_number}_gateway_firmware",
+    )
+    for entity_id in sample_entities:
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state == STATE_UNAVAILABLE
 
 
 @pytest.mark.parametrize(

--- a/tests/components/lamarzocco/test_bluetooth.py
+++ b/tests/components/lamarzocco/test_bluetooth.py
@@ -324,7 +324,9 @@ async def test_manual_offline_mode(
     freezer: FrozenDateTimeFactory,
     mock_ble_device_from_address: MagicMock,
 ) -> None:
-    """Test the manual offline mode."""
+    """Test that manual offline mode successfully sets up and updates entities via Bluetooth,
+    and marks non-Bluetooth entities as unavailable.
+    """
 
     mock_config_entry_bluetooth.add_to_hass(hass)
     hass.config_entries.async_update_entry(

--- a/tests/components/lamarzocco/test_bluetooth.py
+++ b/tests/components/lamarzocco/test_bluetooth.py
@@ -324,9 +324,7 @@ async def test_manual_offline_mode(
     freezer: FrozenDateTimeFactory,
     mock_ble_device_from_address: MagicMock,
 ) -> None:
-    """Test that manual offline mode successfully sets up and updates entities via Bluetooth,
-    and marks non-Bluetooth entities as unavailable.
-    """
+    """Test that manual offline mode successfully sets up and updates entities via Bluetooth, and marks non-Bluetooth entities as unavailable."""
 
     mock_config_entry_bluetooth.add_to_hass(hass)
     hass.config_entries.async_update_entry(

--- a/tests/components/lamarzocco/test_config_flow.py
+++ b/tests/components/lamarzocco/test_config_flow.py
@@ -525,3 +525,45 @@ async def test_options_flow(
         CONF_USE_BLUETOOTH: False,
         CONF_OFFLINE_MODE: False,
     }
+
+
+async def test_options_flow_bluetooth_required_for_offline_mode(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test options flow."""
+    await async_init_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USE_BLUETOOTH: False,
+            CONF_OFFLINE_MODE: True,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["errors"] == {CONF_USE_BLUETOOTH: "bluetooth_required_offline"}
+
+    # recover
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USE_BLUETOOTH: True,
+            CONF_OFFLINE_MODE: True,
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_USE_BLUETOOTH: True,
+        CONF_OFFLINE_MODE: True,
+    }

--- a/tests/components/lamarzocco/test_config_flow.py
+++ b/tests/components/lamarzocco/test_config_flow.py
@@ -11,6 +11,7 @@ import pytest
 from homeassistant.components.lamarzocco.config_flow import CONF_MACHINE
 from homeassistant.components.lamarzocco.const import (
     CONF_INSTALLATION_KEY,
+    CONF_OFFLINE_MODE,
     CONF_USE_BLUETOOTH,
     DOMAIN,
 )
@@ -522,4 +523,5 @@ async def test_options_flow(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_USE_BLUETOOTH: False,
+        CONF_OFFLINE_MODE: False,
     }

--- a/tests/components/lamarzocco/test_config_flow.py
+++ b/tests/components/lamarzocco/test_config_flow.py
@@ -531,7 +531,7 @@ async def test_options_flow_bluetooth_required_for_offline_mode(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test options flow."""
+    """Test options flow validates that Bluetooth is required when offline mode is enabled."""
     await async_init_integration(hass, mock_config_entry)
     assert mock_config_entry.state is ConfigEntryState.LOADED
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change allows users which do not want to use the cloud to manually enter into the offline mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42582
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
