### PR TITLE
Add support for choose selector

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -456,9 +456,7 @@ class ChooseSelector(Selector[ChooseSelectorConfig]):
         if "choices" in _config:
             for choice in _config["choices"].values():
                 if isinstance(choice["selector"], Selector):
-                    choice["selector"] = {
-                        choice["selector"].selector_type: choice["selector"].config
-                    }
+                    choice["selector"] = choice["selector"].serialize()
         return {"selector": {self.selector_type: _config}}
 
     def __call__(self, data: Any) -> Any:
@@ -1292,14 +1290,8 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
         _config = deepcopy(self.config)
         if "fields" in _config:
             for field_items in _config["fields"].values():
-                if isinstance(field_items["selector"], ObjectSelector):
+                if isinstance(field_items["selector"], Selector):
                     field_items["selector"] = field_items["selector"].serialize()
-                elif isinstance(field_items["selector"], Selector):
-                    field_items["selector"] = {
-                        field_items["selector"].selector_type: field_items[
-                            "selector"
-                        ].config
-                    }
         return {"selector": {self.selector_type: _config}}
 
     def __call__(self, data: Any) -> Any:

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -467,7 +467,7 @@ class ChooseSelector(Selector[ChooseSelectorConfig]):
             for choice in self.config["choices"].values():
                 try:
                     validated = selector(choice["selector"])(data)  # type: ignore[operator]
-                except:  # noqa: E722
+                except (vol.Invalid, vol.MultipleInvalid):
                     continue
                 else:
                     return validated
@@ -479,11 +479,12 @@ class ChooseSelector(Selector[ChooseSelectorConfig]):
         if data["active_choice"] not in data:
             raise vol.Invalid("Missing value for active choice")
 
-        selector(self.config["choices"][data["active_choice"]]["selector"])(  # type: ignore[operator]
+        choices = self.config.get("choices", {})
+        if data["active_choice"] not in choices:
+            raise vol.Invalid("Invalid active_choice key")
+        return selector(choices[data["active_choice"]]["selector"])(  # type: ignore[operator]
             data[data["active_choice"]]
         )
-
-        return data[data["active_choice"]]
 
 
 class ColorRGBSelectorConfig(BaseSelectorConfig):

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -418,6 +418,43 @@ class BooleanSelector(Selector[BooleanSelectorConfig]):
         return value
 
 
+class ChooseSelectorConfig(BaseSelectorConfig):
+    """Class to represent a choose selector config."""
+
+    choices: Required[dict[str, Selector]]
+
+
+@SELECTORS.register("choose")
+class ChooseSelector(Selector[ChooseSelectorConfig]):
+    """Selector allowing to choose one of several selectors."""
+
+    selector_type = "choose"
+
+    CONFIG_SCHEMA = make_selector_config_schema(
+        {
+            vol.Required("choices"): {
+                str: {
+                    vol.Required("selector"): vol.Any(Selector, validate_selector),
+                }
+            }
+        }
+    )
+
+    def __init__(self, config: ChooseSelectorConfig | None = None) -> None:
+        """Instantiate a selector."""
+        super().__init__(config)
+
+    def __call__(self, data: Any) -> Any:
+        """Validate the passed selection."""
+        if not isinstance(data, dict):
+            raise vol.Invalid("Value should be a dictionary")
+        if "active_choice" not in data:
+            raise vol.Invalid("Missing active_choice key")
+        if data["active_choice"] not in data:
+            raise vol.Invalid("Missing value for active choice")
+        return data
+
+
 class ColorRGBSelectorConfig(BaseSelectorConfig):
     """Class to represent a color RGB selector config."""
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1305,9 +1305,7 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
         _config = deepcopy(self.config)
         if "fields" in _config:
             for field_items in _config["fields"].values():
-                if isinstance(field_items["selector"], ObjectSelector):
-                    field_items["selector"] = field_items["selector"].serialize()
-                elif isinstance(field_items["selector"], Selector):
+                if isinstance(field_items["selector"], Selector):
                     field_items["selector"] = field_items["selector"].serialize()[
                         "selector"
                     ]

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -438,6 +438,7 @@ class ChooseSelectorConfig(BaseSelectorConfig):
     """Class to represent a choose selector config."""
 
     choices: Required[dict[str, ChooseSelectorChoiceConfig]]
+    translation_key: str
 
 
 @SELECTORS.register("choose")
@@ -453,7 +454,8 @@ class ChooseSelector(Selector[ChooseSelectorConfig]):
                     str: {
                         vol.Required("selector"): vol.Any(Selector, validate_selector),
                     }
-                }
+                },
+                vol.Optional("translation_key"): cv.string,
             },
         ),
         reject_nested_choose_selector,

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -323,6 +323,10 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                 ),
                 slug_validator=vol.Any("_", cv.slug),
             ),
+            vol.Optional("choices"): cv.schema_with_slug_keys(
+                translation_value_validator,
+                slug_validator=translation_key_validator,
+            ),
             vol.Optional("options"): gen_data_entry_schema(
                 config=config,
                 integration=integration,

--- a/tests/helpers/snapshots/test_selector.ambr
+++ b/tests/helpers/snapshots/test_selector.ambr
@@ -1,4 +1,71 @@
 # serializer version: 1
+# name: test_choose_selector_serialize
+  dict({
+    'selector': dict({
+      'choose': dict({
+        'choices': dict({
+          'entity_choice': dict({
+            'selector': dict({
+              'entity': dict({
+                'domain': list([
+                  'light',
+                ]),
+                'multiple': False,
+                'reorder': False,
+              }),
+            }),
+          }),
+          'number_choice': dict({
+            'selector': dict({
+              'number': dict({
+                'max': 100.0,
+                'min': 0.0,
+                'mode': 'slider',
+                'step': 1.0,
+              }),
+            }),
+          }),
+          'text_choice': dict({
+            'selector': dict({
+              'text': dict({
+                'multiline': True,
+                'multiple': False,
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  })
+# ---
+# name: test_choose_selector_serialize.1
+  dict({
+    'selector': dict({
+      'choose': dict({
+        'choices': dict({
+          'number_choice': dict({
+            'selector': dict({
+              'number': dict({
+                'max': 100.0,
+                'min': 0.0,
+                'mode': 'slider',
+                'step': 1.0,
+              }),
+            }),
+          }),
+          'text_choice': dict({
+            'selector': dict({
+              'text': dict({
+                'multiline': True,
+                'multiple': False,
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  })
+# ---
 # name: test_nested_object_selectors
   dict({
     'selector': dict({

--- a/tests/helpers/snapshots/test_selector.ambr
+++ b/tests/helpers/snapshots/test_selector.ambr
@@ -25,6 +25,34 @@
               }),
             }),
           }),
+          'object_choice': dict({
+            'selector': dict({
+              'object': dict({
+                'description_field': 'percentage',
+                'fields': dict({
+                  'name': dict({
+                    'required': True,
+                    'selector': dict({
+                      'text': dict({
+                        'multiline': False,
+                        'multiple': False,
+                      }),
+                    }),
+                  }),
+                  'percentage': dict({
+                    'selector': dict({
+                      'number': dict({
+                        'mode': 'box',
+                        'step': 1.0,
+                      }),
+                    }),
+                  }),
+                }),
+                'label_field': 'name',
+                'multiple': False,
+              }),
+            }),
+          }),
           'text_choice': dict({
             'selector': dict({
               'text': dict({
@@ -50,6 +78,70 @@
                 'min': 0.0,
                 'mode': 'slider',
                 'step': 1.0,
+              }),
+            }),
+          }),
+          'object_choice': dict({
+            'selector': dict({
+              'object': dict({
+                'description_field': 'percentage',
+                'fields': dict({
+                  'name': dict({
+                    'required': True,
+                    'selector': dict({
+                      'text': dict({
+                        'multiline': False,
+                        'multiple': False,
+                      }),
+                    }),
+                  }),
+                  'object': dict({
+                    'selector': dict({
+                      'object': dict({
+                        'fields': dict({
+                          'choose': dict({
+                            'required': True,
+                            'selector': dict({
+                              'choose': dict({
+                                'choices': dict({
+                                  'number_choice': dict({
+                                    'selector': dict({
+                                      'number': dict({
+                                        'max': 100.0,
+                                        'min': 0.0,
+                                        'mode': 'slider',
+                                        'step': 1.0,
+                                      }),
+                                    }),
+                                  }),
+                                  'text_choice': dict({
+                                    'selector': dict({
+                                      'text': dict({
+                                        'multiline': True,
+                                        'multiple': False,
+                                      }),
+                                    }),
+                                  }),
+                                }),
+                              }),
+                            }),
+                          }),
+                        }),
+                        'multiple': False,
+                      }),
+                    }),
+                  }),
+                  'percentage': dict({
+                    'selector': dict({
+                      'number': dict({
+                        'mode': 'box',
+                        'step': 1.0,
+                      }),
+                    }),
+                  }),
+                }),
+                'label_field': 'name',
+                'multiple': False,
               }),
             }),
           }),

--- a/tests/helpers/snapshots/test_selector.ambr
+++ b/tests/helpers/snapshots/test_selector.ambr
@@ -83,64 +83,60 @@
           }),
           'object': dict({
             'selector': dict({
-              'selector': dict({
-                'object': dict({
-                  'description_field': 'other_name',
-                  'fields': dict({
-                    'new_object': dict({
-                      'required': True,
-                      'selector': dict({
-                        'selector': dict({
-                          'object': dict({
-                            'description_field': 'description',
-                            'fields': dict({
-                              'description': dict({
-                                'required': True,
-                                'selector': dict({
-                                  'text': dict({
-                                    'multiline': False,
-                                    'multiple': False,
-                                  }),
-                                }),
-                              }),
-                              'title': dict({
-                                'required': True,
-                                'selector': dict({
-                                  'text': dict({
-                                    'multiline': False,
-                                    'multiple': False,
-                                  }),
-                                }),
+              'object': dict({
+                'description_field': 'other_name',
+                'fields': dict({
+                  'new_object': dict({
+                    'required': True,
+                    'selector': dict({
+                      'object': dict({
+                        'description_field': 'description',
+                        'fields': dict({
+                          'description': dict({
+                            'required': True,
+                            'selector': dict({
+                              'text': dict({
+                                'multiline': False,
+                                'multiple': False,
                               }),
                             }),
-                            'label_field': 'title',
-                            'multiple': False,
+                          }),
+                          'title': dict({
+                            'required': True,
+                            'selector': dict({
+                              'text': dict({
+                                'multiline': False,
+                                'multiple': False,
+                              }),
+                            }),
                           }),
                         }),
-                      }),
-                    }),
-                    'no_name': dict({
-                      'required': True,
-                      'selector': dict({
-                        'text': dict({
-                          'multiline': False,
-                          'multiple': False,
-                        }),
-                      }),
-                    }),
-                    'other_name': dict({
-                      'required': True,
-                      'selector': dict({
-                        'text': dict({
-                          'multiline': False,
-                          'multiple': False,
-                        }),
+                        'label_field': 'title',
+                        'multiple': False,
                       }),
                     }),
                   }),
-                  'label_field': 'no_name',
-                  'multiple': False,
+                  'no_name': dict({
+                    'required': True,
+                    'selector': dict({
+                      'text': dict({
+                        'multiline': False,
+                        'multiple': False,
+                      }),
+                    }),
+                  }),
+                  'other_name': dict({
+                    'required': True,
+                    'selector': dict({
+                      'text': dict({
+                        'multiline': False,
+                        'multiple': False,
+                      }),
+                    }),
+                  }),
                 }),
+                'label_field': 'no_name',
+                'multiple': False,
               }),
             }),
           }),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -517,6 +517,174 @@ def test_boolean_selector_schema(schema, valid_selections, invalid_selections) -
     ("schema", "valid_selections", "invalid_selections"),
     [
         (
+            {
+                "choices": {
+                    "text_choice": {"selector": {"text": {}}},
+                    "number_choice": {"selector": {"number": {"min": 0, "max": 100}}},
+                }
+            },
+            (
+                # Direct value matching text selector
+                "some text",
+                # Direct value matching number selector
+                42,
+                # Explicit choice with active_choice key
+                {"active_choice": "text_choice", "text_choice": "hello world"},
+                {"active_choice": "number_choice", "number_choice": 50},
+            ),
+            (
+                # None doesn't match any selector
+                None,
+                # Missing active_choice key
+                {"text_choice": "hello"},
+                # Invalid active_choice key
+                {"active_choice": "invalid", "invalid": "value"},
+                # Missing value for active choice
+                {"active_choice": "text_choice"},
+                # Wrong value type for number selector
+                {"active_choice": "number_choice", "number_choice": "not a number"},
+            ),
+        ),
+        (
+            {
+                "choices": {
+                    "entity": {"selector": {"entity": {}}},
+                    "device": {"selector": {"device": {}}},
+                    "text": {"selector": {"text": {}}},
+                }
+            },
+            (
+                # Direct value matching entity selector
+                "sensor.abc123",
+                FAKE_UUID,
+                # Explicit choice
+                {"active_choice": "entity", "entity": "light.bedroom"},
+                {"active_choice": "device", "device": "device123"},
+                {"active_choice": "text", "text": "some text"},
+            ),
+            (
+                None,
+                # List doesn't match any selector
+                ["sensor.abc", "light.def"],
+                # Missing active_choice key
+                {"entity": "sensor.abc"},
+                # Invalid active_choice
+                {"active_choice": "area", "area": "area123"},
+            ),
+        ),
+    ],
+)
+def test_choose_selector_schema(schema, valid_selections, invalid_selections) -> None:
+    """Test choose selector."""
+
+    def get_selected_value(data):
+        """Get the selected value from the input."""
+        if isinstance(data, dict) and "active_choice" in data:
+            return data[data["active_choice"]]
+        return data
+
+    _test_selector(
+        "choose", schema, valid_selections, invalid_selections, get_selected_value
+    )
+
+
+@pytest.mark.parametrize(
+    ("schema", "raises"),
+    [
+        # Valid schemas
+        (
+            {
+                "choices": {
+                    "text": {"selector": {"text": {}}},
+                    "number": {"selector": {"number": {}}},
+                }
+            },
+            does_not_raise(),
+        ),
+        (
+            {
+                "choices": {
+                    "text": {"selector": selector.TextSelector()},
+                    "number": {"selector": selector.NumberSelector()},
+                }
+            },
+            does_not_raise(),
+        ),
+        # Invalid schemas
+        (
+            {},  # Missing required 'choices' key
+            pytest.raises(vol.Invalid),
+        ),
+        (
+            {
+                "choices": {}  # Empty choices dict
+            },
+            does_not_raise(),  # Empty dict is technically valid
+        ),
+        (
+            {
+                "choices": {
+                    "text": {}  # Missing required 'selector' key in choice
+                }
+            },
+            pytest.raises(vol.Invalid),
+        ),
+        (
+            {
+                "choices": {
+                    "invalid": {"selector": {"not_exist": {}}}  # Invalid selector type
+                }
+            },
+            pytest.raises(vol.Invalid),
+        ),
+        (
+            {
+                "choices": "not a dict"  # choices should be a dict
+            },
+            pytest.raises(vol.Invalid),
+        ),
+    ],
+)
+def test_choose_selector_validate_schema(
+    schema: dict, raises: AbstractContextManager
+) -> None:
+    """Test choose selector schema validation."""
+    with raises:
+        selector.validate_selector({"choose": schema})
+
+
+def test_choose_selector_serialize(snapshot: SnapshotAssertion) -> None:
+    """Test choose selector serialization."""
+    # Test with dict-based selectors
+    choose_selector = selector.ChooseSelector(
+        {
+            "choices": {
+                "text_choice": {"selector": {"text": {"multiline": True}}},
+                "number_choice": {"selector": {"number": {"min": 0, "max": 100}}},
+                "entity_choice": {"selector": {"entity": {"domain": "light"}}},
+            }
+        }
+    )
+    assert choose_selector.serialize() == snapshot
+
+    # Test with Selector object instances
+    choose_selector_objects = selector.ChooseSelector(
+        {
+            "choices": {
+                "text_choice": {"selector": selector.TextSelector({"multiline": True})},
+                "number_choice": {
+                    "selector": selector.NumberSelector({"min": 0, "max": 100})
+                },
+            }
+        }
+    )
+    assert choose_selector_objects.serialize() == snapshot
+
+
+@pytest.mark.parametrize(
+    ("schema", "valid_selections", "invalid_selections"),
+    [
+        (
             {},
             ("6b68b250388cbe0d620c92dd3acc93ec", "76f2e8f9a6491a1b580b3a8967c27ddd"),
             (None, True, 1),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -679,6 +679,24 @@ def test_choose_selector_serialize(snapshot: SnapshotAssertion) -> None:
                 "text_choice": {"selector": {"text": {"multiline": True}}},
                 "number_choice": {"selector": {"number": {"min": 0, "max": 100}}},
                 "entity_choice": {"selector": {"entity": {"domain": "light"}}},
+                "object_choice": {
+                    "selector": {
+                        "object": {
+                            "fields": {
+                                "name": {
+                                    "required": True,
+                                    "selector": {"text": {}},
+                                },
+                                "percentage": {
+                                    "selector": {"number": {}},
+                                },
+                            },
+                            "multiple": False,
+                            "label_field": "name",
+                            "description_field": "percentage",
+                        }
+                    }
+                },
             }
         }
     )
@@ -691,6 +709,56 @@ def test_choose_selector_serialize(snapshot: SnapshotAssertion) -> None:
                 "text_choice": {"selector": selector.TextSelector({"multiline": True})},
                 "number_choice": {
                     "selector": selector.NumberSelector({"min": 0, "max": 100})
+                },
+                "object_choice": {
+                    "selector": selector.ObjectSelector(
+                        {
+                            "fields": {
+                                "name": {
+                                    "required": True,
+                                    "selector": selector.TextSelector({}),
+                                },
+                                "percentage": {
+                                    "selector": selector.NumberSelector({}),
+                                },
+                                "object": {
+                                    "selector": selector.ObjectSelector(
+                                        {
+                                            "fields": {
+                                                "choose": {
+                                                    "required": True,
+                                                    "selector": selector.ChooseSelector(
+                                                        {
+                                                            "choices": {
+                                                                "text_choice": {
+                                                                    "selector": selector.TextSelector(
+                                                                        {
+                                                                            "multiline": True
+                                                                        }
+                                                                    )
+                                                                },
+                                                                "number_choice": {
+                                                                    "selector": selector.NumberSelector(
+                                                                        {
+                                                                            "min": 0,
+                                                                            "max": 100,
+                                                                        }
+                                                                    )
+                                                                },
+                                                            }
+                                                        }
+                                                    ),
+                                                },
+                                            }
+                                        }
+                                    ),
+                                },
+                            },
+                            "multiple": False,
+                            "label_field": "name",
+                            "description_field": "percentage",
+                        }
+                    )
                 },
             }
         }

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -643,6 +643,23 @@ def test_choose_selector_schema(schema, valid_selections, invalid_selections) ->
             },
             pytest.raises(vol.Invalid),
         ),
+        (
+            {
+                "choices": {
+                    "invalid": {
+                        "selector": {
+                            "choose": {
+                                "choices": {
+                                    "text": {"selector": {"text": {}}},
+                                    "number": {"selector": {"number": {}}},
+                                }
+                            }
+                        }
+                    }  # Nested choose is not allowed
+                }
+            },
+            pytest.raises(vol.Invalid),
+        ),
     ],
 )
 def test_choose_selector_validate_schema(


### PR DESCRIPTION

## Proposed change

Add a new selector `choose` that allows the user to choose between multiple selectors.

This is useful if a field accepts multiple type of values, like an `entity_id` or a numeric value.

Example config:

```yaml
    lower_threshold:
      required: false
      selector:
        choose:
          choices:
            number:
              selector:
                number:
                  min: 0
                  max: 100
                  step: 0.1
            entity:
              selector:
                entity:
                  filter:
                    domain: number
```

Needs: https://github.com/home-assistant/frontend/pull/28624

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
