### PR TITLE
Update to Improv Wifi Config flow for 2.3 changes

### DIFF
--- a/homeassistant/components/improv_ble/config_flow.py
+++ b/homeassistant/components/improv_ble/config_flow.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncIterator, Callable, Coroutine
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from bleak import BleakError
 from improv_ble_client import (
@@ -61,6 +61,10 @@ class ImprovBLEConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _authorize_task: asyncio.Task | None = None
     _can_identify: bool | None = None
+    _can_set_hostname: bool | None = None
+    _can_get_device_info: bool | None = None
+    _hostname: str | None = None
+    _new_hostname: str | None = None
     _credentials: Credentials | None = None
     _provision_result: ConfigFlowResult | None = None
     _provision_task: asyncio.Task | None = None
@@ -249,8 +253,12 @@ class ImprovBLEConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Start improv flow.
 
-        If the device supports identification, show a menu, if it does not,
-        ask for WiFi credentials.
+        Show a menu when either:
+        * The device supports identification
+        * Device information is available
+
+        Otherwise, if the device supports setting hostname we move to that step
+        and if it doesn't we ask the user for wifi details
         """
         # mypy is not aware that we can't get here without having these set already
         assert self._discovery_info is not None
@@ -258,26 +266,73 @@ class ImprovBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         if not self._device:
             self._device = ImprovBLEClient(self._discovery_info.device)
         device = self._device
-
-        if self._can_identify is None:
+        try:
+            await self._try_call(device.ensure_connected())
+        except AbortFlow as err:
+            return self.async_abort(reason=err.reason)
+        self._can_set_hostname = device.can_set_hostname
+        if self._can_set_hostname and self._hostname is None:
             try:
-                await self._try_call(device.ensure_connected())
-                self._can_identify = device.can_identify
+                self._hostname = await self._try_call(device.get_hostname())
             except AbortFlow as err:
                 return self.async_abort(reason=err.reason)
-        if self._can_identify:
+
+        self._can_identify = device.can_identify
+        self._can_get_device_info = device.can_get_device_info
+
+        if self._can_identify or self._can_get_device_info:
             return await self.async_step_main_menu()
+        if self._can_set_hostname:
+            return await self.async_step_set_hostname()
         return await self.async_step_provision()
 
     async def async_step_main_menu(self, _: None = None) -> ConfigFlowResult:
-        """Show the main menu."""
+        """Show the main menu with identify option if available or if can_get_device_info is true.
+
+        Then either set_hostname or provision menu options depending on if can_set_hostname is true.
+        If can_get_device_info is true on the device, sets the device_info as description_placeholders.
+        """
+        if TYPE_CHECKING:
+            assert self._device is not None
+
+        menu_options = []
+        if self._can_identify:
+            menu_options.append("identify")
+        if self._can_set_hostname:
+            menu_options.append("set_hostname")
+        else:
+            menu_options.append("provision")
+
+        description_placeholders = {}
+        if self._can_get_device_info:
+            try:
+                device_info = await self._try_call(self._device.get_device_info())
+                description_placeholders["firmware_name"] = str(
+                    device_info.firmware_name
+                )
+                description_placeholders["firmware_version"] = str(
+                    device_info.firmware_version
+                )
+                description_placeholders["hardware_chip"] = str(
+                    device_info.hardware_chip
+                )
+                description_placeholders["device_name"] = str(device_info.device_name)
+            except AbortFlow as err:
+                return self.async_abort(reason=err.reason)
+
         return self.async_show_menu(
-            step_id="main_menu",
-            menu_options=[
-                "identify",
-                "provision",
-            ],
+            step_id="main_menu_with_device_info"
+            if self._can_get_device_info
+            else "main_menu",
+            menu_options=menu_options,
+            description_placeholders=description_placeholders,
         )
+
+    async def async_step_main_menu_with_device_info(
+        self, _: None = None
+    ) -> ConfigFlowResult:
+        """Handle main menu step with device_info shown."""
+        return await self.async_step_main_menu()  # pragma: no cover
 
     async def async_step_identify(
         self, user_input: dict[str, Any] | None = None
@@ -293,6 +348,42 @@ class ImprovBLEConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason=err.reason)
             return self.async_show_form(step_id="identify")
         return await self.async_step_start_improv()
+
+    async def async_step_set_hostname(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle set hostname step."""
+
+        if TYPE_CHECKING:
+            assert self._device is not None
+            assert self._hostname is not None
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="set_hostname",
+                data_schema=vol.Schema(
+                    {vol.Required("hostname", default=self._hostname): str}
+                ),
+            )
+
+        self._new_hostname = user_input["hostname"]
+        if self._hostname is self._new_hostname:
+            return await self.async_step_provision()
+
+        try:
+            need_authorization = await self._try_call(self._device.need_authorization())
+        except AbortFlow as err:
+            return self.async_abort(reason=err.reason)
+        _LOGGER.debug("Need authorization for set hostname: %s", need_authorization)
+        if need_authorization:
+            return await self.async_step_authorize()
+
+        try:
+            await self._try_call(self._device.set_hostname(self._new_hostname))
+        except AbortFlow as err:
+            return self.async_abort(reason=err.reason)
+
+        return await self.async_step_provision()
 
     @asynccontextmanager
     async def _async_provision_context(
@@ -502,6 +593,17 @@ class ImprovBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         if self._unsub:
             self._unsub()
             self._unsub = None
+
+        if (
+            self._can_set_hostname
+            and self._new_hostname is not None
+            and self._new_hostname is not self._hostname
+        ):
+            try:
+                await self._try_call(self._device.set_hostname(self._new_hostname))
+            except AbortFlow as err:
+                return self.async_abort(reason=err.reason)
+
         return self.async_show_progress_done(next_step_id="provision")
 
     @staticmethod

--- a/homeassistant/components/improv_ble/config_flow.py
+++ b/homeassistant/components/improv_ble/config_flow.py
@@ -33,6 +33,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers.device_registry import format_mac
 
+from ...helpers import selector
 from . import async_get_provisioning_futures
 from .const import DOMAIN, PROVISIONING_TIMEOUT
 
@@ -362,7 +363,17 @@ class ImprovBLEConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="set_hostname",
                 data_schema=vol.Schema(
-                    {vol.Required("hostname", default=self._hostname): str}
+                    {
+                        vol.Required(
+                            "hostname", default=self._hostname
+                        ): selector.TextSelector(
+                            selector.TextSelectorConfig(
+                                multiline=False,
+                                type=selector.TextSelectorType.TEXT,
+                                multiple=False,
+                            )
+                        )
+                    }
                 ),
             )
 

--- a/homeassistant/components/improv_ble/config_flow.py
+++ b/homeassistant/components/improv_ble/config_flow.py
@@ -31,9 +31,9 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
+from homeassistant.helpers import selector
 from homeassistant.helpers.device_registry import format_mac
 
-from ...helpers import selector
 from . import async_get_provisioning_futures
 from .const import DOMAIN, PROVISIONING_TIMEOUT
 

--- a/homeassistant/components/improv_ble/strings.json
+++ b/homeassistant/components/improv_ble/strings.json
@@ -28,7 +28,16 @@
         "description": "Choose next step.",
         "menu_options": {
           "identify": "Identify device",
-          "provision": "Connect device to a Wi-Fi network"
+          "provision": "Connect device to a Wi-Fi network",
+          "set_hostname": "Set hostname"
+        }
+      },
+      "main_menu_with_device_info": {
+        "description": "[%key:component::improv_ble::config::step::main_menu::description%]\n\nFirmware Name: {firmware_name}\nFirmware Version: {firmware_version}\nHardware Chip/Variant: {hardware_chip}\nDevice Name: {device_name}",
+        "menu_options": {
+          "identify": "[%key:component::improv_ble::config::step::main_menu::menu_options::identify%]",
+          "provision": "[%key:component::improv_ble::config::step::main_menu::menu_options::provision%]",
+          "set_hostname": "[%key:component::improv_ble::config::step::main_menu::menu_options::set_hostname%]"
         }
       },
       "provision": {
@@ -37,6 +46,12 @@
           "ssid": "SSID"
         },
         "description": "Enter Wi-Fi credentials to connect the device to your network."
+      },
+      "set_hostname": {
+        "data": {
+          "hostname": "Hostname"
+        },
+        "description": "Enter the hostname to assign to the device or leave as the default provided. This will usually be used determine the entity name of the device in Home Assistant and for mDNS broadcasts. It should be unique among all devices connected to the same Wi-Fi network and should contain only alphanumeric characters and the '-' sign."
       },
       "user": {
         "data": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR enhances the Improv Wifi BLE Config Flow for changes to the specification as of v2.3
https://www.improv-wifi.com/ble/
Specifically 2.1 (Get Device Info) and 2.3 (Get/Set Hostname) - 2.2 Wifi Scanning is not implemented in this PR

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # 
- This PR is related to release: https://github.com/home-assistant-libs/py-improv-ble-client/releases/tag/2.0.1
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

https://github.com/home-assistant/core/pull/158804
https://github.com/home-assistant/core/pull/158266

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
