### PR TITLE
Make valid options an attribute of Tuya device wrapper

### DIFF
--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -99,7 +99,7 @@ class _AlarmActionWrapper(DPCodeEnumWrapper):
     def __init__(self, dpcode: str, type_information: EnumTypeInformation) -> None:
         """Init _AlarmActionWrapper."""
         super().__init__(dpcode, type_information)
-        self.range = [
+        self.options = [
             ha_action
             for ha_action, tuya_action in self._ACTION_MAPPINGS.items()
             if tuya_action in type_information.range
@@ -185,12 +185,12 @@ class TuyaAlarmEntity(TuyaEntity, AlarmControlPanelEntity):
         self._state_wrapper = state_wrapper
 
         # Determine supported modes
-        if action_wrapper.range:
-            if "arm_home" in action_wrapper.range:
+        if action_wrapper.options:
+            if "arm_home" in action_wrapper.options:
                 self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
-            if "arm_away" in action_wrapper.range:
+            if "arm_away" in action_wrapper.options:
                 self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_AWAY
-            if "trigger" in action_wrapper.range:
+            if "trigger" in action_wrapper.options:
                 self._attr_supported_features |= AlarmControlPanelEntityFeature.TRIGGER
 
     @property

--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -96,20 +96,17 @@ class _AlarmActionWrapper(DPCodeEnumWrapper):
         "trigger": "sos",
     }
 
-    def __init__(self, dpcode: str, type_information: EnumTypeInformation) -> None:
-        """Init _AlarmActionWrapper."""
-        super().__init__(dpcode, type_information)
-        self.options = [
-            ha_action
-            for ha_action, tuya_action in self._ACTION_MAPPINGS.items()
-            if tuya_action in type_information.range
-        ]
+    def supports_action(self, action: str) -> bool:
+        """Return if action is supported."""
+        return (
+            mapped_value := self._ACTION_MAPPINGS.get(action)
+        ) is not None and mapped_value in self.options
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
         """Convert value to raw value."""
         if (
             mapped_value := self._ACTION_MAPPINGS.get(value)
-        ) is not None and mapped_value in self.type_information.range:
+        ) is not None and mapped_value in self.options:
             return mapped_value
         raise ValueError(f"Unsupported value {value} for {self.dpcode}")
 
@@ -185,13 +182,12 @@ class TuyaAlarmEntity(TuyaEntity, AlarmControlPanelEntity):
         self._state_wrapper = state_wrapper
 
         # Determine supported modes
-        if action_wrapper.options:
-            if "arm_home" in action_wrapper.options:
-                self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
-            if "arm_away" in action_wrapper.options:
-                self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_AWAY
-            if "trigger" in action_wrapper.options:
-                self._attr_supported_features |= AlarmControlPanelEntityFeature.TRIGGER
+        if action_wrapper.supports_action("arm_home"):
+            self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
+        if action_wrapper.supports_action("arm_away"):
+            self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_AWAY
+        if action_wrapper.supports_action("trigger"):
+            self._attr_supported_features |= AlarmControlPanelEntityFeature.TRIGGER
 
     @property
     def alarm_state(self) -> AlarmControlPanelState | None:

--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -95,7 +95,6 @@ class _AlarmActionWrapper(DPCodeEnumWrapper):
         "disarm": "disarmed",
         "trigger": "sos",
     }
-    range: list[str]
 
     def __init__(self, dpcode: str, type_information: EnumTypeInformation) -> None:
         """Init _AlarmActionWrapper."""
@@ -186,12 +185,13 @@ class TuyaAlarmEntity(TuyaEntity, AlarmControlPanelEntity):
         self._state_wrapper = state_wrapper
 
         # Determine supported modes
-        if "arm_home" in action_wrapper.range:
-            self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
-        if "arm_away" in action_wrapper.range:
-            self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_AWAY
-        if "trigger" in action_wrapper.range:
-            self._attr_supported_features |= AlarmControlPanelEntityFeature.TRIGGER
+        if action_wrapper.range:
+            if "arm_home" in action_wrapper.range:
+                self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
+            if "arm_away" in action_wrapper.range:
+                self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_AWAY
+            if "trigger" in action_wrapper.range:
+                self._attr_supported_features |= AlarmControlPanelEntityFeature.TRIGGER
 
     @property
     def alarm_state(self) -> AlarmControlPanelState | None:

--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -100,13 +100,13 @@ class _AlarmActionWrapper(DPCodeEnumWrapper):
         """Return if action is supported."""
         return (
             mapped_value := self._ACTION_MAPPINGS.get(action)
-        ) is not None and mapped_value in self.type_information.range
+        ) is not None and mapped_value in self.range
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
         """Convert value to raw value."""
         if (
             mapped_value := self._ACTION_MAPPINGS.get(value)
-        ) is not None and mapped_value in self.type_information.range:
+        ) is not None and mapped_value in self.range:
             return mapped_value
         raise ValueError(f"Unsupported value {value} for {self.dpcode}")
 

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -373,7 +373,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         if hvac_mode_wrapper:
             self._attr_hvac_modes = [HVACMode.OFF]
             unknown_hvac_modes: list[str] = []
-            for tuya_mode in hvac_mode_wrapper.type_information.range:
+            for tuya_mode in hvac_mode_wrapper.range:
                 if tuya_mode in TUYA_HVAC_TO_HA:
                     ha_mode = TUYA_HVAC_TO_HA[tuya_mode]
                     self._hvac_to_tuya[ha_mode] = tuya_mode
@@ -404,7 +404,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         # Determine fan modes
         if fan_mode_wrapper:
             self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
-            self._attr_fan_modes = fan_mode_wrapper.type_information.range
+            self._attr_fan_modes = fan_mode_wrapper.range
 
         # Determine swing modes
         if swing_wrapper:

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -373,7 +373,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         if hvac_mode_wrapper:
             self._attr_hvac_modes = [HVACMode.OFF]
             unknown_hvac_modes: list[str] = []
-            for tuya_mode in hvac_mode_wrapper.range:
+            for tuya_mode in hvac_mode_wrapper.options:
                 if tuya_mode in TUYA_HVAC_TO_HA:
                     ha_mode = TUYA_HVAC_TO_HA[tuya_mode]
                     self._hvac_to_tuya[ha_mode] = tuya_mode
@@ -404,7 +404,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         # Determine fan modes
         if fan_mode_wrapper:
             self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
-            self._attr_fan_modes = fan_mode_wrapper.range
+            self._attr_fan_modes = fan_mode_wrapper.options
 
         # Determine swing modes
         if swing_wrapper:

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -104,17 +104,17 @@ class _InstructionEnumWrapper(DPCodeEnumWrapper, _InstructionWrapper):
     stop_instruction = "stop"
 
     def get_open_command(self, device: CustomerDevice) -> dict[str, Any] | None:
-        if self.open_instruction in self.range:
+        if self.open_instruction in self.options:
             return {"code": self.dpcode, "value": self.open_instruction}
         return None
 
     def get_close_command(self, device: CustomerDevice) -> dict[str, Any] | None:
-        if self.close_instruction in self.range:
+        if self.close_instruction in self.options:
             return {"code": self.dpcode, "value": self.close_instruction}
         return None
 
     def get_stop_command(self, device: CustomerDevice) -> dict[str, Any] | None:
-        if self.stop_instruction in self.range:
+        if self.stop_instruction in self.options:
             return {"code": self.dpcode, "value": self.stop_instruction}
         return None
 

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -104,17 +104,17 @@ class _InstructionEnumWrapper(DPCodeEnumWrapper, _InstructionWrapper):
     stop_instruction = "stop"
 
     def get_open_command(self, device: CustomerDevice) -> dict[str, Any] | None:
-        if self.open_instruction in self.type_information.range:
+        if self.open_instruction in self.range:
             return {"code": self.dpcode, "value": self.open_instruction}
         return None
 
     def get_close_command(self, device: CustomerDevice) -> dict[str, Any] | None:
-        if self.close_instruction in self.type_information.range:
+        if self.close_instruction in self.range:
             return {"code": self.dpcode, "value": self.close_instruction}
         return None
 
     def get_stop_command(self, device: CustomerDevice) -> dict[str, Any] | None:
-        if self.stop_instruction in self.type_information.range:
+        if self.stop_instruction in self.range:
             return {"code": self.dpcode, "value": self.stop_instruction}
         return None
 

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -31,10 +31,12 @@ from .models import (
 class _DPCodeEventWrapper(DPCodeTypeInformationWrapper):
     """Base class for Tuya event wrappers."""
 
-    @property
-    def event_types(self) -> list[str]:
-        """Return the event types for the DP code."""
-        return ["triggered"]
+    range: list[str]
+
+    def __init__(self, dpcode: str, type_information: Any) -> None:
+        """Init _DPCodeEventWrapper."""
+        super().__init__(dpcode, type_information)
+        self.range = ["triggered"]
 
     def get_event_type(
         self, device: CustomerDevice, updated_status_properties: list[str] | None
@@ -54,11 +56,6 @@ class _DPCodeEventWrapper(DPCodeTypeInformationWrapper):
 
 class _EventEnumWrapper(DPCodeEnumWrapper, _DPCodeEventWrapper):
     """Wrapper for event enum DP codes."""
-
-    @property
-    def event_types(self) -> list[str]:
-        """Return the event types for the enum."""
-        return self.range
 
     def get_event_type(
         self, device: CustomerDevice, updated_status_properties: list[str] | None
@@ -232,7 +229,7 @@ class TuyaEventEntity(TuyaEntity, EventEntity):
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._dpcode_wrapper = dpcode_wrapper
-        self._attr_event_types = dpcode_wrapper.event_types
+        self._attr_event_types = dpcode_wrapper.range
 
     async def _handle_state_update(
         self,

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -31,12 +31,12 @@ from .models import (
 class _DPCodeEventWrapper(DPCodeTypeInformationWrapper):
     """Base class for Tuya event wrappers."""
 
-    range: list[str]
+    options: list[str]
 
     def __init__(self, dpcode: str, type_information: Any) -> None:
         """Init _DPCodeEventWrapper."""
         super().__init__(dpcode, type_information)
-        self.range = ["triggered"]
+        self.options = ["triggered"]
 
     def get_event_type(
         self, device: CustomerDevice, updated_status_properties: list[str] | None
@@ -229,7 +229,7 @@ class TuyaEventEntity(TuyaEntity, EventEntity):
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._dpcode_wrapper = dpcode_wrapper
-        self._attr_event_types = dpcode_wrapper.range
+        self._attr_event_types = dpcode_wrapper.options
 
     async def _handle_state_update(
         self,

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -31,12 +31,10 @@ from .models import (
 class _DPCodeEventWrapper(DPCodeTypeInformationWrapper):
     """Base class for Tuya event wrappers."""
 
-    options: list[str]
-
-    def __init__(self, dpcode: str, type_information: Any) -> None:
-        """Init _DPCodeEventWrapper."""
-        super().__init__(dpcode, type_information)
-        self.options = ["triggered"]
+    @property
+    def event_types(self) -> list[str]:
+        """Return the event types for the DP code."""
+        return ["triggered"]
 
     def get_event_type(
         self, device: CustomerDevice, updated_status_properties: list[str] | None
@@ -56,6 +54,11 @@ class _DPCodeEventWrapper(DPCodeTypeInformationWrapper):
 
 class _EventEnumWrapper(DPCodeEnumWrapper, _DPCodeEventWrapper):
     """Wrapper for event enum DP codes."""
+
+    @property
+    def event_types(self) -> list[str]:
+        """Return the event types for the enum."""
+        return self.options
 
     def get_event_type(
         self, device: CustomerDevice, updated_status_properties: list[str] | None
@@ -229,7 +232,7 @@ class TuyaEventEntity(TuyaEntity, EventEntity):
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._dpcode_wrapper = dpcode_wrapper
-        self._attr_event_types = dpcode_wrapper.options
+        self._attr_event_types = dpcode_wrapper.event_types
 
     async def _handle_state_update(
         self,

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -58,7 +58,7 @@ class _EventEnumWrapper(DPCodeEnumWrapper, _DPCodeEventWrapper):
     @property
     def event_types(self) -> list[str]:
         """Return the event types for the enum."""
-        return self.type_information.range
+        return self.range
 
     def get_event_type(
         self, device: CustomerDevice, updated_status_properties: list[str] | None

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -79,17 +79,17 @@ class _FanSpeedEnumWrapper(DPCodeEnumWrapper):
 
     def get_speed_count(self) -> int:
         """Get the number of speeds supported by the fan."""
-        return len(self.type_information.range)
+        return len(self.range)
 
     def read_device_status(self, device: CustomerDevice) -> int | None:
         """Get the current speed as a percentage."""
         if (value := super().read_device_status(device)) is None:
             return None
-        return ordered_list_item_to_percentage(self.type_information.range, value)
+        return ordered_list_item_to_percentage(self.range, value)
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
         """Convert a Home Assistant value back to a raw device value."""
-        return percentage_to_ordered_list_item(self.type_information.range, value)
+        return percentage_to_ordered_list_item(self.range, value)
 
 
 class _FanSpeedIntegerWrapper(DPCodeIntegerWrapper):
@@ -197,7 +197,7 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
 
         if mode_wrapper:
             self._attr_supported_features |= FanEntityFeature.PRESET_MODE
-            self._attr_preset_modes = mode_wrapper.type_information.range
+            self._attr_preset_modes = mode_wrapper.range
 
         if speed_wrapper:
             self._attr_supported_features |= FanEntityFeature.SET_SPEED

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -77,10 +77,6 @@ def _has_a_valid_dpcode(device: CustomerDevice) -> bool:
 class _FanSpeedEnumWrapper(DPCodeEnumWrapper):
     """Wrapper for fan speed DP code (from an enum)."""
 
-    def get_speed_count(self) -> int:
-        """Get the number of speeds supported by the fan."""
-        return len(self.range)
-
     def read_device_status(self, device: CustomerDevice) -> int | None:
         """Get the current speed as a percentage."""
         if (value := super().read_device_status(device)) is None:
@@ -99,10 +95,6 @@ class _FanSpeedIntegerWrapper(DPCodeIntegerWrapper):
         """Init DPCodeIntegerWrapper."""
         super().__init__(dpcode, type_information)
         self._remap_helper = RemapHelper.from_type_information(type_information, 1, 100)
-
-    def get_speed_count(self) -> int:
-        """Get the number of speeds supported by the fan."""
-        return 100
 
     def read_device_status(self, device: CustomerDevice) -> int | None:
         """Get the current speed as a percentage."""
@@ -201,7 +193,8 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
 
         if speed_wrapper:
             self._attr_supported_features |= FanEntityFeature.SET_SPEED
-            self._attr_speed_count = speed_wrapper.get_speed_count()
+            if speed_wrapper.range is not None:
+                self._attr_speed_count = len(speed_wrapper.range)
 
         if oscillate_wrapper:
             self._attr_supported_features |= FanEntityFeature.OSCILLATE

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -81,11 +81,11 @@ class _FanSpeedEnumWrapper(DPCodeEnumWrapper):
         """Get the current speed as a percentage."""
         if (value := super().read_device_status(device)) is None:
             return None
-        return ordered_list_item_to_percentage(self.range, value)
+        return ordered_list_item_to_percentage(self.options, value)
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
         """Convert a Home Assistant value back to a raw device value."""
-        return percentage_to_ordered_list_item(self.range, value)
+        return percentage_to_ordered_list_item(self.options, value)
 
 
 class _FanSpeedIntegerWrapper(DPCodeIntegerWrapper):
@@ -189,12 +189,12 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
 
         if mode_wrapper:
             self._attr_supported_features |= FanEntityFeature.PRESET_MODE
-            self._attr_preset_modes = mode_wrapper.range
+            self._attr_preset_modes = mode_wrapper.options
 
         if speed_wrapper:
             self._attr_supported_features |= FanEntityFeature.SET_SPEED
-            if speed_wrapper.range is not None:
-                self._attr_speed_count = len(speed_wrapper.range)
+            if speed_wrapper.options is not None:
+                self._attr_speed_count = len(speed_wrapper.options)
 
         if oscillate_wrapper:
             self._attr_supported_features |= FanEntityFeature.OSCILLATE

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -163,7 +163,7 @@ class TuyaHumidifierEntity(TuyaEntity, HumidifierEntity):
         # Determine mode support and provided modes
         if mode_wrapper:
             self._attr_supported_features |= HumidifierEntityFeature.MODES
-            self._attr_available_modes = mode_wrapper.range
+            self._attr_available_modes = mode_wrapper.options
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -163,7 +163,7 @@ class TuyaHumidifierEntity(TuyaEntity, HumidifierEntity):
         # Determine mode support and provided modes
         if mode_wrapper:
             self._attr_supported_features |= HumidifierEntityFeature.MODES
-            self._attr_available_modes = mode_wrapper.type_information.range
+            self._attr_available_modes = mode_wrapper.range
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -706,7 +706,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         elif (
             color_supported(color_modes)
             and color_mode_wrapper is not None
-            and WorkMode.WHITE in color_mode_wrapper.type_information.range
+            and WorkMode.WHITE in color_mode_wrapper.range
         ):
             color_modes.add(ColorMode.WHITE)
             self._white_color_mode = ColorMode.WHITE

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -706,7 +706,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         elif (
             color_supported(color_modes)
             and color_mode_wrapper is not None
-            and WorkMode.WHITE in color_mode_wrapper.range
+            and WorkMode.WHITE in color_mode_wrapper.options
         ):
             color_modes.add(ColorMode.WHITE)
             self._white_color_mode = ColorMode.WHITE

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -22,7 +22,6 @@ class DeviceWrapper:
     """Base device wrapper."""
 
     options: list[str] | None = None
-    """Valid options for the wrapper, if applicable."""
 
     def read_device_status(self, device: CustomerDevice) -> Any | None:
         """Read device status and convert to a Home Assistant value."""

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -133,6 +133,12 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
     """Simple wrapper for EnumTypeInformation values."""
 
     _DPTYPE = EnumTypeInformation
+    range: list[str]
+
+    def __init__(self, dpcode: str, type_information: EnumTypeInformation) -> None:
+        """Init DPCodeEnumWrapper."""
+        super().__init__(dpcode, type_information)
+        self.range = type_information.range
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
         """Convert a Home Assistant value back to a raw device value."""

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -21,7 +21,8 @@ from .type_information import (
 class DeviceWrapper:
     """Base device wrapper."""
 
-    range: list[str] | None = None
+    options: list[str] | None = None
+    """Valid options for the wrapper, if applicable."""
 
     def read_device_status(self, device: CustomerDevice) -> Any | None:
         """Read device status and convert to a Home Assistant value."""
@@ -135,12 +136,12 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
     """Simple wrapper for EnumTypeInformation values."""
 
     _DPTYPE = EnumTypeInformation
-    range: list[str]
+    options: list[str]
 
     def __init__(self, dpcode: str, type_information: EnumTypeInformation) -> None:
         """Init DPCodeEnumWrapper."""
         super().__init__(dpcode, type_information)
-        self.range = type_information.range
+        self.options = type_information.range
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
         """Convert a Home Assistant value back to a raw device value."""

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -21,6 +21,8 @@ from .type_information import (
 class DeviceWrapper:
     """Base device wrapper."""
 
+    range: list[str] | None = None
+
     def read_device_status(self, device: CustomerDevice) -> Any | None:
         """Read device status and convert to a Home Assistant value."""
         raise NotImplementedError

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -400,7 +400,7 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._dpcode_wrapper = dpcode_wrapper
-        self._attr_options = dpcode_wrapper.range
+        self._attr_options = dpcode_wrapper.options
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -400,7 +400,7 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._dpcode_wrapper = dpcode_wrapper
-        self._attr_options = dpcode_wrapper.type_information.range
+        self._attr_options = dpcode_wrapper.range
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -135,7 +135,7 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
             self._attr_supported_features |= VacuumEntityFeature.PAUSE
 
         if charge_wrapper or (
-            mode_wrapper and TUYA_MODE_RETURN_HOME in mode_wrapper.range
+            mode_wrapper and TUYA_MODE_RETURN_HOME in mode_wrapper.options
         ):
             self._attr_supported_features |= VacuumEntityFeature.RETURN_HOME
 
@@ -148,7 +148,7 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
             )
 
         if fan_speed_wrapper:
-            self._attr_fan_speed_list = fan_speed_wrapper.range
+            self._attr_fan_speed_list = fan_speed_wrapper.options
             self._attr_supported_features |= VacuumEntityFeature.FAN_SPEED
 
     @property

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -135,8 +135,7 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
             self._attr_supported_features |= VacuumEntityFeature.PAUSE
 
         if charge_wrapper or (
-            mode_wrapper
-            and TUYA_MODE_RETURN_HOME in mode_wrapper.type_information.range
+            mode_wrapper and TUYA_MODE_RETURN_HOME in mode_wrapper.range
         ):
             self._attr_supported_features |= VacuumEntityFeature.RETURN_HOME
 
@@ -149,7 +148,7 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
             )
 
         if fan_speed_wrapper:
-            self._attr_fan_speed_list = fan_speed_wrapper.type_information.range
+            self._attr_fan_speed_list = fan_speed_wrapper.range
             self._attr_supported_features |= VacuumEntityFeature.FAN_SPEED
 
     @property


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Make `options` an optional attribute of `DeviceWrapper` (non-optional for `DPCodeEnumWrapper`)

- Replace references to `wrapper.type_information.range` with `wrapper.options`

- Drop unnecessary `get_speed_count` method in `fan` platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
