### PR TITLE
Enable HomeWizard Battery group mode by default when device controls batteries

### DIFF
--- a/homeassistant/components/homewizard/select.py
+++ b/homeassistant/components/homewizard/select.py
@@ -44,9 +44,8 @@ class HomeWizardBatteryModeSelectEntity(HomeWizardEntity, SelectEntity):
         """Initialize the switch."""
         super().__init__(coordinator)
 
-        battery_count = getattr(
-            getattr(coordinator.data, "batteries", None), "battery_count", None
-        )
+        batteries = coordinator.data.batteries
+        battery_count = batteries.battery_count if batteries is not None else None
         entity_registry_enabled_default = (
             battery_count is not None and battery_count > 0
         )

--- a/homeassistant/components/homewizard/select.py
+++ b/homeassistant/components/homewizard/select.py
@@ -44,11 +44,17 @@ class HomeWizardBatteryModeSelectEntity(HomeWizardEntity, SelectEntity):
         """Initialize the switch."""
         super().__init__(coordinator)
 
+        battery_count = getattr(
+            getattr(coordinator.data, "batteries", None), "battery_count", None
+        )
+        entity_registry_enabled_default = (
+            battery_count is not None and battery_count > 0
+        )
         description = SelectEntityDescription(
             key="battery_group_mode",
             translation_key="battery_group_mode",
             entity_category=EntityCategory.CONFIG,
-            entity_registry_enabled_default=False,
+            entity_registry_enabled_default=entity_registry_enabled_default,
             options=[
                 str(mode)
                 for mode in (coordinator.data.device.supported_battery_modes() or [])

--- a/tests/components/homewizard/fixtures/HWE-P1-no-batteries/batteries.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-no-batteries/batteries.json
@@ -1,0 +1,9 @@
+{
+  "mode": "zero",
+  "permissions": ["charge_allowed", "discharge_allowed"],
+  "battery_count": 0,
+  "power_w": 0,
+  "target_power_w": 0,
+  "max_consumption_w": 0,
+  "max_production_w": 0
+}

--- a/tests/components/homewizard/fixtures/HWE-P1-no-batteries/data.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-no-batteries/data.json
@@ -1,0 +1,82 @@
+{
+  "wifi_ssid": "My Wi-Fi",
+  "wifi_strength": 100,
+  "smr_version": 50,
+  "meter_model": "ISKRA  2M550T-101",
+  "unique_id": "00112233445566778899AABBCCDDEEFF",
+  "active_tariff": 2,
+  "total_power_import_kwh": 13779.338,
+  "total_power_import_t1_kwh": 10830.511,
+  "total_power_import_t2_kwh": 2948.827,
+  "total_power_import_t3_kwh": 2948.827,
+  "total_power_import_t4_kwh": 2948.827,
+  "total_power_export_kwh": 13086.777,
+  "total_power_export_t1_kwh": 4321.333,
+  "total_power_export_t2_kwh": 8765.444,
+  "total_power_export_t3_kwh": 8765.444,
+  "total_power_export_t4_kwh": 8765.444,
+  "active_power_w": -123,
+  "active_power_l1_w": -123,
+  "active_power_l2_w": 456,
+  "active_power_l3_w": 123.456,
+  "active_voltage_l1_v": 230.111,
+  "active_voltage_l2_v": 230.222,
+  "active_voltage_l3_v": 230.333,
+  "active_current_l1_a": -4,
+  "active_current_l2_a": 2,
+  "active_current_l3_a": 0,
+  "active_frequency_hz": 50,
+  "voltage_sag_l1_count": 1,
+  "voltage_sag_l2_count": 2,
+  "voltage_sag_l3_count": 3,
+  "voltage_swell_l1_count": 4,
+  "voltage_swell_l2_count": 5,
+  "voltage_swell_l3_count": 6,
+  "any_power_fail_count": 4,
+  "long_power_fail_count": 5,
+  "total_gas_m3": 1122.333,
+  "gas_timestamp": 210314112233,
+  "gas_unique_id": "01FFEEDDCCBBAA99887766554433221100",
+  "active_power_average_w": 123.0,
+  "montly_power_peak_w": 1111.0,
+  "montly_power_peak_timestamp": 230101080010,
+  "active_liter_lpm": 12.345,
+  "total_liter_m3": 1234.567,
+  "external": [
+    {
+      "unique_id": "47303031",
+      "type": "gas_meter",
+      "timestamp": 230125220957,
+      "value": 111.111,
+      "unit": "m3"
+    },
+    {
+      "unique_id": "57303031",
+      "type": "water_meter",
+      "timestamp": 230125220957,
+      "value": 222.222,
+      "unit": "m3"
+    },
+    {
+      "unique_id": "5757303031",
+      "type": "warm_water_meter",
+      "timestamp": 230125220957,
+      "value": 333.333,
+      "unit": "m3"
+    },
+    {
+      "unique_id": "48303031",
+      "type": "heat_meter",
+      "timestamp": 230125220957,
+      "value": 444.444,
+      "unit": "GJ"
+    },
+    {
+      "unique_id": "4948303031",
+      "type": "inlet_heat_meter",
+      "timestamp": 230125220957,
+      "value": 555.555,
+      "unit": "m3"
+    }
+  ]
+}

--- a/tests/components/homewizard/fixtures/HWE-P1-no-batteries/device.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-no-batteries/device.json
@@ -1,0 +1,7 @@
+{
+  "product_type": "HWE-P1",
+  "product_name": "P1 meter",
+  "serial": "5c2fafabcdef",
+  "firmware_version": "4.19",
+  "api_version": "v1"
+}

--- a/tests/components/homewizard/fixtures/HWE-P1-no-batteries/system.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-no-batteries/system.json
@@ -1,0 +1,3 @@
+{
+  "cloud_enabled": true
+}

--- a/tests/components/homewizard/test_select.py
+++ b/tests/components/homewizard/test_select.py
@@ -77,7 +77,6 @@ async def test_entities_not_created_for_device(
         ("HWE-P1", "select.device_battery_group_mode"),
     ],
 )
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_select_entity_snapshots(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -115,7 +114,6 @@ async def test_select_entity_snapshots(
         ("HWE-P1", "select.device_battery_group_mode", "zero", Batteries.Mode.ZERO),
     ],
 )
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_select_set_option(
     hass: HomeAssistant,
     mock_homewizardenergy: MagicMock,
@@ -144,7 +142,6 @@ async def test_select_set_option(
         ("HWE-P1", "select.device_battery_group_mode", "to_full"),
     ],
 )
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_select_request_error(
     hass: HomeAssistant,
     mock_homewizardenergy: MagicMock,
@@ -174,7 +171,6 @@ async def test_select_request_error(
         ("HWE-P1", "select.device_battery_group_mode", "to_full"),
     ],
 )
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_select_unauthorized_error(
     hass: HomeAssistant,
     mock_homewizardenergy: MagicMock,
@@ -206,7 +202,6 @@ async def test_select_unauthorized_error(
         ("select.device_battery_group_mode", "combined"),
     ],
 )
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_select_unreachable(
     hass: HomeAssistant,
     mock_homewizardenergy: MagicMock,
@@ -230,7 +225,6 @@ async def test_select_unreachable(
         ("HWE-P1", "select.device_battery_group_mode"),
     ],
 )
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_select_multiple_state_changes(
     hass: HomeAssistant,
     mock_homewizardenergy: MagicMock,
@@ -275,7 +269,7 @@ async def test_select_multiple_state_changes(
     ("device_fixture", "entity_ids"),
     [
         (
-            "HWE-P1",
+            "HWE-P1-no-batteries",
             [
                 "select.device_battery_group_mode",
             ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Battery group mode was always disabled by default, but with this PR we enable it by default _when_ the P1 Meter / kWh Meter has control over batteries.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42665
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
