### PR TITLE
KNX Fan: Add support for switch addresses

### DIFF
--- a/homeassistant/components/knx/fan.py
+++ b/homeassistant/components/knx/fan.py
@@ -165,7 +165,12 @@ class KnxYamlFan(_KnxFan, KnxYamlEntity):
                 group_address_oscillation_state=config.get(
                     FanSchema.CONF_OSCILLATION_STATE_ADDRESS
                 ),
+                group_address_switch=config.get(FanSchema.CONF_SWITCH_ADDRESS),
+                group_address_switch_state=config.get(
+                    FanSchema.CONF_SWITCH_STATE_ADDRESS
+                ),
                 max_step=max_step,
+                sync_state=config.get(CONF_SYNC_STATE, True),
             ),
         )
         # FanSpeedMode.STEP if max_step is set

--- a/homeassistant/components/knx/fan.py
+++ b/homeassistant/components/knx/fan.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Final
+from typing import Any
 
 from propcache.api import cached_property
 from xknx.devices import Fan as XknxFan
@@ -32,11 +32,10 @@ from .storage.const import (
     CONF_GA_OSCILLATION,
     CONF_GA_SPEED,
     CONF_GA_STEP,
+    CONF_GA_SWITCH,
     CONF_SPEED,
 )
 from .storage.util import ConfigExtractor
-
-DEFAULT_PERCENTAGE: Final = 50
 
 
 async def async_setup_entry(
@@ -77,26 +76,24 @@ class _KnxFan(FanEntity):
     _device: XknxFan
     _step_range: tuple[int, int] | None
 
+    def _get_knx_speed(self, percentage: int) -> int:
+        """Convert percentage to KNX speed value."""
+        if self._step_range is not None:
+            return math.ceil(percentage_to_ranged_value(self._step_range, percentage))
+        return percentage
+
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
-        if self._step_range:
-            step = math.ceil(percentage_to_ranged_value(self._step_range, percentage))
-            await self._device.set_speed(step)
-        else:
-            await self._device.set_speed(percentage)
+        await self._device.set_speed(self._get_knx_speed(percentage))
 
     @cached_property
     def supported_features(self) -> FanEntityFeature:
         """Flag supported features."""
-        flags = (
-            FanEntityFeature.SET_SPEED
-            | FanEntityFeature.TURN_ON
-            | FanEntityFeature.TURN_OFF
-        )
-
+        flags = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        if self._device.speed.initialized:
+            flags |= FanEntityFeature.SET_SPEED
         if self._device.supports_oscillation:
             flags |= FanEntityFeature.OSCILLATE
-
         return flags
 
     @property
@@ -118,6 +115,11 @@ class _KnxFan(FanEntity):
             return super().speed_count
         return int_states_in_range(self._step_range)
 
+    @property
+    def is_on(self) -> bool:
+        """Return the current fan state of the device."""
+        return self._device.is_on
+
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -125,14 +127,12 @@ class _KnxFan(FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn on the fan."""
-        if percentage is None:
-            await self.async_set_percentage(DEFAULT_PERCENTAGE)
-        else:
-            await self.async_set_percentage(percentage)
+        speed = self._get_knx_speed(percentage) if percentage is not None else None
+        await self._device.turn_on(speed)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
-        await self.async_set_percentage(0)
+        await self._device.turn_off()
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Oscillate the fan."""
@@ -210,6 +210,8 @@ class KnxUiFan(_KnxFan, KnxUiEntity):
             group_address_oscillation_state=knx_conf.get_state_and_passive(
                 CONF_GA_OSCILLATION
             ),
+            group_address_switch=knx_conf.get_write(CONF_GA_SWITCH),
+            group_address_switch_state=knx_conf.get_state_and_passive(CONF_GA_SWITCH),
             max_step=max_step,
             sync_state=knx_conf.get(CONF_SYNC_STATE),
         )

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -576,19 +576,40 @@ class FanSchema(KNXPlatformSchema):
     CONF_STATE_ADDRESS = CONF_STATE_ADDRESS
     CONF_OSCILLATION_ADDRESS = "oscillation_address"
     CONF_OSCILLATION_STATE_ADDRESS = "oscillation_state_address"
+    CONF_SWITCH_ADDRESS = "switch_address"
+    CONF_SWITCH_STATE_ADDRESS = "switch_state_address"
 
     DEFAULT_NAME = "KNX Fan"
 
-    ENTITY_SCHEMA = vol.Schema(
-        {
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-            vol.Required(KNX_ADDRESS): ga_list_validator,
-            vol.Optional(CONF_STATE_ADDRESS): ga_list_validator,
-            vol.Optional(CONF_OSCILLATION_ADDRESS): ga_list_validator,
-            vol.Optional(CONF_OSCILLATION_STATE_ADDRESS): ga_list_validator,
-            vol.Optional(FanConf.MAX_STEP): cv.byte,
-            vol.Optional(CONF_ENTITY_CATEGORY): ENTITY_CATEGORIES_SCHEMA,
-        }
+    ENTITY_SCHEMA = vol.All(
+        vol.Schema(
+            {
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                vol.Optional(KNX_ADDRESS): ga_list_validator,
+                vol.Optional(CONF_STATE_ADDRESS): ga_list_validator,
+                vol.Optional(CONF_SWITCH_ADDRESS): ga_list_validator,
+                vol.Optional(CONF_SWITCH_STATE_ADDRESS): ga_list_validator,
+                vol.Optional(CONF_OSCILLATION_ADDRESS): ga_list_validator,
+                vol.Optional(CONF_OSCILLATION_STATE_ADDRESS): ga_list_validator,
+                vol.Optional(FanConf.MAX_STEP): cv.byte,
+                vol.Optional(CONF_ENTITY_CATEGORY): ENTITY_CATEGORIES_SCHEMA,
+                vol.Optional(CONF_SYNC_STATE, default=True): sync_state_validator,
+            }
+        ),
+        vol.Any(
+            vol.Schema(
+                {vol.Required(KNX_ADDRESS): object},
+                extra=vol.ALLOW_EXTRA,
+            ),
+            vol.Schema(
+                {vol.Required(CONF_SWITCH_ADDRESS): object},
+                extra=vol.ALLOW_EXTRA,
+            ),
+            msg=(
+                f"At least one of '{KNX_ADDRESS}' or"
+                f" '{CONF_SWITCH_ADDRESS}' is required."
+            ),
+        ),
     )
 
 

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -224,40 +224,58 @@ DATETIME_KNX_SCHEMA = vol.Schema(
     }
 )
 
-FAN_KNX_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_SPEED): GroupSelect(
-            GroupSelectOption(
-                translation_key="percentage_mode",
-                schema={
-                    vol.Required(CONF_GA_SPEED): GASelector(
-                        write_required=True, valid_dpt="5.001"
-                    ),
-                },
+FAN_KNX_SCHEMA = AllSerializeFirst(
+    vol.Schema(
+        {
+            vol.Optional(CONF_GA_SWITCH): GASelector(
+                write_required=True, valid_dpt="1"
             ),
-            GroupSelectOption(
-                translation_key="step_mode",
-                schema={
-                    vol.Required(CONF_GA_STEP): GASelector(
-                        write_required=True, valid_dpt="5.010"
-                    ),
-                    vol.Required(FanConf.MAX_STEP, default=3): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=1,
-                            max=100,
-                            step=1,
-                            mode=selector.NumberSelectorMode.BOX,
-                        )
-                    ),
-                },
+            vol.Optional(CONF_SPEED): GroupSelect(
+                GroupSelectOption(
+                    translation_key="percentage_mode",
+                    schema={
+                        vol.Required(CONF_GA_SPEED): GASelector(
+                            write_required=True, valid_dpt="5.001"
+                        ),
+                    },
+                ),
+                GroupSelectOption(
+                    translation_key="step_mode",
+                    schema={
+                        vol.Required(CONF_GA_STEP): GASelector(
+                            write_required=True, valid_dpt="5.010"
+                        ),
+                        vol.Required(
+                            FanConf.MAX_STEP, default=3
+                        ): selector.NumberSelector(
+                            selector.NumberSelectorConfig(
+                                min=1,
+                                max=100,
+                                step=1,
+                                mode=selector.NumberSelectorMode.BOX,
+                            )
+                        ),
+                    },
+                ),
+                collapsible=False,
             ),
-            collapsible=False,
+            vol.Optional(CONF_GA_OSCILLATION): GASelector(
+                write_required=True, valid_dpt="1"
+            ),
+            vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+        }
+    ),
+    vol.Any(
+        vol.Schema(
+            {vol.Required(CONF_GA_SWITCH): object},
+            extra=vol.ALLOW_EXTRA,
         ),
-        vol.Optional(CONF_GA_OSCILLATION): GASelector(
-            write_required=True, valid_dpt="1"
+        vol.Schema(
+            {vol.Required(CONF_SPEED): object},
+            extra=vol.ALLOW_EXTRA,
         ),
-        vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
-    }
+        msg=("At least one of 'Switch' or 'Fan speed' is required."),
+    ),
 )
 
 

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -467,6 +467,10 @@
               "description": "Toggle oscillation of the fan.",
               "label": "Oscillation"
             },
+            "ga_switch": {
+              "description": "Group address to turn the fan on/off.",
+              "label": "Switch"
+            },
             "speed": {
               "description": "Control the speed of the fan.",
               "ga_speed": {

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -1038,9 +1038,31 @@
     'id': 1,
     'result': list([
       dict({
+        'name': 'ga_switch',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
+          'write': dict({
+            'required': True,
+          }),
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
         'collapsible': False,
         'name': 'speed',
-        'required': True,
+        'optional': True,
+        'required': False,
         'schema': list([
           dict({
             'schema': list([

--- a/tests/components/knx/test_fan.py
+++ b/tests/components/knx/test_fan.py
@@ -153,7 +153,7 @@ async def test_fan_oscillation(hass: HomeAssistant, knx: KNXTestKit) -> None:
 @pytest.mark.parametrize(
     ("knx_data", "expected_read_response", "expected_state"),
     [
-        (
+        (  # percent mode fan with oscillation
             {
                 "speed": {
                     "ga_speed": {"write": "1/1/0", "state": "1/1/1"},
@@ -164,7 +164,7 @@ async def test_fan_oscillation(hass: HomeAssistant, knx: KNXTestKit) -> None:
             [("1/1/1", (0x55,)), ("2/2/2", True)],
             {"state": STATE_ON, "percentage": 33, "oscillating": True},
         ),
-        (
+        (  # step only fan
             {
                 "speed": {
                     "ga_step": {"write": "1/1/0", "state": "1/1/1"},
@@ -174,6 +174,14 @@ async def test_fan_oscillation(hass: HomeAssistant, knx: KNXTestKit) -> None:
             },
             [("1/1/1", (2,))],
             {"state": STATE_ON, "percentage": 66},
+        ),
+        (  # switch only fan
+            {
+                "ga_switch": {"write": "1/1/0", "state": "1/1/1"},
+                "sync_state": True,
+            },
+            [("1/1/1", True)],
+            {"state": STATE_ON, "percentage": None},
         ),
     ],
 )

--- a/tests/components/knx/test_fan.py
+++ b/tests/components/knx/test_fan.py
@@ -109,6 +109,72 @@ async def test_fan_step(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await knx.assert_telegram_count(0)
 
 
+async def test_fan_switch(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test KNX fan with switch only."""
+    await knx.setup_integration(
+        {
+            FanSchema.PLATFORM: {
+                CONF_NAME: "test",
+                FanSchema.CONF_SWITCH_ADDRESS: "1/2/3",
+            }
+        }
+    )
+
+    # turn on fan
+    await hass.services.async_call(
+        "fan", "turn_on", {"entity_id": "fan.test"}, blocking=True
+    )
+    await knx.assert_write("1/2/3", True)
+
+    # turn off fan
+    await hass.services.async_call(
+        "fan", "turn_off", {"entity_id": "fan.test"}, blocking=True
+    )
+    await knx.assert_write("1/2/3", False)
+
+
+async def test_fan_switch_step(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test KNX fan with speed steps and switch address."""
+    await knx.setup_integration(
+        {
+            FanSchema.PLATFORM: {
+                CONF_NAME: "test",
+                KNX_ADDRESS: "1/1/1",
+                FanSchema.CONF_SWITCH_ADDRESS: "2/2/2",
+                FanConf.MAX_STEP: 4,
+            }
+        }
+    )
+
+    # turn on fan without percentage - actuator sets default speed
+    await hass.services.async_call(
+        "fan", "turn_on", {"entity_id": "fan.test"}, blocking=True
+    )
+    await knx.assert_write("2/2/2", True)
+
+    # turn on with speed 75% - step 3 - turn_on sends switch ON again
+    await hass.services.async_call(
+        "fan", "turn_on", {"entity_id": "fan.test", "percentage": 75}, blocking=True
+    )
+    await knx.assert_write("2/2/2", True)
+    await knx.assert_write("1/1/1", (3,))
+
+    # set speed to 25% - step 1 - set_percentage doesn't send switch ON
+    await hass.services.async_call(
+        "fan",
+        "set_percentage",
+        {"entity_id": "fan.test", "percentage": 25},
+        blocking=True,
+    )
+    await knx.assert_write("1/1/1", (1,))
+
+    # turn off fan - no percentage change sent
+    await hass.services.async_call(
+        "fan", "turn_off", {"entity_id": "fan.test"}, blocking=True
+    )
+    await knx.assert_write("2/2/2", False)
+
+
 async def test_fan_oscillation(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX fan oscillation."""
     await knx.setup_integration(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds support for knx fan entities that either only support switching (on/off binary) or support switching in addition to setting a speed. The actuators default turn-on speed will be respected then.

- [x] requires a release of `xknx` with https://github.com/XKNX/xknx/pull/1775 this is added to HA here https://github.com/home-assistant/core/pull/159371

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #159371  https://github.com/home-assistant/core/pull/73131
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42642
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
