### PR TITLE
Move Tuya vacuum entity logic to wrapper class

### DIFF
--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -55,7 +55,7 @@ class _VacuumActivityWrapper(DeviceWrapper):
         pause_wrapper: DPCodeBooleanWrapper | None = None,
         status_wrapper: DPCodeEnumWrapper | None = None,
     ) -> None:
-        """Init DeviceWrapper."""
+        """Init _VacuumActivityWrapper."""
         self._pause_wrapper = pause_wrapper
         self._status_wrapper = status_wrapper
 
@@ -94,7 +94,7 @@ class _VacuumActionWrapper(DeviceWrapper):
         mode_wrapper: DPCodeEnumWrapper | None,
         switch_wrapper: DPCodeBooleanWrapper | None,
     ) -> None:
-        """Init DeviceWrapper."""
+        """Init _VacuumActionWrapper."""
         self._charge_wrapper = charge_wrapper
         self._locate_wrapper = locate_wrapper
         self._mode_wrapper = mode_wrapper
@@ -115,7 +115,7 @@ class _VacuumActionWrapper(DeviceWrapper):
 
     @classmethod
     def find_dpcode(cls, device: CustomerDevice) -> Self:
-        """Find and return a DPCodeTypeInformationWrapper for the given DP codes."""
+        """Find and return a _VacuumActionWrapper for the given DP codes."""
         return cls(
             charge_wrapper=DPCodeBooleanWrapper.find_dpcode(
                 device, DPCode.SWITCH_CHARGE, prefer_function=True

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Self
 
 from tuya_sharing import CustomerDevice, Manager
 
@@ -18,34 +18,140 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
-from .models import DPCodeBooleanWrapper, DPCodeEnumWrapper
+from .models import DeviceWrapper, DPCodeBooleanWrapper, DPCodeEnumWrapper
 
-TUYA_MODE_RETURN_HOME = "chargego"
-TUYA_STATUS_TO_HA = {
-    "charge_done": VacuumActivity.DOCKED,
-    "chargecompleted": VacuumActivity.DOCKED,
-    "chargego": VacuumActivity.DOCKED,
-    "charging": VacuumActivity.DOCKED,
-    "cleaning": VacuumActivity.CLEANING,
-    "docking": VacuumActivity.RETURNING,
-    "goto_charge": VacuumActivity.RETURNING,
-    "goto_pos": VacuumActivity.CLEANING,
-    "mop_clean": VacuumActivity.CLEANING,
-    "part_clean": VacuumActivity.CLEANING,
-    "paused": VacuumActivity.PAUSED,
-    "pick_zone_clean": VacuumActivity.CLEANING,
-    "pos_arrived": VacuumActivity.CLEANING,
-    "pos_unarrive": VacuumActivity.CLEANING,
-    "random": VacuumActivity.CLEANING,
-    "sleep": VacuumActivity.IDLE,
-    "smart_clean": VacuumActivity.CLEANING,
-    "smart": VacuumActivity.CLEANING,
-    "spot_clean": VacuumActivity.CLEANING,
-    "standby": VacuumActivity.IDLE,
-    "wall_clean": VacuumActivity.CLEANING,
-    "wall_follow": VacuumActivity.CLEANING,
-    "zone_clean": VacuumActivity.CLEANING,
-}
+
+class _VacuumActivityWrapper(DeviceWrapper):
+    """Wrapper for the state of a device."""
+
+    _TUYA_STATUS_TO_HA = {
+        "charge_done": VacuumActivity.DOCKED,
+        "chargecompleted": VacuumActivity.DOCKED,
+        "chargego": VacuumActivity.DOCKED,
+        "charging": VacuumActivity.DOCKED,
+        "cleaning": VacuumActivity.CLEANING,
+        "docking": VacuumActivity.RETURNING,
+        "goto_charge": VacuumActivity.RETURNING,
+        "goto_pos": VacuumActivity.CLEANING,
+        "mop_clean": VacuumActivity.CLEANING,
+        "part_clean": VacuumActivity.CLEANING,
+        "paused": VacuumActivity.PAUSED,
+        "pick_zone_clean": VacuumActivity.CLEANING,
+        "pos_arrived": VacuumActivity.CLEANING,
+        "pos_unarrive": VacuumActivity.CLEANING,
+        "random": VacuumActivity.CLEANING,
+        "sleep": VacuumActivity.IDLE,
+        "smart_clean": VacuumActivity.CLEANING,
+        "smart": VacuumActivity.CLEANING,
+        "spot_clean": VacuumActivity.CLEANING,
+        "standby": VacuumActivity.IDLE,
+        "wall_clean": VacuumActivity.CLEANING,
+        "wall_follow": VacuumActivity.CLEANING,
+        "zone_clean": VacuumActivity.CLEANING,
+    }
+
+    def __init__(
+        self,
+        pause_wrapper: DPCodeBooleanWrapper | None = None,
+        status_wrapper: DPCodeEnumWrapper | None = None,
+    ) -> None:
+        """Init DeviceWrapper."""
+        self._pause_wrapper = pause_wrapper
+        self._status_wrapper = status_wrapper
+
+    @classmethod
+    def find_dpcode(cls, device: CustomerDevice) -> Self | None:
+        """Find and return a _VacuumActivityWrapper for the given DP codes."""
+        pause_wrapper = DPCodeBooleanWrapper.find_dpcode(device, DPCode.PAUSE)
+        status_wrapper = DPCodeEnumWrapper.find_dpcode(device, DPCode.STATUS)
+        if pause_wrapper or status_wrapper:
+            return cls(pause_wrapper=pause_wrapper, status_wrapper=status_wrapper)
+        return None
+
+    def read_device_status(self, device: CustomerDevice) -> VacuumActivity | None:
+        """Read the device status."""
+        if (
+            self._status_wrapper
+            and (status := self._status_wrapper.read_device_status(device)) is not None
+        ):
+            return self._TUYA_STATUS_TO_HA.get(status)
+
+        if self._pause_wrapper and self._pause_wrapper.read_device_status(device):
+            return VacuumActivity.PAUSED
+        return None
+
+
+class _VacuumActionWrapper(DeviceWrapper):
+    """Wrapper for sending actions to a vacuum."""
+
+    _TUYA_MODE_RETURN_HOME = "chargego"
+
+    def __init__(
+        self,
+        charge_wrapper: DPCodeBooleanWrapper | None,
+        locate_wrapper: DPCodeBooleanWrapper | None,
+        pause_wrapper: DPCodeBooleanWrapper | None,
+        mode_wrapper: DPCodeEnumWrapper | None,
+        switch_wrapper: DPCodeBooleanWrapper | None,
+    ) -> None:
+        """Init DeviceWrapper."""
+        self._charge_wrapper = charge_wrapper
+        self._locate_wrapper = locate_wrapper
+        self._mode_wrapper = mode_wrapper
+        self._switch_wrapper = switch_wrapper
+
+        self.options = []
+        if charge_wrapper or (
+            mode_wrapper and self._TUYA_MODE_RETURN_HOME in mode_wrapper.options
+        ):
+            self.options.append("return_to_base")
+        if locate_wrapper:
+            self.options.append("locate")
+        if pause_wrapper:
+            self.options.append("pause")
+        if switch_wrapper:
+            self.options.append("start")
+            self.options.append("stop")
+
+    @classmethod
+    def find_dpcode(cls, device: CustomerDevice) -> Self:
+        """Find and return a DPCodeTypeInformationWrapper for the given DP codes."""
+        return cls(
+            charge_wrapper=DPCodeBooleanWrapper.find_dpcode(
+                device, DPCode.SWITCH_CHARGE, prefer_function=True
+            ),
+            locate_wrapper=DPCodeBooleanWrapper.find_dpcode(
+                device, DPCode.SEEK, prefer_function=True
+            ),
+            mode_wrapper=DPCodeEnumWrapper.find_dpcode(
+                device, DPCode.MODE, prefer_function=True
+            ),
+            pause_wrapper=DPCodeBooleanWrapper.find_dpcode(device, DPCode.PAUSE),
+            switch_wrapper=DPCodeBooleanWrapper.find_dpcode(
+                device, DPCode.POWER_GO, prefer_function=True
+            ),
+        )
+
+    def get_update_commands(
+        self, device: CustomerDevice, value: Any
+    ) -> list[dict[str, Any]]:
+        """Get the commands for the action wrapper."""
+        if value == "locate" and self._locate_wrapper:
+            return self._locate_wrapper.get_update_commands(device, True)
+        if value == "pause" and self._switch_wrapper:
+            return self._switch_wrapper.get_update_commands(device, False)
+        if value == "return_to_base":
+            if self._charge_wrapper:
+                return self._charge_wrapper.get_update_commands(device, True)
+            if self._mode_wrapper:
+                return self._mode_wrapper.get_update_commands(
+                    device, self._TUYA_MODE_RETURN_HOME
+                )
+        if value == "start" and self._switch_wrapper:
+            return self._switch_wrapper.get_update_commands(device, True)
+        if value == "stop" and self._switch_wrapper:
+            return self._switch_wrapper.get_update_commands(device, False)
+        return []
 
 
 async def async_setup_entry(
@@ -67,26 +173,10 @@ async def async_setup_entry(
                     TuyaVacuumEntity(
                         device,
                         manager,
-                        charge_wrapper=DPCodeBooleanWrapper.find_dpcode(
-                            device, DPCode.SWITCH_CHARGE, prefer_function=True
-                        ),
+                        action_wrapper=_VacuumActionWrapper.find_dpcode(device),
+                        activity_wrapper=_VacuumActivityWrapper.find_dpcode(device),
                         fan_speed_wrapper=DPCodeEnumWrapper.find_dpcode(
                             device, DPCode.SUCTION, prefer_function=True
-                        ),
-                        locate_wrapper=DPCodeBooleanWrapper.find_dpcode(
-                            device, DPCode.SEEK, prefer_function=True
-                        ),
-                        mode_wrapper=DPCodeEnumWrapper.find_dpcode(
-                            device, DPCode.MODE, prefer_function=True
-                        ),
-                        pause_wrapper=DPCodeBooleanWrapper.find_dpcode(
-                            device, DPCode.PAUSE
-                        ),
-                        status_wrapper=DPCodeEnumWrapper.find_dpcode(
-                            device, DPCode.STATUS
-                        ),
-                        switch_wrapper=DPCodeBooleanWrapper.find_dpcode(
-                            device, DPCode.POWER_GO, prefer_function=True
                         ),
                     )
                 )
@@ -109,43 +199,33 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         device: CustomerDevice,
         device_manager: Manager,
         *,
-        charge_wrapper: DPCodeBooleanWrapper | None,
+        action_wrapper: _VacuumActionWrapper | None,
+        activity_wrapper: _VacuumActivityWrapper | None,
         fan_speed_wrapper: DPCodeEnumWrapper | None,
-        locate_wrapper: DPCodeBooleanWrapper | None,
-        mode_wrapper: DPCodeEnumWrapper | None,
-        pause_wrapper: DPCodeBooleanWrapper | None,
-        status_wrapper: DPCodeEnumWrapper | None,
-        switch_wrapper: DPCodeBooleanWrapper | None,
     ) -> None:
         """Init Tuya vacuum."""
         super().__init__(device, device_manager)
-        self._charge_wrapper = charge_wrapper
+        self._action_wrapper = action_wrapper
+        self._activity_wrapper = activity_wrapper
         self._fan_speed_wrapper = fan_speed_wrapper
-        self._locate_wrapper = locate_wrapper
-        self._mode_wrapper = mode_wrapper
-        self._pause_wrapper = pause_wrapper
-        self._status_wrapper = status_wrapper
-        self._switch_wrapper = switch_wrapper
 
         self._attr_fan_speed_list = []
         self._attr_supported_features = VacuumEntityFeature.SEND_COMMAND
-        if status_wrapper or pause_wrapper:
+
+        if action_wrapper and action_wrapper.options:
+            if "pause" in action_wrapper.options:
+                self._attr_supported_features |= VacuumEntityFeature.PAUSE
+            if "return_to_base" in action_wrapper.options:
+                self._attr_supported_features |= VacuumEntityFeature.RETURN_HOME
+            if "locate" in action_wrapper.options:
+                self._attr_supported_features |= VacuumEntityFeature.LOCATE
+            if "start" in action_wrapper.options:
+                self._attr_supported_features |= VacuumEntityFeature.START
+            if "stop" in action_wrapper.options:
+                self._attr_supported_features |= VacuumEntityFeature.STOP
+
+        if activity_wrapper:
             self._attr_supported_features |= VacuumEntityFeature.STATE
-        if pause_wrapper:
-            self._attr_supported_features |= VacuumEntityFeature.PAUSE
-
-        if charge_wrapper or (
-            mode_wrapper and TUYA_MODE_RETURN_HOME in mode_wrapper.options
-        ):
-            self._attr_supported_features |= VacuumEntityFeature.RETURN_HOME
-
-        if locate_wrapper:
-            self._attr_supported_features |= VacuumEntityFeature.LOCATE
-
-        if switch_wrapper:
-            self._attr_supported_features |= (
-                VacuumEntityFeature.STOP | VacuumEntityFeature.START
-            )
 
         if fan_speed_wrapper:
             self._attr_fan_speed_list = fan_speed_wrapper.options
@@ -159,37 +239,27 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
     @property
     def activity(self) -> VacuumActivity | None:
         """Return Tuya vacuum device state."""
-        if (status := self._read_wrapper(self._status_wrapper)) is not None:
-            return TUYA_STATUS_TO_HA.get(status)
-
-        if self._read_wrapper(self._pause_wrapper):
-            return VacuumActivity.PAUSED
-        return None
+        return self._read_wrapper(self._activity_wrapper)
 
     async def async_start(self, **kwargs: Any) -> None:
         """Start the device."""
-        await self._async_send_wrapper_updates(self._switch_wrapper, True)
+        await self._async_send_wrapper_updates(self._action_wrapper, "start")
 
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the device."""
-        await self._async_send_wrapper_updates(self._switch_wrapper, False)
+        await self._async_send_wrapper_updates(self._action_wrapper, "stop")
 
     async def async_pause(self, **kwargs: Any) -> None:
         """Pause the device."""
-        await self.async_stop(**kwargs)
+        await self._async_send_wrapper_updates(self._action_wrapper, "pause")
 
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Return device to dock."""
-        if self._charge_wrapper:
-            await self._async_send_wrapper_updates(self._charge_wrapper, True)
-        else:
-            await self._async_send_wrapper_updates(
-                self._mode_wrapper, TUYA_MODE_RETURN_HOME
-            )
+        await self._async_send_wrapper_updates(self._action_wrapper, "return_to_base")
 
     async def async_locate(self, **kwargs: Any) -> None:
         """Locate the device."""
-        await self._async_send_wrapper_updates(self._locate_wrapper, True)
+        await self._async_send_wrapper_updates(self._action_wrapper, "locate")
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set fan speed."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
~Needs #159254~

The `TuyaVacuumEntity` currently uses 7 separate wrapper classes:
- two for extracting the `activity`
- four for sending actions
- one for fan control/status

This moves more logic from the TuyaVacuumEntity to the wrappers so that only three wrappers are passed to the entity:
- a single one for the `activity` property
- a single one for sending actions
- and keep one for fan control/status

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
