### PR TITLE
Use is over == comparison for FlowResultType in flow tests

### DIFF
--- a/tests/auth/providers/test_trusted_networks.py
+++ b/tests/auth/providers/test_trusted_networks.py
@@ -267,7 +267,7 @@ async def test_login_flow(
     # not from trusted network
     flow = await provider.async_login_flow({"ip_address": ip_address("127.0.0.1")})
     step = await flow.async_step_init()
-    assert step["type"] == FlowResultType.ABORT
+    assert step["type"] is FlowResultType.ABORT
     assert step["reason"] == "not_allowed"
 
     # from trusted network, list users
@@ -282,7 +282,7 @@ async def test_login_flow(
 
     # login with valid user
     step = await flow.async_step_init({"user": user.id})
-    assert step["type"] == FlowResultType.CREATE_ENTRY
+    assert step["type"] is FlowResultType.CREATE_ENTRY
     assert step["data"]["user"] == user.id
 
 
@@ -309,7 +309,7 @@ async def test_trusted_users_login(
         {"ip_address": ip_address("127.0.0.1")}
     )
     step = await flow.async_step_init()
-    assert step["type"] == FlowResultType.ABORT
+    assert step["type"] is FlowResultType.ABORT
     assert step["reason"] == "not_allowed"
 
     # from trusted network, list users intersect trusted_users
@@ -396,7 +396,7 @@ async def test_trusted_group_login(
         {"ip_address": ip_address("127.0.0.1")}
     )
     step = await flow.async_step_init()
-    assert step["type"] == FlowResultType.ABORT
+    assert step["type"] is FlowResultType.ABORT
     assert step["reason"] == "not_allowed"
 
     # from trusted network, list users intersect trusted_users
@@ -437,7 +437,7 @@ async def test_bypass_login_flow(
         {"ip_address": ip_address("127.0.0.1")}
     )
     step = await flow.async_step_init()
-    assert step["type"] == FlowResultType.ABORT
+    assert step["type"] is FlowResultType.ABORT
     assert step["reason"] == "not_allowed"
 
     # from trusted network, only one available user, bypass the login flow
@@ -445,7 +445,7 @@ async def test_bypass_login_flow(
         {"ip_address": ip_address("192.168.0.1")}
     )
     step = await flow.async_step_init()
-    assert step["type"] == FlowResultType.CREATE_ENTRY
+    assert step["type"] is FlowResultType.CREATE_ENTRY
     assert step["data"]["user"] == owner.id
 
     user = await manager_bypass_login.async_create_user("test-user")

--- a/tests/components/actron_air/test_config_flow.py
+++ b/tests/components/actron_air/test_config_flow.py
@@ -174,7 +174,7 @@ async def test_user_flow_duplicate_account(
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     # Should abort because the account is already configured
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 

--- a/tests/components/airq/test_config_flow.py
+++ b/tests/components/airq/test_config_flow.py
@@ -119,7 +119,7 @@ async def test_options_flow(hass: HomeAssistant, user_input) -> None:
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
     assert entry.options == {}
 
@@ -127,5 +127,5 @@ async def test_options_flow(hass: HomeAssistant, user_input) -> None:
         result["flow_id"], user_input=user_input
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == entry.options == DEFAULT_OPTIONS | user_input

--- a/tests/components/ambient_network/test_config_flow.py
+++ b/tests/components/ambient_network/test_config_flow.py
@@ -28,7 +28,7 @@ async def test_happy_path(
     setup_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert setup_result["type"] == FlowResultType.FORM
+    assert setup_result["type"] is FlowResultType.FORM
     assert setup_result["step_id"] == "user"
 
     with patch.object(
@@ -41,7 +41,7 @@ async def test_happy_path(
             {"location": {"latitude": 10.0, "longitude": 20.0, "radius": 1.0}},
         )
 
-    assert user_result["type"] == FlowResultType.FORM
+    assert user_result["type"] is FlowResultType.FORM
     assert user_result["step_id"] == "station"
 
     stations_result = await hass.config_entries.flow.async_configure(
@@ -51,7 +51,7 @@ async def test_happy_path(
         },
     )
 
-    assert stations_result["type"] == FlowResultType.CREATE_ENTRY
+    assert stations_result["type"] is FlowResultType.CREATE_ENTRY
     assert stations_result["title"] == config_entry.title
     assert stations_result["data"] == config_entry.data
     assert len(mock_setup_entry.mock_calls) == 1
@@ -67,7 +67,7 @@ async def test_no_station_found(
     setup_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert setup_result["type"] == FlowResultType.FORM
+    assert setup_result["type"] is FlowResultType.FORM
     assert setup_result["step_id"] == "user"
 
     with patch.object(
@@ -80,6 +80,6 @@ async def test_no_station_found(
             {"location": {"latitude": 10.0, "longitude": 20.0, "radius": 1.0}},
         )
 
-    assert user_result["type"] == FlowResultType.FORM
+    assert user_result["type"] is FlowResultType.FORM
     assert user_result["step_id"] == "user"
     assert user_result["errors"] == {"base": "no_stations_found"}

--- a/tests/components/anova/test_config_flow.py
+++ b/tests/components/anova/test_config_flow.py
@@ -23,7 +23,7 @@ async def test_flow_user(hass: HomeAssistant, anova_api: AnovaApi) -> None:
         result["flow_id"],
         user_input=CONF_INPUT,
     )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_USERNAME: "sample@gmail.com",
         CONF_PASSWORD: "sample",

--- a/tests/components/anthropic/test_config_flow.py
+++ b/tests/components/anthropic/test_config_flow.py
@@ -263,7 +263,7 @@ async def test_subentry_web_search_user_location(
             "recommended": False,
         },
     )
-    assert options["type"] == FlowResultType.FORM
+    assert options["type"] is FlowResultType.FORM
     assert options["step_id"] == "advanced"
 
     # Configure advanced step
@@ -274,7 +274,7 @@ async def test_subentry_web_search_user_location(
             "chat_model": "claude-sonnet-4-5",
         },
     )
-    assert options["type"] == FlowResultType.FORM
+    assert options["type"] is FlowResultType.FORM
     assert options["step_id"] == "model"
 
     hass.config.country = "US"
@@ -354,7 +354,7 @@ async def test_model_list(
             "recommended": False,
         },
     )
-    assert options["type"] == FlowResultType.FORM
+    assert options["type"] is FlowResultType.FORM
     assert options["step_id"] == "advanced"
     assert options["data_schema"].schema["chat_model"].config["options"] == [
         {
@@ -429,7 +429,7 @@ async def test_model_list_error(
                 "recommended": False,
             },
         )
-    assert options["type"] == FlowResultType.FORM
+    assert options["type"] is FlowResultType.FORM
     assert options["step_id"] == "advanced"
     assert options["data_schema"].schema["chat_model"].config["options"] == []
 
@@ -634,7 +634,7 @@ async def test_subentry_options_switching(
     assert subentry_flow["step_id"] == "init"
 
     for step_options in new_options:
-        assert subentry_flow["type"] == FlowResultType.FORM
+        assert subentry_flow["type"] is FlowResultType.FORM
         assert not subentry_flow["errors"]
 
         # Test that current options are showed as suggested values:

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -76,7 +76,7 @@ async def test_ws_setup_depose_mfa(
 
     flow = result["result"]
     # Cannot use identity `is` check here as the value is parsed from JSON
-    assert flow["type"] == FlowResultType.FORM.value
+    assert flow["type"] is FlowResultType.FORM.value
     assert flow["handler"] == "example_module"
     assert flow["step_id"] == "init"
     assert flow["data_schema"][0] == {"type": "string", "name": "pin", "required": True}
@@ -96,7 +96,7 @@ async def test_ws_setup_depose_mfa(
 
     flow = result["result"]
     # Cannot use identity `is` check here as the value is parsed from JSON
-    assert flow["type"] == FlowResultType.CREATE_ENTRY.value
+    assert flow["type"] is FlowResultType.CREATE_ENTRY.value
     assert flow["handler"] == "example_module"
     assert flow["data"]["result"] is None
 

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -96,7 +96,7 @@ async def test_ws_setup_depose_mfa(
 
     flow = result["result"]
     # Cannot use identity `is` check here as the value is parsed from JSON
-    assert flow["type"] is FlowResultType.CREATE_ENTRY.value
+    assert flow["type"] == FlowResultType.CREATE_ENTRY.value
     assert flow["handler"] == "example_module"
     assert flow["data"]["result"] is None
 

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -76,7 +76,7 @@ async def test_ws_setup_depose_mfa(
 
     flow = result["result"]
     # Cannot use identity `is` check here as the value is parsed from JSON
-    assert flow["type"] is FlowResultType.FORM.value
+    assert flow["type"] == FlowResultType.FORM.value
     assert flow["handler"] == "example_module"
     assert flow["step_id"] == "init"
     assert flow["data_schema"][0] == {"type": "string", "name": "pin", "required": True}

--- a/tests/components/compit/test_config_flow.py
+++ b/tests/components/compit/test_config_flow.py
@@ -35,7 +35,7 @@ async def test_async_step_user_success(
         result["flow_id"], CONFIG_INPUT
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == CONFIG_INPUT[CONF_EMAIL]
     assert result["data"] == CONFIG_INPUT
     assert len(mock_setup_entry.mock_calls) == 1
@@ -70,14 +70,14 @@ async def test_async_step_user_failed_auth(
         result["flow_id"], CONFIG_INPUT
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": expected_error}
 
     # Test success after error is cleared
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], CONFIG_INPUT
     )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == CONFIG_INPUT[CONF_EMAIL]
     assert result["data"] == CONFIG_INPUT
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -1028,7 +1028,7 @@ async def test_get_progress_subscribe_create_entry(hass: HomeAssistant) -> None:
             "test", context={"source": core_ce.SOURCE_IMPORT}, data={}
         )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert len(subscription_mock.mock_calls) == 0
 
 

--- a/tests/components/cookidoo/test_config_flow.py
+++ b/tests/components/cookidoo/test_config_flow.py
@@ -47,7 +47,7 @@ async def test_flow_user_success(
         user_input=MOCK_DATA_USER_STEP,
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "language"
 
     result = await hass.config_entries.flow.async_configure(
@@ -97,7 +97,7 @@ async def test_flow_user_init_data_unknown_error_and_recover_on_step_1(
         user_input=MOCK_DATA_USER_STEP,
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "language"
 
     result = await hass.config_entries.flow.async_configure(
@@ -137,7 +137,7 @@ async def test_flow_user_init_data_unknown_error_and_recover_on_step_2(
         user_input=MOCK_DATA_USER_STEP,
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "language"
 
     result = await hass.config_entries.flow.async_configure(
@@ -269,7 +269,7 @@ async def test_flow_reconfigure_init_data_unknown_error_and_recover_on_step_1(
         user_input={**MOCK_DATA_USER_STEP, CONF_COUNTRY: "DE"},
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "language"
 
     result = await hass.config_entries.flow.async_configure(
@@ -318,7 +318,7 @@ async def test_flow_reconfigure_init_data_unknown_error_and_recover_on_step_2(
         user_input={**MOCK_DATA_USER_STEP, CONF_COUNTRY: "DE"},
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "language"
 
     result = await hass.config_entries.flow.async_configure(

--- a/tests/components/datadog/test_config_flow.py
+++ b/tests/components/datadog/test_config_flow.py
@@ -24,13 +24,13 @@ async def test_user_flow_success(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             datadog.DOMAIN, context={"source": SOURCE_USER}
         )
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
 
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_CONFIG
         )
         assert result2["title"] == f"Datadog {MOCK_CONFIG['host']}"
-        assert result2["type"] == FlowResultType.CREATE_ENTRY
+        assert result2["type"] is FlowResultType.CREATE_ENTRY
         assert result2["data"] == MOCK_DATA
         assert result2["options"] == MOCK_OPTIONS
 
@@ -48,7 +48,7 @@ async def test_user_flow_retry_after_connection_fail(hass: HomeAssistant) -> Non
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_CONFIG
         )
-        assert result2["type"] == FlowResultType.FORM
+        assert result2["type"] is FlowResultType.FORM
         assert result2["errors"] == {"base": "cannot_connect"}
 
     with patch(
@@ -57,7 +57,7 @@ async def test_user_flow_retry_after_connection_fail(hass: HomeAssistant) -> Non
         result3 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_CONFIG
         )
-        assert result3["type"] == FlowResultType.CREATE_ENTRY
+        assert result3["type"] is FlowResultType.CREATE_ENTRY
         assert result3["data"] == MOCK_DATA
         assert result3["options"] == MOCK_OPTIONS
 
@@ -104,13 +104,13 @@ async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:
         side_effect=OSError("connection failed"),
     ):
         result = await hass.config_entries.options.async_init(mock_entry.entry_id)
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
 
         result2 = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input=MOCK_OPTIONS
         )
 
-        assert result2["type"] == FlowResultType.FORM
+        assert result2["type"] is FlowResultType.FORM
         assert result2["errors"] == {"base": "cannot_connect"}
 
     with patch(
@@ -119,7 +119,7 @@ async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:
         result3 = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input=MOCK_OPTIONS
         )
-        assert result3["type"] == FlowResultType.CREATE_ENTRY
+        assert result3["type"] is FlowResultType.CREATE_ENTRY
         assert result3["data"] == MOCK_OPTIONS
 
 
@@ -141,7 +141,7 @@ async def test_import_flow(
             data=MOCK_CONFIG,
         )
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"] == MOCK_DATA
         assert result["options"] == MOCK_OPTIONS
 
@@ -200,11 +200,11 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         side_effect=OSError,
     ):
         result = await hass.config_entries.options.async_init(mock_entry.entry_id)
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         result2 = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input=new_options
         )
-        assert result2["type"] == FlowResultType.FORM
+        assert result2["type"] is FlowResultType.FORM
         assert result2["errors"] == {"base": "cannot_connect"}
 
     # ValueError Case
@@ -213,11 +213,11 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         side_effect=ValueError,
     ):
         result = await hass.config_entries.options.async_init(mock_entry.entry_id)
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         result2 = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input=new_options
         )
-        assert result2["type"] == FlowResultType.FORM
+        assert result2["type"] is FlowResultType.FORM
         assert result2["errors"] == {"base": "cannot_connect"}
 
     # Success Case
@@ -231,7 +231,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
             result["flow_id"], user_input=new_options
         )
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"] == new_options
         mock_instance.increment.assert_called_once_with("connection_test")
 
@@ -253,5 +253,5 @@ async def test_import_flow_abort_already_configured_service(
         data=MOCK_CONFIG,
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -2306,7 +2306,7 @@ async def test_reconfigure_preserves_existing_config_entry_fields(
 
     result = await config_entry.start_reconfigure_flow(hass)
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
 
     mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)

--- a/tests/components/energyid/test_config_flow.py
+++ b/tests/components/energyid/test_config_flow.py
@@ -470,7 +470,7 @@ async def test_config_flow_reauth_success(
         )
         await hass.async_block_till_done()
 
-        assert result2["type"] == FlowResultType.ABORT
+        assert result2["type"] is FlowResultType.ABORT
         # Entry should be updated
         updated_entry = hass.config_entries.async_get_entry(entry.entry_id)
         assert updated_entry.data[CONF_PROVISIONING_KEY] == "new_key"

--- a/tests/components/enigma2/test_config_flow.py
+++ b/tests/components/enigma2/test_config_flow.py
@@ -24,7 +24,7 @@ async def user_flow(hass: HomeAssistant) -> str:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
     return result["flow_id"]
 
@@ -79,7 +79,7 @@ async def test_form_user_errors(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
     assert result["errors"] == {"base": error_value}
 

--- a/tests/components/epic_games_store/test_config_flow.py
+++ b/tests/components/epic_games_store/test_config_flow.py
@@ -39,7 +39,7 @@ async def test_form(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
 
     with patch(
@@ -55,7 +55,7 @@ async def test_form(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["result"].unique_id == f"freegames-{MOCK_LANGUAGE}-{MOCK_COUNTRY}"
     assert (
         result2["title"]
@@ -85,7 +85,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result2["type"] == FlowResultType.FORM
+    assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -107,7 +107,7 @@ async def test_form_cannot_connect_wrong_param(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result2["type"] == FlowResultType.FORM
+    assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}
 
 
@@ -130,7 +130,7 @@ async def test_form_service_error(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["result"].unique_id == f"freegames-{MOCK_LANGUAGE}-{MOCK_COUNTRY}"
     assert (
         result2["title"]

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -344,7 +344,7 @@ async def test_user_resolve_error(hass: HomeAssistant, mock_client: APIClient) -
         user_input={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
     )
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == "test"
     assert result2["data"] == {
         CONF_HOST: "127.0.0.1",
@@ -434,7 +434,7 @@ async def test_user_connection_error(
         user_input={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
     )
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == "test"
     assert result2["data"] == {
         CONF_HOST: "127.0.0.1",
@@ -512,7 +512,7 @@ async def test_user_invalid_password(
         result["flow_id"], user_input={CONF_PASSWORD: "good"}
     )
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == "test"
     assert result2["data"] == {
         CONF_HOST: "127.0.0.1",
@@ -765,7 +765,7 @@ async def test_login_connection_error(
         result["flow_id"], user_input={CONF_PASSWORD: "good"}
     )
 
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == "test"
     assert result2["data"] == {
         CONF_HOST: "127.0.0.1",

--- a/tests/components/esphome/test_repairs.py
+++ b/tests/components/esphome/test_repairs.py
@@ -87,7 +87,7 @@ async def test_device_conflict_manual(
         "name": "test",
         "stored_mac": "11:22:33:44:55:aa",
     }
-    assert data["type"] == FlowResultType.MENU
+    assert data["type"] is FlowResultType.MENU
     assert data["step_id"] == "init"
 
     data = await process_repair_fix_flow(
@@ -102,7 +102,7 @@ async def test_device_conflict_manual(
         "name": "test",
         "stored_mac": "11:22:33:44:55:aa",
     }
-    assert data["type"] == FlowResultType.FORM
+    assert data["type"] is FlowResultType.FORM
     assert data["step_id"] == "manual"
 
     device_info = DeviceInfo(
@@ -116,7 +116,7 @@ async def test_device_conflict_manual(
     caplog.clear()
     data = await process_repair_fix_flow(client, flow_id)
 
-    assert data["type"] == FlowResultType.CREATE_ENTRY
+    assert data["type"] is FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
     assert "Unexpected device found" not in caplog.text
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
@@ -205,7 +205,7 @@ async def test_device_conflict_migration(
         "name": "test",
         "stored_mac": "11:22:33:44:55:aa",
     }
-    assert data["type"] == FlowResultType.MENU
+    assert data["type"] is FlowResultType.MENU
     assert data["step_id"] == "init"
 
     data = await process_repair_fix_flow(
@@ -220,13 +220,13 @@ async def test_device_conflict_migration(
         "name": "test",
         "stored_mac": "11:22:33:44:55:aa",
     }
-    assert data["type"] == FlowResultType.FORM
+    assert data["type"] is FlowResultType.FORM
     assert data["step_id"] == "migrate"
 
     caplog.clear()
     data = await process_repair_fix_flow(client, flow_id)
 
-    assert data["type"] == FlowResultType.CREATE_ENTRY
+    assert data["type"] is FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
     assert "Unexpected device found" not in caplog.text
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is None

--- a/tests/components/esphome/test_repairs.py
+++ b/tests/components/esphome/test_repairs.py
@@ -87,7 +87,7 @@ async def test_device_conflict_manual(
         "name": "test",
         "stored_mac": "11:22:33:44:55:aa",
     }
-    assert data["type"] is FlowResultType.MENU
+    assert data["type"] == FlowResultType.MENU
     assert data["step_id"] == "init"
 
     data = await process_repair_fix_flow(
@@ -102,7 +102,7 @@ async def test_device_conflict_manual(
         "name": "test",
         "stored_mac": "11:22:33:44:55:aa",
     }
-    assert data["type"] is FlowResultType.FORM
+    assert data["type"] == FlowResultType.FORM
     assert data["step_id"] == "manual"
 
     device_info = DeviceInfo(
@@ -116,7 +116,7 @@ async def test_device_conflict_manual(
     caplog.clear()
     data = await process_repair_fix_flow(client, flow_id)
 
-    assert data["type"] is FlowResultType.CREATE_ENTRY
+    assert data["type"] == FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
     assert "Unexpected device found" not in caplog.text
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
@@ -205,7 +205,7 @@ async def test_device_conflict_migration(
         "name": "test",
         "stored_mac": "11:22:33:44:55:aa",
     }
-    assert data["type"] is FlowResultType.MENU
+    assert data["type"] == FlowResultType.MENU
     assert data["step_id"] == "init"
 
     data = await process_repair_fix_flow(
@@ -220,13 +220,13 @@ async def test_device_conflict_migration(
         "name": "test",
         "stored_mac": "11:22:33:44:55:aa",
     }
-    assert data["type"] is FlowResultType.FORM
+    assert data["type"] == FlowResultType.FORM
     assert data["step_id"] == "migrate"
 
     caplog.clear()
     data = await process_repair_fix_flow(client, flow_id)
 
-    assert data["type"] is FlowResultType.CREATE_ENTRY
+    assert data["type"] == FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
     assert "Unexpected device found" not in caplog.text
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is None

--- a/tests/components/firefly_iii/test_config_flow.py
+++ b/tests/components/firefly_iii/test_config_flow.py
@@ -97,7 +97,7 @@ async def test_form_exceptions(
         user_input=MOCK_USER_SETUP,
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": reason}
 
     mock_firefly_client.get_about.side_effect = None

--- a/tests/components/folder_watcher/test_config_flow.py
+++ b/tests/components/folder_watcher/test_config_flow.py
@@ -26,7 +26,7 @@ async def test_form(hass: HomeAssistant, tmp_path: Path) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -34,7 +34,7 @@ async def test_form(hass: HomeAssistant, tmp_path: Path) -> None:
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"Folder Watcher {path}"
     assert result["options"] == {CONF_FOLDER: path, CONF_PATTERNS: ["*"]}
 
@@ -51,7 +51,7 @@ async def test_form_not_allowed_path(hass: HomeAssistant, tmp_path: Path) -> Non
         {CONF_FOLDER: path},
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "not_allowed_dir"}
 
     hass.config.allowlist_external_dirs = {tmp_path}
@@ -62,7 +62,7 @@ async def test_form_not_allowed_path(hass: HomeAssistant, tmp_path: Path) -> Non
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"Folder Watcher {path}"
     assert result["options"] == {CONF_FOLDER: path, CONF_PATTERNS: ["*"]}
 
@@ -79,7 +79,7 @@ async def test_form_not_directory(hass: HomeAssistant, tmp_path: Path) -> None:
         {CONF_FOLDER: "not_a_directory"},
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "not_dir"}
 
     hass.config.allowlist_external_dirs = {path}
@@ -90,7 +90,7 @@ async def test_form_not_directory(hass: HomeAssistant, tmp_path: Path) -> None:
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"Folder Watcher {path}"
     assert result["options"] == {CONF_FOLDER: path, CONF_PATTERNS: ["*"]}
 
@@ -109,7 +109,7 @@ async def test_form_not_readable_dir(hass: HomeAssistant, tmp_path: Path) -> Non
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "not_readable_dir"}
 
     hass.config.allowlist_external_dirs = {path}
@@ -120,7 +120,7 @@ async def test_form_not_readable_dir(hass: HomeAssistant, tmp_path: Path) -> Non
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"Folder Watcher {path}"
     assert result["options"] == {CONF_FOLDER: path, CONF_PATTERNS: ["*"]}
 
@@ -146,5 +146,5 @@ async def test_form_already_configured(hass: HomeAssistant, tmp_path: Path) -> N
         {CONF_FOLDER: path},
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/gardena_bluetooth/test_config_flow.py
+++ b/tests/components/gardena_bluetooth/test_config_flow.py
@@ -70,14 +70,14 @@ async def test_user_selection_replaces_ignored(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_ADDRESS: WATER_TIMER_SERVICE_INFO.address},
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/history_stats/test_config_flow.py
+++ b/tests/components/history_stats/test_config_flow.py
@@ -273,7 +273,7 @@ async def test_config_flow_preview_success(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] is None
 
@@ -293,7 +293,7 @@ async def test_config_flow_preview_success(
         },
     )
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "options"
     assert result["errors"] is None
     assert result["preview"] == "history_stats"
@@ -395,7 +395,7 @@ async def test_options_flow_preview(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
     assert result["preview"] == "history_stats"
 
@@ -470,7 +470,7 @@ async def test_options_flow_preview_errors(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
     assert result["preview"] == "history_stats"
 
@@ -554,7 +554,7 @@ async def test_options_flow_sensor_preview_config_entry_removed(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
     assert result["preview"] == "history_stats"
 

--- a/tests/components/homeassistant_hardware/test_config_flow_failures.py
+++ b/tests/components/homeassistant_hardware/test_config_flow_failures.py
@@ -108,7 +108,7 @@ async def test_config_flow_thread_addon_info_fails(
         )
 
         # Cannot get addon info
-        assert result["type"] == FlowResultType.ABORT
+        assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "addon_info_failed"
         assert result["description_placeholders"] == {
             "model": TEST_HARDWARE_NAME,
@@ -159,7 +159,7 @@ async def test_config_flow_thread_addon_install_fails(
         )
 
         # Cannot install addon
-        assert result["type"] == FlowResultType.ABORT
+        assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "addon_install_failed"
         assert result["description_placeholders"] == {
             "model": TEST_HARDWARE_NAME,
@@ -206,7 +206,7 @@ async def test_config_flow_thread_addon_set_config_fails(
             ),
         )
 
-        assert pick_thread_progress_result["type"] == FlowResultType.ABORT
+        assert pick_thread_progress_result["type"] is FlowResultType.ABORT
         assert pick_thread_progress_result["reason"] == "addon_set_config_failed"
         assert pick_thread_progress_result["description_placeholders"] == {
             "model": TEST_HARDWARE_NAME,
@@ -252,7 +252,7 @@ async def test_config_flow_thread_flasher_run_fails(
             ),
         )
 
-        assert pick_thread_progress_result["type"] == FlowResultType.ABORT
+        assert pick_thread_progress_result["type"] is FlowResultType.ABORT
         assert pick_thread_progress_result["reason"] == "addon_start_failed"
         assert pick_thread_progress_result["description_placeholders"] == {
             "model": TEST_HARDWARE_NAME,
@@ -434,7 +434,7 @@ async def test_options_flow_zigbee_to_thread_zha_configured(
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
         )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "zha_still_using_stick"
     assert result["description_placeholders"] == {
         "model": TEST_HARDWARE_NAME,
@@ -486,7 +486,7 @@ async def test_options_flow_thread_to_zigbee_otbr_configured(
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
         )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "otbr_still_using_stick"
     assert result["description_placeholders"] == {
         "model": TEST_HARDWARE_NAME,

--- a/tests/components/homee/test_config_flow.py
+++ b/tests/components/homee/test_config_flow.py
@@ -95,7 +95,7 @@ async def test_config_flow_errors(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     flow_id = result["flow_id"]
 
     mock_homee.get_access_token.side_effect = side_eff
@@ -108,7 +108,7 @@ async def test_config_flow_errors(
         },
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == error
 
     mock_homee.get_access_token.side_effect = None
@@ -122,7 +122,7 @@ async def test_config_flow_errors(
         },
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 @pytest.mark.usefixtures("mock_homee")
@@ -237,7 +237,7 @@ async def test_zeroconf_confirm_errors(
         },
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == error
 
     mock_homee.get_access_token.side_effect = None
@@ -249,7 +249,7 @@ async def test_zeroconf_confirm_errors(
         },
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_zeroconf_already_configured(

--- a/tests/components/homewizard/test_repair.py
+++ b/tests/components/homewizard/test_repair.py
@@ -59,18 +59,18 @@ async def test_repair_acquires_token(
     result = await start_repair_fix_flow(client, DOMAIN, issue_id)
 
     flow_id = result["flow_id"]
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     result = await process_repair_fix_flow(client, flow_id)
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "authorize"
 
     # Simulate user not pressing the button
     result = await process_repair_fix_flow(client, flow_id, json={})
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "authorize"
     assert result["errors"] == {"base": "authorization_failed"}
 
@@ -79,7 +79,7 @@ async def test_repair_acquires_token(
     mock_homewizardenergy_v2.get_token.return_value = "cool_token"
     result = await process_repair_fix_flow(client, flow_id, json={})
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert mock_config_entry.data[CONF_TOKEN] == "cool_token"
     assert mock_config_entry.state is ConfigEntryState.LOADED
 

--- a/tests/components/homewizard/test_repair.py
+++ b/tests/components/homewizard/test_repair.py
@@ -59,18 +59,18 @@ async def test_repair_acquires_token(
     result = await start_repair_fix_flow(client, DOMAIN, issue_id)
 
     flow_id = result["flow_id"]
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     result = await process_repair_fix_flow(client, flow_id)
 
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "authorize"
 
     # Simulate user not pressing the button
     result = await process_repair_fix_flow(client, flow_id, json={})
 
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "authorize"
     assert result["errors"] == {"base": "authorization_failed"}
 
@@ -79,7 +79,7 @@ async def test_repair_acquires_token(
     mock_homewizardenergy_v2.get_token.return_value = "cool_token"
     result = await process_repair_fix_flow(client, flow_id, json={})
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert mock_config_entry.data[CONF_TOKEN] == "cool_token"
     assert mock_config_entry.state is ConfigEntryState.LOADED
 

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -365,7 +365,7 @@ async def test_ssdp(
         assert result["data_schema"] is not None
         assert result["data_schema"]({})[CONF_URL] == url + "/"
 
-    if result["type"] == FlowResultType.ABORT:
+    if result["type"] is FlowResultType.ABORT:
         return
 
     login_requests_mock.request(
@@ -379,7 +379,7 @@ async def test_ssdp(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == service_info.upnp[ATTR_UPNP_MODEL_NAME]
     assert result["result"].data[CONF_UPNP_UDN] == service_info.upnp[ATTR_UPNP_UDN]
 

--- a/tests/components/inels/test_config_flow.py
+++ b/tests/components/inels/test_config_flow.py
@@ -44,7 +44,7 @@ async def test_mqtt_setup(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> N
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == TITLE
     assert result["result"].data == {}
 

--- a/tests/components/intellifire/test_config_flow.py
+++ b/tests/components/intellifire/test_config_flow.py
@@ -24,7 +24,7 @@ async def test_standard_config_with_single_fireplace(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "cloud_api"
 
@@ -33,7 +33,7 @@ async def test_standard_config_with_single_fireplace(
         {CONF_USERNAME: "donJulio", CONF_PASSWORD: "Tequila0FD00m"},
     )
     # For a single fireplace we just create it
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "ip_address": "192.168.2.108",
         "api_key": "B5C4DA27AAEF31D1FB21AFF9BFA6BCD2",
@@ -59,7 +59,7 @@ async def test_standard_config_with_pre_configured_fireplace(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "cloud_api"
 
@@ -69,7 +69,7 @@ async def test_standard_config_with_pre_configured_fireplace(
     )
 
     # For a single fireplace we just create it
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "no_available_devices"
 
 
@@ -98,7 +98,7 @@ async def test_standard_config_with_single_fireplace_and_bad_credentials(
     # Erase the error
     mock_cloud_interface.login_with_credentials.side_effect = None
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "api_error"}
     assert result["step_id"] == "cloud_api"
     result = await hass.config_entries.flow.async_configure(
@@ -106,7 +106,7 @@ async def test_standard_config_with_single_fireplace_and_bad_credentials(
         {CONF_USERNAME: "donJulio", CONF_PASSWORD: "Tequila0FD00m"},
     )
     # For a single fireplace we just create it
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "ip_address": "192.168.2.108",
         "api_key": "B5C4DA27AAEF31D1FB21AFF9BFA6BCD2",
@@ -128,7 +128,7 @@ async def test_standard_config_with_multiple_fireplace(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "cloud_api"
 
@@ -137,13 +137,13 @@ async def test_standard_config_with_multiple_fireplace(
         {CONF_USERNAME: "donJulio", CONF_PASSWORD: "Tequila0FD00m"},
     )
     # When we have multiple fireplaces we get to pick a serial
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "pick_cloud_device"
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_SERIAL: "4GC295860E5837G40D9974B7FD459234"},
     )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "ip_address": "192.168.2.109",
         "api_key": "D4C5EB28BBFF41E1FB21AFF9BFA6CD34",
@@ -172,14 +172,14 @@ async def test_dhcp_discovery_intellifire_device(
             hostname="zentrios-Test",
         ),
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "cloud_api"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_USERNAME: "donJulio", CONF_PASSWORD: "Tequila0FD00m"},
     )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_dhcp_discovery_non_intellifire_device(
@@ -202,7 +202,7 @@ async def test_dhcp_discovery_non_intellifire_device(
             hostname="zentrios-Evil",
         ),
     )
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_intellifire_device"
     # Test is finished - the DHCP scanner detected a hostname that "might" be an IntelliFire device, but it was not.
 
@@ -217,7 +217,7 @@ async def test_reauth_flow(
 
     mock_config_entry_current.add_to_hass(hass)
     result = await mock_config_entry_current.start_reauth_flow(hass)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     result["step_id"] = "cloud_api"
 
     result = await hass.config_entries.flow.async_configure(
@@ -225,5 +225,5 @@ async def test_reauth_flow(
         {CONF_USERNAME: "donJulio", CONF_PASSWORD: "Tequila0FD00m"},
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"

--- a/tests/components/iotty/test_config_flow.py
+++ b/tests/components/iotty/test_config_flow.py
@@ -50,7 +50,7 @@ async def test_config_flow_no_credentials(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "missing_credentials"
 
 
@@ -71,7 +71,7 @@ async def test_full_flow(
         DOMAIN, context={"source": config_entries.SOURCE_USER, "entry_id": DOMAIN}
     )
 
-    assert result.get("type") == FlowResultType.EXTERNAL_STEP
+    assert result.get("type") is FlowResultType.EXTERNAL_STEP
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,

--- a/tests/components/jellyfin/test_config_flow.py
+++ b/tests/components/jellyfin/test_config_flow.py
@@ -441,7 +441,7 @@ async def test_options_flow(
 
     assert config_entry.options == {}
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
 
     # Audio Codec
@@ -449,7 +449,7 @@ async def test_options_flow(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={}
     )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert CONF_AUDIO_CODEC not in config_entry.options
 
     # Bad
@@ -479,5 +479,5 @@ async def test_setting_codec(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_AUDIO_CODEC: codec}
     )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert config_entry.options[CONF_AUDIO_CODEC] == codec

--- a/tests/components/london_underground/test_config_flow.py
+++ b/tests/components/london_underground/test_config_flow.py
@@ -44,7 +44,7 @@ async def test_options(
     """Test updating options."""
     result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -54,7 +54,7 @@ async def test_options(
         },
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_LINE: ["Bakerloo", "Central"],
     }

--- a/tests/components/mcp_server/test_config_flow.py
+++ b/tests/components/mcp_server/test_config_flow.py
@@ -26,7 +26,7 @@ async def test_form(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert not result["errors"]
 
     result = await hass.config_entries.flow.async_configure(
@@ -35,7 +35,7 @@ async def test_form(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Assist"
     assert len(mock_setup_entry.mock_calls) == 1
     assert result["data"] == {CONF_LLM_HASS_API: ["assist"]}
@@ -57,7 +57,7 @@ async def test_form_errors(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert not result["errors"]
 
     result = await hass.config_entries.flow.async_configure(
@@ -66,5 +66,5 @@ async def test_form_errors(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == errors

--- a/tests/components/mold_indicator/test_config_flow.py
+++ b/tests/components/mold_indicator/test_config_flow.py
@@ -229,7 +229,7 @@ async def test_config_flow_preview_success(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] is None
     assert result["preview"] == "mold_indicator"
@@ -294,7 +294,7 @@ async def test_options_flow_preview(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
     assert result["preview"] == "mold_indicator"
 
@@ -361,7 +361,7 @@ async def test_options_flow_sensor_preview_config_entry_removed(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
     assert result["preview"] == "mold_indicator"
 

--- a/tests/components/mopeka/test_config_flow.py
+++ b/tests/components/mopeka/test_config_flow.py
@@ -254,7 +254,7 @@ async def test_async_step_reconfigure_options(hass: HomeAssistant) -> None:
     assert entry.data[CONF_MEDIUM_TYPE] == MediumType.AIR.value
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
     schema: vol.Schema = result["data_schema"]
     medium_type_key = next(
@@ -266,7 +266,7 @@ async def test_async_step_reconfigure_options(hass: HomeAssistant) -> None:
         result["flow_id"],
         user_input={CONF_MEDIUM_TYPE: MediumType.FRESH_WATER.value},
     )
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
 
     # Verify the new configuration
     assert entry.data[CONF_MEDIUM_TYPE] == MediumType.FRESH_WATER.value

--- a/tests/components/nasweb/test_config_flow.py
+++ b/tests/components/nasweb/test_config_flow.py
@@ -34,7 +34,7 @@ async def _add_test_config_entry(hass: HomeAssistant) -> ConfigFlowResult:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == FlowResultType.FORM
+    assert result.get("type") is FlowResultType.FORM
     assert not result.get("errors")
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -52,7 +52,7 @@ async def test_form(
     """Test the form."""
     result = await _add_test_config_entry(hass)
 
-    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
     assert result.get("title") == "1.1.1.1"
     assert result.get("data") == TEST_USER_INPUT
 
@@ -76,7 +76,7 @@ async def test_form_cannot_connect(
             result["flow_id"], TEST_USER_INPUT
         )
 
-    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("type") is FlowResultType.FORM
     assert result2.get("errors") == {"base": "cannot_connect"}
 
 
@@ -97,7 +97,7 @@ async def test_form_invalid_auth(
             result["flow_id"], TEST_USER_INPUT
         )
 
-    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("type") is FlowResultType.FORM
     assert result2.get("errors") == {"base": "invalid_auth"}
 
 
@@ -116,7 +116,7 @@ async def test_form_missing_internal_url(
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], TEST_USER_INPUT
         )
-        assert result2.get("type") == FlowResultType.FORM
+        assert result2.get("type") is FlowResultType.FORM
         assert result2.get("errors") == {"base": "missing_internal_url"}
 
 
@@ -136,13 +136,13 @@ async def test_form_missing_nasweb_data(
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], TEST_USER_INPUT
         )
-        assert result2.get("type") == FlowResultType.FORM
+        assert result2.get("type") is FlowResultType.FORM
         assert result2.get("errors") == {"base": "missing_nasweb_data"}
     with patch(BASE_CONFIG_FLOW + "WebioAPI.status_subscription", return_value=False):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], TEST_USER_INPUT
         )
-        assert result2.get("type") == FlowResultType.FORM
+        assert result2.get("type") is FlowResultType.FORM
         assert result2.get("errors") == {"base": "missing_nasweb_data"}
 
 
@@ -162,7 +162,7 @@ async def test_missing_status(
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], TEST_USER_INPUT
         )
-        assert result2.get("type") == FlowResultType.FORM
+        assert result2.get("type") is FlowResultType.FORM
         assert result2.get("errors") == {"base": "missing_status"}
 
 
@@ -182,7 +182,7 @@ async def test_form_exception(
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], TEST_USER_INPUT
         )
-        assert result2.get("type") == FlowResultType.FORM
+        assert result2.get("type") is FlowResultType.FORM
         assert result2.get("errors") == {"base": "unknown"}
 
 
@@ -204,5 +204,5 @@ async def test_form_already_configured(
     )
     await hass.async_block_till_done()
 
-    assert result2_2.get("type") == FlowResultType.ABORT
+    assert result2_2.get("type") is FlowResultType.ABORT
     assert result2_2.get("reason") == "already_configured"

--- a/tests/components/ntfy/test_config_flow.py
+++ b/tests/components/ntfy/test_config_flow.py
@@ -343,7 +343,7 @@ async def test_invalid_topic(hass: HomeAssistant, mock_random: AsyncMock) -> Non
         },
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_topic"}
 
     result = await hass.config_entries.subentries.async_configure(

--- a/tests/components/openai_conversation/test_config_flow.py
+++ b/tests/components/openai_conversation/test_config_flow.py
@@ -207,7 +207,7 @@ async def test_subentry_unsupported_model(
     subentry_flow = await mock_config_entry.start_subentry_reconfigure_flow(
         hass, subentry.subentry_id
     )
-    assert subentry_flow["type"] == FlowResultType.FORM
+    assert subentry_flow["type"] is FlowResultType.FORM
     assert subentry_flow["step_id"] == "init"
 
     # Configure initial step
@@ -220,7 +220,7 @@ async def test_subentry_unsupported_model(
         },
     )
     await hass.async_block_till_done()
-    assert subentry_flow["type"] == FlowResultType.FORM
+    assert subentry_flow["type"] is FlowResultType.FORM
     assert subentry_flow["step_id"] == "advanced"
 
     # Configure advanced step
@@ -800,7 +800,7 @@ async def test_subentry_switching(
     assert subentry_flow["step_id"] == "init"
 
     for step_options in new_options:
-        assert subentry_flow["type"] == FlowResultType.FORM
+        assert subentry_flow["type"] is FlowResultType.FORM
 
         # Test that current options are showed as suggested values:
         for key in subentry_flow["data_schema"].schema:
@@ -834,7 +834,7 @@ async def test_subentry_web_search_user_location(
     subentry_flow = await mock_config_entry.start_subentry_reconfigure_flow(
         hass, subentry.subentry_id
     )
-    assert subentry_flow["type"] == FlowResultType.FORM
+    assert subentry_flow["type"] is FlowResultType.FORM
     assert subentry_flow["step_id"] == "init"
 
     # Configure initial step
@@ -845,7 +845,7 @@ async def test_subentry_web_search_user_location(
             CONF_PROMPT: "Speak like a pirate",
         },
     )
-    assert subentry_flow["type"] == FlowResultType.FORM
+    assert subentry_flow["type"] is FlowResultType.FORM
     assert subentry_flow["step_id"] == "advanced"
 
     # Configure advanced step
@@ -859,7 +859,7 @@ async def test_subentry_web_search_user_location(
         },
     )
     await hass.async_block_till_done()
-    assert subentry_flow["type"] == FlowResultType.FORM
+    assert subentry_flow["type"] is FlowResultType.FORM
     assert subentry_flow["step_id"] == "model"
 
     hass.config.country = "US"

--- a/tests/components/pglab/test_config_flow.py
+++ b/tests/components/pglab/test_config_flow.py
@@ -49,7 +49,7 @@ async def test_mqtt_setup(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> N
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["result"].data == {"discovery_prefix": "pglab/discovery"}
 
 

--- a/tests/components/qbittorrent/test_config_flow.py
+++ b/tests/components/qbittorrent/test_config_flow.py
@@ -83,7 +83,7 @@ async def test_flow_user(hass: HomeAssistant, mock_api: requests_mock.Mocker) ->
             result["flow_id"], USER_INPUT
         )
         await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
     assert result["data"] == {
         CONF_URL: "http://localhost:8080",

--- a/tests/components/qbus/test_config_flow.py
+++ b/tests/components/qbus/test_config_flow.py
@@ -45,7 +45,7 @@ async def test_step_discovery_confirm_create_entry(
             DOMAIN, context={"source": SOURCE_MQTT}, data=discovery
         )
 
-    assert result.get("type") == FlowResultType.FORM
+    assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "discovery_confirm"
 
     result = await hass.config_entries.flow.async_configure(
@@ -53,7 +53,7 @@ async def test_step_discovery_confirm_create_entry(
     )
     await hass.async_block_till_done()
 
-    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
     assert result.get("data") == {
         CONF_ID: "UL1",
         CONF_SERIAL_NUMBER: "000001",
@@ -85,7 +85,7 @@ async def test_step_mqtt_invalid(
         DOMAIN, context={"source": SOURCE_MQTT}, data=discovery
     )
 
-    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "invalid_discovery_info"
 
 
@@ -117,7 +117,7 @@ async def test_handle_gateway_topic_when_online(
         )
 
     assert mock_publish.called is mqtt_publish
-    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "discovery_in_progress"
 
 
@@ -143,7 +143,7 @@ async def test_handle_config_topic(
         )
 
     assert mock_publish.called
-    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "discovery_in_progress"
 
 
@@ -162,7 +162,7 @@ async def test_handle_device_topic_missing_config(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_MQTT}, data=discovery
     )
 
-    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "invalid_discovery_info"
 
 
@@ -188,7 +188,7 @@ async def test_handle_device_topic_device_not_found(
             DOMAIN, context={"source": SOURCE_MQTT}, data=discovery
         )
 
-    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "invalid_discovery_info"
 
 
@@ -198,5 +198,5 @@ async def test_step_user_not_supported(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "not_supported"

--- a/tests/components/rainbird/test_config_flow.py
+++ b/tests/components/rainbird/test_config_flow.py
@@ -379,7 +379,7 @@ async def test_reauth_flow(
         result["flow_id"],
         {CONF_PASSWORD: "incorrect_password"},
     )
-    assert result.get("type") == FlowResultType.FORM
+    assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "reauth_confirm"
     assert result.get("errors") == {"base": "invalid_auth"}
 
@@ -388,7 +388,7 @@ async def test_reauth_flow(
         result["flow_id"],
         {CONF_PASSWORD: PASSWORD},
     )
-    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "reauth_successful"
 
     entries = hass.config_entries.async_entries(DOMAIN)

--- a/tests/components/roborock/test_config_flow.py
+++ b/tests/components/roborock/test_config_flow.py
@@ -213,7 +213,7 @@ async def test_options_flow_drawables(
             mock_roborock_entry.entry_id
         )
 
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == DRAWABLES
         with patch(
             "homeassistant.components.roborock.async_setup_entry", return_value=True
@@ -224,7 +224,7 @@ async def test_options_flow_drawables(
             )
             await hass.async_block_till_done()
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         assert mock_roborock_entry.options[DRAWABLES][Drawable.PREDICTED_PATH] is True
         assert len(mock_setup.mock_calls) == 1
 

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -2160,7 +2160,7 @@ async def test_dhcp_while_user_flow_pending(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
         )
-    assert result_user["type"] == FlowResultType.FORM
+    assert result_user["type"] is FlowResultType.FORM
     assert result_user["step_id"] == "user"
 
     # While user flow is pending (form shown), trigger DHCP flow
@@ -2178,4 +2178,4 @@ async def test_dhcp_while_user_flow_pending(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_DHCP},
             data=dhcp_data,
         )
-    assert result_dhcp["type"] == FlowResultType.ABORT
+    assert result_dhcp["type"] is FlowResultType.ABORT

--- a/tests/components/sma/test_config_flow.py
+++ b/tests/components/sma/test_config_flow.py
@@ -175,7 +175,7 @@ async def test_dhcp_already_configured_duplicate(
         data=DHCP_DISCOVERY_DUPLICATE_001,
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     await hass.async_block_till_done()
 

--- a/tests/components/snoo/test_config_flow.py
+++ b/tests/components/snoo/test_config_flow.py
@@ -33,7 +33,7 @@ async def test_config_flow_success(
         },
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "test-username"
     assert result["data"] == {
         CONF_USERNAME: "test-username",
@@ -72,7 +72,7 @@ async def test_form_auth_issues(
         },
     )
     # Reset auth back to the original
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": error_msg}
     bypass_api.authorize.side_effect = None
     result = await hass.config_entries.flow.async_configure(
@@ -83,7 +83,7 @@ async def test_form_auth_issues(
         },
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "test-username"
     assert result["data"] == {
         CONF_USERNAME: "test-username",

--- a/tests/components/statistics/test_config_flow.py
+++ b/tests/components/statistics/test_config_flow.py
@@ -316,7 +316,7 @@ async def test_config_flow_preview_success(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] is None
 
@@ -335,7 +335,7 @@ async def test_config_flow_preview_success(
         },
     )
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "options"
     assert result["errors"] is None
     assert result["preview"] == "statistics"
@@ -390,7 +390,7 @@ async def test_options_flow_preview(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
     assert result["preview"] == "statistics"
 
@@ -452,7 +452,7 @@ async def test_options_flow_sensor_preview_config_entry_removed(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
     assert result["preview"] == "statistics"
 

--- a/tests/components/swiss_public_transport/test_config_flow.py
+++ b/tests/components/swiss_public_transport/test_config_flow.py
@@ -129,7 +129,7 @@ async def test_flow_user_init_data_success(
         )
 
         if time_mode_input:
-            assert result["type"] == FlowResultType.FORM
+            assert result["type"] is FlowResultType.FORM
             if CONF_TIME_FIXED in time_mode_input:
                 assert result["step_id"] == "time_fixed"
             if CONF_TIME_OFFSET in time_mode_input:
@@ -139,7 +139,7 @@ async def test_flow_user_init_data_success(
                 user_input=time_mode_input,
             )
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["result"].title == config_title
 
         assert result["data"] == {**user_input, **(time_mode_input or {})}
@@ -182,7 +182,7 @@ async def test_flow_user_init_data_error_and_recover_on_step_1(
             user_input=MOCK_USER_DATA_STEP,
         )
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["result"].title == "test_start test_destination"
 
         assert result["data"] == MOCK_USER_DATA_STEP
@@ -222,7 +222,7 @@ async def test_flow_user_init_data_error_and_recover_on_step_2(
             result["flow_id"],
             user_input=MOCK_USER_DATA_STEP_TIME_FIXED,
         )
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "time_fixed"
 
     with patch(
@@ -246,7 +246,7 @@ async def test_flow_user_init_data_error_and_recover_on_step_2(
             user_input=user_input,
         )
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["result"].title == "test_start test_destination at 18:03:00"
 
 

--- a/tests/components/tedee/test_config_flow.py
+++ b/tests/components/tedee/test_config_flow.py
@@ -34,7 +34,7 @@ async def test_flow(hass: HomeAssistant, mock_tedee: MagicMock) -> None:
             DOMAIN, context={"source": SOURCE_USER}
         )
         await hass.async_block_till_done()
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
 
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -44,7 +44,7 @@ async def test_flow(hass: HomeAssistant, mock_tedee: MagicMock) -> None:
             },
         )
 
-        assert result2["type"] == FlowResultType.CREATE_ENTRY
+        assert result2["type"] is FlowResultType.CREATE_ENTRY
         assert result2["data"] == {
             CONF_HOST: "192.168.1.62",
             CONF_LOCAL_ACCESS_TOKEN: "token",

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -42,7 +42,7 @@ async def test_options_flow(
     await hass.async_block_till_done()
 
     assert result["step_id"] == "init"
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
 
     # test: valid input
 
@@ -54,7 +54,7 @@ async def test_options_flow(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][ATTR_PARSER] == PARSER_PLAIN_TEXT
 
 

--- a/tests/components/threshold/test_config_flow.py
+++ b/tests/components/threshold/test_config_flow.py
@@ -204,7 +204,7 @@ async def test_config_flow_preview_success(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] is None
     assert result["preview"] == "threshold"
@@ -259,7 +259,7 @@ async def test_options_flow_preview(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
     assert result["preview"] == "threshold"
 
@@ -309,7 +309,7 @@ async def test_options_flow_sensor_preview_config_entry_removed(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
     assert result["preview"] == "threshold"
 

--- a/tests/components/tolo/test_config_flow.py
+++ b/tests/components/tolo/test_config_flow.py
@@ -151,7 +151,7 @@ async def test_reconfigure_walkthrough(
         result["flow_id"], user_input={CONF_HOST: "127.0.0.4"}
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert config_entry.data[CONF_HOST] == "127.0.0.4"
 
@@ -171,7 +171,7 @@ async def test_reconfigure_error_then_fix(
         result["flow_id"], user_input={CONF_HOST: "127.0.0.5"}
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "cannot_connect"
 
@@ -180,7 +180,7 @@ async def test_reconfigure_error_then_fix(
         result["flow_id"], user_input={CONF_HOST: "127.0.0.4"}
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert config_entry.data[CONF_HOST] == "127.0.0.4"
 
@@ -204,7 +204,7 @@ async def test_reconfigure_duplicate_ip(
         result["flow_id"], user_input={CONF_HOST: "127.0.0.6"}
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
     assert config_entry.data[CONF_HOST] == "127.0.0.1"

--- a/tests/components/wmspro/test_config_flow.py
+++ b/tests/components/wmspro/test_config_flow.py
@@ -271,7 +271,7 @@ async def test_config_flow_cannot_connect(
             },
         )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
     with patch(

--- a/tests/components/zeroconf/test_repairs.py
+++ b/tests/components/zeroconf/test_repairs.py
@@ -269,7 +269,7 @@ async def test_duplicate_repair_issue_repair_flow(
         result = await start_repair_fix_flow(client, DOMAIN, issue.issue_id)
 
         flow_id = result["flow_id"]
-        assert result["type"] is FlowResultType.FORM
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "confirm_recreate"
 
         result = await process_repair_fix_flow(client, flow_id, json={})

--- a/tests/components/zeroconf/test_repairs.py
+++ b/tests/components/zeroconf/test_repairs.py
@@ -269,7 +269,7 @@ async def test_duplicate_repair_issue_repair_flow(
         result = await start_repair_fix_flow(client, DOMAIN, issue.issue_id)
 
         flow_id = result["flow_id"]
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "confirm_recreate"
 
         result = await process_repair_fix_flow(client, flow_id, json={})

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -1729,7 +1729,7 @@ def advanced_pick_radio(
             user_input={"next_step_id": config_flow.SETUP_STRATEGY_ADVANCED},
         )
 
-        assert advanced_strategy_result["type"] == FlowResultType.MENU
+        assert advanced_strategy_result["type"] is FlowResultType.MENU
         assert advanced_strategy_result["step_id"] == "choose_formation_strategy"
 
         return advanced_strategy_result

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -5264,7 +5264,7 @@ async def test_addon_rf_region_new_network(
         },
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "rf_region"
 
     # Check that all expected RF regions are available
@@ -5435,7 +5435,7 @@ async def test_addon_rf_region_migrate_network(
         },
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "rf_region"
 
     result = await hass.config_entries.flow.async_configure(

--- a/tests/helpers/test_schema_config_entry_flow.py
+++ b/tests/helpers/test_schema_config_entry_flow.py
@@ -342,33 +342,33 @@ async def test_menu_step(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             TEST_DOMAIN, context={"source": "user"}
         )
-        assert result["type"] == FlowResultType.MENU
+        assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "user"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"next_step_id": "option1"},
         )
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "option1"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == FlowResultType.MENU
+        assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "menu2"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"next_step_id": "option3"},
         )
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "option3"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "option4"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_schema_none(hass: HomeAssistant) -> None:
@@ -391,15 +391,15 @@ async def test_schema_none(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             TEST_DOMAIN, context={"source": "user"}
         )
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "option1"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "option3"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_last_step(hass: HomeAssistant) -> None:
@@ -425,22 +425,22 @@ async def test_last_step(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             TEST_DOMAIN, context={"source": "user"}
         )
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "step1"
         assert result["last_step"] is False
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "step2"
         assert result["last_step"] is None
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "step3"
         assert result["last_step"] is True
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_next_step_function(hass: HomeAssistant) -> None:
@@ -468,15 +468,15 @@ async def test_next_step_function(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             TEST_DOMAIN, context={"source": "user"}
         )
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "step1"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "step2"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_suggested_values(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1382,7 +1382,7 @@ async def test_reauth_issue_flow_returns_abort(
     issue = await _test_reauth_issue(hass, manager, issue_registry)
 
     result = await manager.flow.async_configure(issue.data["flow_id"], {})
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert len(issue_registry.issues) == 0
 
 
@@ -3415,7 +3415,7 @@ async def test_unique_id_update_existing_entry_without_reload(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert result["description_placeholders"]["title"] == "Other device"
     assert entry.data["host"] == "1.1.1.1"
@@ -3468,7 +3468,7 @@ async def test_unique_id_update_existing_entry_with_reload(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert result["description_placeholders"]["title"] == "Other device"
     assert entry.data["host"] == "1.1.1.1"
@@ -3489,7 +3489,7 @@ async def test_unique_id_update_existing_entry_with_reload(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert result["description_placeholders"]["title"] == "Other device"
     assert entry.data["host"] == "2.2.2.2"
@@ -3545,7 +3545,7 @@ async def test_unique_id_from_discovery_in_setup_retry(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert len(async_reload.mock_calls) == 0
 
@@ -3567,7 +3567,7 @@ async def test_unique_id_from_discovery_in_setup_retry(
         )
         await hass.async_block_till_done()
 
-    assert discovery_result["type"] == FlowResultType.ABORT
+    assert discovery_result["type"] is FlowResultType.ABORT
     assert discovery_result["reason"] == "already_configured"
     assert len(async_reload.mock_calls) == 1
 
@@ -3613,7 +3613,7 @@ async def test_unique_id_not_update_existing_entry(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data["host"] == "0.0.0.0"
     assert entry.data["additional"] == "data"
@@ -5506,7 +5506,7 @@ async def test_async_abort_entries_match(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == reason
 
     # For a domain with no entries, there should never be a match
@@ -5519,7 +5519,7 @@ async def test_async_abort_entries_match(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "no_match"
 
 
@@ -5565,7 +5565,7 @@ async def test_async_abort_entries_match_context(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == reason
 
 
@@ -5659,7 +5659,7 @@ async def test_async_abort_entries_match_options_flow(
             original_entry.entry_id, data=matchers
         )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == reason
 
 
@@ -5865,7 +5865,7 @@ async def test_unique_id_update_while_setup_in_progress(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data["host"] == "1.1.1.1"
     assert entry.data["additional"] == "data"
@@ -6620,7 +6620,7 @@ async def test_update_entry_and_reload(
     if raises:
         assert isinstance(err, raises)
     else:
-        assert result["type"] == FlowResultType.ABORT
+        assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == reason
     # Assert entry was reloaded
     assert len(comp.async_setup_entry.mock_calls) == calls_entry_load_unload[0]
@@ -6697,7 +6697,7 @@ async def test_update_entry_without_reload(
     assert entry.data == {"vendor": "data2"}
     assert entry.options == {"vendor": "options2"}
     assert entry.state == config_entries.ConfigEntryState.LOADED
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == reason
     # Assert entry is not reloaded
     assert len(comp.async_setup_entry.mock_calls) == 1
@@ -6844,7 +6844,7 @@ async def test_update_subentry_and_abort(
     if raises:
         assert isinstance(err, raises)
     else:
-        assert result["type"] == FlowResultType.ABORT
+        assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "reconfigure_successful"
 
 
@@ -9204,12 +9204,12 @@ async def test_options_flow_config_entry(
         == "The config entry is not available during initialisation"
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["errors"] == {}
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["errors"]["entry_id"] == original_entry.entry_id
     assert result["errors"]["entry"] is original_entry
@@ -9218,7 +9218,7 @@ async def test_options_flow_config_entry(
     options_flow.handler = "123"
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["errors"]["entry_id"] == "123"
     assert isinstance(result["errors"]["entry"], config_entries.UnknownEntry)
@@ -9228,7 +9228,7 @@ async def test_options_flow_config_entry(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"abort": True}
     )
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "abort"
 
 
@@ -9404,7 +9404,7 @@ async def test_add_description_placeholder_automatically(
     assert len(flows) == 1
 
     result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], None)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["description_placeholders"] == {"name": "test_title"}
 
 
@@ -9428,7 +9428,7 @@ async def test_add_description_placeholder_automatically_not_overwrites(
     assert len(flows) == 1
 
     result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], None)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["description_placeholders"] == {"name": "Custom title"}
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enum comparison should use `is` rather than `==`

This is a simple replace of `== FlowResultType` with `is FlowResultType`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
