### PR TITLE
Pass ssl parameter to pyhik HikCamera

### DIFF
--- a/homeassistant/components/hikvision/__init__.py
+++ b/homeassistant/components/hikvision/__init__.py
@@ -51,7 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HikvisionConfigEntry) ->
 
     try:
         camera = await hass.async_add_executor_job(
-            HikCamera, url, port, username, password
+            HikCamera, url, port, username, password, ssl
         )
     except requests.exceptions.RequestException as err:
         raise ConfigEntryNotReady(f"Unable to connect to {host}") from err

--- a/homeassistant/components/hikvision/config_flow.py
+++ b/homeassistant/components/hikvision/config_flow.py
@@ -49,7 +49,7 @@ class HikvisionConfigFlow(ConfigFlow, domain=DOMAIN):
 
             try:
                 camera = await self.hass.async_add_executor_job(
-                    HikCamera, url, port, username, password
+                    HikCamera, url, port, username, password, ssl
                 )
                 device_id = camera.get_id()
                 device_name = camera.get_name
@@ -102,7 +102,7 @@ class HikvisionConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             camera = await self.hass.async_add_executor_job(
-                HikCamera, url, port, username, password
+                HikCamera, url, port, username, password, ssl
             )
             device_id = camera.get_id()
             device_name = camera.get_name

--- a/tests/components/hikvision/test_config_flow.py
+++ b/tests/components/hikvision/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 import requests
 
 from homeassistant.components.hikvision.const import DOMAIN
@@ -310,3 +311,66 @@ async def test_import_flow_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize("ssl", [False, True])
+async def test_form_passes_ssl_parameter(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_hikcamera: MagicMock,
+    ssl: bool,
+) -> None:
+    """Test user flow passes ssl parameter to HikCamera."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: TEST_HOST,
+            CONF_PORT: TEST_PORT,
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+            CONF_SSL: ssl,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_SSL] is ssl
+
+    # Verify HikCamera was called with the ssl parameter
+    expected_url = f"{'https' if ssl else 'http'}://{TEST_HOST}"
+    mock_hikcamera.assert_called_once_with(
+        expected_url, TEST_PORT, TEST_USERNAME, TEST_PASSWORD, ssl
+    )
+
+
+@pytest.mark.parametrize("ssl", [False, True])
+async def test_import_flow_passes_ssl_parameter(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_hikcamera: MagicMock,
+    ssl: bool,
+) -> None:
+    """Test import flow passes ssl parameter to HikCamera."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_PORT: TEST_PORT,
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+            CONF_SSL: ssl,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_SSL] is ssl
+
+    # Verify HikCamera was called with the ssl parameter
+    expected_url = f"{'https' if ssl else 'http'}://{TEST_HOST}"
+    mock_hikcamera.assert_called_once_with(
+        expected_url, TEST_PORT, TEST_USERNAME, TEST_PASSWORD, ssl
+    )

--- a/tests/components/hikvision/test_init.py
+++ b/tests/components/hikvision/test_init.py
@@ -2,18 +2,10 @@
 
 from unittest.mock import MagicMock
 
-import pytest
 import requests
 
-from homeassistant.components.hikvision.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_SSL,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_SSL
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
@@ -33,11 +25,38 @@ async def test_setup_and_unload_entry(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     mock_hikcamera.return_value.start_stream.assert_called_once()
 
+    # Verify HikCamera was called with the ssl parameter
+    mock_hikcamera.assert_called_once_with(
+        f"http://{TEST_HOST}", TEST_PORT, TEST_USERNAME, TEST_PASSWORD, False
+    )
+
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
     mock_hikcamera.return_value.disconnect.assert_called_once()
+
+
+async def test_setup_entry_with_ssl(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hikcamera: MagicMock,
+) -> None:
+    """Test setup with ssl enabled passes ssl parameter to HikCamera."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, data={**mock_config_entry.data, CONF_SSL: True}
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    # Verify HikCamera was called with ssl=True
+    mock_hikcamera.assert_called_once_with(
+        f"https://{TEST_HOST}", TEST_PORT, TEST_USERNAME, TEST_PASSWORD, True
+    )
 
 
 async def test_setup_entry_connection_error(
@@ -70,34 +89,3 @@ async def test_setup_entry_no_device_id(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-@pytest.mark.parametrize("ssl", [False, True])
-async def test_setup_entry_passes_ssl_parameter(
-    hass: HomeAssistant,
-    mock_hikcamera: MagicMock,
-    ssl: bool,
-) -> None:
-    """Test that ssl parameter is passed to HikCamera."""
-    mock_config_entry = MockConfigEntry(
-        title="Test Camera",
-        domain=DOMAIN,
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_PORT: TEST_PORT,
-            CONF_USERNAME: TEST_USERNAME,
-            CONF_PASSWORD: TEST_PASSWORD,
-            CONF_SSL: ssl,
-        },
-        unique_id="test_device_id",
-    )
-
-    await setup_integration(hass, mock_config_entry)
-
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-
-    # Verify HikCamera was called with the ssl parameter
-    expected_url = f"{'https' if ssl else 'http'}://{TEST_HOST}"
-    mock_hikcamera.assert_called_once_with(
-        expected_url, TEST_PORT, TEST_USERNAME, TEST_PASSWORD, ssl
-    )


### PR DESCRIPTION
Pass the ssl configuration value to the HikCamera constructor in both the setup entry and config flow, enabling proper SSL verification control when connecting to Hikvision devices.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
