### PR TITLE
Deprecate pyserial-asyncio in requirements manager

### DIFF
--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -28,6 +28,13 @@ DISCOVERY_INTEGRATIONS: dict[str, Iterable[str]] = {
     "ssdp": ("ssdp",),
     "zeroconf": ("zeroconf", "homekit"),
 }
+DEPRECATED_PACKAGES: dict[str, str] = {
+    # old_package_name: reason
+    "pyserial-asyncio": (
+        "is deprecated, will be rejected after 2026.2, "
+        "and should be replaced by pyserial-asyncio-fast"
+    ),
+}
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -258,6 +265,16 @@ class RequirementsManager:
                 _LOGGER.warning("Skipping requirement %s. This may cause issues", req)
 
             requirements = [r for r in requirements if r not in skipped_requirements]
+
+        if DEPRECATED_PACKAGES:
+            for req in requirements:
+                if (req_name := Requirement(req).name) in DEPRECATED_PACKAGES:
+                    _LOGGER.warning(
+                        "Requirement %s for integration %s %s",
+                        req_name,
+                        name,
+                        DEPRECATED_PACKAGES[req_name],
+                    )
 
         if not (missing := self._find_missing_requirements(requirements)):
             return

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -279,13 +279,17 @@ class RequirementsManager:
                             ),
                         )
             if skip_pip_packages := self.hass.config.skip_pip_packages:
+                skipped_requirements: set[str] = set()
                 for requirement_string, requirement_details in all_requirements.items():
                     if requirement_details.name in skip_pip_packages:
                         _LOGGER.warning(
                             "Skipping requirement %s. This may cause issues",
                             requirement_string,
                         )
-                        requirements.remove(requirement_string)
+                        skipped_requirements.add(requirement_string)
+                requirements = [
+                    r for r in requirements if r not in skipped_requirements
+                ]
 
         if not (missing := self._find_missing_requirements(requirements)):
             return

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -35,7 +35,7 @@ DISCOVERY_INTEGRATIONS: dict[str, Iterable[str]] = {
 }
 DEPRECATED_PACKAGES: dict[str, tuple[str, str]] = {
     # old_package_name: (reason, breaks_in_ha_version)
-    "pyserial-asyncio": ("should be replaced by pyserial-asyncio-fast", "2026.2"),
+    "pyserial-asyncio": ("should be replaced by pyserial-asyncio-fast", "2026.4"),
 }
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -266,13 +266,14 @@ class RequirementsManager:
             if DEPRECATED_PACKAGES:
                 for requirement_string, requirement_details in all_requirements.items():
                     if deprecation := DEPRECATED_PACKAGES.get(requirement_details.name):
+                        reason, breaks_in_ha_version = deprecation
                         _LOGGER.warning(
                             "Detected that %sintegration '%s' %s. %s %s",
                             "" if is_built_in else "custom ",
                             name,
-                            f"has requirement '{requirement_string}' which {deprecation[0]}",
+                            f"has requirement '{requirement_string}' which {reason}",
                             f"This will stop working in Home Assistant {breaks_in_ha_version}, please"
-                            if (breaks_in_ha_version := deprecation[1])
+                            if breaks_in_ha_version
                             else "Please",
                             async_suggest_report_issue(
                                 self.hass, integration_domain=name

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -35,7 +35,7 @@ DISCOVERY_INTEGRATIONS: dict[str, Iterable[str]] = {
 }
 DEPRECATED_PACKAGES: dict[str, tuple[str, str]] = {
     # old_package_name: (reason, breaks_in_ha_version)
-    "pyserial-asyncio": ("should be replaced by pyserial-asyncio-fast", "2026.4"),
+    "pyserial-asyncio": ("should be replaced by pyserial-asyncio-fast", "2026.7"),
 }
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -671,19 +671,10 @@ async def test_install_deprecated_package(
         ) as mock_inst,
     ):
         await async_process_requirements(hass, "test_component", ["hello==1.0.0"])
-        await async_process_requirements(
-            hass, "test_component", ["pyserial-asyncio>=0.6"]
-        )
 
     assert len(mock_inst.mock_calls) == 1
 
     assert (
         "Requirement hello==1.0.0 for integration test_component is deprecated "
         "for testing"
-    ) in caplog.text
-
-    assert (
-        "Requirement pyserial-asyncio>=0.6 for integration test_component is "
-        "deprecated, will be rejected after 2026.2, and should be replaced by "
-        "pyserial-asyncio-fast"
     ) in caplog.text

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -685,6 +685,14 @@ async def test_discovery_requirements_dhcp(hass: HomeAssistant) -> None:
             "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+"
             "label%3A%22integration%3A+test_component%22",
         ),
+        (
+            "pyserial-asyncio>=0.6",
+            True,
+            "which should be replaced by pyserial-asyncio-fast. This will stop"
+            " working in Home Assistant 2026.4, please create a bug report at "
+            "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+"
+            "label%3A%22integration%3A+test_component%22",
+        ),
     ],
 )
 async def test_install_deprecated_package(

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -681,7 +681,7 @@ async def test_discovery_requirements_dhcp(hass: HomeAssistant) -> None:
             "pyserial-asyncio",
             False,
             "which should be replaced by pyserial-asyncio-fast. This will stop"
-            " working in Home Assistant 2026.4, please create a bug report at "
+            " working in Home Assistant 2026.7, please create a bug report at "
             "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+"
             "label%3A%22integration%3A+test_component%22",
         ),
@@ -689,7 +689,7 @@ async def test_discovery_requirements_dhcp(hass: HomeAssistant) -> None:
             "pyserial-asyncio>=0.6",
             True,
             "which should be replaced by pyserial-asyncio-fast. This will stop"
-            " working in Home Assistant 2026.4, please create a bug report at "
+            " working in Home Assistant 2026.7, please create a bug report at "
             "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+"
             "label%3A%22integration%3A+test_component%22",
         ),

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -678,10 +678,12 @@ async def test_install_deprecated_package(
     assert len(mock_inst.mock_calls) == 1
 
     assert (
-        "Requirement hello for integration test_component is deprecated for testing"
-        in caplog.text
-    )
+        "Requirement hello==1.0.0 for integration test_component is deprecated "
+        "for testing"
+    ) in caplog.text
+
     assert (
-        "Requirement pyserial-asyncio for integration test_component is deprecated, "
-        "will be rejected after 2026.2, and should be replaced by pyserial-asyncio-fast"
+        "Requirement pyserial-asyncio>=0.6 for integration test_component is "
+        "deprecated, will be rejected after 2026.2, and should be replaced by "
+        "pyserial-asyncio-fast"
     ) in caplog.text

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -681,7 +681,7 @@ async def test_discovery_requirements_dhcp(hass: HomeAssistant) -> None:
             "pyserial-asyncio",
             False,
             "which should be replaced by pyserial-asyncio-fast. This will stop"
-            " working in Home Assistant 2026.2, please create a bug report at "
+            " working in Home Assistant 2026.4, please create a bug report at "
             "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+"
             "label%3A%22integration%3A+test_component%22",
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #116635

This adds the ability to define a list of requirements that should not be referenced by integrations, and marks pyserial-asyncio as deprecated.

cc @bdraco / @MartinHjelmare

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2894
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
