### PR TITLE
KNX Sensor: set device and state class for YAML entities based on DPT

### DIFF
--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -22,8 +22,12 @@ from homeassistant.components.cover import (
 )
 from homeassistant.components.number import NumberMode
 from homeassistant.components.sensor import (
-    CONF_STATE_CLASS,
+    CONF_STATE_CLASS as CONF_SENSOR_STATE_CLASS,
+)
+from homeassistant.components.sensor import (
     DEVICE_CLASSES_SCHEMA as SENSOR_DEVICE_CLASSES_SCHEMA,
+)
+from homeassistant.components.sensor import (
     STATE_CLASSES_SCHEMA,
 )
 from homeassistant.components.switch import (
@@ -64,6 +68,7 @@ from .const import (
     NumberConf,
     SceneConf,
 )
+from .dpt import get_supported_dpts
 from .validation import (
     backwards_compatible_xknx_climate_enum_member,
     dpt_base_type_validator,
@@ -74,6 +79,7 @@ from .validation import (
     string_type_validator,
     sync_state_validator,
     validate_number_attributes,
+    validate_sensor_attributes,
 )
 
 
@@ -141,6 +147,13 @@ def select_options_sub_validator(entity_config: OrderedDict) -> OrderedDict:
             raise vol.Invalid(f"duplicate item for 'payload' not allowed: {payload}")
         payloads_seen.add(payload)
     return entity_config
+
+
+def _sensor_attribute_sub_validator(config: dict) -> dict:
+    """Validate that state_class is compatible with device_class and unit_of_measurement."""
+    transcoder: type[DPTBase] = DPTBase.parse_transcoder(config[CONF_TYPE])  # type: ignore[assignment]  # already checked in sensor_type_validator
+    dpt_metadata = get_supported_dpts()[transcoder.dpt_number_str()]
+    return validate_sensor_attributes(dpt_metadata, config)
 
 
 #########
@@ -848,17 +861,20 @@ class SensorSchema(KNXPlatformSchema):
     CONF_SYNC_STATE = CONF_SYNC_STATE
     DEFAULT_NAME = "KNX Sensor"
 
-    ENTITY_SCHEMA = vol.Schema(
-        {
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-            vol.Optional(CONF_SYNC_STATE, default=True): sync_state_validator,
-            vol.Optional(CONF_ALWAYS_CALLBACK, default=False): cv.boolean,
-            vol.Optional(CONF_STATE_CLASS): STATE_CLASSES_SCHEMA,
-            vol.Required(CONF_TYPE): sensor_type_validator,
-            vol.Required(CONF_STATE_ADDRESS): ga_list_validator,
-            vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
-            vol.Optional(CONF_ENTITY_CATEGORY): ENTITY_CATEGORIES_SCHEMA,
-        }
+    ENTITY_SCHEMA = vol.All(
+        vol.Schema(
+            {
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                vol.Optional(CONF_SYNC_STATE, default=True): sync_state_validator,
+                vol.Optional(CONF_ALWAYS_CALLBACK, default=False): cv.boolean,
+                vol.Optional(CONF_SENSOR_STATE_CLASS): STATE_CLASSES_SCHEMA,
+                vol.Required(CONF_TYPE): sensor_type_validator,
+                vol.Required(CONF_STATE_ADDRESS): ga_list_validator,
+                vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
+                vol.Optional(CONF_ENTITY_CATEGORY): ENTITY_CATEGORIES_SCHEMA,
+            }
+        ),
+        _sensor_attribute_sub_validator,
     )
 
 

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -23,11 +23,7 @@ from homeassistant.components.cover import (
 from homeassistant.components.number import NumberMode
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS as CONF_SENSOR_STATE_CLASS,
-)
-from homeassistant.components.sensor import (
     DEVICE_CLASSES_SCHEMA as SENSOR_DEVICE_CLASSES_SCHEMA,
-)
-from homeassistant.components.sensor import (
     STATE_CLASSES_SCHEMA,
 )
 from homeassistant.components.switch import (

--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -213,18 +213,22 @@ class KnxYamlSensor(_KnxSensor, KnxYamlEntity):
                 value_type=config[CONF_TYPE],
             ),
         )
+        dpt_string = self._device.sensor_value.dpt_class.dpt_number_str()
+        dpt_info = get_supported_dpts()[dpt_string]
+
         if device_class := config.get(CONF_DEVICE_CLASS):
             self._attr_device_class = device_class
         else:
-            self._attr_device_class = try_parse_enum(
-                SensorDeviceClass, self._device.ha_device_class()
-            )
+            self._attr_device_class = dpt_info["sensor_device_class"]
 
+        self._attr_state_class = (
+            config.get(CONF_STATE_CLASS) or dpt_info["sensor_state_class"]
+        )
+
+        self._attr_native_unit_of_measurement = dpt_info["unit"]
         self._attr_force_update = config[SensorSchema.CONF_ALWAYS_CALLBACK]
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_unique_id = str(self._device.sensor_value.group_address_state)
-        self._attr_native_unit_of_measurement = self._device.unit_of_measurement()
-        self._attr_state_class = config.get(CONF_STATE_CLASS)
         self._attr_extra_state_attributes = {}
 
 

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -13,9 +13,7 @@ from homeassistant.components.number import (
 )
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS as CONF_SENSOR_STATE_CLASS,
-    DEVICE_CLASS_STATE_CLASSES,
     DEVICE_CLASS_UNITS as SENSOR_DEVICE_CLASS_UNITS,
-    STATE_CLASS_UNITS,
     SensorDeviceClass,
     SensorStateClass,
 )
@@ -52,7 +50,7 @@ from ..const import (
     SceneConf,
 )
 from ..dpt import get_supported_dpts
-from ..validation import validate_number_attributes
+from ..validation import validate_number_attributes, validate_sensor_attributes
 from .const import (
     CONF_ALWAYS_CALLBACK,
     CONF_COLOR,
@@ -684,62 +682,11 @@ CLIMATE_KNX_SCHEMA = vol.Schema(
 )
 
 
-def _validate_sensor_attributes(config: dict) -> dict:
+def _sensor_attribute_sub_validator(config: dict) -> dict:
     """Validate that state_class is compatible with device_class and unit_of_measurement."""
     dpt = config[CONF_GA_SENSOR][CONF_DPT]
     dpt_metadata = get_supported_dpts()[dpt]
-    state_class = config.get(
-        CONF_SENSOR_STATE_CLASS,
-        dpt_metadata["sensor_state_class"],
-    )
-    device_class = config.get(
-        CONF_DEVICE_CLASS,
-        dpt_metadata["sensor_device_class"],
-    )
-    unit_of_measurement = config.get(
-        CONF_UNIT_OF_MEASUREMENT,
-        dpt_metadata["unit"],
-    )
-    if (
-        state_class
-        and device_class
-        and (state_classes := DEVICE_CLASS_STATE_CLASSES.get(device_class)) is not None
-        and state_class not in state_classes
-    ):
-        raise vol.Invalid(
-            f"State class '{state_class}' is not valid for device class '{device_class}'. "
-            f"Valid options are: {', '.join(sorted(map(str, state_classes), key=str.casefold))}",
-            path=[CONF_SENSOR_STATE_CLASS],
-        )
-    if (
-        device_class
-        and (d_c_units := SENSOR_DEVICE_CLASS_UNITS.get(device_class)) is not None
-        and unit_of_measurement not in d_c_units
-    ):
-        raise vol.Invalid(
-            f"Unit of measurement '{unit_of_measurement}' is not valid for device class '{device_class}'. "
-            f"Valid options are: {', '.join(sorted(map(str, d_c_units), key=str.casefold))}",
-            path=(
-                [CONF_DEVICE_CLASS]
-                if CONF_DEVICE_CLASS in config
-                else [CONF_UNIT_OF_MEASUREMENT]
-            ),
-        )
-    if (
-        state_class
-        and (s_c_units := STATE_CLASS_UNITS.get(state_class)) is not None
-        and unit_of_measurement not in s_c_units
-    ):
-        raise vol.Invalid(
-            f"Unit of measurement '{unit_of_measurement}' is not valid for state class '{state_class}'. "
-            f"Valid options are: {', '.join(sorted(map(str, s_c_units), key=str.casefold))}",
-            path=(
-                [CONF_SENSOR_STATE_CLASS]
-                if CONF_SENSOR_STATE_CLASS in config
-                else [CONF_UNIT_OF_MEASUREMENT]
-            ),
-        )
-    return config
+    return validate_sensor_attributes(dpt_metadata, config)
 
 
 SENSOR_KNX_SCHEMA = AllSerializeFirst(
@@ -788,7 +735,7 @@ SENSOR_KNX_SCHEMA = AllSerializeFirst(
             ),
         },
     ),
-    _validate_sensor_attributes,
+    _sensor_attribute_sub_validator,
 )
 
 KNX_SCHEMA_FOR_PLATFORM = {

--- a/homeassistant/components/knx/validation.py
+++ b/homeassistant/components/knx/validation.py
@@ -24,7 +24,7 @@ from homeassistant.const import CONF_DEVICE_CLASS, CONF_UNIT_OF_MEASUREMENT
 from homeassistant.helpers import config_validation as cv
 
 from .const import NumberConf
-from .dpt import get_supported_dpts, DPTInfo
+from .dpt import DPTInfo, get_supported_dpts
 
 
 def dpt_subclass_validator(dpt_base_class: type[DPTBase]) -> Callable[[Any], str | int]:
@@ -153,6 +153,7 @@ def backwards_compatible_xknx_climate_enum_member(enumClass: type[Enum]) -> vol.
         enumClass.__getitem__,
     )
 
+
 def validate_number_attributes(
     transcoder: type[DPTNumeric], config: dict[str, Any]
 ) -> dict[str, Any]:
@@ -224,6 +225,7 @@ def validate_number_attributes(
         )
 
     return config
+
 
 def validate_sensor_attributes(
     dpt_info: DPTInfo, config: dict[str, Any]

--- a/homeassistant/components/knx/validation.py
+++ b/homeassistant/components/knx/validation.py
@@ -14,11 +14,17 @@ from xknx.telegram.address import IndividualAddress, parse_device_group_address
 from homeassistant.components.number import (
     DEVICE_CLASS_UNITS as NUMBER_DEVICE_CLASS_UNITS,
 )
+from homeassistant.components.sensor import (
+    CONF_STATE_CLASS as CONF_SENSOR_STATE_CLASS,
+    DEVICE_CLASS_STATE_CLASSES,
+    DEVICE_CLASS_UNITS,
+    STATE_CLASS_UNITS,
+)
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_UNIT_OF_MEASUREMENT
 from homeassistant.helpers import config_validation as cv
 
 from .const import NumberConf
-from .dpt import get_supported_dpts
+from .dpt import get_supported_dpts, DPTInfo
 
 
 def dpt_subclass_validator(dpt_base_class: type[DPTBase]) -> Callable[[Any], str | int]:
@@ -147,7 +153,6 @@ def backwards_compatible_xknx_climate_enum_member(enumClass: type[Enum]) -> vol.
         enumClass.__getitem__,
     )
 
-
 def validate_number_attributes(
     transcoder: type[DPTNumeric], config: dict[str, Any]
 ) -> dict[str, Any]:
@@ -218,4 +223,65 @@ def validate_number_attributes(
             ),
         )
 
+    return config
+
+def validate_sensor_attributes(
+    dpt_info: DPTInfo, config: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate that state_class is compatible with device_class and unit_of_measurement.
+
+    Works for both, UI and YAML configuration schema since they
+    share same names for all tested attributes.
+    """
+    state_class = config.get(
+        CONF_SENSOR_STATE_CLASS,
+        dpt_info["sensor_state_class"],
+    )
+    device_class = config.get(
+        CONF_DEVICE_CLASS,
+        dpt_info["sensor_device_class"],
+    )
+    unit_of_measurement = config.get(
+        CONF_UNIT_OF_MEASUREMENT,
+        dpt_info["unit"],
+    )
+    if (
+        state_class
+        and device_class
+        and (state_classes := DEVICE_CLASS_STATE_CLASSES.get(device_class)) is not None
+        and state_class not in state_classes
+    ):
+        raise vol.Invalid(
+            f"State class '{state_class}' is not valid for device class '{device_class}'. "
+            f"Valid options are: {', '.join(sorted(map(str, state_classes), key=str.casefold))}",
+            path=[CONF_SENSOR_STATE_CLASS],
+        )
+    if (
+        device_class
+        and (d_c_units := DEVICE_CLASS_UNITS.get(device_class)) is not None
+        and unit_of_measurement not in d_c_units
+    ):
+        raise vol.Invalid(
+            f"Unit of measurement '{unit_of_measurement}' is not valid for device class '{device_class}'. "
+            f"Valid options are: {', '.join(sorted(map(str, d_c_units), key=str.casefold))}",
+            path=(
+                [CONF_DEVICE_CLASS]
+                if CONF_DEVICE_CLASS in config
+                else [CONF_UNIT_OF_MEASUREMENT]
+            ),
+        )
+    if (
+        state_class
+        and (s_c_units := STATE_CLASS_UNITS.get(state_class)) is not None
+        and unit_of_measurement not in s_c_units
+    ):
+        raise vol.Invalid(
+            f"Unit of measurement '{unit_of_measurement}' is not valid for state class '{state_class}'. "
+            f"Valid options are: {', '.join(sorted(map(str, s_c_units), key=str.casefold))}",
+            path=(
+                [CONF_SENSOR_STATE_CLASS]
+                if CONF_SENSOR_STATE_CLASS in config
+                else [CONF_UNIT_OF_MEASUREMENT]
+            ),
+        )
     return config

--- a/tests/components/knx/test_sensor.py
+++ b/tests/components/knx/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.knx.const import (
     CONF_SYNC_STATE,
 )
 from homeassistant.components.knx.schema import SensorSchema
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import CONF_NAME, CONF_TYPE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant, State
 
@@ -42,13 +43,18 @@ async def test_sensor(hass: HomeAssistant, knx: KNXTestKit) -> None:
     # StateUpdater initialize state
     await knx.assert_read("1/1/1")
     await knx.receive_response("1/1/1", (0, 40))
-    state = hass.states.get("sensor.test")
-    assert state.state == "40"
+    knx.assert_state(
+        "sensor.test",
+        "40",
+        # default values for DPT type "current"
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit_of_measurement="mA",
+    )
 
     # update from KNX
     await knx.receive_write("1/1/1", (0x03, 0xE8))
-    state = hass.states.get("sensor.test")
-    assert state.state == "1000"
+    knx.assert_state("sensor.test", "1000")
 
     # don't answer to GroupValueRead requests
     await knx.receive_read("1/1/1")
@@ -186,8 +192,8 @@ async def test_always_callback(hass: HomeAssistant, knx: KNXTestKit) -> None:
             (0, 0),
             {
                 "state": "0.0",
-                "device_class": "temperature",
-                "state_class": "measurement",
+                "device_class": SensorDeviceClass.TEMPERATURE,
+                "state_class": SensorStateClass.MEASUREMENT,
                 "unit_of_measurement": "°C",
             },
         ),
@@ -206,8 +212,8 @@ async def test_always_callback(hass: HomeAssistant, knx: KNXTestKit) -> None:
             (1, 2, 3, 4),
             {
                 "state": "16909060",
-                "device_class": "energy",
-                "state_class": "total_increasing",
+                "device_class": SensorDeviceClass.ENERGY,
+                "state_class": SensorStateClass.TOTAL_INCREASING,
             },
         ),
     ],

--- a/tests/components/knx/test_sensor.py
+++ b/tests/components/knx/test_sensor.py
@@ -196,14 +196,17 @@ async def test_sensor_yaml_attribute_validation(
                     CONF_NAME: "test",
                     CONF_STATE_ADDRESS: "1/1/1",
                     CONF_TYPE: "9.001",  # temperature 2 byte float
-                    CONF_SENSOR_STATE_CLASS: "totoal_increasing",  # invalid for temperature
+                    CONF_SENSOR_STATE_CLASS: "total_increasing",  # invalid for temperature
                 }
             }
         )
     assert len(caplog.messages) == 2
     record = caplog.records[0]
     assert record.levelname == "ERROR"
-    assert "Invalid config for 'knx': expected SensorStateClass" in record.message
+    assert (
+        "Invalid config for 'knx': State class 'total_increasing' is not valid for device class"
+        in record.message
+    )
 
     record = caplog.records[1]
     assert record.levelname == "ERROR"

--- a/tests/components/knx/test_time_server.py
+++ b/tests/components/knx/test_time_server.py
@@ -111,9 +111,9 @@ async def test_time_server_load_from_config_store(
         {}, config_store_fixture="config_store_time_server.json"
     )
     # Verify all three formats are written on startup
-    await knx.assert_write("1/1/1", RAW_TIME)
-    await knx.assert_write("2/2/2", RAW_DATE)
-    await knx.assert_write("3/3/3", RAW_DATETIME)
+    await knx.assert_write("1/1/1", RAW_TIME, ignore_order=True)
+    await knx.assert_write("2/2/2", RAW_DATE, ignore_order=True)
+    await knx.assert_write("3/3/3", RAW_DATETIME, ignore_order=True)
 
     client = await hass_ws_client(hass)
     # Verify configuration was loaded


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Like for UI sensor entities, use the configured datapoint type (KNX DPT) to assign `device_class` and `state_class`.

`device_class` and `native_unit_of_measurement` have been assigned before too - sourced from definitions in the `xknx` library. `device_class` definitions are now sourced from the integration code https://github.com/home-assistant/core/blob/37d3b73c1b3d13f17a304fe7b3741ae2ed65022a/homeassistant/components/knx/dpt.py#L59

Users can still override those via YAML - as they could before. 

YAML sensors `state_class`, `device_class` and `unit_of_measurement` are now validated for compatibility (as they are in UI).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42912
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
