### PR TITLE
Fix hikvision camera.get_id

### DIFF
--- a/homeassistant/components/hikvision/__init__.py
+++ b/homeassistant/components/hikvision/__init__.py
@@ -56,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HikvisionConfigEntry) ->
     except requests.exceptions.RequestException as err:
         raise ConfigEntryNotReady(f"Unable to connect to {host}") from err
 
-    device_id = camera.get_id()
+    device_id = camera.get_id
     if device_id is None:
         raise ConfigEntryNotReady(f"Unable to get device ID from {host}")
 

--- a/homeassistant/components/hikvision/config_flow.py
+++ b/homeassistant/components/hikvision/config_flow.py
@@ -51,7 +51,7 @@ class HikvisionConfigFlow(ConfigFlow, domain=DOMAIN):
                 camera = await self.hass.async_add_executor_job(
                     HikCamera, url, port, username, password
                 )
-                device_id = camera.get_id()
+                device_id = camera.get_id
                 device_name = camera.get_name
             except requests.exceptions.RequestException:
                 _LOGGER.exception("Error connecting to Hikvision device")

--- a/homeassistant/components/hikvision/config_flow.py
+++ b/homeassistant/components/hikvision/config_flow.py
@@ -104,7 +104,7 @@ class HikvisionConfigFlow(ConfigFlow, domain=DOMAIN):
             camera = await self.hass.async_add_executor_job(
                 HikCamera, url, port, username, password
             )
-            device_id = camera.get_id()
+            device_id = camera.get_id
             device_name = camera.get_name
         except requests.exceptions.RequestException:
             _LOGGER.exception(

--- a/homeassistant/components/hikvision/config_flow.py
+++ b/homeassistant/components/hikvision/config_flow.py
@@ -51,12 +51,12 @@ class HikvisionConfigFlow(ConfigFlow, domain=DOMAIN):
                 camera = await self.hass.async_add_executor_job(
                     HikCamera, url, port, username, password
                 )
-                device_id = camera.get_id
-                device_name = camera.get_name
             except requests.exceptions.RequestException:
                 _LOGGER.exception("Error connecting to Hikvision device")
                 errors["base"] = "cannot_connect"
             else:
+                device_id = camera.get_id
+                device_name = camera.get_name
                 if device_id is None:
                     errors["base"] = "cannot_connect"
                 else:
@@ -104,14 +104,14 @@ class HikvisionConfigFlow(ConfigFlow, domain=DOMAIN):
             camera = await self.hass.async_add_executor_job(
                 HikCamera, url, port, username, password
             )
-            device_id = camera.get_id
-            device_name = camera.get_name
         except requests.exceptions.RequestException:
             _LOGGER.exception(
                 "Error connecting to Hikvision device during import, aborting"
             )
             return self.async_abort(reason="cannot_connect")
 
+        device_id = camera.get_id
+        device_name = camera.get_name
         if device_id is None:
             return self.async_abort(reason="cannot_connect")
 

--- a/tests/components/hikvision/conftest.py
+++ b/tests/components/hikvision/conftest.py
@@ -69,7 +69,7 @@ def mock_hikcamera() -> Generator[MagicMock]:
         ),
     ):
         camera = hikcamera_mock.return_value
-        camera.get_id.return_value = TEST_DEVICE_ID
+        camera.get_id = TEST_DEVICE_ID
         camera.get_name = TEST_DEVICE_NAME
         camera.get_type = "Camera"
         camera.current_event_states = {

--- a/tests/components/hikvision/test_binary_sensor.py
+++ b/tests/components/hikvision/test_binary_sensor.py
@@ -241,7 +241,7 @@ async def test_yaml_import_abort_creates_issue(
     issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test YAML import creates issue when import is aborted."""
-    mock_hikcamera.return_value.get_id.return_value = None
+    mock_hikcamera.return_value.get_id = None
 
     await async_setup_component(
         hass,

--- a/tests/components/hikvision/test_config_flow.py
+++ b/tests/components/hikvision/test_config_flow.py
@@ -70,7 +70,7 @@ async def test_form_cannot_connect(
     mock_hikcamera: MagicMock,
 ) -> None:
     """Test we handle cannot connect error and can recover."""
-    mock_hikcamera.return_value.get_id.return_value = None
+    mock_hikcamera.return_value.get_id = None
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -91,7 +91,7 @@ async def test_form_cannot_connect(
     assert result["errors"] == {"base": "cannot_connect"}
 
     # Recover from error
-    mock_hikcamera.return_value.get_id.return_value = TEST_DEVICE_ID
+    mock_hikcamera.return_value.get_id = TEST_DEVICE_ID
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -138,7 +138,7 @@ async def test_form_exception(
 
     # Recover from error
     mock_hikcamera.side_effect = None
-    mock_hikcamera.return_value.get_id.return_value = TEST_DEVICE_ID
+    mock_hikcamera.return_value.get_id = TEST_DEVICE_ID
     mock_hikcamera.return_value.get_name = TEST_DEVICE_NAME
 
     result = await hass.config_entries.flow.async_configure(
@@ -269,7 +269,7 @@ async def test_import_flow_no_device_id(
     mock_hikcamera: MagicMock,
 ) -> None:
     """Test YAML import flow aborts when device_id is None."""
-    mock_hikcamera.return_value.get_id.return_value = None
+    mock_hikcamera.return_value.get_id = None
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/hikvision/test_init.py
+++ b/tests/components/hikvision/test_init.py
@@ -53,7 +53,7 @@ async def test_setup_entry_no_device_id(
     mock_hikcamera: MagicMock,
 ) -> None:
     """Test setup fails when device_id is None."""
-    mock_hikcamera.return_value.get_id.return_value = None
+    mock_hikcamera.return_value.get_id = None
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)


### PR DESCRIPTION
The pyhik library defines get_id as a `@property`, not a method. Changed camera.get_id() to camera.get_id to match the upstream API.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
