### PR TITLE
Add Beoremote One diagnostics to Bang & Olufsen

### DIFF
--- a/homeassistant/components/bang_olufsen/diagnostics.py
+++ b/homeassistant/components/bang_olufsen/diagnostics.py
@@ -70,6 +70,6 @@ async def async_get_config_entry_diagnostics(
                     data[f"remote_{remote.serial_number}_{key_type}_event"] = state_dict
 
         # Add remote Mozart model
-        data[f"remote_{remote.serial_number}"] = remote.to_dict()
+        data[f"remote_{remote.serial_number}"] = dict(remote)
 
     return data

--- a/homeassistant/components/bang_olufsen/diagnostics.py
+++ b/homeassistant/components/bang_olufsen/diagnostics.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import entity_registry as er
 
 from . import BeoConfigEntry
 from .const import DOMAIN
-from .util import get_device_buttons
+from .util import get_device_buttons, get_remote_keys, get_remotes
 
 
 async def async_get_config_entry_diagnostics(
@@ -52,5 +52,24 @@ async def async_get_config_entry_diagnostics(
                 # Remove context as it is not relevant
                 state_dict.pop("context")
                 data[f"{device_button}_event"] = state_dict
+
+    # Get remotes
+    for remote in await get_remotes(config_entry.runtime_data.client):
+        # Get key Event entity states (if enabled)
+        for key_type in get_remote_keys():
+            if entity_id := entity_registry.async_get_entity_id(
+                EVENT_DOMAIN,
+                DOMAIN,
+                f"{remote.serial_number}_{config_entry.unique_id}_{key_type}",
+            ):
+                if state := hass.states.get(entity_id):
+                    state_dict = dict(state.as_dict())
+
+                    # Remove context as it is not relevant
+                    state_dict.pop("context")
+                    data[f"remote_{remote.serial_number}_{key_type}_event"] = state_dict
+
+        # Add remote Mozart model
+        data[f"remote_{remote.serial_number}"] = remote.to_dict()
 
     return data

--- a/homeassistant/components/bang_olufsen/event.py
+++ b/homeassistant/components/bang_olufsen/event.py
@@ -16,11 +16,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import BeoConfigEntry
 from .const import (
-    BEO_REMOTE_CONTROL_KEYS,
     BEO_REMOTE_KEY_EVENTS,
-    BEO_REMOTE_KEYS,
-    BEO_REMOTE_SUBMENU_CONTROL,
-    BEO_REMOTE_SUBMENU_LIGHT,
     CONNECTION_STATUS,
     DEVICE_BUTTON_EVENTS,
     DOMAIN,
@@ -29,7 +25,7 @@ from .const import (
     WebsocketNotification,
 )
 from .entity import BeoEntity
-from .util import get_device_buttons, get_remotes
+from .util import get_device_buttons, get_remote_keys, get_remotes
 
 PARALLEL_UPDATES = 0
 
@@ -40,38 +36,19 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Event entities from config entry."""
-    entities: list[BeoEvent] = []
-
-    async_add_entities(
+    entities: list[BeoEvent] = [
         BeoButtonEvent(config_entry, button_type)
         for button_type in get_device_buttons(config_entry.data[CONF_MODEL])
-    )
+    ]
 
     # Check for connected Beoremote One
     remotes = await get_remotes(config_entry.runtime_data.client)
 
     for remote in remotes:
-        # Add Light keys
         entities.extend(
             [
-                BeoRemoteKeyEvent(
-                    config_entry,
-                    remote,
-                    f"{BEO_REMOTE_SUBMENU_LIGHT}/{key_type}",
-                )
-                for key_type in BEO_REMOTE_KEYS
-            ]
-        )
-
-        # Add Control keys
-        entities.extend(
-            [
-                BeoRemoteKeyEvent(
-                    config_entry,
-                    remote,
-                    f"{BEO_REMOTE_SUBMENU_CONTROL}/{key_type}",
-                )
-                for key_type in (*BEO_REMOTE_KEYS, *BEO_REMOTE_CONTROL_KEYS)
+                BeoRemoteKeyEvent(config_entry, remote, key_type)
+                for key_type in get_remote_keys()
             ]
         )
 

--- a/homeassistant/components/bang_olufsen/util.py
+++ b/homeassistant/components/bang_olufsen/util.py
@@ -11,7 +11,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import DEVICE_BUTTONS, DOMAIN, BeoButtons, BeoModel
+from .const import (
+    BEO_REMOTE_CONTROL_KEYS,
+    BEO_REMOTE_KEYS,
+    BEO_REMOTE_SUBMENU_CONTROL,
+    BEO_REMOTE_SUBMENU_LIGHT,
+    DEVICE_BUTTONS,
+    DOMAIN,
+    BeoButtons,
+    BeoModel,
+)
 
 
 def get_device(hass: HomeAssistant, unique_id: str) -> DeviceEntry:
@@ -64,3 +73,14 @@ def get_device_buttons(model: BeoModel) -> list[str]:
         buttons.remove(BeoButtons.BLUETOOTH)
 
     return buttons
+
+
+def get_remote_keys() -> list[str]:
+    """Get remote keys for the Beoremote One. Formatted for Home Assistant use."""
+    return [
+        *[f"{BEO_REMOTE_SUBMENU_LIGHT}/{key_type}" for key_type in BEO_REMOTE_KEYS],
+        *[
+            f"{BEO_REMOTE_SUBMENU_CONTROL}/{key_type}"
+            for key_type in (*BEO_REMOTE_KEYS, *BEO_REMOTE_CONTROL_KEYS)
+        ],
+    ]

--- a/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
+++ b/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
@@ -90,6 +90,19 @@
       'name': 'BEORC',
       'serialNumber': '55555555',
     }),
+    'remote_55555555_Control/Play_event': dict({
+      'attributes': dict({
+        'device_class': 'button',
+        'event_type': None,
+        'event_types': list([
+          'key_press',
+          'key_release',
+        ]),
+        'friendly_name': 'Beoremote One-55555555-11111111 Control - Play',
+      }),
+      'entity_id': 'event.beoremote_one_55555555_11111111_control_play',
+      'state': 'unknown',
+    }),
     'websocket_connected': False,
   })
 # ---

--- a/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
+++ b/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
@@ -84,11 +84,14 @@
     }),
     'remote_55555555': dict({
       'address': '',
-      'appVersion': '1.0.0',
-      'batteryLevel': 50,
+      'app_version': '1.0.0',
+      'battery_level': 50,
       'connected': True,
+      'db_version': None,
+      'last_seen': None,
       'name': 'BEORC',
-      'serialNumber': '55555555',
+      'serial_number': '55555555',
+      'updated': None,
     }),
     'remote_55555555_Control/Play_event': dict({
       'attributes': dict({

--- a/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
+++ b/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
@@ -82,6 +82,14 @@
       'entity_id': 'media_player.beosound_balance_11111111',
       'state': 'playing',
     }),
+    'remote_55555555': dict({
+      'address': '',
+      'appVersion': '1.0.0',
+      'batteryLevel': 50,
+      'connected': True,
+      'name': 'BEORC',
+      'serialNumber': '55555555',
+    }),
     'websocket_connected': False,
   })
 # ---

--- a/tests/components/bang_olufsen/test_diagnostics.py
+++ b/tests/components/bang_olufsen/test_diagnostics.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .conftest import mock_websocket_connection
-from .const import TEST_BUTTON_EVENT_ENTITY_ID
+from .const import TEST_BUTTON_EVENT_ENTITY_ID, TEST_REMOTE_KEY_EVENT_ENTITY_ID
 
 from tests.common import AsyncMock, MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
@@ -25,8 +25,11 @@ async def test_async_get_config_entry_diagnostics(
 ) -> None:
     """Test config entry diagnostics."""
 
-    # Enable an Event entity
+    # Enable a button and remote key Event entity
     entity_registry.async_update_entity(TEST_BUTTON_EVENT_ENTITY_ID, disabled_by=None)
+    entity_registry.async_update_entity(
+        TEST_REMOTE_KEY_EVENT_ENTITY_ID, disabled_by=None
+    )
     hass.config_entries.async_schedule_reload(mock_config_entry.entry_id)
 
     # Re-trigger WebSocket events after the reload


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add [Beoremote One](https://www.bang-olufsen.com/en/dk/accessories/beoremote-one) diagnostics. This includes any enabled Event entities and the internal class for a remote.

Additionally simplify key type generation with a helper function.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42649
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
