### PR TITLE
Allow reconfigure open_router subentries

### DIFF
--- a/homeassistant/components/open_router/config_flow.py
+++ b/homeassistant/components/open_router/config_flow.py
@@ -146,7 +146,7 @@ class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
                 return self.async_create_entry(
                     title=self.models[user_input[CONF_MODEL]].name, data=user_input
                 )
-            return self.async_update_reload_and_abort(
+            return self.async_update_and_abort(
                 self._get_entry(),
                 self._get_reconfigure_subentry(),
                 data=user_input,
@@ -246,7 +246,7 @@ class AITaskDataFlowHandler(OpenRouterSubentryFlowHandler):
                 return self.async_create_entry(
                     title=self.models[user_input[CONF_MODEL]].name, data=user_input
                 )
-            return self.async_update_reload_and_abort(
+            return self.async_update_and_abort(
                 self._get_entry(),
                 self._get_reconfigure_subentry(),
                 data=user_input,

--- a/homeassistant/components/open_router/config_flow.py
+++ b/homeassistant/components/open_router/config_flow.py
@@ -14,7 +14,9 @@ from python_open_router import (
 import voluptuous as vol
 
 from homeassistant.config_entries import (
+    SOURCE_USER,
     ConfigEntry,
+    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     ConfigSubentryFlow,
@@ -106,16 +108,50 @@ class OpenRouterSubentryFlowHandler(ConfigSubentryFlow):
 class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
     """Handle subentry flow."""
 
+    def __init__(self) -> None:
+        """Initialize the subentry flow."""
+        super().__init__()
+        self.options: dict[str, Any] = {}
+
+    @property
+    def _is_new(self) -> bool:
+        """Return if this is a new subentry."""
+        return self.source == SOURCE_USER
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
-        """User flow to create a sensor subentry."""
+        """User flow to create a conversation agent."""
+        self.options = RECOMMENDED_CONVERSATION_OPTIONS.copy()
+        return await self.async_step_init(user_input)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Handle reconfiguration of a conversation agent."""
+        self.options = self._get_reconfigure_subentry().data.copy()
+        return await self.async_step_init(user_input)
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Manage conversation agent configuration."""
+        if self._get_entry().state != ConfigEntryState.LOADED:
+            return self.async_abort(reason="entry_not_loaded")
+
         if user_input is not None:
             if not user_input.get(CONF_LLM_HASS_API):
                 user_input.pop(CONF_LLM_HASS_API, None)
-            return self.async_create_entry(
-                title=self.models[user_input[CONF_MODEL]].name, data=user_input
+            if self._is_new:
+                return self.async_create_entry(
+                    title=self.models[user_input[CONF_MODEL]].name, data=user_input
+                )
+            return self.async_update_reload_and_abort(
+                self._get_entry(),
+                self._get_reconfigure_subentry(),
+                data=user_input,
             )
+
         try:
             await self._get_models()
         except OpenRouterError:
@@ -123,6 +159,7 @@ class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
         except Exception:
             _LOGGER.exception("Unexpected exception")
             return self.async_abort(reason="unknown")
+
         options = [
             SelectOptionDict(value=model.id, label=model.name)
             for model in self.models.values()
@@ -135,11 +172,14 @@ class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
             )
             for api in llm.async_get_apis(self.hass)
         ]
+
         return self.async_show_form(
-            step_id="user",
+            step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_MODEL): SelectSelector(
+                    vol.Required(
+                        CONF_MODEL, default=self.options.get(CONF_MODEL)
+                    ): SelectSelector(
                         SelectSelectorConfig(
                             options=options, mode=SelectSelectorMode.DROPDOWN, sort=True
                         ),
@@ -147,14 +187,18 @@ class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
                     vol.Optional(
                         CONF_PROMPT,
                         description={
-                            "suggested_value": RECOMMENDED_CONVERSATION_OPTIONS[
-                                CONF_PROMPT
-                            ]
+                            "suggested_value": self.options.get(
+                                CONF_PROMPT,
+                                RECOMMENDED_CONVERSATION_OPTIONS[CONF_PROMPT],
+                            )
                         },
                     ): TemplateSelector(),
                     vol.Optional(
                         CONF_LLM_HASS_API,
-                        default=RECOMMENDED_CONVERSATION_OPTIONS[CONF_LLM_HASS_API],
+                        default=self.options.get(
+                            CONF_LLM_HASS_API,
+                            RECOMMENDED_CONVERSATION_OPTIONS[CONF_LLM_HASS_API],
+                        ),
                     ): SelectSelector(
                         SelectSelectorConfig(options=hass_apis, multiple=True)
                     ),
@@ -166,14 +210,48 @@ class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
 class AITaskDataFlowHandler(OpenRouterSubentryFlowHandler):
     """Handle subentry flow."""
 
+    def __init__(self) -> None:
+        """Initialize the subentry flow."""
+        super().__init__()
+        self.options: dict[str, Any] = {}
+
+    @property
+    def _is_new(self) -> bool:
+        """Return if this is a new subentry."""
+        return self.source == SOURCE_USER
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
-        """User flow to create a sensor subentry."""
+        """User flow to create an AI task."""
+        self.options = {}
+        return await self.async_step_init(user_input)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Handle reconfiguration of an AI task."""
+        self.options = self._get_reconfigure_subentry().data.copy()
+        return await self.async_step_init(user_input)
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Manage AI task configuration."""
+        if self._get_entry().state != ConfigEntryState.LOADED:
+            return self.async_abort(reason="entry_not_loaded")
+
         if user_input is not None:
-            return self.async_create_entry(
-                title=self.models[user_input[CONF_MODEL]].name, data=user_input
+            if self._is_new:
+                return self.async_create_entry(
+                    title=self.models[user_input[CONF_MODEL]].name, data=user_input
+                )
+            return self.async_update_reload_and_abort(
+                self._get_entry(),
+                self._get_reconfigure_subentry(),
+                data=user_input,
             )
+
         try:
             await self._get_models()
         except OpenRouterError:
@@ -181,16 +259,20 @@ class AITaskDataFlowHandler(OpenRouterSubentryFlowHandler):
         except Exception:
             _LOGGER.exception("Unexpected exception")
             return self.async_abort(reason="unknown")
+
         options = [
             SelectOptionDict(value=model.id, label=model.name)
             for model in self.models.values()
             if SupportedParameter.STRUCTURED_OUTPUTS in model.supported_parameters
         ]
+
         return self.async_show_form(
-            step_id="user",
+            step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_MODEL): SelectSelector(
+                    vol.Required(
+                        CONF_MODEL, default=self.options.get(CONF_MODEL)
+                    ): SelectSelector(
                         SelectSelectorConfig(
                             options=options, mode=SelectSelectorMode.DROPDOWN, sort=True
                         ),

--- a/homeassistant/components/open_router/strings.json
+++ b/homeassistant/components/open_router/strings.json
@@ -22,6 +22,7 @@
     "ai_task_data": {
       "abort": {
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "entry_not_loaded": "The main integration entry is not loaded. Please ensure the integration is loaded before reconfiguring.",
         "unknown": "[%key:common::config_flow::error::unknown%]"
       },
       "entry_type": "AI task",
@@ -29,6 +30,15 @@
         "user": "Add AI task"
       },
       "step": {
+        "init": {
+          "data": {
+            "model": "Model"
+          },
+          "data_description": {
+            "model": "The model to use for the AI task"
+          },
+          "description": "Configure the AI task"
+        },
         "user": {
           "data": {
             "model": "[%key:component::open_router::config_subentries::conversation::step::user::data::model%]"
@@ -39,6 +49,7 @@
     "conversation": {
       "abort": {
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "entry_not_loaded": "The main integration entry is not loaded. Please ensure the integration is loaded before reconfiguring.",
         "unknown": "[%key:common::config_flow::error::unknown%]"
       },
       "entry_type": "Conversation agent",
@@ -46,6 +57,18 @@
         "user": "Add conversation agent"
       },
       "step": {
+        "init": {
+          "data": {
+            "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
+            "model": "Model",
+            "prompt": "[%key:common::config_flow::data::prompt%]"
+          },
+          "data_description": {
+            "model": "The model to use for the conversation agent",
+            "prompt": "Instruct how the LLM should respond. This can be a template."
+          },
+          "description": "Configure the conversation agent"
+        },
         "user": {
           "data": {
             "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",

--- a/homeassistant/components/open_router/strings.json
+++ b/homeassistant/components/open_router/strings.json
@@ -32,7 +32,7 @@
       "step": {
         "init": {
           "data": {
-            "model": "Model"
+            "model": "[%key:component::open_router::config_subentries::conversation::step::user::data::model%]"
           },
           "data_description": {
             "model": "The model to use for the AI task"

--- a/homeassistant/components/open_router/strings.json
+++ b/homeassistant/components/open_router/strings.json
@@ -60,7 +60,7 @@
         "init": {
           "data": {
             "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
-            "model": "Model",
+            "model": "[%key:component::open_router::config_subentries::conversation::step::user::data::model%]",
             "prompt": "[%key:common::config_flow::data::prompt%]"
           },
           "data_description": {

--- a/homeassistant/components/open_router/strings.json
+++ b/homeassistant/components/open_router/strings.json
@@ -32,24 +32,19 @@
       "step": {
         "init": {
           "data": {
-            "model": "[%key:component::open_router::config_subentries::conversation::step::user::data::model%]"
+            "model": "[%key:component::open_router::config_subentries::conversation::step::init::data::model%]"
           },
           "data_description": {
             "model": "The model to use for the AI task"
           },
           "description": "Configure the AI task"
-        },
-        "user": {
-          "data": {
-            "model": "[%key:component::open_router::config_subentries::conversation::step::user::data::model%]"
-          }
         }
       }
     },
     "conversation": {
       "abort": {
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-        "entry_not_loaded": "The main integration entry is not loaded. Please ensure the integration is loaded before reconfiguring.",
+        "entry_not_loaded": "[%key:component::open_router::config_subentries::ai_task_data::abort::entry_not_loaded%]",
         "unknown": "[%key:common::config_flow::error::unknown%]"
       },
       "entry_type": "Conversation agent",
@@ -60,18 +55,6 @@
         "init": {
           "data": {
             "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
-            "model": "[%key:component::open_router::config_subentries::conversation::step::user::data::model%]",
-            "prompt": "[%key:common::config_flow::data::prompt%]"
-          },
-          "data_description": {
-            "model": "The model to use for the conversation agent",
-            "prompt": "Instruct how the LLM should respond. This can be a template."
-          },
-          "description": "Configure the conversation agent"
-        },
-        "user": {
-          "data": {
-            "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
             "model": "Model",
             "prompt": "[%key:common::config_flow::data::prompt%]"
           },
@@ -79,7 +62,7 @@
             "model": "The model to use for the conversation agent",
             "prompt": "Instruct how the LLM should respond. This can be a template."
           },
-          "description": "Configure the new conversation agent"
+          "description": "Configure the conversation agent"
         }
       }
     }

--- a/tests/components/open_router/__init__.py
+++ b/tests/components/open_router/__init__.py
@@ -11,3 +11,15 @@ async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) 
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+
+
+def get_subentry_id(mock_config_entry: MockConfigEntry, subentry_type: str) -> str:
+    """Get the subentry ID for a given index."""
+    ids = [
+        subentry_id
+        for subentry_id, subentry in mock_config_entry.subentries.items()
+        if subentry.subentry_type == subentry_type
+    ]
+    if not ids:
+        raise ValueError(f"No subentry found for type {subentry_type}")
+    return ids[0]

--- a/tests/components/open_router/test_config_flow.py
+++ b/tests/components/open_router/test_config_flow.py
@@ -118,7 +118,7 @@ async def test_create_conversation_agent(
     )
     assert result["type"] is FlowResultType.FORM
     assert not result["errors"]
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "init"
 
     assert result["data_schema"].schema["model"].config["options"] == [
         {"value": "openai/gpt-3.5-turbo", "label": "OpenAI: GPT-3.5 Turbo"},
@@ -157,7 +157,7 @@ async def test_create_conversation_agent_no_control(
     )
     assert result["type"] is FlowResultType.FORM
     assert not result["errors"]
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "init"
 
     assert result["data_schema"].schema["model"].config["options"] == [
         {"value": "openai/gpt-3.5-turbo", "label": "OpenAI: GPT-3.5 Turbo"},
@@ -195,7 +195,7 @@ async def test_create_ai_task(
     )
     assert result["type"] is FlowResultType.FORM
     assert not result["errors"]
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "init"
 
     assert result["data_schema"].schema["model"].config["options"] == [
         {"value": "openai/gpt-4", "label": "OpenAI: GPT-4"},

--- a/tests/components/open_router/test_config_flow.py
+++ b/tests/components/open_router/test_config_flow.py
@@ -238,3 +238,225 @@ async def test_subentry_exceptions(
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == reason
+
+
+async def test_reconfigure_conversation_agent(
+    hass: HomeAssistant,
+    mock_open_router_client: AsyncMock,
+    mock_openai_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguring a conversation agent."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Store old subentry IDs
+    old_subentries = set(mock_config_entry.subentries)
+
+    # Create a conversation agent first
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "openai/gpt-3.5-turbo",
+            CONF_PROMPT: "original prompt",
+            CONF_LLM_HASS_API: ["assist"],
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    # Get the new subentry_id
+    new_subentry_id = list(set(mock_config_entry.subentries) - old_subentries)[0]
+
+    # Now reconfigure it
+    result = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, new_subentry_id
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    # Update the configuration
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "openai/gpt-4",
+            CONF_PROMPT: "updated prompt",
+            CONF_LLM_HASS_API: ["assist"],
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+
+async def test_reconfigure_ai_task(
+    hass: HomeAssistant,
+    mock_open_router_client: AsyncMock,
+    mock_openai_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguring an AI task."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Store old subentry IDs
+    old_subentries = set(mock_config_entry.subentries)
+
+    # Create an AI task first
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "ai_task_data"),
+        context={"source": SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {CONF_MODEL: "openai/gpt-4"},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    # Get the new subentry_id
+    new_subentry_id = list(set(mock_config_entry.subentries) - old_subentries)[0]
+
+    # Now reconfigure it
+    result = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, new_subentry_id
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    # Update the configuration
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {CONF_MODEL: "openai/gpt-4"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+
+@pytest.mark.parametrize(
+    ("exception", "reason"),
+    [(OpenRouterError("exception"), "cannot_connect"), (Exception, "unknown")],
+)
+async def test_reconfigure_conversation_agent_with_error_recovery(
+    hass: HomeAssistant,
+    mock_open_router_client: AsyncMock,
+    mock_openai_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    reason: str,
+) -> None:
+    """Test reconfiguring a conversation agent with error and recovery."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Store old subentry IDs
+    old_subentries = set(mock_config_entry.subentries)
+
+    # Create a conversation agent first
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "openai/gpt-3.5-turbo",
+            CONF_PROMPT: "original prompt",
+            CONF_LLM_HASS_API: ["assist"],
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    # Get the new subentry_id
+    new_subentry_id = list(set(mock_config_entry.subentries) - old_subentries)[0]
+
+    # Trigger an error during reconfiguration
+    mock_open_router_client.get_models.side_effect = exception
+
+    result = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, new_subentry_id
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == reason
+
+    # Recover from error
+    mock_open_router_client.get_models.side_effect = None
+
+    result = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, new_subentry_id
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    # Successfully update the configuration
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "openai/gpt-4",
+            CONF_PROMPT: "updated prompt",
+            CONF_LLM_HASS_API: ["assist"],
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+
+@pytest.mark.parametrize(
+    ("exception", "reason"),
+    [(OpenRouterError("exception"), "cannot_connect"), (Exception, "unknown")],
+)
+async def test_reconfigure_ai_task_with_error_recovery(
+    hass: HomeAssistant,
+    mock_open_router_client: AsyncMock,
+    mock_openai_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    reason: str,
+) -> None:
+    """Test reconfiguring an AI task with error and recovery."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Store old subentry IDs
+    old_subentries = set(mock_config_entry.subentries)
+
+    # Create an AI task first
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "ai_task_data"),
+        context={"source": SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {CONF_MODEL: "openai/gpt-4"},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    # Get the new subentry_id
+    new_subentry_id = list(set(mock_config_entry.subentries) - old_subentries)[0]
+
+    # Trigger an error during reconfiguration
+    mock_open_router_client.get_models.side_effect = exception
+
+    result = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, new_subentry_id
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == reason
+
+    # Recover from error
+    mock_open_router_client.get_models.side_effect = None
+
+    result = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, new_subentry_id
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    # Successfully update the configuration
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {CONF_MODEL: "openai/gpt-4"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allow reconfigure open_router subentries
    
This PR allows to reconfigure subentries of open_router integration by updating models and prompt.
    
Before this PR, one could only set model and prompt when creating the subentry.
    
This specifically allows to tune the prompt or try different models provided by open_router.

<img width="1087" height="447" alt="image" src="https://github.com/user-attachments/assets/d5c7ed3a-02f9-427a-bcbf-0811ce732dbe" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
