### PR TITLE
Add domain driven triggers to lock platform

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -132,6 +132,7 @@ _EXPERIMENTAL_TRIGGER_PLATFORMS = {
     "fan",
     "lawn_mower",
     "light",
+    "lock",
     "media_player",
     "switch",
     "text",

--- a/homeassistant/components/lock/icons.json
+++ b/homeassistant/components/lock/icons.json
@@ -22,5 +22,19 @@
     "unlock": {
       "service": "mdi:lock-open-variant"
     }
+  },
+  "triggers": {
+    "jammed": {
+      "trigger": "mdi:lock-alert"
+    },
+    "locked": {
+      "trigger": "mdi:lock"
+    },
+    "opened": {
+      "trigger": "mdi:lock-open-variant"
+    },
+    "unlocked": {
+      "trigger": "mdi:lock-open-variant"
+    }
   }
 }

--- a/homeassistant/components/lock/strings.json
+++ b/homeassistant/components/lock/strings.json
@@ -1,4 +1,8 @@
 {
+  "common": {
+    "trigger_behavior_description": "The behavior of the targeted locks to trigger on.",
+    "trigger_behavior_name": "Behavior"
+  },
   "device_automation": {
     "action_type": {
       "lock": "Lock {entity_name}",
@@ -50,6 +54,15 @@
       "message": "The code for {entity_id} doesn't match pattern {code_format}."
     }
   },
+  "selector": {
+    "trigger_behavior": {
+      "options": {
+        "any": "Any",
+        "first": "First",
+        "last": "Last"
+      }
+    }
+  },
   "services": {
     "lock": {
       "description": "Locks a lock.",
@@ -82,5 +95,47 @@
       "name": "Unlock"
     }
   },
-  "title": "Lock"
+  "title": "Lock",
+  "triggers": {
+    "jammed": {
+      "description": "Triggers after one or more locks got jammed.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::lock::common::trigger_behavior_description%]",
+          "name": "[%key:component::lock::common::trigger_behavior_name%]"
+        }
+      },
+      "name": "Lock jammed"
+    },
+    "locked": {
+      "description": "Triggers after one or more locks lock.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::lock::common::trigger_behavior_description%]",
+          "name": "[%key:component::lock::common::trigger_behavior_name%]"
+        }
+      },
+      "name": "Lock locked"
+    },
+    "opened": {
+      "description": "Triggers after one or more locks open.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::lock::common::trigger_behavior_description%]",
+          "name": "[%key:component::lock::common::trigger_behavior_name%]"
+        }
+      },
+      "name": "Lock opened"
+    },
+    "unlocked": {
+      "description": "Triggers after one or more locks unlock.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::lock::common::trigger_behavior_description%]",
+          "name": "[%key:component::lock::common::trigger_behavior_name%]"
+        }
+      },
+      "name": "Lock unlocked"
+    }
+  }
 }

--- a/homeassistant/components/lock/strings.json
+++ b/homeassistant/components/lock/strings.json
@@ -98,7 +98,7 @@
   "title": "Lock",
   "triggers": {
     "jammed": {
-      "description": "Triggers after one or more locks got jammed.",
+      "description": "Triggers after one or more locks jam.",
       "fields": {
         "behavior": {
           "description": "[%key:component::lock::common::trigger_behavior_description%]",

--- a/homeassistant/components/lock/trigger.py
+++ b/homeassistant/components/lock/trigger.py
@@ -1,0 +1,18 @@
+"""Provides triggers for locks."""
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.trigger import Trigger, make_entity_target_state_trigger
+
+from .const import DOMAIN, LockState
+
+TRIGGERS: dict[str, type[Trigger]] = {
+    "jammed": make_entity_target_state_trigger(DOMAIN, LockState.JAMMED),
+    "locked": make_entity_target_state_trigger(DOMAIN, LockState.LOCKED),
+    "opened": make_entity_target_state_trigger(DOMAIN, LockState.OPEN),
+    "unlocked": make_entity_target_state_trigger(DOMAIN, LockState.UNLOCKED),
+}
+
+
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+    """Return the triggers for locks."""
+    return TRIGGERS

--- a/homeassistant/components/lock/triggers.yaml
+++ b/homeassistant/components/lock/triggers.yaml
@@ -1,0 +1,20 @@
+.trigger_common: &trigger_common
+  target:
+    entity:
+      domain: lock
+  fields:
+    behavior:
+      required: true
+      default: any
+      selector:
+        select:
+          options:
+            - first
+            - last
+            - any
+          translation_key: trigger_behavior
+
+jammed: *trigger_common
+locked: *trigger_common
+opened: *trigger_common
+unlocked: *trigger_common

--- a/tests/components/lock/test_trigger.py
+++ b/tests/components/lock/test_trigger.py
@@ -1,0 +1,261 @@
+"""Test lock triggers."""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.lock import DOMAIN, LockState
+from homeassistant.const import ATTR_LABEL_ID, CONF_ENTITY_ID
+from homeassistant.core import HomeAssistant, ServiceCall
+
+from tests.components import (
+    StateDescription,
+    arm_trigger,
+    other_states,
+    parametrize_target_entities,
+    parametrize_trigger_states,
+    set_or_remove_state,
+    target_entities,
+)
+
+
+@pytest.fixture(autouse=True, name="stub_blueprint_populate")
+def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
+    """Stub copying the blueprints to the config folder."""
+
+
+@pytest.fixture(name="enable_experimental_triggers_conditions")
+def enable_experimental_triggers_conditions() -> Generator[None]:
+    """Enable experimental triggers and conditions."""
+    with patch(
+        "homeassistant.components.labs.async_is_preview_feature_enabled",
+        return_value=True,
+    ):
+        yield
+
+
+@pytest.fixture
+async def target_locks(hass: HomeAssistant) -> list[str]:
+    """Create multiple lock entities associated with different targets."""
+    return (await target_entities(hass, DOMAIN))["included"]
+
+
+@pytest.mark.parametrize(
+    "trigger_key",
+    [
+        "lock.jammed",
+        "lock.locked",
+        "lock.opened",
+        "lock.unlocked",
+    ],
+)
+async def test_lock_triggers_gated_by_labs_flag(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, trigger_key: str
+) -> None:
+    """Test the lock triggers are gated by the labs flag."""
+    await arm_trigger(hass, trigger_key, None, {ATTR_LABEL_ID: "test_label"})
+    assert (
+        "Unnamed automation failed to setup triggers and has been disabled: Trigger "
+        f"'{trigger_key}' requires the experimental 'New triggers and conditions' "
+        "feature to be enabled in Home Assistant Labs settings (feature flag: "
+        "'new_triggers_conditions')"
+    ) in caplog.text
+
+
+@pytest.mark.usefixtures("enable_experimental_triggers_conditions")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities(DOMAIN),
+)
+@pytest.mark.parametrize(
+    ("trigger", "states"),
+    [
+        *parametrize_trigger_states(
+            trigger="lock.jammed",
+            target_states=[LockState.JAMMED],
+            other_states=other_states(LockState.JAMMED),
+        ),
+        *parametrize_trigger_states(
+            trigger="lock.locked",
+            target_states=[LockState.LOCKED],
+            other_states=other_states(LockState.LOCKED),
+        ),
+        *parametrize_trigger_states(
+            trigger="lock.opened",
+            target_states=[LockState.OPEN],
+            other_states=other_states(LockState.OPEN),
+        ),
+        *parametrize_trigger_states(
+            trigger="lock.unlocked",
+            target_states=[LockState.UNLOCKED],
+            other_states=other_states(LockState.UNLOCKED),
+        ),
+    ],
+)
+async def test_lock_state_trigger_behavior_any(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    target_locks: list[str],
+    trigger_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    states: list[StateDescription],
+) -> None:
+    """Test that the lock state trigger fires when any lock state changes to a specific state."""
+    other_entity_ids = set(target_locks) - {entity_id}
+
+    # Set all locks, including the tested one, to the initial state
+    for eid in target_locks:
+        set_or_remove_state(hass, eid, states[0]["included"])
+        await hass.async_block_till_done()
+
+    await arm_trigger(hass, trigger, {}, trigger_target_config)
+
+    for state in states[1:]:
+        included_state = state["included"]
+        set_or_remove_state(hass, entity_id, included_state)
+        await hass.async_block_till_done()
+        assert len(service_calls) == state["count"]
+        for service_call in service_calls:
+            assert service_call.data[CONF_ENTITY_ID] == entity_id
+        service_calls.clear()
+
+        # Check if changing other locks also triggers
+        for other_entity_id in other_entity_ids:
+            set_or_remove_state(hass, other_entity_id, included_state)
+            await hass.async_block_till_done()
+        assert len(service_calls) == (entities_in_target - 1) * state["count"]
+        service_calls.clear()
+
+
+@pytest.mark.usefixtures("enable_experimental_triggers_conditions")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities(DOMAIN),
+)
+@pytest.mark.parametrize(
+    ("trigger", "states"),
+    [
+        *parametrize_trigger_states(
+            trigger="lock.jammed",
+            target_states=[LockState.JAMMED],
+            other_states=other_states(LockState.JAMMED),
+        ),
+        *parametrize_trigger_states(
+            trigger="lock.locked",
+            target_states=[LockState.LOCKED],
+            other_states=other_states(LockState.LOCKED),
+        ),
+        *parametrize_trigger_states(
+            trigger="lock.opened",
+            target_states=[LockState.OPEN],
+            other_states=other_states(LockState.OPEN),
+        ),
+        *parametrize_trigger_states(
+            trigger="lock.unlocked",
+            target_states=[LockState.UNLOCKED],
+            other_states=other_states(LockState.UNLOCKED),
+        ),
+    ],
+)
+async def test_lock_state_trigger_behavior_first(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    target_locks: list[str],
+    trigger_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    states: list[StateDescription],
+) -> None:
+    """Test that the lock state trigger fires when the first lock changes to a specific state."""
+    other_entity_ids = set(target_locks) - {entity_id}
+
+    # Set all locks, including the tested one, to the initial state
+    for eid in target_locks:
+        set_or_remove_state(hass, eid, states[0]["included"])
+        await hass.async_block_till_done()
+
+    await arm_trigger(hass, trigger, {"behavior": "first"}, trigger_target_config)
+
+    for state in states[1:]:
+        included_state = state["included"]
+        set_or_remove_state(hass, entity_id, included_state)
+        await hass.async_block_till_done()
+        assert len(service_calls) == state["count"]
+        for service_call in service_calls:
+            assert service_call.data[CONF_ENTITY_ID] == entity_id
+        service_calls.clear()
+
+        # Triggering other locks should not cause the trigger to fire again
+        for other_entity_id in other_entity_ids:
+            set_or_remove_state(hass, other_entity_id, included_state)
+            await hass.async_block_till_done()
+        assert len(service_calls) == 0
+
+
+@pytest.mark.usefixtures("enable_experimental_triggers_conditions")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities(DOMAIN),
+)
+@pytest.mark.parametrize(
+    ("trigger", "states"),
+    [
+        *parametrize_trigger_states(
+            trigger="lock.jammed",
+            target_states=[LockState.JAMMED],
+            other_states=other_states(LockState.JAMMED),
+        ),
+        *parametrize_trigger_states(
+            trigger="lock.locked",
+            target_states=[LockState.LOCKED],
+            other_states=other_states(LockState.LOCKED),
+        ),
+        *parametrize_trigger_states(
+            trigger="lock.opened",
+            target_states=[LockState.OPEN],
+            other_states=other_states(LockState.OPEN),
+        ),
+        *parametrize_trigger_states(
+            trigger="lock.unlocked",
+            target_states=[LockState.UNLOCKED],
+            other_states=other_states(LockState.UNLOCKED),
+        ),
+    ],
+)
+async def test_lock_state_trigger_behavior_last(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    target_locks: list[str],
+    trigger_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    states: list[StateDescription],
+) -> None:
+    """Test that the lock state trigger fires when the last lock changes to a specific state."""
+    other_entity_ids = set(target_locks) - {entity_id}
+
+    # Set all locks, including the tested one, to the initial state
+    for eid in target_locks:
+        set_or_remove_state(hass, eid, states[0]["included"])
+        await hass.async_block_till_done()
+
+    await arm_trigger(hass, trigger, {"behavior": "last"}, trigger_target_config)
+
+    for state in states[1:]:
+        included_state = state["included"]
+        for other_entity_id in other_entity_ids:
+            set_or_remove_state(hass, other_entity_id, included_state)
+            await hass.async_block_till_done()
+        assert len(service_calls) == 0
+
+        set_or_remove_state(hass, entity_id, included_state)
+        await hass.async_block_till_done()
+        assert len(service_calls) == state["count"]
+        for service_call in service_calls:
+            assert service_call.data[CONF_ENTITY_ID] == entity_id
+        service_calls.clear()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I'm not 100% sure about the trigger description translations, if they are correct.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #158424 fixes #158425 fixes #158426 fixes #158427
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
