### PR TITLE
Add last_changed and last_updated for the Opower statistics

### DIFF
--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -1,5 +1,6 @@
 """Coordinator to handle Opower connections."""
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
 from typing import Any, cast
@@ -44,7 +45,16 @@ _LOGGER = logging.getLogger(__name__)
 type OpowerConfigEntry = ConfigEntry[OpowerCoordinator]
 
 
-class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
+@dataclass
+class OpowerData:
+    """Class to hold Opower data."""
+
+    account: Account
+    forecast: Forecast | None
+    latest_read: datetime | None
+
+
+class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
     """Handle fetching Opower data, updating sensors and inserting statistics."""
 
     config_entry: OpowerConfigEntry
@@ -85,7 +95,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
 
     async def _async_update_data(
         self,
-    ) -> dict[str, Forecast]:
+    ) -> dict[str, OpowerData]:
         """Fetch data from API endpoint."""
         try:
             # Login expires after a few minutes.
@@ -98,24 +108,37 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
         except CannotConnect as err:
             _LOGGER.error("Error during login: %s", err)
             raise UpdateFailed(f"Error during login: {err}") from err
-        try:
-            forecasts: list[Forecast] = await self.api.async_get_forecast()
-        except ApiException as err:
-            _LOGGER.error("Error getting forecasts: %s", err)
-            raise
-        _LOGGER.debug("Updating sensor data with: %s", forecasts)
-        # Because Opower provides historical usage/cost with a delay of a couple of days
-        # we need to insert data into statistics.
-        await self._insert_statistics()
-        return {forecast.account.utility_account_id: forecast for forecast in forecasts}
 
-    async def _insert_statistics(self) -> None:
-        """Insert Opower statistics."""
         try:
             accounts = await self.api.async_get_accounts()
         except ApiException as err:
             _LOGGER.error("Error getting accounts: %s", err)
             raise
+
+        try:
+            forecasts_list = await self.api.async_get_forecast()
+        except ApiException as err:
+            _LOGGER.error("Error getting forecasts: %s", err)
+            raise
+
+        forecasts = {f.account.utility_account_id: f for f in forecasts_list}
+        _LOGGER.debug("Updating sensor data with: %s", forecasts)
+
+        # Because Opower provides historical usage/cost with a delay of a couple of days
+        # we need to insert data into statistics.
+        latest_reads = await self._insert_statistics(accounts)
+        return {
+            account.utility_account_id: OpowerData(
+                account=account,
+                forecast=forecasts.get(account.utility_account_id),
+                latest_read=latest_reads.get(account.utility_account_id),
+            )
+            for account in accounts
+        }
+
+    async def _insert_statistics(self, accounts: list[Account]) -> dict[str, datetime]:
+        """Insert Opower statistics."""
+        latest_reads: dict[str, datetime] = {}
         for account in accounts:
             id_prefix = (
                 (
@@ -277,6 +300,13 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                 return_sum = _safe_get_sum(stats.get(return_statistic_id, []))
                 last_stats_time = stats[consumption_statistic_id][0]["start"]
 
+            if cost_reads:
+                latest_reads[account.utility_account_id] = cost_reads[-1].start_time
+            elif last_stats_time is not None:
+                latest_reads[account.utility_account_id] = dt_util.utc_from_timestamp(
+                    last_stats_time
+                )
+
             cost_statistics = []
             compensation_statistics = []
             consumption_statistics = []
@@ -342,6 +372,8 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                 return_statistic_id,
             )
             async_add_external_statistics(self.hass, return_metadata, return_statistics)
+
+        return latest_reads
 
     async def _async_maybe_migrate_statistics(
         self,

--- a/homeassistant/components/opower/sensor.py
+++ b/homeassistant/components/opower/sensor.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 
-from opower import Forecast, MeterType, UnitOfMeasure
+from opower import MeterType, UnitOfMeasure
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -22,7 +22,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import OpowerConfigEntry, OpowerCoordinator
+from .coordinator import OpowerConfigEntry, OpowerCoordinator, OpowerData
 
 PARALLEL_UPDATES = 0
 
@@ -31,8 +31,18 @@ PARALLEL_UPDATES = 0
 class OpowerEntityDescription(SensorEntityDescription):
     """Class describing Opower sensors entities."""
 
-    value_fn: Callable[[Forecast], str | float | date]
+    value_fn: Callable[[OpowerData], str | float | date | datetime | None]
 
+
+COMMON_SENSORS: tuple[OpowerEntityDescription, ...] = (
+    OpowerEntityDescription(
+        key="latest_read",
+        translation_key="latest_read",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.latest_read,
+    ),
+)
 
 # suggested_display_precision=0 for all sensors since
 # Opower provides 0 decimal points for all these.
@@ -46,7 +56,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
         # Not TOTAL_INCREASING because it can decrease for accounts with solar
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.usage_to_date,
+        value_fn=lambda data: data.forecast.usage_to_date if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="elec_forecasted_usage",
@@ -55,7 +65,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.forecasted_usage,
+        value_fn=lambda data: data.forecast.forecasted_usage if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="elec_typical_usage",
@@ -64,7 +74,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.typical_usage,
+        value_fn=lambda data: data.forecast.typical_usage if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="elec_cost_to_date",
@@ -73,7 +83,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.cost_to_date,
+        value_fn=lambda data: data.forecast.cost_to_date if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="elec_forecasted_cost",
@@ -82,7 +92,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.forecasted_cost,
+        value_fn=lambda data: data.forecast.forecasted_cost if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="elec_typical_cost",
@@ -91,7 +101,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.typical_cost,
+        value_fn=lambda data: data.forecast.typical_cost if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="elec_start_date",
@@ -99,7 +109,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: data.start_date,
+        value_fn=lambda data: data.forecast.start_date if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="elec_end_date",
@@ -107,7 +117,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: data.end_date,
+        value_fn=lambda data: data.forecast.end_date if data.forecast else None,
     ),
 )
 GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
@@ -118,7 +128,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfVolume.CENTUM_CUBIC_FEET,
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.usage_to_date,
+        value_fn=lambda data: data.forecast.usage_to_date if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="gas_forecasted_usage",
@@ -127,7 +137,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfVolume.CENTUM_CUBIC_FEET,
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.forecasted_usage,
+        value_fn=lambda data: data.forecast.forecasted_usage if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="gas_typical_usage",
@@ -136,7 +146,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfVolume.CENTUM_CUBIC_FEET,
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.typical_usage,
+        value_fn=lambda data: data.forecast.typical_usage if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="gas_cost_to_date",
@@ -145,7 +155,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.cost_to_date,
+        value_fn=lambda data: data.forecast.cost_to_date if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="gas_forecasted_cost",
@@ -154,7 +164,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.forecasted_cost,
+        value_fn=lambda data: data.forecast.forecasted_cost if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="gas_typical_cost",
@@ -163,7 +173,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.typical_cost,
+        value_fn=lambda data: data.forecast.typical_cost if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="gas_start_date",
@@ -171,7 +181,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: data.start_date,
+        value_fn=lambda data: data.forecast.start_date if data.forecast else None,
     ),
     OpowerEntityDescription(
         key="gas_end_date",
@@ -179,7 +189,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: data.end_date,
+        value_fn=lambda data: data.forecast.end_date if data.forecast else None,
     ),
 )
 
@@ -193,32 +203,38 @@ async def async_setup_entry(
 
     coordinator = entry.runtime_data
     entities: list[OpowerSensor] = []
-    forecasts = coordinator.data.values()
-    for forecast in forecasts:
-        device_id = f"{coordinator.api.utility.subdomain()}_{forecast.account.utility_account_id}"
+    opower_data_list = coordinator.data.values()
+    for opower_data in opower_data_list:
+        account = opower_data.account
+        forecast = opower_data.forecast
+        device_id = (
+            f"{coordinator.api.utility.subdomain()}_{account.utility_account_id}"
+        )
         device = DeviceInfo(
             identifiers={(DOMAIN, device_id)},
-            name=f"{forecast.account.meter_type.name} account {forecast.account.utility_account_id}",
+            name=f"{account.meter_type.name} account {account.utility_account_id}",
             manufacturer="Opower",
             model=coordinator.api.utility.name(),
             entry_type=DeviceEntryType.SERVICE,
         )
-        sensors: tuple[OpowerEntityDescription, ...] = ()
+        sensors: tuple[OpowerEntityDescription, ...] = COMMON_SENSORS
         if (
-            forecast.account.meter_type == MeterType.ELEC
+            account.meter_type == MeterType.ELEC
+            and forecast is not None
             and forecast.unit_of_measure == UnitOfMeasure.KWH
         ):
-            sensors = ELEC_SENSORS
+            sensors += ELEC_SENSORS
         elif (
-            forecast.account.meter_type == MeterType.GAS
+            account.meter_type == MeterType.GAS
+            and forecast is not None
             and forecast.unit_of_measure in [UnitOfMeasure.THERM, UnitOfMeasure.CCF]
         ):
-            sensors = GAS_SENSORS
+            sensors += GAS_SENSORS
         entities.extend(
             OpowerSensor(
                 coordinator,
                 sensor,
-                forecast.account.utility_account_id,
+                account.utility_account_id,
                 device,
                 device_id,
             )
@@ -250,7 +266,7 @@ class OpowerSensor(CoordinatorEntity[OpowerCoordinator], SensorEntity):
         self.utility_account_id = utility_account_id
 
     @property
-    def native_value(self) -> StateType | date:
+    def native_value(self) -> StateType | date | datetime:
         """Return the state."""
         return self.entity_description.value_fn(
             self.coordinator.data[self.utility_account_id]

--- a/homeassistant/components/opower/sensor.py
+++ b/homeassistant/components/opower/sensor.py
@@ -36,11 +36,18 @@ class OpowerEntityDescription(SensorEntityDescription):
 
 COMMON_SENSORS: tuple[OpowerEntityDescription, ...] = (
     OpowerEntityDescription(
-        key="latest_read",
-        translation_key="latest_read",
+        key="last_changed",
+        translation_key="last_changed",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.latest_read,
+        value_fn=lambda data: data.last_changed,
+    ),
+    OpowerEntityDescription(
+        key="last_updated",
+        translation_key="last_updated",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.last_updated,
     ),
 )
 

--- a/homeassistant/components/opower/strings.json
+++ b/homeassistant/components/opower/strings.json
@@ -116,8 +116,11 @@
       "gas_usage_to_date": {
         "name": "Current bill gas usage to date"
       },
-      "latest_read": {
-        "name": "Latest read"
+      "last_changed": {
+        "name": "Last changed"
+      },
+      "last_updated": {
+        "name": "Last updated"
       }
     }
   },

--- a/homeassistant/components/opower/strings.json
+++ b/homeassistant/components/opower/strings.json
@@ -115,6 +115,9 @@
       },
       "gas_usage_to_date": {
         "name": "Current bill gas usage to date"
+      },
+      "latest_read": {
+        "name": "Latest read"
       }
     }
   },

--- a/tests/components/opower/test_sensor.py
+++ b/tests/components/opower/test_sensor.py
@@ -1,13 +1,16 @@
 """Tests for the Opower sensor platform."""
 
+from datetime import datetime
 from unittest.mock import AsyncMock
 
+from opower import CostRead
 import pytest
 
 from homeassistant.components.recorder import Recorder
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfEnergy, UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 
@@ -19,6 +22,15 @@ async def test_sensors(
     mock_opower_api: AsyncMock,
 ) -> None:
     """Test the creation and values of Opower sensors."""
+    mock_opower_api.async_get_cost_reads.return_value = [
+        CostRead(
+            start_time=dt_util.as_utc(datetime(2023, 1, 1, 8)),
+            end_time=dt_util.as_utc(datetime(2023, 1, 1, 9)),
+            consumption=1.5,
+            provided_cost=0.5,
+        ),
+    ]
+
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -49,6 +61,13 @@ async def test_sensors(
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "USD"
     assert state.state == "20.0"
 
+    entry = entity_registry.async_get("sensor.elec_account_111111_latest_read")
+    assert entry
+    assert entry.unique_id == "pge_111111_latest_read"
+    state = hass.states.get("sensor.elec_account_111111_latest_read")
+    assert state
+    assert state.state == "2023-01-01T16:00:00+00:00"
+
     # Check gas sensors
     entry = entity_registry.async_get(
         "sensor.gas_account_222222_current_bill_gas_usage_to_date"
@@ -70,3 +89,10 @@ async def test_sensors(
     assert state
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "USD"
     assert state.state == "15.0"
+
+    entry = entity_registry.async_get("sensor.gas_account_222222_latest_read")
+    assert entry
+    assert entry.unique_id == "pge_222222_latest_read"
+    state = hass.states.get("sensor.gas_account_222222_latest_read")
+    assert state
+    assert state.state == "2023-01-01T16:00:00+00:00"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Opower inserts statistics without any associated entities. Add last_changed and last_updated sensors for these statistics to give an indication the integration is working and to provide info on how stale the usage/cost statistics are (they are typically a couple of days behind).

Background: Opower recently stopped returning forecast data which results in no sensors, see https://github.com/home-assistant/core/issues/158704. This is now confusing users since they think the integration isn't working when it's working fine and inserts statistics. These new sensors will help clear the confusion and will allow automations to update the new entities, thus try to fetch updated cost reads and insert updated statistics, if the data is too stale. The Opower fetches data every 12 hours.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/158704
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42612
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
