### PR TITLE
Use is over == comparison for ConfigEntryState in tests

### DIFF
--- a/tests/components/azure_data_explorer/conftest.py
+++ b/tests/components/azure_data_explorer/conftest.py
@@ -72,7 +72,7 @@ async def _entry(hass: HomeAssistant, filter_schema: dict[str, Any], entry) -> N
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {CONF_FILTER: filter_schema}}
     )
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     # Clear the component_loaded event from the queue.
     async_fire_time_changed(
@@ -87,7 +87,7 @@ async def mock_entry_with_one_event(
     hass: HomeAssistant, entry_managed
 ) -> MockConfigEntry:
     """Use the entry and add a single test event to the queue."""
-    assert entry_managed.state == ConfigEntryState.LOADED
+    assert entry_managed.state is ConfigEntryState.LOADED
     hass.states.async_set("sensor.test", STATE_ON)
     return entry_managed
 

--- a/tests/components/azure_data_explorer/test_init.py
+++ b/tests/components/azure_data_explorer/test_init.py
@@ -106,10 +106,10 @@ async def test_unload_entry(
     this verifies that the unload, calls async_stop, which calls async_send and
     shuts down the hub.
     """
-    assert entry_managed.state == ConfigEntryState.LOADED
+    assert entry_managed.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(entry_managed.entry_id)
     mock_managed_streaming.assert_not_called()
-    assert entry_managed.state == ConfigEntryState.NOT_LOADED
+    assert entry_managed.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.freeze_time("2024-01-01 00:00:00")
@@ -261,4 +261,4 @@ async def test_connection(
     entry.add_to_hass(hass)
     mock_execute_query.side_effect = sideeffect
     await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR

--- a/tests/components/backblaze_b2/test_init.py
+++ b/tests/components/backblaze_b2/test_init.py
@@ -22,12 +22,12 @@ async def test_load_unload_config_entry(
     """Test loading and unloading the integration."""
     await setup_integration(hass, mock_config_entry)
 
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.NOT_LOADED  # type: ignore[comparison-overlap]
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED  # type: ignore[comparison-overlap]
 
 
 async def test_setup_entry_invalid_auth(

--- a/tests/components/bang_olufsen/test_init.py
+++ b/tests/components/bang_olufsen/test_init.py
@@ -22,13 +22,13 @@ async def test_setup_entry(
 ) -> None:
     """Test async_setup_entry."""
 
-    assert mock_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
     # Load entry
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     # Check that the device has been registered properly
     device = device_registry.async_get_device(
@@ -57,13 +57,13 @@ async def test_setup_entry_failed(
         "", (ServerTimeoutError(), TimeoutError())
     )
 
-    assert mock_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
     # Load entry
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
     # Ensure that the connection has been checked, API client correctly closed
     # and WebSocket connection has not been initialized
@@ -80,12 +80,12 @@ async def test_unload_entry(
     """Test unload_entry."""
 
     # Load entry
-    assert mock_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
     assert hasattr(mock_config_entry, "runtime_data")
 
     # Unload entry
@@ -97,4 +97,4 @@ async def test_unload_entry(
 
     # Ensure that the entry is not loaded and has been removed from hass
     assert not hasattr(mock_config_entry, "runtime_data")
-    assert mock_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/elevenlabs/test_setup.py
+++ b/tests/components/elevenlabs/test_setup.py
@@ -18,10 +18,10 @@ async def test_setup(
     """Test entry setup without any exceptions."""
     mock_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_entry.entry_id)
-    assert mock_entry.state == ConfigEntryState.LOADED
+    assert mock_entry.state is ConfigEntryState.LOADED
     # Unload
     await hass.config_entries.async_unload(mock_entry.entry_id)
-    assert mock_entry.state == ConfigEntryState.NOT_LOADED
+    assert mock_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_setup_connect_error(
@@ -33,4 +33,4 @@ async def test_setup_connect_error(
     mock_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_entry.entry_id)
     # Ensure is not ready
-    assert mock_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -96,7 +96,7 @@ async def _test_setup_and_signaling(
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 1
     config_entry = config_entries[0]
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     after_setup_fn()
 
     receive_message_callback = Mock(spec_set=WebRTCSendMessage)
@@ -183,7 +183,7 @@ async def _test_setup_and_signaling(
 
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.NOT_LOADED
+        assert config_entry.state is ConfigEntryState.NOT_LOADED
         assert teardown.call_count == 2
 
 
@@ -625,7 +625,7 @@ async def test_setup_with_setup_entry_error(
     await hass.async_block_till_done(wait_background_tasks=True)
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 1
-    assert config_entries[0].state == ConfigEntryState.SETUP_ERROR
+    assert config_entries[0].state is ConfigEntryState.SETUP_ERROR
     assert expected_log_message in caplog.text
 
 

--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -254,7 +254,7 @@ async def setup_bridge(
         with patch("homeassistant.components.hue.HueBridge", return_value=mock_bridge):
             await hass.config_entries.async_setup(config_entry.entry_id)
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 async def setup_platform(

--- a/tests/components/mysensors/test_init.py
+++ b/tests/components/mysensors/test_init.py
@@ -29,7 +29,7 @@ async def test_load_unload(
     """Test loading and unloading the MySensors config entry."""
     config_entry = integration
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     entity_id = "binary_sensor.door_sensor_1_1"
     state = hass.states.get(entity_id)

--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -313,7 +313,7 @@ async def setup_base_platform(
             await hass.async_block_till_done()
 
         yield _setup_func
-        if config_entry.state == ConfigEntryState.LOADED:
+        if config_entry.state is ConfigEntryState.LOADED:
             await hass.config_entries.async_unload(config_entry.entry_id)
 
 

--- a/tests/components/nintendo_parental_controls/test_coordinator.py
+++ b/tests/components/nintendo_parental_controls/test_coordinator.py
@@ -33,7 +33,7 @@ async def test_invalid_authentication(
     )
     assert len(entries) == 0
     # Ensure the config entry is marked as error
-    assert mock_config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_no_devices(
@@ -53,4 +53,4 @@ async def test_no_devices(
     )
     assert len(entries) == 0
     # Ensure the config entry is marked as error
-    assert mock_config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR

--- a/tests/components/nintendo_parental_controls/test_init.py
+++ b/tests/components/nintendo_parental_controls/test_init.py
@@ -27,4 +27,4 @@ async def test_invalid_authentication(
     )
     assert len(entries) == 0
     # Ensure the config entry is marked as error
-    assert mock_config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR

--- a/tests/components/nmap_tracker/test_init.py
+++ b/tests/components/nmap_tracker/test_init.py
@@ -58,7 +58,7 @@ async def test_migrate_entry(hass: HomeAssistant) -> None:
         CONF_MAC_EXCLUDE: [],
         CONF_OPTIONS: DEFAULT_OPTIONS,
     }
-    assert updated_entry.state == ConfigEntryState.LOADED
+    assert updated_entry.state is ConfigEntryState.LOADED
 
 
 async def test_migrate_entry_fails_on_downgrade(hass: HomeAssistant) -> None:
@@ -90,4 +90,4 @@ async def test_migrate_entry_fails_on_downgrade(hass: HomeAssistant) -> None:
     updated_entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
     assert updated_entry
     assert updated_entry.version == 2
-    assert updated_entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert updated_entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -968,7 +968,7 @@ async def test_privacy_mode_on(
     reolink_host: MagicMock,
     config_entry: MockConfigEntry,
 ) -> None:
-    """Test successful setup even when privacy mode is turned on."""
+    """Test successful setup eis ConfigEntryState.e is turned on."""
     reolink_host.baichuan.privacy_mode.return_value = True
     reolink_host.get_states = AsyncMock(side_effect=LoginPrivacyModeError("Test error"))
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -968,7 +968,7 @@ async def test_privacy_mode_on(
     reolink_host: MagicMock,
     config_entry: MockConfigEntry,
 ) -> None:
-    """Test successful setup eis ConfigEntryState.e is turned on."""
+    """Test successful setup even when privacy mode is turned on."""
     reolink_host.baichuan.privacy_mode.return_value = True
     reolink_host.get_states = AsyncMock(side_effect=LoginPrivacyModeError("Test error"))
 
@@ -976,7 +976,7 @@ async def test_privacy_mode_on(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_LoginPrivacyModeError(

--- a/tests/components/sftp_storage/test_backup.py
+++ b/tests/components/sftp_storage/test_backup.py
@@ -87,7 +87,7 @@ async def test_agents_info(
     assert (
         response["result"]
         == {"agents": [{"agent_id": "backup.local", "name": "local"}]}
-        or config_entry.state == ConfigEntryState.NOT_LOADED
+        or config_entry.state is ConfigEntryState.NOT_LOADED
     )
 
 

--- a/tests/components/sftp_storage/test_backup.py
+++ b/tests/components/sftp_storage/test_backup.py
@@ -87,7 +87,7 @@ async def test_agents_info(
     assert (
         response["result"]
         == {"agents": [{"agent_id": "backup.local", "name": "local"}]}
-        or config_entry.state is ConfigEntryState.NOT_LOADED
+        or config_entry.state == ConfigEntryState.NOT_LOADED
     )
 
 

--- a/tests/components/smhi/test_init.py
+++ b/tests/components/smhi/test_init.py
@@ -78,4 +78,4 @@ async def test_migrate_from_future_version(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/snoo/test_init.py
+++ b/tests/components/snoo/test_init.py
@@ -15,7 +15,7 @@ async def test_async_setup_entry(hass: HomeAssistant, bypass_api: AsyncMock) -> 
     """Test a successful setup entry."""
     entry = await async_init_integration(hass)
     assert len(hass.states.async_all("sensor")) == 2
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_cannot_auth(hass: HomeAssistant, bypass_api: AsyncMock) -> None:

--- a/tests/components/solarlog/test_init.py
+++ b/tests/components/solarlog/test_init.py
@@ -62,7 +62,7 @@ async def test_setup_error(
 
     assert mock_config_entry.state == error
 
-    if error == ConfigEntryState.SETUP_RETRY:
+    if error is ConfigEntryState.SETUP_RETRY:
         assert len(hass.config_entries.flow.async_progress()) == 0
 
 
@@ -117,7 +117,7 @@ async def test_other_exceptions_during_first_refresh(
     await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
     assert len(hass.config_entries.flow.async_progress()) == 0
 

--- a/tests/components/telegram_bot/test_webhooks.py
+++ b/tests/components/telegram_bot/test_webhooks.py
@@ -42,7 +42,7 @@ async def test_set_webhooks_failed(
         assert mock_set_webhook.call_count == 2
 
         # SETUP_ERROR is result of ConfigEntryNotReady("Failed to register webhook with Telegram") in webhooks.py
-        assert mock_webhooks_config_entry.state == ConfigEntryState.SETUP_ERROR
+        assert mock_webhooks_config_entry.state is ConfigEntryState.SETUP_ERROR
 
         # test fail after retries
 
@@ -55,7 +55,7 @@ async def test_set_webhooks_failed(
         # 3 retries
         assert mock_set_webhook.call_count == 3
 
-        assert mock_webhooks_config_entry.state == ConfigEntryState.SETUP_ERROR
+        assert mock_webhooks_config_entry.state is ConfigEntryState.SETUP_ERROR
         await hass.async_block_till_done()
 
 
@@ -72,7 +72,7 @@ async def test_set_webhooks(
 
     await hass.async_block_till_done()
 
-    assert mock_webhooks_config_entry.state == ConfigEntryState.LOADED
+    assert mock_webhooks_config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_webhooks_update_invalid_json(
@@ -125,7 +125,7 @@ async def test_webhooks_deregister_failed(
     """Test deregister webhooks."""
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     with patch(
         "homeassistant.components.telegram_bot.webhooks.Bot.delete_webhook",
@@ -134,4 +134,4 @@ async def test_webhooks_deregister_failed(
         await hass.config_entries.async_unload(config_entry.entry_id)
 
     mock_delete_webhook.assert_called_once()
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/tibber/test_init.py
+++ b/tests/components/tibber/test_init.py
@@ -13,9 +13,9 @@ async def test_entry_unload(
 ) -> None:
     """Test unloading the entry."""
     entry = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "tibber")
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(entry.entry_id)
     mock_tibber_setup.rt_disconnect.assert_called_once()
     await hass.async_block_till_done(wait_background_tasks=True)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/transmission/test_services.py
+++ b/tests/components/transmission/test_services.py
@@ -31,7 +31,7 @@ async def test_service_config_entry_not_loaded_state(
     """Test service call when config entry is in failed state."""
     mock_config_entry.add_to_hass(hass)
 
-    assert mock_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
     with pytest.raises(ServiceValidationError, match="service_not_found"):
         await hass.services.async_call(

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -39,7 +39,7 @@ async def test_setup_entry_fails_config_entry_not_ready(
     ):
         config_entry = await config_entry_factory()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_entry_fails_trigger_reauth_flow(
@@ -56,7 +56,7 @@ async def test_setup_entry_fails_trigger_reauth_flow(
         config_entry = await config_entry_factory()
         mock_flow_init.assert_called_once()
 
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 @pytest.mark.parametrize(

--- a/tests/components/wled/test_coordinator.py
+++ b/tests/components/wled/test_coordinator.py
@@ -214,7 +214,7 @@ async def test_fail_when_other_device(
 
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
     assert mock_config_entry.reason
     assert (
         "MAC address does not match the configured device." in mock_config_entry.reason
@@ -238,7 +238,7 @@ async def test_fail_when_unsupported_version(
 
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
     assert mock_config_entry.reason
     assert (
         "The WLED device's firmware version is not supported:"

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -2332,7 +2332,7 @@ async def test_driver_ready_event(
     await hass.async_block_till_done()
 
     assert len(config_entry_state_changes) == 4
-    assert config_entry_state_changes[0] == ConfigEntryState.UNLOAD_IN_PROGRESS
-    assert config_entry_state_changes[1] == ConfigEntryState.NOT_LOADED
-    assert config_entry_state_changes[2] == ConfigEntryState.SETUP_IN_PROGRESS
-    assert config_entry_state_changes[3] == ConfigEntryState.LOADED
+    assert config_entry_state_changes[0] is ConfigEntryState.UNLOAD_IN_PROGRESS
+    assert config_entry_state_changes[1] is ConfigEntryState.NOT_LOADED
+    assert config_entry_state_changes[2] is ConfigEntryState.SETUP_IN_PROGRESS
+    assert config_entry_state_changes[3] is ConfigEntryState.LOADED


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enum comparison should use `is` rather than `==`

This is a simple replace of `== ConfigEntryState` with `is ConfigEntryState`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
