### PR TITLE
Update py-improv-ble-client to 2.0.1

### DIFF
--- a/homeassistant/components/improv_ble/config_flow.py
+++ b/homeassistant/components/improv_ble/config_flow.py
@@ -261,7 +261,8 @@ class ImprovBLEConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if self._can_identify is None:
             try:
-                self._can_identify = await self._try_call(device.can_identify())
+                await self._try_call(device.ensure_connected())
+                self._can_identify = device.can_identify
             except AbortFlow as err:
                 return self.async_abort(reason=err.reason)
         if self._can_identify:

--- a/homeassistant/components/improv_ble/manifest.json
+++ b/homeassistant/components/improv_ble/manifest.json
@@ -13,5 +13,5 @@
   "documentation": "https://www.home-assistant.io/integrations/improv_ble",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["py-improv-ble-client==1.0.3"]
+  "requirements": ["py-improv-ble-client==2.0.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1810,7 +1810,7 @@ py-dactyl==2.0.4
 py-dormakaba-dkey==1.0.6
 
 # homeassistant.components.improv_ble
-py-improv-ble-client==1.0.3
+py-improv-ble-client==2.0.1
 
 # homeassistant.components.madvr
 py-madvr2==1.6.40

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1550,7 +1550,7 @@ py-dactyl==2.0.4
 py-dormakaba-dkey==1.0.6
 
 # homeassistant.components.improv_ble
-py-improv-ble-client==1.0.3
+py-improv-ble-client==2.0.1
 
 # homeassistant.components.madvr
 py-madvr2==1.6.40

--- a/tests/components/improv_ble/test_config_flow.py
+++ b/tests/components/improv_ble/test_config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import Callable
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from bleak.exc import BleakError
 from improv_ble_client import (
@@ -294,8 +294,13 @@ async def test_bluetooth_rediscovery_after_successful_provision(
     assert result["step_id"] == "bluetooth_confirm"
 
     # Start provisioning
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=False
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=False,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -375,8 +380,13 @@ async def _test_common_success_with_identify(
     hass: HomeAssistant, result: FlowResult, address: str
 ) -> None:
     """Test bluetooth and user flow success paths."""
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=True
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=True,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -420,8 +430,13 @@ async def _test_common_success_wo_identify(
     placeholders: dict[str, str] | None = None,
 ) -> None:
     """Test bluetooth and user flow success paths."""
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=False
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=False,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -475,8 +490,13 @@ async def _test_common_success_wo_identify_w_authorize(
     hass: HomeAssistant, result: FlowResult, address: str
 ) -> None:
     """Test bluetooth and user flow success paths."""
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=False
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=False,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -571,7 +591,7 @@ async def test_bluetooth_step_already_in_progress(hass: HomeAssistant) -> None:
         (improv_ble_errors.CharacteristicMissingError, "characteristic_missing"),
     ],
 )
-async def test_can_identify_fails(hass: HomeAssistant, exc, error) -> None:
+async def test_ensure_connected_fails(hass: HomeAssistant, exc, error) -> None:
     """Test bluetooth flow with error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -588,7 +608,8 @@ async def test_can_identify_fails(hass: HomeAssistant, exc, error) -> None:
     assert result["errors"] is None
 
     with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", side_effect=exc
+        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected",
+        side_effect=exc,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -622,8 +643,13 @@ async def test_identify_fails(hass: HomeAssistant, exc, error) -> None:
     assert result["step_id"] == "bluetooth_confirm"
     assert result["errors"] is None
 
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=True
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=True,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -665,8 +691,13 @@ async def test_need_authorization_fails(hass: HomeAssistant, exc, error) -> None
     assert result["step_id"] == "bluetooth_confirm"
     assert result["errors"] is None
 
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=False
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=False,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -709,8 +740,13 @@ async def test_authorize_fails(hass: HomeAssistant, exc, error) -> None:
     assert result["step_id"] == "bluetooth_confirm"
     assert result["errors"] is None
 
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=False
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=False,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -752,8 +788,13 @@ async def _test_provision_error(hass: HomeAssistant, exc) -> str:
     assert result["step_id"] == "bluetooth_confirm"
     assert result["errors"] is None
 
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=False
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=False,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -878,8 +919,13 @@ async def test_flow_chaining_with_next_flow(hass: HomeAssistant) -> None:
     assert result["step_id"] == "bluetooth_confirm"
 
     # Start provisioning
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=False
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=False,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -946,8 +992,13 @@ async def test_flow_chaining_timeout(hass: HomeAssistant) -> None:
     assert result["step_id"] == "bluetooth_confirm"
 
     # Start provisioning
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=False
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=False,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -998,8 +1049,13 @@ async def test_flow_chaining_with_redirect_url(hass: HomeAssistant) -> None:
     assert result["step_id"] == "bluetooth_confirm"
 
     # Start provisioning
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=False
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=False,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -1069,8 +1125,13 @@ async def test_flow_chaining_future_already_done(
     assert result["step_id"] == "bluetooth_confirm"
 
     # Start provisioning
-    with patch(
-        f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify", return_value=False
+    with (
+        patch(
+            f"{IMPROV_BLE}.config_flow.ImprovBLEClient.can_identify",
+            return_value=False,
+            new_callable=PropertyMock,
+        ),
+        patch(f"{IMPROV_BLE}.config_flow.ImprovBLEClient.ensure_connected"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates the py-improv-ble-client to 2.0.1 in preparation of https://github.com/home-assistant/core/pull/159222
https://github.com/home-assistant-libs/py-improv-ble-client/releases/tag/2.0.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
