### PR TITLE
Adjust volvo update interval

### DIFF
--- a/tests/components/volvo/snapshots/test_diagnostics.ambr
+++ b/tests/components/volvo/snapshots/test_diagnostics.ambr
@@ -95,6 +95,27 @@
       }),
     }),
     'Volvo medium interval coordinator': dict({
+      'averageEnergyConsumption': dict({
+        'extra_data': dict({
+        }),
+        'timestamp': '2024-12-30T14:53:44.785000+00:00',
+        'unit': 'kWh/100km',
+        'value': 22.6,
+      }),
+      'averageSpeed': dict({
+        'extra_data': dict({
+        }),
+        'timestamp': '2024-12-30T14:18:56.849000+00:00',
+        'unit': 'km/h',
+        'value': 53,
+      }),
+      'averageSpeedAutomatic': dict({
+        'extra_data': dict({
+        }),
+        'timestamp': '2024-12-30T14:18:56.849000+00:00',
+        'unit': 'km/h',
+        'value': 26,
+      }),
       'batteryChargeLevel': dict({
         'extra_data': dict({
           'updated_at': '2025-07-02T08:51:23Z',
@@ -158,6 +179,13 @@
         'unit': None,
         'value': 'AC',
       }),
+      'distanceToEmptyBattery': dict({
+        'extra_data': dict({
+        }),
+        'timestamp': '2024-12-30T14:30:08.338000+00:00',
+        'unit': 'km',
+        'value': 250,
+      }),
       'electricRange': dict({
         'extra_data': dict({
           'updated_at': '2025-07-02T08:51:23Z',
@@ -192,14 +220,35 @@
         'unit': 'percentage',
         'value': 90,
       }),
-    }),
-    'Volvo slow interval coordinator': dict({
-      'availabilityStatus': dict({
+      'tripMeterAutomatic': dict({
         'extra_data': dict({
         }),
-        'timestamp': '2024-12-30T14:32:26.169000+00:00',
+        'timestamp': '2024-12-30T14:18:56.849000+00:00',
+        'unit': 'km',
+        'value': 18.2,
+      }),
+      'tripMeterManual': dict({
+        'extra_data': dict({
+        }),
+        'timestamp': '2024-12-30T14:18:56.849000+00:00',
+        'unit': 'km',
+        'value': 3822.9,
+      }),
+    }),
+    'Volvo slow interval coordinator': dict({
+      'brakeFluidLevelWarning': dict({
+        'extra_data': dict({
+        }),
+        'timestamp': '2024-12-30T14:18:56.849000+00:00',
         'unit': None,
-        'value': 'AVAILABLE',
+        'value': 'NO_WARNING',
+      }),
+      'engineCoolantLevelWarning': dict({
+        'extra_data': dict({
+        }),
+        'timestamp': '2024-12-30T14:18:56.849000+00:00',
+        'unit': None,
+        'value': 'NO_WARNING',
       }),
       'location': dict({
         'extra_data': dict({
@@ -218,40 +267,33 @@
         }),
         'type': 'Feature',
       }),
-    }),
-    'Volvo very slow interval coordinator': dict({
-      'averageEnergyConsumption': dict({
-        'extra_data': dict({
-        }),
-        'timestamp': '2024-12-30T14:53:44.785000+00:00',
-        'unit': 'kWh/100km',
-        'value': 22.6,
-      }),
-      'averageSpeed': dict({
+      'odometer': dict({
         'extra_data': dict({
         }),
         'timestamp': '2024-12-30T14:18:56.849000+00:00',
-        'unit': 'km/h',
-        'value': 53,
+        'unit': 'km',
+        'value': 30000,
       }),
-      'averageSpeedAutomatic': dict({
-        'extra_data': dict({
-        }),
-        'timestamp': '2024-12-30T14:18:56.849000+00:00',
-        'unit': 'km/h',
-        'value': 26,
-      }),
-      'battery_capacity_kwh': dict({
-        'extra_data': dict({
-        }),
-        'value': 81.608,
-      }),
-      'brakeFluidLevelWarning': dict({
+      'oilLevelWarning': dict({
         'extra_data': dict({
         }),
         'timestamp': '2024-12-30T14:18:56.849000+00:00',
         'unit': None,
         'value': 'NO_WARNING',
+      }),
+    }),
+    'Volvo very slow interval coordinator': dict({
+      'availabilityStatus': dict({
+        'extra_data': dict({
+        }),
+        'timestamp': '2024-12-30T14:32:26.169000+00:00',
+        'unit': None,
+        'value': 'AVAILABLE',
+      }),
+      'battery_capacity_kwh': dict({
+        'extra_data': dict({
+        }),
+        'value': 81.608,
       }),
       'brakeLightCenterWarning': dict({
         'extra_data': dict({
@@ -288,26 +330,12 @@
         'unit': None,
         'value': 'NO_WARNING',
       }),
-      'distanceToEmptyBattery': dict({
-        'extra_data': dict({
-        }),
-        'timestamp': '2024-12-30T14:30:08.338000+00:00',
-        'unit': 'km',
-        'value': 250,
-      }),
       'distanceToService': dict({
         'extra_data': dict({
         }),
         'timestamp': '2024-12-30T14:18:56.849000+00:00',
         'unit': 'km',
         'value': 29000,
-      }),
-      'engineCoolantLevelWarning': dict({
-        'extra_data': dict({
-        }),
-        'timestamp': '2024-12-30T14:18:56.849000+00:00',
-        'unit': None,
-        'value': 'NO_WARNING',
       }),
       'engineHoursToService': dict({
         'extra_data': dict({
@@ -373,20 +401,6 @@
         'value': 'NO_WARNING',
       }),
       'lowBeamRightWarning': dict({
-        'extra_data': dict({
-        }),
-        'timestamp': '2024-12-30T14:18:56.849000+00:00',
-        'unit': None,
-        'value': 'NO_WARNING',
-      }),
-      'odometer': dict({
-        'extra_data': dict({
-        }),
-        'timestamp': '2024-12-30T14:18:56.849000+00:00',
-        'unit': 'km',
-        'value': 30000,
-      }),
-      'oilLevelWarning': dict({
         'extra_data': dict({
         }),
         'timestamp': '2024-12-30T14:18:56.849000+00:00',
@@ -469,20 +483,6 @@
         'timestamp': '2024-12-30T14:18:56.849000+00:00',
         'unit': 'months',
         'value': 23,
-      }),
-      'tripMeterAutomatic': dict({
-        'extra_data': dict({
-        }),
-        'timestamp': '2024-12-30T14:18:56.849000+00:00',
-        'unit': 'km',
-        'value': 18.2,
-      }),
-      'tripMeterManual': dict({
-        'extra_data': dict({
-        }),
-        'timestamp': '2024-12-30T14:18:56.849000+00:00',
-        'unit': 'km',
-        'value': 3822.9,
       }),
       'turnIndicationFrontLeftWarning': dict({
         'extra_data': dict({


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR changes the update interval of the coordinators and the data they poll. The total number of requests per day is, with 6.336 as a maximum (depending on the vehicle), still well below the limit of 10.000.

I'm not sure if this counts as a breaking change, since the recommendation in the docs is to use an API key per vehicle (and request limit is counted per API key). If you consider this as a breaking change, just let me know, and I'll add the section back to this description.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #156760
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42618
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
