### PR TITLE
Fix evict_faked_translations fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1270,9 +1270,11 @@ def evict_faked_translations(translations_once) -> Generator[_patch]:
     component_paths = components.__path__
 
     for call in mock_component_strings.mock_calls:
+        _components: set[str] = call.args[2]
         integrations: dict[str, loader.Integration] = call.args[3]
-        for domain, integration in integrations.items():
-            if any(
+        for domain in _components:
+            # If the integration exists, don't evict from cache
+            if (integration := integrations.get(domain)) and any(
                 pathlib.Path(f"{component_path}/{domain}") == integration.file_path
                 for component_path in component_paths
             ):

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -1,6 +1,6 @@
 """Test test fixture configuration."""
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from http import HTTPStatus
 import pathlib
 import socket
@@ -90,12 +90,25 @@ async def test_evict_faked_translations_assumptions(hass: HomeAssistant) -> None
     assert integration.file_path == pathlib.Path("custom_components/test")
 
 
-async def test_evict_faked_translations(hass: HomeAssistant, translations_once) -> None:
+@pytest.mark.parametrize(
+    "prepare_integration",
+    [
+        # Fake integration backed by a module
+        lambda hass: mock_integration(hass, MockModule("test"), built_in=True),
+        # fake integration not backed by a module
+        lambda hass: None,
+    ],
+)
+async def test_evict_faked_translations(
+    hass: HomeAssistant,
+    translations_once,
+    prepare_integration: Callable[[HomeAssistant], None],
+) -> None:
     """Test the evict_faked_translations fixture.
 
-    In this test, we load translations for a fake integration backed by a module
-    and a real integration, then ensure that after the fixture is torn down, only
-    the real integration remains in the translations cache.
+    In this test, we load translations for a fake integration , then ensure that
+    after the fixture is torn down, only the real integration remains in the
+    translations cache.
     """
     cache: translation._TranslationsCacheData = translations_once.kwargs["return_value"]
     fake_domain = "test"
@@ -117,51 +130,8 @@ async def test_evict_faked_translations(hass: HomeAssistant, translations_once) 
     next(gen)
 
     # Try loading translations for mock integration
-    mock_integration(hass, MockModule(fake_domain), built_in=True)
+    prepare_integration(hass)
     await translation.async_load_integrations(hass, {fake_domain, real_domain})
-    assert fake_domain in cache.loaded["en"]
-    assert real_domain in cache.loaded["en"]
-
-    # Tear down the evict_faked_translations fixture
-    with pytest.raises(StopIteration):
-        next(gen)
-
-    # The mock integration should be removed from the cache, the real domain should still be there
-    assert fake_domain not in cache.loaded["en"]
-    assert real_domain in cache.loaded["en"]
-
-
-async def test_evict_faked_translations_2(
-    hass: HomeAssistant, translations_once
-) -> None:
-    """Test the evict_faked_translations fixture.
-
-    In this test, we load translations for a fake integration not backed by a module
-    and a real integration, then ensure that after the fixture is torn down, only
-    the real integration remains in the translations cache.
-    """
-    cache: translation._TranslationsCacheData = translations_once.kwargs["return_value"]
-    fake_domain = "test"
-    real_domain = "homeassistant"
-
-    if "en" in cache.loaded:
-        # Evict the real domain from the cache in case it's been loaded before
-        cache.loaded["en"].discard(real_domain)
-
-        assert fake_domain not in cache.loaded["en"]
-        assert real_domain not in cache.loaded["en"]
-
-    # The evict_faked_translations fixture has module scope, so we set it up and
-    # tear it down manually
-    real_func = get_real_func(evict_faked_translations)
-    gen: Generator = real_func(translations_once)
-
-    # Set up the evict_faked_translations fixture
-    next(gen)
-
-    # Try loading translations for non existing integration
-    await translation.async_load_integrations(hass, {fake_domain, real_domain})
-
     assert fake_domain in cache.loaded["en"]
     assert real_domain in cache.loaded["en"]
 

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -91,16 +91,22 @@ async def test_evict_faked_translations_assumptions(hass: HomeAssistant) -> None
 
 
 async def test_evict_faked_translations(hass: HomeAssistant, translations_once) -> None:
-    """Test the evict_faked_translations fixture."""
+    """Test the evict_faked_translations fixture.
+
+    In this test, we load translations for a fake integration backed by a module
+    and a real integration, then ensure that after the fixture is torn down, only
+    the real integration remains in the translations cache.
+    """
     cache: translation._TranslationsCacheData = translations_once.kwargs["return_value"]
     fake_domain = "test"
     real_domain = "homeassistant"
 
-    # Evict the real domain from the cache in case it's been loaded before
-    cache.loaded["en"].discard(real_domain)
+    if "en" in cache.loaded:
+        # Evict the real domain from the cache in case it's been loaded before
+        cache.loaded["en"].discard(real_domain)
 
-    assert fake_domain not in cache.loaded["en"]
-    assert real_domain not in cache.loaded["en"]
+        assert fake_domain not in cache.loaded["en"]
+        assert real_domain not in cache.loaded["en"]
 
     # The evict_faked_translations fixture has module scope, so we set it up and
     # tear it down manually
@@ -110,8 +116,52 @@ async def test_evict_faked_translations(hass: HomeAssistant, translations_once) 
     # Set up the evict_faked_translations fixture
     next(gen)
 
+    # Try loading translations for mock integration
     mock_integration(hass, MockModule(fake_domain), built_in=True)
     await translation.async_load_integrations(hass, {fake_domain, real_domain})
+    assert fake_domain in cache.loaded["en"]
+    assert real_domain in cache.loaded["en"]
+
+    # Tear down the evict_faked_translations fixture
+    with pytest.raises(StopIteration):
+        next(gen)
+
+    # The mock integration should be removed from the cache, the real domain should still be there
+    assert fake_domain not in cache.loaded["en"]
+    assert real_domain in cache.loaded["en"]
+
+
+async def test_evict_faked_translations_2(
+    hass: HomeAssistant, translations_once
+) -> None:
+    """Test the evict_faked_translations fixture.
+
+    In this test, we load translations for a fake integration not backed by a module
+    and a real integration, then ensure that after the fixture is torn down, only
+    the real integration remains in the translations cache.
+    """
+    cache: translation._TranslationsCacheData = translations_once.kwargs["return_value"]
+    fake_domain = "test"
+    real_domain = "homeassistant"
+
+    if "en" in cache.loaded:
+        # Evict the real domain from the cache in case it's been loaded before
+        cache.loaded["en"].discard(real_domain)
+
+        assert fake_domain not in cache.loaded["en"]
+        assert real_domain not in cache.loaded["en"]
+
+    # The evict_faked_translations fixture has module scope, so we set it up and
+    # tear it down manually
+    real_func = get_real_func(evict_faked_translations)
+    gen: Generator = real_func(translations_once)
+
+    # Set up the evict_faked_translations fixture
+    next(gen)
+
+    # Try loading translations for non existing integration
+    await translation.async_load_integrations(hass, {fake_domain, real_domain})
+
     assert fake_domain in cache.loaded["en"]
     assert real_domain in cache.loaded["en"]
 

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -106,7 +106,7 @@ async def test_evict_faked_translations(
 ) -> None:
     """Test the evict_faked_translations fixture.
 
-    In this test, we load translations for a fake integration , then ensure that
+    In this test, we load translations for a fake integration, then ensure that
     after the fixture is torn down, only the real integration remains in the
     translations cache.
     """


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `evict_faked_translations` fixture so we also evict non-existing integrations from the translation cache

This replaces https://github.com/home-assistant/core/pull/159376 which hid the problem

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
