### PR TITLE
Only allow unique location names in google air quality

### DIFF
--- a/homeassistant/components/google_air_quality/config_flow.py
+++ b/homeassistant/components/google_air_quality/config_flow.py
@@ -105,7 +105,7 @@ def _is_location_name_already_configured(hass: HomeAssistant, new_data: str) -> 
     """Check if the location name is already configured."""
     for entry in hass.config_entries.async_entries(DOMAIN):
         for subentry in entry.subentries.values():
-            if subentry.title == new_data:
+            if subentry.title.lower() == new_data.lower():
                 return True
     return False
 

--- a/homeassistant/components/google_air_quality/config_flow.py
+++ b/homeassistant/components/google_air_quality/config_flow.py
@@ -187,10 +187,19 @@ class LocationSubentryFlowHandler(ConfigSubentryFlow):
         description_placeholders: dict[str, str] = {}
         if user_input is not None:
             if _is_location_already_configured(self.hass, user_input[CONF_LOCATION]):
-                return self.async_abort(reason="already_configured")
+                errors["base"] = "location_already_configured"
             if _is_location_name_already_configured(self.hass, user_input[CONF_NAME]):
-                return self.async_abort(reason="name_already_in_use")
+                errors["base"] = "location_name_already_configured"
             api: GoogleAirQualityApi = self._get_entry().runtime_data.api
+            if errors:
+                return self.async_show_form(
+                    step_id="location",
+                    data_schema=self.add_suggested_values_to_schema(
+                        _get_location_schema(self.hass), user_input
+                    ),
+                    errors=errors,
+                    description_placeholders=description_placeholders,
+                )
             if await _validate_input(user_input, api, errors, description_placeholders):
                 return self.async_create_entry(
                     title=user_input[CONF_NAME],

--- a/homeassistant/components/google_air_quality/config_flow.py
+++ b/homeassistant/components/google_air_quality/config_flow.py
@@ -101,6 +101,15 @@ def _is_location_already_configured(
     return False
 
 
+def _is_location_name_already_configured(hass: HomeAssistant, new_data: str) -> bool:
+    """Check if the location is already configured."""
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        for subentry in entry.subentries.values():
+            if subentry.title == new_data:
+                return True
+    return False
+
+
 class GoogleAirQualityConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Google AirQuality."""
 
@@ -179,6 +188,8 @@ class LocationSubentryFlowHandler(ConfigSubentryFlow):
         if user_input is not None:
             if _is_location_already_configured(self.hass, user_input[CONF_LOCATION]):
                 return self.async_abort(reason="already_configured")
+            if _is_location_name_already_configured(self.hass, user_input[CONF_NAME]):
+                return self.async_abort(reason="name_already_in_use")
             api: GoogleAirQualityApi = self._get_entry().runtime_data.api
             if await _validate_input(user_input, api, errors, description_placeholders):
                 return self.async_create_entry(

--- a/homeassistant/components/google_air_quality/config_flow.py
+++ b/homeassistant/components/google_air_quality/config_flow.py
@@ -102,7 +102,7 @@ def _is_location_already_configured(
 
 
 def _is_location_name_already_configured(hass: HomeAssistant, new_data: str) -> bool:
-    """Check if the location is already configured."""
+    """Check if the location name is already configured."""
     for entry in hass.config_entries.async_entries(DOMAIN):
         for subentry in entry.subentries.values():
             if subentry.title == new_data:

--- a/homeassistant/components/google_air_quality/strings.json
+++ b/homeassistant/components/google_air_quality/strings.json
@@ -47,13 +47,12 @@
   "config_subentries": {
     "location": {
       "abort": {
-        "already_configured": "[%key:common::config_flow::abort::already_configured_location%]",
-        "name_already_in_use": "Location name is already in use.",
         "unable_to_fetch": "[%key:component::google_air_quality::common::unable_to_fetch%]"
       },
       "entry_type": "Air quality location",
       "error": {
-        "no_data_for_location": "Information is unavailable for this location. Please try a different location.",
+        "location_already_configured": "[%key:common::config_flow::abort::already_configured_location%]",
+        "location_name_already_configured": "Location name already configured.",
         "unknown": "[%key:common::config_flow::error::unknown%]"
       },
       "initiate_flow": {

--- a/homeassistant/components/google_air_quality/strings.json
+++ b/homeassistant/components/google_air_quality/strings.json
@@ -48,6 +48,7 @@
     "location": {
       "abort": {
         "already_configured": "[%key:common::config_flow::abort::already_configured_location%]",
+        "name_already_in_use": "Location name is already in use.",
         "unable_to_fetch": "[%key:component::google_air_quality::common::unable_to_fetch%]"
       },
       "entry_type": "Air quality location",

--- a/tests/components/google_air_quality/test_config_flow.py
+++ b/tests/components/google_air_quality/test_config_flow.py
@@ -356,6 +356,41 @@ async def test_subentry_flow_location_already_configured(
     assert len(entry.subentries) == 1
 
 
+async def test_subentry_flow_location_name_already_configured(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: AsyncMock,
+) -> None:
+    """Test user input for a location name that already exists."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": "user"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "location"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Home",
+            CONF_LOCATION: {
+                CONF_LATITUDE: 30.1,
+                CONF_LONGITUDE: 40.1,
+            },
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "name_already_in_use"
+
+    entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert len(entry.subentries) == 1
+
+
 async def test_subentry_flow_entry_not_loaded(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:

--- a/tests/components/google_air_quality/test_config_flow.py
+++ b/tests/components/google_air_quality/test_config_flow.py
@@ -349,8 +349,8 @@ async def test_subentry_flow_location_already_configured(
         },
     )
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"]["base"] == "location_already_configured"
 
     entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
     assert len(entry.subentries) == 1
@@ -384,8 +384,8 @@ async def test_subentry_flow_location_name_already_configured(
         },
     )
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "name_already_in_use"
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"]["base"] == "location_name_already_configured"
 
     entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
     assert len(entry.subentries) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently its allowed to create multiple locations with the same name, which is confusing. With this PR the names stay unique.
Example before:
<img width="746" height="587" alt="image" src="https://github.com/user-attachments/assets/8fc3d89d-0006-4e22-a72f-1c3cea4ca6ed" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
