### PR TITLE
File integration: support overwriting

### DIFF
--- a/homeassistant/components/file/config_flow.py
+++ b/homeassistant/components/file/config_flow.py
@@ -32,7 +32,7 @@ from homeassistant.helpers.selector import (
     TextSelectorType,
 )
 
-from .const import CONF_TIMESTAMP, DOMAIN
+from .const import CONF_OVERWRITE, CONF_TIMESTAMP, DOMAIN
 
 BOOLEAN_SELECTOR = BooleanSelector(BooleanSelectorConfig())
 TEMPLATE_SELECTOR = TemplateSelector(TemplateSelectorConfig())
@@ -48,6 +48,7 @@ FILE_OPTIONS_SCHEMAS = {
     Platform.NOTIFY.value: vol.Schema(
         {
             vol.Optional(CONF_TIMESTAMP, default=False): BOOLEAN_SELECTOR,
+            vol.Optional(CONF_OVERWRITE, default=False): BOOLEAN_SELECTOR,
         }
     ),
 }

--- a/homeassistant/components/file/const.py
+++ b/homeassistant/components/file/const.py
@@ -2,6 +2,7 @@
 
 DOMAIN = "file"
 
+CONF_OVERWRITE = "overwrite"
 CONF_TIMESTAMP = "timestamp"
 
 DEFAULT_NAME = "File"

--- a/homeassistant/components/file/notify.py
+++ b/homeassistant/components/file/notify.py
@@ -51,7 +51,7 @@ class FileNotifyEntity(NotifyEntity):
         filepath = self._file_path
         try:
             file_was_empty = (
-                not os.path.exists(filepath) or os.stat(filepath).st_size == 0
+                not os.path.exists(filepath) or os.path.getsize(filepath) == 0
             )
             file_mode = "w" if self._overwrite else "a"
             with open(filepath, file_mode, encoding="utf8") as file:

--- a/homeassistant/components/file/notify.py
+++ b/homeassistant/components/file/notify.py
@@ -50,7 +50,9 @@ class FileNotifyEntity(NotifyEntity):
         file: TextIO
         filepath = self._file_path
         try:
-            file_was_empty = not os.path.exists(filepath) or os.stat(filepath).st_size == 0
+            file_was_empty = (
+                not os.path.exists(filepath) or os.stat(filepath).st_size == 0
+            )
             file_mode = "w" if self._overwrite else "a"
             with open(filepath, file_mode, encoding="utf8") as file:
                 if file_was_empty:

--- a/homeassistant/components/file/notify.py
+++ b/homeassistant/components/file/notify.py
@@ -17,7 +17,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_TIMESTAMP, DEFAULT_NAME, DOMAIN, FILE_ICON
+from .const import CONF_OVERWRITE, CONF_TIMESTAMP, DEFAULT_NAME, DOMAIN, FILE_ICON
 
 
 async def async_setup_entry(
@@ -40,6 +40,7 @@ class FileNotifyEntity(NotifyEntity):
         """Initialize the service."""
         self._file_path: str = config[CONF_FILE_PATH]
         self._add_timestamp: bool = config.get(CONF_TIMESTAMP, False)
+        self._overwrite: bool = config.get(CONF_OVERWRITE, False)
         # Only import a name from an imported entity
         self._attr_name = config.get(CONF_NAME, DEFAULT_NAME)
         self._attr_unique_id = unique_id
@@ -49,7 +50,8 @@ class FileNotifyEntity(NotifyEntity):
         file: TextIO
         filepath = self._file_path
         try:
-            with open(filepath, "a", encoding="utf8") as file:
+            file_mode = "w" if self._overwrite else "a"
+            with open(filepath, file_mode, encoding="utf8") as file:
                 if os.stat(filepath).st_size == 0:
                     title = (
                         f"{title or ATTR_TITLE_DEFAULT} notifications (Log"

--- a/homeassistant/components/file/notify.py
+++ b/homeassistant/components/file/notify.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, TextIO
+from typing import Any, Literal, TextIO
 
 from homeassistant.components.notify import (
     ATTR_TITLE_DEFAULT,
@@ -48,12 +48,12 @@ class FileNotifyEntity(NotifyEntity):
     def send_message(self, message: str, title: str | None = None) -> None:
         """Send a message to a file."""
         file: TextIO
+        file_mode: Literal["a", "w"] = "w" if self._overwrite else "a"
         filepath = self._file_path
         try:
             file_was_empty = (
                 not os.path.exists(filepath) or os.path.getsize(filepath) == 0
             )
-            file_mode = "w" if self._overwrite else "a"
             with open(filepath, file_mode, encoding="utf8") as file:
                 if file_was_empty:
                     title = (

--- a/homeassistant/components/file/notify.py
+++ b/homeassistant/components/file/notify.py
@@ -50,9 +50,10 @@ class FileNotifyEntity(NotifyEntity):
         file: TextIO
         filepath = self._file_path
         try:
+            file_was_empty = not os.path.exists(filepath) or os.stat(filepath).st_size == 0
             file_mode = "w" if self._overwrite else "a"
             with open(filepath, file_mode, encoding="utf8") as file:
-                if os.stat(filepath).st_size == 0:
+                if file_was_empty:
                     title = (
                         f"{title or ATTR_TITLE_DEFAULT} notifications (Log"
                         f" started: {dt_util.utcnow().isoformat()})\n{'-' * 80}\n"

--- a/homeassistant/components/file/strings.json
+++ b/homeassistant/components/file/strings.json
@@ -10,10 +10,12 @@
       "notify": {
         "data": {
           "file_path": "[%key:component::file::config::step::sensor::data::file_path%]",
+          "overwrite": "Overwrite file",
           "timestamp": "Timestamp"
         },
         "data_description": {
           "file_path": "A local file path to write the notification to",
+          "overwrite": "Overwrite existing file contents instead of appending.",
           "timestamp": "Add a timestamp to the notification"
         },
         "description": "Set up a service that allows to write notification to a file.",
@@ -69,11 +71,13 @@
     "step": {
       "init": {
         "data": {
+          "overwrite": "[%key:component::file::config::step::notify::data::overwrite%]",
           "timestamp": "[%key:component::file::config::step::notify::data::timestamp%]",
           "unit_of_measurement": "[%key:component::file::config::step::sensor::data::unit_of_measurement%]",
           "value_template": "[%key:component::file::config::step::sensor::data::value_template%]"
         },
         "data_description": {
+          "overwrite": "[%key:component::file::config::step::notify::data_description::overwrite%]",
           "timestamp": "[%key:component::file::config::step::notify::data_description::timestamp%]",
           "unit_of_measurement": "[%key:component::file::config::step::sensor::data_description::unit_of_measurement%]",
           "value_template": "[%key:component::file::config::step::sensor::data_description::value_template%]"

--- a/tests/components/file/test_config_flow.py
+++ b/tests/components/file/test_config_flow.py
@@ -17,7 +17,7 @@ MOCK_CONFIG_NOTIFY = {
     "platform": "notify",
     "file_path": "some_file",
 }
-MOCK_OPTIONS_NOTIFY = {"timestamp": True}
+MOCK_OPTIONS_NOTIFY = {"timestamp": True, "overwrite": True}
 MOCK_CONFIG_SENSOR = {
     "platform": "sensor",
     "file_path": "some/path",
@@ -166,7 +166,12 @@ async def test_not_allowed(
             MOCK_OPTIONS_SENSOR,
             {CONF_UNIT_OF_MEASUREMENT: "mm"},
         ),
-        ("notify", MOCK_CONFIG_NOTIFY, MOCK_OPTIONS_NOTIFY, {"timestamp": False}),
+        (
+            "notify",
+            MOCK_CONFIG_NOTIFY,
+            MOCK_OPTIONS_NOTIFY,
+            {"timestamp": False, "overwrite": False},
+        ),
     ],
 )
 async def test_options_flow(

--- a/tests/components/file/test_notify.py
+++ b/tests/components/file/test_notify.py
@@ -28,10 +28,12 @@ from tests.common import MockConfigEntry
     ],
 )
 @pytest.mark.parametrize("timestamp", [False, True], ids=["no_timestamp", "timestamp"])
+@pytest.mark.parametrize("overwrite", [False, True], ids=["no_overwrite", "overwrite"])
 async def test_notify_file(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_is_allowed_path: MagicMock,
+    overwrite: bool,
     timestamp: bool,
     domain: str,
     service: str,
@@ -69,7 +71,10 @@ async def test_notify_file(
         await hass.services.async_call(domain, service, params, blocking=True)
 
         assert m_open.call_count == 1
-        assert m_open.call_args == call(full_filename, "a", encoding="utf8")
+        if not overwrite:
+            assert m_open.call_args == call(full_filename, "a", encoding="utf8")
+        else:
+            assert m_open.call_args == call(full_filename, "w", encoding="utf8")
 
         assert m_open.return_value.write.call_count == 2
         if not timestamp:

--- a/tests/components/file/test_notify.py
+++ b/tests/components/file/test_notify.py
@@ -60,9 +60,11 @@ async def test_notify_file(
     m_open = mock_open()
     with (
         patch("homeassistant.components.file.notify.open", m_open, create=True),
-        patch("homeassistant.components.file.notify.os.stat") as mock_st,
+        patch("homeassistant.components.file.notify.os.path.exists") as mock_exist,
+        patch("homeassistant.components.file.notify.os.path.getsize") as mock_getsize,
     ):
-        mock_st.return_value.st_size = 0
+        mock_exist.return_value = False
+        mock_getsize.return_value = 0
         title = (
             f"{ATTR_TITLE_DEFAULT} notifications "
             f"(Log started: {dt_util.utcnow().isoformat()})\n{'-' * 80}\n"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
File integration exposes **Notification to file service**, which currently appends to a specified file (using file mode `a`). This constrains the file integration to work with logs only. 
This PR adds optional "Overwrite" configuration to File integration, which defaults to false. When set, the files are opened for writing in mode `w`, replacing existing content with only the current payload.

The motivation for this change is to allows Home Assistant and AI assistants to produce useful content, and save it to files that can be used either within or outside of Home Assistant.

<img width="434" height="465" alt="Screenshot 2025-12-19 084432" src="https://github.com/user-attachments/assets/558a9cc0-f2c9-4e7b-88fd-02d395df76bb" />

### Example: `append.txt`
```
Home Assistant notifications (Log started: 2025-12-19T16:51:05.236502+00:00)
--------------------------------------------------------------------------------
<h1>Update</h1>
<p>2025-12-19 08:52:05.385270-08:00</p>
<h1>Update</h1>
<p>2025-12-19 08:53:05.383673-08:00</p>
<h1>Update</h1>
<p>2025-12-19 08:54:05.382051-08:00</p>
```
_continued..._

### Example: `overwrite.txt`
```
<h1>Update</h1>
<p>2025-12-19 21:54:05.362566-08:00</p>
```
_end of file_

### Automation used to generate examples:
```yaml
triggers:
  - trigger: time_pattern
    seconds: "5"
conditions: []
actions:
  - alias: Append to file
    action: notify.send_message
    data:
      entity_id: notify.file_append
      message: |
        <h1>Update</h1>
        <p>{{ now() }}</p>
  - alias: Overwrite file
    action: notify.send_message
    data:
      entity_id: notify.file_overwrite
      message: |
        <h1>Update</h1>
        <p>{{ now() }}</p>
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # n/a
- This PR is related to issue: n/a
- Link to documentation pull request: TBD
- Link to developer documentation pull request: n/a
- Link to frontend pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
