### PR TITLE
Support media player grouping in bluesound integration

### DIFF
--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -479,15 +479,14 @@ class BluesoundPlayer(CoordinatorEntity[BluesoundCoordinator], MediaPlayerEntity
 
     async def async_unjoin(self) -> None:
         """Unjoin the player from a group."""
-        if self._sync_status.leader is None:
-            return
+        if self._sync_status.leader is not None:
+            leader_id = f"{self._sync_status.leader.ip}:{self._sync_status.leader.port}"
+            async_dispatcher_send(
+                self.hass, dispatcher_unjoin_signal(leader_id), self.host, self.port
+            )
 
-        leader_id = f"{self._sync_status.leader.ip}:{self._sync_status.leader.port}"
-
-        _LOGGER.debug("Trying to unjoin player: %s", self.id)
-        async_dispatcher_send(
-            self.hass, dispatcher_unjoin_signal(leader_id), self.host, self.port
-        )
+        if self._sync_status.followers is not None:
+            await self._player.remove_follower(self.host, self.port)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -589,8 +589,6 @@ class BluesoundPlayer(CoordinatorEntity[BluesoundCoordinator], MediaPlayerEntity
             match entity_ids:
                 case [entity_id]:
                     grouped_entity_ids.append(entity_id)
-                case _:
-                    pass
 
         return grouped_entity_ids
 

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -475,7 +475,7 @@ class BluesoundPlayer(CoordinatorEntity[BluesoundCoordinator], MediaPlayerEntity
             DOMAIN,
             f"deprecated_service_{SERVICE_JOIN}",
             is_fixable=False,
-            breaks_in_ha_version="2026.12.0",
+            breaks_in_ha_version="2026.7.0",
             issue_domain=DOMAIN,
             severity=ir.IssueSeverity.WARNING,
             translation_key="deprecated_service_join",

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -499,7 +499,7 @@ class BluesoundPlayer(CoordinatorEntity[BluesoundCoordinator], MediaPlayerEntity
             DOMAIN,
             f"deprecated_service_{SERVICE_UNJOIN}",
             is_fixable=False,
-            breaks_in_ha_version="2026.12.0",
+            breaks_in_ha_version="2026.7.0",
             issue_domain=DOMAIN,
             severity=ir.IssueSeverity.WARNING,
             translation_key="deprecated_service_unjoin",

--- a/homeassistant/components/bluesound/strings.json
+++ b/homeassistant/components/bluesound/strings.json
@@ -41,9 +41,17 @@
       "description": "Use `button.{name}_clear_sleep_timer` instead.\n\nPlease replace this action and adjust your automations and scripts.",
       "title": "Detected use of deprecated action bluesound.clear_sleep_timer"
     },
+    "deprecated_service_join": {
+      "description": "Use the `media_player.join` action instead.\n\nPlease replace this action and adjust your automations and scripts.",
+      "title": "Detected use of deprecated action bluesound.join"
+    },
     "deprecated_service_set_sleep_timer": {
       "description": "Use `button.{name}_set_sleep_timer` instead.\n\nPlease replace this action and adjust your automations and scripts.",
       "title": "Detected use of deprecated action bluesound.set_sleep_timer"
+    },
+    "deprecated_service_unjoin": {
+      "description": "Use the `media_player.unjoin` action instead.\n\nPlease replace this action and adjust your automations and scripts.",
+      "title": "Detected use of deprecated action bluesound.unjoin"
     }
   },
   "services": {

--- a/homeassistant/components/bluesound/utils.py
+++ b/homeassistant/components/bluesound/utils.py
@@ -24,7 +24,7 @@ def dispatcher_unjoin_signal(leader_id: str) -> str:
 
 
 def id_to_paired_player(id: str) -> PairedPlayer | None:
-    """Try to convert id in format 'ip:port' to PariedPlayer. Returns None if unable to do so."""
+    """Try to convert id in format 'ip:port' to PairedPlayer. Returns None if unable to do so."""
     match id.rsplit(":", 1):
         case [str() as ip, str() as port] if port.isdigit():
             return PairedPlayer(ip, int(port))

--- a/homeassistant/components/bluesound/utils.py
+++ b/homeassistant/components/bluesound/utils.py
@@ -1,5 +1,7 @@
 """Utility functions for the Bluesound component."""
 
+from pyblu import PairedPlayer
+
 from homeassistant.helpers.device_registry import format_mac
 
 
@@ -19,3 +21,12 @@ def dispatcher_unjoin_signal(leader_id: str) -> str:
     Id is ip_address:port. This can be obtained from sync_status.id.
     """
     return f"bluesound_unjoin_{leader_id}"
+
+
+def id_to_paired_player(id: str) -> PairedPlayer | None:
+    """Try to convert id in format 'ip:port' to PariedPlayer. Returns None if unable to do so."""
+    match id.rsplit(":", 1):
+        case [str() as ip, str() as port] if port.isdigit():
+            return PairedPlayer(ip, int(port))
+        case _:
+            return None

--- a/tests/components/bluesound/snapshots/test_media_player.ambr
+++ b/tests/components/bluesound/snapshots/test_media_player.ambr
@@ -3,6 +3,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'player-name1111',
+      'group_members': None,
       'is_volume_muted': False,
       'master': False,
       'media_album_name': 'album',
@@ -19,7 +20,7 @@
         'input3',
         '4',
       ]),
-      'supported_features': <MediaPlayerEntityFeature: 196157>,
+      'supported_features': <MediaPlayerEntityFeature: 720445>,
       'volume_level': 0.1,
     }),
     'context': <ANY>,

--- a/tests/components/bluesound/test_media_player.py
+++ b/tests/components/bluesound/test_media_player.py
@@ -291,7 +291,7 @@ async def test_join(
     setup_config_entry_secondary: None,
     player_mocks: PlayerMocks,
 ) -> None:
-    """Test the join action."""
+    """Test the bluesound.join action."""
     await hass.services.async_call(
         DOMAIN,
         SERVICE_JOIN,
@@ -313,7 +313,7 @@ async def test_unjoin(
     setup_config_entry_secondary: None,
     player_mocks: PlayerMocks,
 ) -> None:
-    """Test the unjoin action."""
+    """Test the bluesound.unjoin action."""
     updated_sync_status = dataclasses.replace(
         player_mocks.player_data.sync_status_long_polling_mock.get(),
         leader=PairedPlayer("2.2.2.2", 11000),

--- a/tests/components/bluesound/test_media_player.py
+++ b/tests/components/bluesound/test_media_player.py
@@ -13,18 +13,20 @@ from homeassistant.components.bluesound import DOMAIN
 from homeassistant.components.bluesound.const import ATTR_MASTER
 from homeassistant.components.bluesound.media_player import (
     SERVICE_CLEAR_TIMER,
-    SERVICE_JOIN,
     SERVICE_SET_TIMER,
 )
 from homeassistant.components.media_player import (
+    ATTR_GROUP_MEMBERS,
     ATTR_INPUT_SOURCE,
     ATTR_MEDIA_VOLUME_LEVEL,
     DOMAIN as MEDIA_PLAYER_DOMAIN,
+    SERVICE_JOIN,
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
     SERVICE_MEDIA_PREVIOUS_TRACK,
     SERVICE_SELECT_SOURCE,
+    SERVICE_UNJOIN,
     SERVICE_VOLUME_DOWN,
     SERVICE_VOLUME_MUTE,
     SERVICE_VOLUME_SET,
@@ -455,3 +457,100 @@ async def test_volume_up_from_6_to_7(
     )
 
     player_mocks.player_data.player.volume.assert_called_once_with(level=7)
+
+
+async def test_attr_group_members(
+    hass: HomeAssistant,
+    setup_config_entry: None,
+    setup_config_entry_secondary: None,
+    player_mocks: PlayerMocks,
+) -> None:
+    """Test the media player grouping for leader."""
+    attr_group_members = hass.states.get("media_player.player_name1111").attributes.get(
+        ATTR_GROUP_MEMBERS
+    )
+    assert attr_group_members is None
+
+    updated_sync_status = dataclasses.replace(
+        player_mocks.player_data.sync_status_long_polling_mock.get(),
+        followers=[PairedPlayer("2.2.2.2", 11000)],
+    )
+    player_mocks.player_data.sync_status_long_polling_mock.set(updated_sync_status)
+
+    # give the long polling loop a chance to update the state; this could be any async call
+    await hass.async_block_till_done()
+
+    attr_group_members = hass.states.get("media_player.player_name1111").attributes.get(
+        ATTR_GROUP_MEMBERS
+    )
+
+    assert attr_group_members == [
+        "media_player.player_name1111",
+        "media_player.player_name2222",
+    ]
+
+
+async def test_join_players(
+    hass: HomeAssistant,
+    setup_config_entry: None,
+    setup_config_entry_secondary: None,
+    player_mocks: PlayerMocks,
+) -> None:
+    """Test the media_player.join action."""
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_JOIN,
+        {
+            ATTR_ENTITY_ID: "media_player.player_name1111",
+            ATTR_GROUP_MEMBERS: "media_player.player_name2222",
+        },
+        blocking=True,
+    )
+
+    player_mocks.player_data.player.add_followers.assert_called_once_with(
+        [PairedPlayer("2.2.2.2", 11000)]
+    )
+
+
+async def test_join_player_cannot_join_to_self(
+    hass: HomeAssistant, setup_config_entry: None, player_mocks: PlayerMocks
+) -> None:
+    """Test that joining to self is not allowed."""
+    with pytest.raises(ServiceValidationError, match="Cannot join player to itself"):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_JOIN,
+            {
+                ATTR_ENTITY_ID: "media_player.player_name1111",
+                ATTR_GROUP_MEMBERS: "media_player.player_name1111",
+            },
+            blocking=True,
+        )
+
+
+async def test_unjoin_player(
+    hass: HomeAssistant,
+    setup_config_entry: None,
+    setup_config_entry_secondary: None,
+    player_mocks: PlayerMocks,
+) -> None:
+    """Test the media_player.unjoin action."""
+    updated_sync_status = dataclasses.replace(
+        player_mocks.player_data.sync_status_long_polling_mock.get(),
+        leader=PairedPlayer("2.2.2.2", 11000),
+    )
+    player_mocks.player_data.sync_status_long_polling_mock.set(updated_sync_status)
+
+    # give the long polling loop a chance to update the state; this could be any async call
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_UNJOIN,
+        {ATTR_ENTITY_ID: "media_player.player_name1111"},
+        blocking=True,
+    )
+
+    player_mocks.player_data_secondary.player.remove_follower.assert_called_once_with(
+        "1.1.1.1", 11000
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!-- ## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
This adds support for `media_player.join` and `media_player.unjoin`. This also deprecates the custom actions for grouping: `bluesound.join` and `bluesound.unjoin`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/core#135033
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#42651
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
