### PR TITLE
Remove migration of wrong encoded folder path from WebDAV

### DIFF
--- a/homeassistant/components/webdav/__init__.py
+++ b/homeassistant/components/webdav/__init__.py
@@ -13,11 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 
 from .const import CONF_BACKUP_PATH, DATA_BACKUP_AGENT_LISTENERS, DOMAIN
-from .helpers import (
-    async_create_client,
-    async_ensure_path_exists,
-    async_migrate_wrong_folder_path,
-)
+from .helpers import async_create_client, async_ensure_path_exists
 
 type WebDavConfigEntry = ConfigEntry[Client]
 
@@ -51,7 +47,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: WebDavConfigEntry) -> bo
         )
 
     path = entry.data.get(CONF_BACKUP_PATH, "/")
-    await async_migrate_wrong_folder_path(client, path)
 
     # Ensure the backup directory exists
     if not await async_ensure_path_exists(client, path):

--- a/homeassistant/components/webdav/helpers.py
+++ b/homeassistant/components/webdav/helpers.py
@@ -3,13 +3,9 @@
 import logging
 
 from aiowebdav2.client import Client, ClientOptions
-from aiowebdav2.exceptions import WebDavError
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,25 +40,3 @@ async def async_ensure_path_exists(client: Client, path: str) -> bool:
             return False
 
     return True
-
-
-async def async_migrate_wrong_folder_path(client: Client, path: str) -> None:
-    """Migrate the wrong encoded folder path to the correct one."""
-    wrong_path = path.replace(" ", "%20")
-    # migrate folder when the old folder exists
-    if wrong_path != path and await client.check(wrong_path):
-        try:
-            await client.move(wrong_path, path)
-        except WebDavError as err:
-            raise ConfigEntryNotReady(
-                translation_domain=DOMAIN,
-                translation_key="failed_to_migrate_folder",
-                translation_placeholders={
-                    "wrong_path": wrong_path,
-                    "correct_path": path,
-                },
-            ) from err
-
-        _LOGGER.debug(
-            "Migrated wrong encoded folder path from %s to %s", wrong_path, path
-        )

--- a/homeassistant/components/webdav/strings.json
+++ b/homeassistant/components/webdav/strings.json
@@ -33,9 +33,6 @@
     "cannot_connect": {
       "message": "Cannot connect to WebDAV server"
     },
-    "failed_to_migrate_folder": {
-      "message": "Failed to migrate wrong encoded folder \"{wrong_path}\" to \"{correct_path}\"."
-    },
     "invalid_username_password": {
       "message": "Invalid username or password"
     }

--- a/tests/components/webdav/test_init.py
+++ b/tests/components/webdav/test_init.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock
 
-from aiowebdav2.exceptions import AccessDeniedError, UnauthorizedError, WebDavError
+from aiowebdav2.exceptions import AccessDeniedError, UnauthorizedError
 import pytest
 
 from homeassistant.components.webdav.const import CONF_BACKUP_PATH, DOMAIN
@@ -13,103 +13,6 @@ from homeassistant.core import HomeAssistant
 from . import setup_integration
 
 from tests.common import MockConfigEntry
-
-
-async def test_migrate_wrong_path(
-    hass: HomeAssistant, webdav_client: AsyncMock
-) -> None:
-    """Test migration of wrong encoded folder path."""
-    webdav_client.list_with_properties.return_value = [
-        {"/wrong%20path": []},
-    ]
-
-    config_entry = MockConfigEntry(
-        title="user@webdav.demo",
-        domain=DOMAIN,
-        data={
-            CONF_URL: "https://webdav.demo",
-            CONF_USERNAME: "user",
-            CONF_PASSWORD: "supersecretpassword",
-            CONF_BACKUP_PATH: "/wrong path",
-        },
-        entry_id="01JKXV07ASC62D620DGYNG2R8H",
-    )
-    await setup_integration(hass, config_entry)
-
-    webdav_client.move.assert_called_once_with("/wrong%20path", "/wrong path")
-
-
-@pytest.mark.parametrize(
-    ("expected_path", "remote_path_check"),
-    [
-        (
-            "/correct path",
-            False,
-        ),  # remote_path_check is False as /correct%20path is not there
-        ("/", True),
-        ("/folder_with_underscores", True),
-    ],
-)
-async def test_migrate_non_wrong_path(
-    hass: HomeAssistant,
-    webdav_client: AsyncMock,
-    expected_path: str,
-    remote_path_check: bool,
-) -> None:
-    """Test no migration of correct folder path."""
-    webdav_client.list_with_properties.return_value = [
-        {expected_path: []},
-    ]
-    # first return is used to check the connectivity
-    # second is used in the migration to determine if wrong quoted path is there
-    webdav_client.check.side_effect = [True, remote_path_check]
-
-    config_entry = MockConfigEntry(
-        title="user@webdav.demo",
-        domain=DOMAIN,
-        data={
-            CONF_URL: "https://webdav.demo",
-            CONF_USERNAME: "user",
-            CONF_PASSWORD: "supersecretpassword",
-            CONF_BACKUP_PATH: expected_path,
-        },
-        entry_id="01JKXV07ASC62D620DGYNG2R8H",
-    )
-
-    await setup_integration(hass, config_entry)
-
-    webdav_client.move.assert_not_called()
-
-
-async def test_migrate_error(
-    hass: HomeAssistant,
-    webdav_client: AsyncMock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test migration of wrong encoded folder path with error."""
-    webdav_client.list_with_properties.return_value = [
-        {"/wrong%20path": []},
-    ]
-    webdav_client.move.side_effect = WebDavError("Failed to move")
-
-    config_entry = MockConfigEntry(
-        title="user@webdav.demo",
-        domain=DOMAIN,
-        data={
-            CONF_URL: "https://webdav.demo",
-            CONF_USERNAME: "user",
-            CONF_PASSWORD: "supersecretpassword",
-            CONF_BACKUP_PATH: "/wrong path",
-        },
-        entry_id="01JKXV07ASC62D620DGYNG2R8H",
-    )
-    await setup_integration(hass, config_entry)
-
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
-    assert (
-        'Failed to migrate wrong encoded folder "/wrong%20path" to "/wrong path"'
-        in caplog.text
-    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the migration of an wrong encoded folder path from WebDAV. This was needed in the first dot release after the beta we released the WebDAV integration. So that was only necessary for beta users back then. This now causes problems from time to time. So lets remove it, as it is not needed anymore.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #158539
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
