### PR TITLE
Add additional numerical climate triggers

### DIFF
--- a/homeassistant/components/climate/icons.json
+++ b/homeassistant/components/climate/icons.json
@@ -98,6 +98,18 @@
     }
   },
   "triggers": {
+    "current_humidity_changed": {
+      "trigger": "mdi:water-percent"
+    },
+    "current_humidity_crossed_threshold": {
+      "trigger": "mdi:water-percent"
+    },
+    "current_temperature_changed": {
+      "trigger": "mdi:thermometer"
+    },
+    "current_temperature_crossed_threshold": {
+      "trigger": "mdi:thermometer"
+    },
     "hvac_mode_changed": {
       "trigger": "mdi:thermostat"
     },
@@ -109,6 +121,12 @@
     },
     "started_heating": {
       "trigger": "mdi:fire"
+    },
+    "target_humidity_changed": {
+      "trigger": "mdi:water-percent"
+    },
+    "target_humidity_crossed_threshold": {
+      "trigger": "mdi:water-percent"
     },
     "target_temperature_changed": {
       "trigger": "mdi:thermometer"

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -312,6 +312,78 @@
   },
   "title": "Climate",
   "triggers": {
+    "current_humidity_changed": {
+      "description": "Triggers after the humidity measured by one or more climate-control devices changes.",
+      "fields": {
+        "above": {
+          "description": "Trigger when the humidity is above this value.",
+          "name": "Above"
+        },
+        "below": {
+          "description": "Trigger when the humidity is below this value.",
+          "name": "Below"
+        }
+      },
+      "name": "Climate-control device current humidity changed"
+    },
+    "current_humidity_crossed_threshold": {
+      "description": "Triggers after the humidity measured by one or more climate-control devices crosses a threshold.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::climate::common::trigger_behavior_description%]",
+          "name": "[%key:component::climate::common::trigger_behavior_name%]"
+        },
+        "lower_limit": {
+          "description": "Lower threshold limit.",
+          "name": "Lower threshold"
+        },
+        "threshold_type": {
+          "description": "Type of threshold crossing to trigger on.",
+          "name": "Threshold type"
+        },
+        "upper_limit": {
+          "description": "Upper threshold limit.",
+          "name": "Upper threshold"
+        }
+      },
+      "name": "Climate-control device current humidity crossed threshold"
+    },
+    "current_temperature_changed": {
+      "description": "Triggers after the temperature measured by one or more climate-control devices changes.",
+      "fields": {
+        "above": {
+          "description": "Trigger when the temperature is above this value.",
+          "name": "Above"
+        },
+        "below": {
+          "description": "Trigger when the temperature is below this value.",
+          "name": "Below"
+        }
+      },
+      "name": "Climate-control device current temperature changed"
+    },
+    "current_temperature_crossed_threshold": {
+      "description": "Triggers after the temperature measured by one or more climate-control devices crosses a threshold.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::climate::common::trigger_behavior_description%]",
+          "name": "[%key:component::climate::common::trigger_behavior_name%]"
+        },
+        "lower_limit": {
+          "description": "Lower threshold limit.",
+          "name": "Lower threshold"
+        },
+        "threshold_type": {
+          "description": "Type of threshold crossing to trigger on.",
+          "name": "Threshold type"
+        },
+        "upper_limit": {
+          "description": "Upper threshold limit.",
+          "name": "Upper threshold"
+        }
+      },
+      "name": "Climate-control device current temperature crossed threshold"
+    },
     "hvac_mode_changed": {
       "description": "Triggers after the mode of one or more climate-control devices changes.",
       "fields": {
@@ -355,6 +427,42 @@
         }
       },
       "name": "Climate-control device started heating"
+    },
+    "target_humidity_changed": {
+      "description": "Triggers after the humidity setpoint of one or more climate-control devices changes.",
+      "fields": {
+        "above": {
+          "description": "Trigger when the target humidity is above this value.",
+          "name": "Above"
+        },
+        "below": {
+          "description": "Trigger when the target humidity is below this value.",
+          "name": "Below"
+        }
+      },
+      "name": "Climate-control device target humidity changed"
+    },
+    "target_humidity_crossed_threshold": {
+      "description": "Triggers after the humidity setpoint of one or more climate-control devices crosses a threshold.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::climate::common::trigger_behavior_description%]",
+          "name": "[%key:component::climate::common::trigger_behavior_name%]"
+        },
+        "lower_limit": {
+          "description": "Lower threshold limit.",
+          "name": "Lower threshold"
+        },
+        "threshold_type": {
+          "description": "Type of threshold crossing to trigger on.",
+          "name": "Threshold type"
+        },
+        "upper_limit": {
+          "description": "Upper threshold limit.",
+          "name": "Upper threshold"
+        }
+      },
+      "name": "Climate-control device target humidity crossed threshold"
     },
     "target_temperature_changed": {
       "description": "Triggers after the temperature setpoint of one or more climate-control devices changes.",

--- a/homeassistant/components/climate/trigger.py
+++ b/homeassistant/components/climate/trigger.py
@@ -17,7 +17,15 @@ from homeassistant.helpers.trigger import (
     make_entity_transition_trigger,
 )
 
-from .const import ATTR_HVAC_ACTION, DOMAIN, HVACAction, HVACMode
+from .const import (
+    ATTR_CURRENT_HUMIDITY,
+    ATTR_CURRENT_TEMPERATURE,
+    ATTR_HUMIDITY,
+    ATTR_HVAC_ACTION,
+    DOMAIN,
+    HVACAction,
+    HVACMode,
+)
 
 CONF_HVAC_MODE = "hvac_mode"
 
@@ -45,12 +53,30 @@ class HVACModeChangedTrigger(EntityTargetStateTriggerBase):
 
 
 TRIGGERS: dict[str, type[Trigger]] = {
+    "current_humidity_changed": make_entity_numerical_state_attribute_changed_trigger(
+        DOMAIN, ATTR_CURRENT_HUMIDITY
+    ),
+    "current_humidity_crossed_threshold": make_entity_numerical_state_attribute_crossed_threshold_trigger(
+        DOMAIN, ATTR_CURRENT_HUMIDITY
+    ),
+    "current_temperature_changed": make_entity_numerical_state_attribute_changed_trigger(
+        DOMAIN, ATTR_CURRENT_TEMPERATURE
+    ),
+    "current_temperature_crossed_threshold": make_entity_numerical_state_attribute_crossed_threshold_trigger(
+        DOMAIN, ATTR_CURRENT_TEMPERATURE
+    ),
     "hvac_mode_changed": HVACModeChangedTrigger,
     "started_cooling": make_entity_target_state_attribute_trigger(
         DOMAIN, ATTR_HVAC_ACTION, HVACAction.COOLING
     ),
     "started_drying": make_entity_target_state_attribute_trigger(
         DOMAIN, ATTR_HVAC_ACTION, HVACAction.DRYING
+    ),
+    "target_humidity_changed": make_entity_numerical_state_attribute_changed_trigger(
+        DOMAIN, ATTR_HUMIDITY
+    ),
+    "target_humidity_crossed_threshold": make_entity_numerical_state_attribute_crossed_threshold_trigger(
+        DOMAIN, ATTR_HUMIDITY
     ),
     "target_temperature_changed": make_entity_numerical_state_attribute_changed_trigger(
         DOMAIN, ATTR_TEMPERATURE

--- a/homeassistant/components/climate/triggers.yaml
+++ b/homeassistant/components/climate/triggers.yaml
@@ -65,6 +65,48 @@ hvac_mode_changed:
             - unknown
           multiple: true
 
+current_humidity_changed:
+  target: *trigger_climate_target
+  fields:
+    above: *number_or_entity
+    below: *number_or_entity
+
+current_humidity_crossed_threshold:
+  target: *trigger_climate_target
+  fields:
+    behavior: *trigger_behavior
+    threshold_type: *trigger_threshold_type
+    lower_limit: *number_or_entity
+    upper_limit: *number_or_entity
+
+target_humidity_changed:
+  target: *trigger_climate_target
+  fields:
+    above: *number_or_entity
+    below: *number_or_entity
+
+target_humidity_crossed_threshold:
+  target: *trigger_climate_target
+  fields:
+    behavior: *trigger_behavior
+    threshold_type: *trigger_threshold_type
+    lower_limit: *number_or_entity
+    upper_limit: *number_or_entity
+
+current_temperature_changed:
+  target: *trigger_climate_target
+  fields:
+    above: *number_or_entity
+    below: *number_or_entity
+
+current_temperature_crossed_threshold:
+  target: *trigger_climate_target
+  fields:
+    behavior: *trigger_behavior
+    threshold_type: *trigger_threshold_type
+    lower_limit: *number_or_entity
+    upper_limit: *number_or_entity
+
 target_temperature_changed:
   target: *trigger_climate_target
   fields:

--- a/tests/components/climate/test_trigger.py
+++ b/tests/components/climate/test_trigger.py
@@ -9,6 +9,9 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components.climate.const import (
+    ATTR_CURRENT_HUMIDITY,
+    ATTR_CURRENT_TEMPERATURE,
+    ATTR_HUMIDITY,
     ATTR_HVAC_ACTION,
     HVACAction,
     HVACMode,
@@ -67,7 +70,13 @@ async def target_climates(hass: HomeAssistant) -> list[str]:
 @pytest.mark.parametrize(
     "trigger_key",
     [
+        "climate.current_humidity_changed",
+        "climate.current_humidity_crossed_threshold",
+        "climate.current_temperature_changed",
+        "climate.current_temperature_crossed_threshold",
         "climate.hvac_mode_changed",
+        "climate.target_humidity_changed",
+        "climate.target_humidity_crossed_threshold",
         "climate.target_temperature_changed",
         "climate.target_temperature_crossed_threshold",
         "climate.turned_off",
@@ -368,7 +377,25 @@ async def test_climate_state_trigger_behavior_any(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_xxx_changed_trigger_states(
+            "climate.current_humidity_changed", ATTR_CURRENT_HUMIDITY
+        ),
+        *parametrize_xxx_changed_trigger_states(
+            "climate.current_temperature_changed", ATTR_CURRENT_TEMPERATURE
+        ),
+        *parametrize_xxx_changed_trigger_states(
+            "climate.target_humidity_changed", ATTR_HUMIDITY
+        ),
+        *parametrize_xxx_changed_trigger_states(
             "climate.target_temperature_changed", ATTR_TEMPERATURE
+        ),
+        *parametrize_xxx_crossed_threshold_trigger_states(
+            "climate.current_humidity_crossed_threshold", ATTR_CURRENT_HUMIDITY
+        ),
+        *parametrize_xxx_crossed_threshold_trigger_states(
+            "climate.current_temperature_crossed_threshold", ATTR_CURRENT_TEMPERATURE
+        ),
+        *parametrize_xxx_crossed_threshold_trigger_states(
+            "climate.target_humidity_crossed_threshold", ATTR_HUMIDITY
         ),
         *parametrize_xxx_crossed_threshold_trigger_states(
             "climate.target_temperature_crossed_threshold", ATTR_TEMPERATURE
@@ -511,6 +538,15 @@ async def test_climate_state_trigger_behavior_first(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_xxx_crossed_threshold_trigger_states(
+            "climate.current_humidity_crossed_threshold", ATTR_CURRENT_HUMIDITY
+        ),
+        *parametrize_xxx_crossed_threshold_trigger_states(
+            "climate.current_temperature_crossed_threshold", ATTR_CURRENT_TEMPERATURE
+        ),
+        *parametrize_xxx_crossed_threshold_trigger_states(
+            "climate.target_humidity_crossed_threshold", ATTR_HUMIDITY
+        ),
+        *parametrize_xxx_crossed_threshold_trigger_states(
             "climate.target_temperature_crossed_threshold", ATTR_TEMPERATURE
         ),
         *parametrize_climate_trigger_states(
@@ -650,6 +686,15 @@ async def test_climate_state_trigger_behavior_last(
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
     [
+        *parametrize_xxx_crossed_threshold_trigger_states(
+            "climate.current_humidity_crossed_threshold", ATTR_CURRENT_HUMIDITY
+        ),
+        *parametrize_xxx_crossed_threshold_trigger_states(
+            "climate.current_temperature_crossed_threshold", ATTR_CURRENT_TEMPERATURE
+        ),
+        *parametrize_xxx_crossed_threshold_trigger_states(
+            "climate.target_humidity_crossed_threshold", ATTR_HUMIDITY
+        ),
         *parametrize_xxx_crossed_threshold_trigger_states(
             "climate.target_temperature_crossed_threshold", ATTR_TEMPERATURE
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add additional numerical climate triggers:
- `climate.current_humidity_changed`
- `climate.current_humidity_crossed_threshold`
- `climate.current_temperature_changed`
- `climate.current_temperature_crossed_threshold`
- `climate.hvac_mode_changed`
- `climate.target_humidity_changed`
- `climate.target_humidity_crossed_threshold`
- `climate.target_temperature_changed`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes #158388
  - fixes #158390
  - fixes #158391
  - fixes #158392
  - fixes #158393
  - fixes #158394
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
