### PR TITLE
Add select platform to Nintendo Switch parental controls

### DIFF
--- a/homeassistant/components/nintendo_parental_controls/__init__.py
+++ b/homeassistant/components/nintendo_parental_controls/__init__.py
@@ -24,6 +24,7 @@ _PLATFORMS: list[Platform] = [
     Platform.TIME,
     Platform.SWITCH,
     Platform.NUMBER,
+    Platform.SELECT,
 ]
 
 PLATFORM_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)

--- a/homeassistant/components/nintendo_parental_controls/select.py
+++ b/homeassistant/components/nintendo_parental_controls/select.py
@@ -86,10 +86,10 @@ class NintendoParentalSelectEntity(NintendoDevice, SelectEntity):
     @property
     def options(self) -> list[str]:
         """Return a list of available options."""
-        return [option.name for option in self.entity_description.options_enum]
+        return [option.name.lower() for option in self.entity_description.options_enum]
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        enum_option = self.entity_description.options_enum[option]
+        enum_option = self.entity_description.options_enum[option.upper()]
         await self.entity_description.set_option_fn(self._device, enum_option)
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/nintendo_parental_controls/select.py
+++ b/homeassistant/components/nintendo_parental_controls/select.py
@@ -1,0 +1,95 @@
+"""Nintendo Switch Parental Controls select entity definitions."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from pynintendoparental.enum import DeviceTimerMode
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import NintendoParentalControlsConfigEntry, NintendoUpdateCoordinator
+from .entity import Device, NintendoDevice
+
+PARALLEL_UPDATES = 1
+
+
+class NintendoParentalSelect(StrEnum):
+    """Store keys for Nintendo Parental Controls select entities."""
+
+    TIMER_MODE = "timer_mode"
+
+
+@dataclass(kw_only=True, frozen=True)
+class NintendoParentalControlsSelectEntityDescription(SelectEntityDescription):
+    """Description for Nintendo Parental Controls select entities."""
+
+    get_option: Callable[[Device], DeviceTimerMode | None]
+    set_option_fn: Callable[[Device, DeviceTimerMode], Coroutine[Any, Any, None]]
+    options_enum: type[DeviceTimerMode]
+
+
+SELECT_DESCRIPTIONS: tuple[NintendoParentalControlsSelectEntityDescription, ...] = (
+    NintendoParentalControlsSelectEntityDescription(
+        key=NintendoParentalSelect.TIMER_MODE,
+        translation_key=NintendoParentalSelect.TIMER_MODE,
+        get_option=lambda device: device.timer_mode,
+        set_option_fn=lambda device, option: device.set_timer_mode(option),
+        options_enum=DeviceTimerMode,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: NintendoParentalControlsConfigEntry,
+    async_add_devices: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the select platform."""
+    async_add_devices(
+        NintendoParentalSelectEntity(
+            coordinator=entry.runtime_data,
+            device=device,
+            description=description,
+        )
+        for device in entry.runtime_data.api.devices.values()
+        for description in SELECT_DESCRIPTIONS
+    )
+
+
+class NintendoParentalSelectEntity(NintendoDevice, SelectEntity):
+    """Nintendo Parental Controls select entity."""
+
+    entity_description: NintendoParentalControlsSelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: NintendoUpdateCoordinator,
+        device: Device,
+        description: NintendoParentalControlsSelectEntityDescription,
+    ) -> None:
+        """Initialize the select entity."""
+        super().__init__(coordinator=coordinator, device=device, key=description.key)
+        self.entity_description = description
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current selected option."""
+        option = self.entity_description.get_option(self._device)
+        return option.name.lower() if option else None
+
+    @property
+    def options(self) -> list[str]:
+        """Return a list of available options."""
+        return [option.name for option in self.entity_description.options_enum]
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        enum_option = self.entity_description.options_enum[option]
+        await self.entity_description.set_option_fn(self._device, enum_option)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/nintendo_parental_controls/strings.json
+++ b/homeassistant/components/nintendo_parental_controls/strings.json
@@ -37,6 +37,15 @@
         "name": "Max screentime today"
       }
     },
+    "select": {
+      "timer_mode": {
+        "name": "Restriction mode",
+        "state": {
+          "daily": "Same for all days",
+          "each_day_of_the_week": "Different for each day"
+        }
+      }
+    },
     "sensor": {
       "playing_time": {
         "name": "Used screen time"

--- a/tests/components/nintendo_parental_controls/conftest.py
+++ b/tests/components/nintendo_parental_controls/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from pynintendoparental import NintendoParental
 from pynintendoparental.device import Device
+from pynintendoparental.enum import DeviceTimerMode
 import pytest
 
 from homeassistant.components.nintendo_parental_controls.const import DOMAIN
@@ -39,9 +40,11 @@ def mock_nintendo_device() -> Device:
     mock.today_playing_time = 110
     mock.today_time_remaining = 10
     mock.bedtime_alarm = time(hour=19)
+    mock.timer_mode = DeviceTimerMode.DAILY
     mock.add_extra_time.return_value = None
     mock.set_bedtime_alarm.return_value = None
     mock.update_max_daily_playtime.return_value = None
+    mock.set_timer_mode.return_value = None
     mock.forced_termination_mode = True
     mock.model = "Test Model"
     mock.generation = "P00"

--- a/tests/components/nintendo_parental_controls/snapshots/test_select.ambr
+++ b/tests/components/nintendo_parental_controls/snapshots/test_select.ambr
@@ -1,0 +1,58 @@
+# serializer version: 1
+# name: test_select[select.home_assistant_test_restriction_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'DAILY',
+        'EACH_DAY_OF_THE_WEEK',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.home_assistant_test_restriction_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Restriction mode',
+    'platform': 'nintendo_parental_controls',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <NintendoParentalSelect.TIMER_MODE: 'timer_mode'>,
+    'unique_id': 'testdevid_timer_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[select.home_assistant_test_restriction_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Home Assistant Test Restriction mode',
+      'options': list([
+        'DAILY',
+        'EACH_DAY_OF_THE_WEEK',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.home_assistant_test_restriction_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'DAILY',
+  })
+# ---

--- a/tests/components/nintendo_parental_controls/snapshots/test_select.ambr
+++ b/tests/components/nintendo_parental_controls/snapshots/test_select.ambr
@@ -6,8 +6,8 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
-        'DAILY',
-        'EACH_DAY_OF_THE_WEEK',
+        'daily',
+        'each_day_of_the_week',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -44,8 +44,8 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Home Assistant Test Restriction mode',
       'options': list([
-        'DAILY',
-        'EACH_DAY_OF_THE_WEEK',
+        'daily',
+        'each_day_of_the_week',
       ]),
     }),
     'context': <ANY>,
@@ -53,6 +53,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'DAILY',
+    'state': 'daily',
   })
 # ---

--- a/tests/components/nintendo_parental_controls/test_select.py
+++ b/tests/components/nintendo_parental_controls/test_select.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+from pynintendoparental.enum import DeviceTimerMode
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.select import (
@@ -54,8 +55,10 @@ async def test_select_option(
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.home_assistant_test_restriction_mode",
-            ATTR_OPTION: "EACH_DAY_OF_THE_WEEK",
+            ATTR_OPTION: DeviceTimerMode.EACH_DAY_OF_THE_WEEK.name.lower(),
         },
         blocking=True,
     )
-    mock_nintendo_device.set_timer_mode.assert_awaited_once_with("EACH_DAY_OF_THE_WEEK")
+    mock_nintendo_device.set_timer_mode.assert_awaited_once_with(
+        DeviceTimerMode.EACH_DAY_OF_THE_WEEK
+    )

--- a/tests/components/nintendo_parental_controls/test_select.py
+++ b/tests/components/nintendo_parental_controls/test_select.py
@@ -1,0 +1,61 @@
+"""Tests for Nintendo Switch Parental Controls select platform."""
+
+from unittest.mock import AsyncMock, patch
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_select(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nintendo_client: AsyncMock,
+    mock_nintendo_device: AsyncMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test select platform."""
+    with patch(
+        "homeassistant.components.nintendo_parental_controls._PLATFORMS",
+        [Platform.SELECT],
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_select_option(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nintendo_client: AsyncMock,
+    mock_nintendo_device: AsyncMock,
+) -> None:
+    """Test select option service."""
+    with patch(
+        "homeassistant.components.nintendo_parental_controls._PLATFORMS",
+        [Platform.SELECT],
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.home_assistant_test_restriction_mode",
+            ATTR_OPTION: "EACH_DAY_OF_THE_WEEK",
+        },
+        blocking=True,
+    )
+    mock_nintendo_device.set_timer_mode.assert_awaited_once_with("EACH_DAY_OF_THE_WEEK")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a select platform to control whether the time restrictions are "a single set of limits for every day of the week" (known internally as "daily"), and "different set of limits for each day of the week" (known internally as "each_day_of_the_week").

<img width="309" height="361" alt="image" src="https://github.com/user-attachments/assets/e886d52d-dddd-48a5-97f1-4090a6910f80" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42604
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
