### PR TITLE
Modernise condition checker in helper

### DIFF
--- a/homeassistant/components/sun/condition.py
+++ b/homeassistant/components/sun/condition.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any, cast
+from typing import Any, Unpack, cast
 
 import voluptuous as vol
 
@@ -13,14 +13,14 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.automation import move_top_level_schema_fields_to_options
 from homeassistant.helpers.condition import (
     Condition,
-    ConditionCheckerType,
+    ConditionChecker,
+    ConditionCheckParams,
     ConditionConfig,
     condition_trace_set_result,
     condition_trace_update_result,
-    trace_condition_function,
 )
 from homeassistant.helpers.sun import get_astral_event_date
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
 
 _OPTIONS_SCHEMA_DICT: dict[vol.Marker, Any] = {
@@ -154,17 +154,16 @@ class SunCondition(Condition):
         assert config.options is not None
         self._options = config.options
 
-    async def async_get_checker(self) -> ConditionCheckerType:
+    async def async_get_checker(self) -> ConditionChecker:
         """Wrap action method with sun based condition."""
         before = self._options.get("before")
         after = self._options.get("after")
         before_offset = self._options.get("before_offset")
         after_offset = self._options.get("after_offset")
 
-        @trace_condition_function
-        def sun_if(hass: HomeAssistant, variables: TemplateVarsType = None) -> bool:
+        def sun_if(**kwargs: Unpack[ConditionCheckParams]) -> bool:
             """Validate time based if-condition."""
-            return sun(hass, before, after, before_offset, after_offset)
+            return sun(self._hass, before, after, before_offset, after_offset)
 
         return sun_if
 

--- a/homeassistant/components/zone/condition.py
+++ b/homeassistant/components/zone/condition.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Unpack, cast
 
 import voluptuous as vol
 
@@ -22,11 +22,11 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.automation import move_top_level_schema_fields_to_options
 from homeassistant.helpers.condition import (
     Condition,
-    ConditionCheckerType,
+    ConditionChecker,
+    ConditionCheckParams,
     ConditionConfig,
-    trace_condition_function,
 )
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+from homeassistant.helpers.typing import ConfigType
 
 from . import in_zone
 
@@ -118,13 +118,12 @@ class ZoneCondition(Condition):
         assert config.options is not None
         self._options = config.options
 
-    async def async_get_checker(self) -> ConditionCheckerType:
+    async def async_get_checker(self) -> ConditionChecker:
         """Wrap action method with zone based condition."""
         entity_ids = self._options.get(CONF_ENTITY_ID, [])
         zone_entity_ids = self._options.get(CONF_ZONE, [])
 
-        @trace_condition_function
-        def if_in_zone(hass: HomeAssistant, variables: TemplateVarsType = None) -> bool:
+        def if_in_zone(**kwargs: Unpack[ConditionCheckParams]) -> bool:
             """Test if condition."""
             errors = []
 
@@ -133,7 +132,7 @@ class ZoneCondition(Condition):
                 entity_ok = False
                 for zone_entity_id in zone_entity_ids:
                     try:
-                        if zone(hass, zone_entity_id, entity_id):
+                        if zone(self._hass, zone_entity_id, entity_id):
                             entity_ok = True
                     except ConditionErrorMessage as ex:
                         errors.append(

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -86,7 +86,7 @@ from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.signal_type import SignalType, SignalTypeFormat
 
 from . import condition, config_validation as cv, service, template
-from .condition import ConditionCheckerType, trace_condition_function
+from .condition import ConditionCheckerTypeOptional, trace_condition_function
 from .dispatcher import async_dispatcher_connect, async_dispatcher_send_internal
 from .event import async_call_later, async_track_template
 from .script_variables import ScriptRunVariables, ScriptVariables
@@ -675,12 +675,14 @@ class _ScriptRun:
 
     ### Condition actions ###
 
-    async def _async_get_condition(self, config: ConfigType) -> ConditionCheckerType:
+    async def _async_get_condition(
+        self, config: ConfigType
+    ) -> ConditionCheckerTypeOptional:
         return await self._script._async_get_condition(config)  # noqa: SLF001
 
     def _test_conditions(
         self,
-        conditions: list[ConditionCheckerType],
+        conditions: list[ConditionCheckerTypeOptional],
         name: str,
         condition_path: str | None = None,
     ) -> bool | None:
@@ -1404,12 +1406,12 @@ def _referenced_extract_ids(data: Any, key: str, found: set[str]) -> None:
 
 
 class _ChooseData(TypedDict):
-    choices: list[tuple[list[ConditionCheckerType], Script]]
+    choices: list[tuple[list[ConditionCheckerTypeOptional], Script]]
     default: Script | None
 
 
 class _IfData(TypedDict):
-    if_conditions: list[ConditionCheckerType]
+    if_conditions: list[ConditionCheckerTypeOptional]
     if_then: Script
     if_else: Script | None
 
@@ -1486,7 +1488,9 @@ class Script:
         self._max_exceeded = max_exceeded
         if script_mode == SCRIPT_MODE_QUEUED:
             self._queue_lck = asyncio.Lock()
-        self._config_cache: dict[frozenset[tuple[str, str]], ConditionCheckerType] = {}
+        self._config_cache: dict[
+            frozenset[tuple[str, str]], ConditionCheckerTypeOptional
+        ] = {}
         self._repeat_script: dict[int, Script] = {}
         self._choose_data: dict[int, _ChooseData] = {}
         self._if_data: dict[int, _IfData] = {}
@@ -1857,7 +1861,9 @@ class Script:
             return
         await asyncio.shield(create_eager_task(self._async_stop(aws, update_state)))
 
-    async def _async_get_condition(self, config: ConfigType) -> ConditionCheckerType:
+    async def _async_get_condition(
+        self, config: ConfigType
+    ) -> ConditionCheckerTypeOptional:
         config_cache_key = frozenset((k, str(v)) for k, v in config.items())
         if not (cond := self._config_cache.get(config_cache_key)):
             cond = await condition.async_from_config(self._hass, config)

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -36,7 +36,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.automation import move_top_level_schema_fields_to_options
 from homeassistant.helpers.condition import (
     Condition,
-    ConditionCheckerType,
+    ConditionChecker,
     async_validate_condition_config,
 )
 from homeassistant.helpers.template import Template
@@ -2126,16 +2126,16 @@ async def test_platform_multiple_conditions(hass: HomeAssistant) -> None:
     class MockCondition1(MockCondition):
         """Mock condition 1."""
 
-        async def async_get_checker(self) -> ConditionCheckerType:
+        async def async_get_checker(self) -> ConditionChecker:
             """Evaluate state based on configuration."""
-            return lambda hass, vars: True
+            return lambda **kwargs: True
 
     class MockCondition2(MockCondition):
         """Mock condition 2."""
 
-        async def async_get_checker(self) -> ConditionCheckerType:
+        async def async_get_checker(self) -> ConditionChecker:
             """Evaluate state based on configuration."""
-            return lambda hass, vars: False
+            return lambda **kwargs: False
 
     async def async_get_conditions(hass: HomeAssistant) -> dict[str, type[Condition]]:
         return {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modernise condition checker in condition helper.

This PR cleans up and improves the new condition interface. In this it is a little similar to #152772, that adjusted the triggers.

The new condition interface is documented as experimental and not yet used by custom components, so we can still make these changes without problems.

It does the following improvements:
- Drops the unneeded suffix: `ConditionCheckerType` -> `ConditionChecker`
- Automatically calls `trace_condition_function`
- Adjusts the signature of `ConditionChecker`
  - Removes superfluous `hass` argument
  - Types arguments as kwargs, to allow for future extensibility
  - Returns `bool`, as integrations should never return `None` from the check


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
