### PR TITLE
Add Computer Name to device in Libre Hardware Monitor

### DIFF
--- a/homeassistant/components/libre_hardware_monitor/__init__.py
+++ b/homeassistant/components/libre_hardware_monitor/__init__.py
@@ -32,15 +32,15 @@ async def async_migrate_entry(
             entity_registry, config_entry.entry_id
         )
         for reg_entry in registry_entries:
-            new_entity_id = f"{config_entry.entry_id}_{reg_entry.unique_id[4:]}"
+            new_unique_id = f"{config_entry.entry_id}_{reg_entry.unique_id[4:]}"
             _LOGGER.debug(
                 "Migrating entity %s unique id from %s to %s",
                 reg_entry.entity_id,
                 reg_entry.unique_id,
-                new_entity_id,
+                new_unique_id,
             )
             entity_registry.async_update_entity(
-                reg_entry.entity_id, new_unique_id=new_entity_id
+                reg_entry.entity_id, new_unique_id=new_unique_id
             )
 
         # Migrate device identifiers

--- a/homeassistant/components/libre_hardware_monitor/config_flow.py
+++ b/homeassistant/components/libre_hardware_monitor/config_flow.py
@@ -46,7 +46,7 @@ class LibreHardwareMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
             try:
-                _ = (await api.get_data()).main_device_ids_and_names.values()
+                computer_name = (await api.get_data()).computer_name
             except LibreHardwareMonitorConnectionError as exception:
                 _LOGGER.error(exception)
                 errors["base"] = "cannot_connect"
@@ -54,7 +54,7 @@ class LibreHardwareMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "no_devices"
             else:
                 return self.async_create_entry(
-                    title=f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}",
+                    title=f"{computer_name} ({user_input[CONF_HOST]}:{user_input[CONF_PORT]})",
                     data=user_input,
                 )
 

--- a/homeassistant/components/libre_hardware_monitor/coordinator.py
+++ b/homeassistant/components/libre_hardware_monitor/coordinator.py
@@ -65,7 +65,7 @@ class LibreHardwareMonitorCoordinator(DataUpdateCoordinator[LibreHardwareMonitor
             lhm_data = await self._api.get_data()
         except LibreHardwareMonitorConnectionError as err:
             raise UpdateFailed(
-                "LibreHardwareMonitor connection failed, will retry"
+                "LibreHardwareMonitor connection failed, will retry", retry_after=30
             ) from err
         except LibreHardwareMonitorNoDevicesError as err:
             raise UpdateFailed("No sensor data available, will retry") from err

--- a/homeassistant/components/libre_hardware_monitor/manifest.json
+++ b/homeassistant/components/libre_hardware_monitor/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "silver",
-  "requirements": ["librehardwaremonitor-api==1.5.0"]
+  "requirements": ["librehardwaremonitor-api==1.6.0"]
 }

--- a/homeassistant/components/libre_hardware_monitor/sensor.py
+++ b/homeassistant/components/libre_hardware_monitor/sensor.py
@@ -66,7 +66,7 @@ class LibreHardwareMonitorSensor(
         # Hardware device
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{entry_id}_{sensor_data.device_id}")},
-            name=sensor_data.device_name,
+            name=f"[{coordinator.data.computer_name}] {sensor_data.device_name}",
             model=sensor_data.device_type,
         )
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1388,7 +1388,7 @@ libpyfoscamcgi==0.0.9
 libpyvivotek==0.6.1
 
 # homeassistant.components.libre_hardware_monitor
-librehardwaremonitor-api==1.5.0
+librehardwaremonitor-api==1.6.0
 
 # homeassistant.components.mikrotik
 librouteros==3.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1219,7 +1219,7 @@ libpyfoscamcgi==0.0.9
 libpyvivotek==0.6.1
 
 # homeassistant.components.libre_hardware_monitor
-librehardwaremonitor-api==1.5.0
+librehardwaremonitor-api==1.6.0
 
 # homeassistant.components.mikrotik
 librouteros==3.2.0

--- a/tests/components/libre_hardware_monitor/fixtures/libre_hardware_monitor.json
+++ b/tests/components/libre_hardware_monitor/fixtures/libre_hardware_monitor.json
@@ -8,7 +8,7 @@
   "Children": [
     {
       "id": 1,
-      "Text": "GAMING",
+      "Text": "GAMING-PC",
       "Min": "",
       "Value": "",
       "Max": "",

--- a/tests/components/libre_hardware_monitor/snapshots/test_sensor.ambr
+++ b/tests/components/libre_hardware_monitor/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_core_tctl_tdie_temperature-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_core_tctl_tdie_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -14,7 +14,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_core_tctl_tdie_temperature',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_core_tctl_tdie_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -36,24 +36,24 @@
     'unit_of_measurement': '°C',
   })
 # ---
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_core_tctl_tdie_temperature-state]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_core_tctl_tdie_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'AMD Ryzen 7 7800X3D Core (Tctl/Tdie) Temperature',
+      'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D Core (Tctl/Tdie) Temperature',
       'max_value': '69.1',
       'min_value': '39.4',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '°C',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_core_tctl_tdie_temperature',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_core_tctl_tdie_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '55.5',
   })
 # ---
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_cpu_total_load-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_cpu_total_load-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -68,7 +68,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_cpu_total_load',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_cpu_total_load',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -90,24 +90,24 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_cpu_total_load-state]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_cpu_total_load-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'AMD Ryzen 7 7800X3D CPU Total Load',
+      'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D CPU Total Load',
       'max_value': '55.8',
       'min_value': '0.0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_cpu_total_load',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_cpu_total_load',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '9.1',
   })
 # ---
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_package_power-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_package_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -122,7 +122,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_package_power',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_package_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -144,24 +144,24 @@
     'unit_of_measurement': 'W',
   })
 # ---
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_package_power-state]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_package_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'AMD Ryzen 7 7800X3D Package Power',
+      'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D Package Power',
       'max_value': '70.1',
       'min_value': '25.1',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'W',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_package_power',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_package_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '39.6',
   })
 # ---
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_package_temperature-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_package_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -176,7 +176,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_package_temperature',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_package_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -198,24 +198,24 @@
     'unit_of_measurement': '°C',
   })
 # ---
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_package_temperature-state]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_package_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'AMD Ryzen 7 7800X3D Package Temperature',
+      'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D Package Temperature',
       'max_value': '74.0',
       'min_value': '38.4',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '°C',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_package_temperature',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_package_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '52.8',
   })
 # ---
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_vddcr_soc_voltage-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_soc_voltage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -230,7 +230,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_vddcr_soc_voltage',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_soc_voltage',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -252,24 +252,24 @@
     'unit_of_measurement': 'V',
   })
 # ---
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_vddcr_soc_voltage-state]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_soc_voltage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'AMD Ryzen 7 7800X3D VDDCR SoC Voltage',
+      'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D VDDCR SoC Voltage',
       'max_value': '1.306',
       'min_value': '1.305',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'V',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_vddcr_soc_voltage',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_soc_voltage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1.305',
   })
 # ---
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_vddcr_voltage-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_voltage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -284,7 +284,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_vddcr_voltage',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_voltage',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -306,24 +306,24 @@
     'unit_of_measurement': 'V',
   })
 # ---
-# name: test_sensors_are_created[sensor.amd_ryzen_7_7800x3d_vddcr_voltage-state]
+# name: test_sensors_are_created[sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_voltage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'AMD Ryzen 7 7800X3D VDDCR Voltage',
+      'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D VDDCR Voltage',
       'max_value': '1.173',
       'min_value': '0.452',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'V',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.amd_ryzen_7_7800x3d_vddcr_voltage',
+    'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_voltage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1.083',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -338,7 +338,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -360,24 +360,24 @@
     'unit_of_measurement': 'V',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage-state]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) +12V Voltage',
+      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) +12V Voltage',
       'max_value': '12.096',
       'min_value': '12.048',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'V',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '12.072',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -392,7 +392,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -414,24 +414,24 @@
     'unit_of_measurement': 'V',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage-state]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) +5V Voltage',
+      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) +5V Voltage',
       'max_value': '5.050',
       'min_value': '5.020',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'V',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '5.030',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -446,7 +446,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -468,24 +468,24 @@
     'unit_of_measurement': 'RPM',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan-state]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Fan',
+      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Fan',
       'max_value': '0',
       'min_value': '0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'RPM',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -500,7 +500,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -522,24 +522,24 @@
     'unit_of_measurement': '°C',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature-state]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Temperature',
+      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Temperature',
       'max_value': '68.0',
       'min_value': '39.0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '°C',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '55.0',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -554,7 +554,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -576,24 +576,24 @@
     'unit_of_measurement': 'RPM',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan-state]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Fan',
+      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Fan',
       'max_value': '0',
       'min_value': '0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'RPM',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -608,7 +608,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -630,23 +630,23 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan-state]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
+      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
       'max_value': None,
       'min_value': None,
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -661,7 +661,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -683,24 +683,24 @@
     'unit_of_measurement': '°C',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature-state]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) System Temperature',
+      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Temperature',
       'max_value': '46.5',
       'min_value': '32.5',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '°C',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '45.5',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -715,7 +715,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -737,24 +737,24 @@
     'unit_of_measurement': 'V',
   })
 # ---
-# name: test_sensors_are_created[sensor.msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage-state]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) Vcore Voltage',
+      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Vcore Voltage',
       'max_value': '1.318',
       'min_value': '1.310',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'V',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1.312',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_core_clock-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_clock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -769,7 +769,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_clock',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_clock',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -791,24 +791,24 @@
     'unit_of_measurement': 'MHz',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_core_clock-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_clock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Core Clock',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Core Clock',
       'max_value': '2805.0',
       'min_value': '210.0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'MHz',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_clock',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_clock',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2805.0',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_core_load-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_load-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -823,7 +823,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_load',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_load',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -845,24 +845,24 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_core_load-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_load-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Core Load',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Core Load',
       'max_value': '19.0',
       'min_value': '0.0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_load',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_load',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '5.0',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_core_temperature-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -877,7 +877,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_temperature',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -899,24 +899,24 @@
     'unit_of_measurement': '°C',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_core_temperature-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Core Temperature',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Core Temperature',
       'max_value': '37.0',
       'min_value': '25.0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '°C',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_temperature',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '36.0',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_fan_1_fan-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -931,7 +931,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -953,24 +953,24 @@
     'unit_of_measurement': 'RPM',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_fan_1_fan-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Fan',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Fan',
       'max_value': '0',
       'min_value': '0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'RPM',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_fan_2_fan-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -985,7 +985,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1007,24 +1007,24 @@
     'unit_of_measurement': 'RPM',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_fan_2_fan-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Fan',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Fan',
       'max_value': '0',
       'min_value': '0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'RPM',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1039,7 +1039,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1061,24 +1061,24 @@
     'unit_of_measurement': '°C',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Hot Spot Temperature',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Hot Spot Temperature',
       'max_value': '43.3',
       'min_value': '32.5',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '°C',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '43.0',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_memory_clock-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_clock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1093,7 +1093,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_memory_clock',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_clock',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1115,24 +1115,24 @@
     'unit_of_measurement': 'MHz',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_memory_clock-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_clock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Memory Clock',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Memory Clock',
       'max_value': '11502.0',
       'min_value': '405.0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'MHz',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_memory_clock',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_clock',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '11252.0',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_memory_controller_load-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_controller_load-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1147,7 +1147,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_memory_controller_load',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_controller_load',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1169,24 +1169,24 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_memory_controller_load-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_controller_load-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Memory Controller Load',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Memory Controller Load',
       'max_value': '49.0',
       'min_value': '0.0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_memory_controller_load',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_controller_load',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_package_power-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_package_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1201,7 +1201,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_package_power',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_package_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1223,24 +1223,24 @@
     'unit_of_measurement': 'W',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_package_power-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_package_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Package Power',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Package Power',
       'max_value': '66.6',
       'min_value': '4.1',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'W',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_package_power',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_package_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '59.6',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1255,7 +1255,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1277,24 +1277,24 @@
     'unit_of_measurement': 'MB/s',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU PCIe Tx Throughput',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU PCIe Tx Throughput',
       'max_value': '2422.8',
       'min_value': '0.0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'MB/s',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '166.1',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_video_engine_load-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_video_engine_load-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1309,7 +1309,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_video_engine_load',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_video_engine_load',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1331,17 +1331,17 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensors_are_created[sensor.nvidia_geforce_rtx_4080_super_gpu_video_engine_load-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_video_engine_load-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Video Engine Load',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Video Engine Load',
       'max_value': '99.0',
       'min_value': '0.0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_video_engine_load',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_video_engine_load',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1352,14 +1352,14 @@
   list([
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) +12V Voltage',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) +12V Voltage',
         'max_value': '12.096',
         'min_value': '12.048',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'V',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1367,14 +1367,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) +5V Voltage',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) +5V Voltage',
         'max_value': '5.050',
         'min_value': '5.020',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'V',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1382,14 +1382,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) Vcore Voltage',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Vcore Voltage',
         'max_value': '1.318',
         'min_value': '1.310',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'V',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1397,14 +1397,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Temperature',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Temperature',
         'max_value': '68.0',
         'min_value': '39.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1412,14 +1412,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) System Temperature',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Temperature',
         'max_value': '46.5',
         'min_value': '32.5',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1427,14 +1427,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Fan',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1442,14 +1442,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Fan',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1457,13 +1457,13 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
         'max_value': None,
         'min_value': None,
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1471,14 +1471,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D VDDCR Voltage',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D VDDCR Voltage',
         'max_value': '1.173',
         'min_value': '0.452',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'V',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_vddcr_voltage',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_voltage',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1486,14 +1486,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D VDDCR SoC Voltage',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D VDDCR SoC Voltage',
         'max_value': '1.306',
         'min_value': '1.305',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'V',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_vddcr_soc_voltage',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_soc_voltage',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1501,14 +1501,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D Package Power',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D Package Power',
         'max_value': '70.1',
         'min_value': '25.1',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'W',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_package_power',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_package_power',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1516,14 +1516,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D Core (Tctl/Tdie) Temperature',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D Core (Tctl/Tdie) Temperature',
         'max_value': '69.1',
         'min_value': '39.4',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_core_tctl_tdie_temperature',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_core_tctl_tdie_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1531,14 +1531,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D Package Temperature',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D Package Temperature',
         'max_value': '74.0',
         'min_value': '38.4',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_package_temperature',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_package_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1546,14 +1546,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D CPU Total Load',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D CPU Total Load',
         'max_value': '55.8',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '%',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_cpu_total_load',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_cpu_total_load',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1561,14 +1561,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Package Power',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Package Power',
         'max_value': '66.6',
         'min_value': '4.1',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'W',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_package_power',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_package_power',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1576,14 +1576,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Core Clock',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Core Clock',
         'max_value': '2805.0',
         'min_value': '210.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'MHz',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_clock',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_clock',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1591,14 +1591,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Memory Clock',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Memory Clock',
         'max_value': '11502.0',
         'min_value': '405.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'MHz',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_memory_clock',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_clock',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1606,14 +1606,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Core Temperature',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Core Temperature',
         'max_value': '37.0',
         'min_value': '25.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_temperature',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1621,14 +1621,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Hot Spot Temperature',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Hot Spot Temperature',
         'max_value': '43.3',
         'min_value': '32.5',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1636,14 +1636,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Core Load',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Core Load',
         'max_value': '19.0',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '%',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_load',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_load',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1651,14 +1651,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Memory Controller Load',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Memory Controller Load',
         'max_value': '49.0',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '%',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_memory_controller_load',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_controller_load',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1666,14 +1666,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Video Engine Load',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Video Engine Load',
         'max_value': '99.0',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '%',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_video_engine_load',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_video_engine_load',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1681,14 +1681,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Fan',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Fan',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1696,14 +1696,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Fan',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Fan',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1711,14 +1711,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU PCIe Tx Throughput',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU PCIe Tx Throughput',
         'max_value': '2422.8',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'MB/s',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1730,14 +1730,14 @@
   list([
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) +12V Voltage',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) +12V Voltage',
         'max_value': '12.096',
         'min_value': '12.048',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'V',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1745,14 +1745,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) +5V Voltage',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) +5V Voltage',
         'max_value': '5.050',
         'min_value': '5.020',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'V',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_5v_voltage',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1760,14 +1760,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) Vcore Voltage',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Vcore Voltage',
         'max_value': '1.318',
         'min_value': '1.310',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'V',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_vcore_voltage',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1775,14 +1775,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Temperature',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Temperature',
         'max_value': '68.0',
         'min_value': '39.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1790,14 +1790,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) System Temperature',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Temperature',
         'max_value': '46.5',
         'min_value': '32.5',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1805,14 +1805,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Fan',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1820,14 +1820,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Fan',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1835,13 +1835,13 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
         'max_value': None,
         'min_value': None,
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1849,14 +1849,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D VDDCR Voltage',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D VDDCR Voltage',
         'max_value': '1.173',
         'min_value': '0.452',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'V',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_vddcr_voltage',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_voltage',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1864,14 +1864,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D VDDCR SoC Voltage',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D VDDCR SoC Voltage',
         'max_value': '1.306',
         'min_value': '1.305',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'V',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_vddcr_soc_voltage',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_vddcr_soc_voltage',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1879,14 +1879,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D Package Power',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D Package Power',
         'max_value': '70.1',
         'min_value': '25.1',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'W',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_package_power',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_package_power',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1894,14 +1894,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D Core (Tctl/Tdie) Temperature',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D Core (Tctl/Tdie) Temperature',
         'max_value': '69.1',
         'min_value': '39.4',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_core_tctl_tdie_temperature',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_core_tctl_tdie_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1909,14 +1909,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D Package Temperature',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D Package Temperature',
         'max_value': '74.0',
         'min_value': '38.4',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_package_temperature',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_package_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1924,14 +1924,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'AMD Ryzen 7 7800X3D CPU Total Load',
+        'friendly_name': '[GAMING-PC] AMD Ryzen 7 7800X3D CPU Total Load',
         'max_value': '55.8',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '%',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.amd_ryzen_7_7800x3d_cpu_total_load',
+      'entity_id': 'sensor.gaming_pc_amd_ryzen_7_7800x3d_cpu_total_load',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1939,14 +1939,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Package Power',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Package Power',
         'max_value': '66.6',
         'min_value': '4.1',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'W',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_package_power',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_package_power',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1954,14 +1954,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Core Clock',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Core Clock',
         'max_value': '2805.0',
         'min_value': '210.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'MHz',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_clock',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_clock',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1969,14 +1969,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Memory Clock',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Memory Clock',
         'max_value': '11502.0',
         'min_value': '405.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'MHz',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_memory_clock',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_clock',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1984,14 +1984,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Core Temperature',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Core Temperature',
         'max_value': '37.0',
         'min_value': '25.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_temperature',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1999,14 +1999,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Hot Spot Temperature',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Hot Spot Temperature',
         'max_value': '43.3',
         'min_value': '32.5',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '°C',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_hot_spot_temperature',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -2014,14 +2014,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Core Load',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Core Load',
         'max_value': '19.0',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '%',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_core_load',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_core_load',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -2029,14 +2029,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Memory Controller Load',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Memory Controller Load',
         'max_value': '49.0',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '%',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_memory_controller_load',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_memory_controller_load',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -2044,14 +2044,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Video Engine Load',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Video Engine Load',
         'max_value': '99.0',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '%',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_video_engine_load',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_video_engine_load',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -2059,14 +2059,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Fan',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Fan',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -2074,14 +2074,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Fan',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Fan',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -2089,14 +2089,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'NVIDIA GeForce RTX 4080 SUPER GPU PCIe Tx Throughput',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU PCIe Tx Throughput',
         'max_value': '2422.8',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'MB/s',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,

--- a/tests/components/libre_hardware_monitor/test_config_flow.py
+++ b/tests/components/libre_hardware_monitor/test_config_flow.py
@@ -42,7 +42,7 @@ async def test_create_entry(
     mock_config_entry = result["result"]
     assert (
         mock_config_entry.title
-        == f"{VALID_CONFIG[CONF_HOST]}:{VALID_CONFIG[CONF_PORT]}"
+        == f"GAMING-PC ({VALID_CONFIG[CONF_HOST]}:{VALID_CONFIG[CONF_PORT]})"
     )
     assert mock_config_entry.data == VALID_CONFIG
 

--- a/tests/components/libre_hardware_monitor/test_init.py
+++ b/tests/components/libre_hardware_monitor/test_init.py
@@ -88,3 +88,8 @@ async def test_migration_to_unique_ids(
     assert (
         entity_registry.async_get_entity_id("sensor", DOMAIN, legacy_entity_id) is None
     )
+
+    updated_config_entry = hass.config_entries.async_get_entry(
+        legacy_config_entry_v1.entry_id
+    )
+    assert updated_config_entry.version == 2

--- a/tests/components/libre_hardware_monitor/test_sensor.py
+++ b/tests/components/libre_hardware_monitor/test_sensor.py
@@ -92,7 +92,7 @@ async def test_sensors_are_updated(
     """Test sensors are updated with properly formatted values."""
     await init_integration(hass, mock_config_entry)
 
-    entity_id = "sensor.amd_ryzen_7_7800x3d_package_temperature"
+    entity_id = "sensor.gaming_pc_amd_ryzen_7_7800x3d_package_temperature"
     state = hass.states.get(entity_id)
 
     assert state
@@ -128,7 +128,7 @@ async def test_sensor_state_is_unknown_when_no_sensor_data_is_provided(
     """Test sensor state is unknown when sensor data is missing."""
     await init_integration(hass, mock_config_entry)
 
-    entity_id = "sensor.amd_ryzen_7_7800x3d_package_temperature"
+    entity_id = "sensor.gaming_pc_amd_ryzen_7_7800x3d_package_temperature"
 
     state = hass.states.get(entity_id)
 
@@ -200,6 +200,7 @@ async def _mock_orphaned_device(
     previous_data = mock_lhm_client.get_data.return_value
 
     mock_lhm_client.get_data.return_value = LibreHardwareMonitorData(
+        computer_name=mock_lhm_client.get_data.return_value.computer_name,
         main_device_ids_and_names=MappingProxyType(
             {
                 device_id: name
@@ -230,6 +231,7 @@ async def test_integration_does_not_log_new_devices_on_first_refresh(
 ) -> None:
     """Test that initial data update does not cause warning about new devices."""
     mock_lhm_client.get_data.return_value = LibreHardwareMonitorData(
+        computer_name=mock_lhm_client.get_data.return_value.computer_name,
         main_device_ids_and_names=MappingProxyType(
             {
                 **mock_lhm_client.get_data.return_value.main_device_ids_and_names,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a user has multiple config entries (= multiple PCs monitored) and those PCs have the same hardware, then HA will resolve entity ID collisions by suffixing entity IDs with `_2`, `_3`, … 
As a result, it’s unclear which entities belong to which config entry/host.

This PR resolves this by also fetching the computer name as provided by the Libre Hardware Monitor API (via the library) and prefixing device names (and subsequently, the derived entity IDs) with it.

Previously, device names were not clearly assigned to a specific PC (= config entry). For example:
```
AMD Ryzen 7 7800X3D
NVIDIA GeForce RTX 4080 SUPER
Samsung SSD 990 EVO Plus 2TB
```

Now they will have a square bracket prefix with the computer name e.g. "GAMING-PC"
```
[GAMING-PC] AMD Ryzen 7 7800X3D
[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER
[GAMING-PC] Samsung SSD 990 EVO Plus 2TB
```

This will also impact the entity IDs that are derived partially from the device name they belong to.
Previous entity IDs looked something like this
```
CPU:
sensor.12th_gen_intel_core_i3_12100_bus_speed_clock
sensor.12th_gen_intel_core_i3_12100_cpu_core_1_clock

GPU:
sensor.nvidia_geforce_rtx_4070_super_d3d_3d_load

Disks:
sensor.netac_ssd_2tb_read_activity_load
sensor.netac_ssd_2tb_read_activity_load_2
sensor.netac_ssd_2tb_read_activity_load_3
```

Now those entity IDs will be prefixed accordingly
```
CPU:
sensor.gaming_pc_12th_gen_intel_core_i3_12100_bus_speed_clock
sensor.gaming_pc_12th_gen_intel_core_i3_12100_cpu_core_1_clock

GPU:
sensor.gaming_pc_nvidia_geforce_rtx_4070_super_d3d_3d_load

Disks:
sensor.gaming_pc_netac_ssd_2tb_read_activity_load
sensor.gaming_pc_netac_ssd_2tb_read_activity_load_2
sensor.gaming_pc_netac_ssd_2tb_read_activity_load_3
```

Additionally, the config entry title is also updated from something like
```
192.168.0.20:8085
```
to also include the computer name:
```
GAMING-PC (192.168.0.20:8085)
```

As this is not a strictly necessary upgrade I have chosen not to force a migration as it would presumably be a breaking change and require a new major config flow version. Previous entries will continue to work as before, the only difference will be that device names will receive the computer name prefix (but nalready existing entity IDs will stay untouched) so nothing should break here.

Will close: https://github.com/home-assistant/core/issues/155953

In order to access the computer name, the library was updated to include it in the data model.
Diff: https://github.com/Sab44/librehardwaremonitor-api/compare/v1.5.0...v1.6.0

Screenshot of 2 monitored PCs with the changes of this PR included:
<img width="1075" height="1078" alt="Screenshot 2025-12-22 at 08 59 25" src="https://github.com/user-attachments/assets/53c1e7d0-a867-45a0-8b35-7a98eedd7a69" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #155953
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
