### PR TITLE
Add support for custom spreadsheets in Google Sheets integration

### DIFF
--- a/homeassistant/components/google_sheets/__init__.py
+++ b/homeassistant/components/google_sheets/__init__.py
@@ -56,8 +56,11 @@ async def async_setup_entry(
 
 
 def async_entry_has_scopes(hass: HomeAssistant, entry: GoogleSheetsConfigEntry) -> bool:
-    """Verify that the config entry desired scope is present in the oauth token."""
-    return DEFAULT_ACCESS in entry.data.get(CONF_TOKEN, {}).get("scope", "").split(" ")
+    """Verify that the config entry desired scopes are present in the oauth token."""
+    return all(
+        scope in entry.data.get(CONF_TOKEN, {}).get("scope", "").split(" ")
+        for scope in DEFAULT_ACCESS
+    )
 
 
 async def async_unload_entry(

--- a/homeassistant/components/google_sheets/config_flow.py
+++ b/homeassistant/components/google_sheets/config_flow.py
@@ -34,7 +34,7 @@ class OAuth2FlowHandler(
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {
-            "scope": DEFAULT_ACCESS,
+            "scope": " ".join(DEFAULT_ACCESS),
             # Add params to ensure we get back a refresh token
             "access_type": "offline",
             "prompt": "consent",

--- a/homeassistant/components/google_sheets/const.py
+++ b/homeassistant/components/google_sheets/const.py
@@ -5,4 +5,7 @@ from __future__ import annotations
 DOMAIN = "google_sheets"
 
 DEFAULT_NAME = "Google Sheets"
-DEFAULT_ACCESS = "https://www.googleapis.com/auth/drive.file"
+DEFAULT_ACCESS = [
+    "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/spreadsheets",
+]

--- a/homeassistant/components/google_sheets/services.py
+++ b/homeassistant/components/google_sheets/services.py
@@ -23,7 +23,6 @@ from homeassistant.core import (
 )
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.selector import ConfigEntrySelector
 from homeassistant.util.json import JsonObjectType
 
 from .const import DOMAIN
@@ -33,25 +32,25 @@ if TYPE_CHECKING:
 
 ADD_CREATED_COLUMN = "add_created_column"
 DATA = "data"
-DATA_CONFIG_ENTRY = "config_entry"
 ROWS = "rows"
+SPREADSHEET_ID = "spreadsheet_id"
 WORKSHEET = "worksheet"
 
 SERVICE_APPEND_SHEET = "append_sheet"
 SERVICE_GET_SHEET = "get_sheet"
 
-SHEET_SERVICE_SCHEMA = vol.All(
+APPEND_SHEET_SERVICE_SCHEMA = vol.All(
     {
-        vol.Required(DATA_CONFIG_ENTRY): ConfigEntrySelector({"integration": DOMAIN}),
+        vol.Optional(SPREADSHEET_ID): cv.string,
         vol.Optional(WORKSHEET): cv.string,
         vol.Optional(ADD_CREATED_COLUMN, default=True): cv.boolean,
         vol.Required(DATA): vol.Any(cv.ensure_list, [dict]),
     },
 )
 
-get_SHEET_SERVICE_SCHEMA = vol.All(
+GET_SHEET_SERVICE_SCHEMA = vol.All(
     {
-        vol.Required(DATA_CONFIG_ENTRY): ConfigEntrySelector({"integration": DOMAIN}),
+        vol.Optional(SPREADSHEET_ID): cv.string,
         vol.Optional(WORKSHEET): cv.string,
         vol.Required(ROWS): cv.positive_int,
     },
@@ -62,14 +61,18 @@ def _append_to_sheet(call: ServiceCall, entry: GoogleSheetsConfigEntry) -> None:
     """Run append in the executor."""
     service = Client(Credentials(entry.data[CONF_TOKEN][CONF_ACCESS_TOKEN]))  # type: ignore[no-untyped-call]
     try:
-        sheet = service.open_by_key(entry.unique_id)
+        spreadsheet = service.open_by_key(
+            call.data.get(SPREADSHEET_ID, entry.unique_id)
+        )
     except RefreshError:
         entry.async_start_reauth(call.hass)
         raise
     except APIError as ex:
         raise HomeAssistantError("Failed to write data") from ex
 
-    worksheet = sheet.worksheet(call.data.get(WORKSHEET, sheet.sheet1.title))
+    worksheet = spreadsheet.worksheet(
+        call.data.get(WORKSHEET, spreadsheet.sheet1.title)
+    )
     columns: list[str] = next(iter(worksheet.get_values("A1:ZZ1")), [])
     add_created_column = call.data[ADD_CREATED_COLUMN]
     now = str(datetime.now())
@@ -92,41 +95,61 @@ def _get_from_sheet(
     """Run get in the executor."""
     service = Client(Credentials(entry.data[CONF_TOKEN][CONF_ACCESS_TOKEN]))  # type: ignore[no-untyped-call]
     try:
-        sheet = service.open_by_key(entry.unique_id)
+        spreadsheet = service.open_by_key(
+            call.data.get(SPREADSHEET_ID, entry.unique_id)
+        )
     except RefreshError:
         entry.async_start_reauth(call.hass)
         raise
     except APIError as ex:
         raise HomeAssistantError("Failed to retrieve data") from ex
 
-    worksheet = sheet.worksheet(call.data.get(WORKSHEET, sheet.sheet1.title))
+    worksheet = spreadsheet.worksheet(
+        call.data.get(WORKSHEET, spreadsheet.sheet1.title)
+    )
     all_values = worksheet.get_values()
     return {"range": all_values[-call.data[ROWS] :]}
 
 
+def _get_config_entry(call: ServiceCall) -> GoogleSheetsConfigEntry:
+    """Get the config entry for the service call."""
+    entries: list[GoogleSheetsConfigEntry] = call.hass.config_entries.async_entries(
+        DOMAIN
+    )
+
+    if not entries:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="missing_config_entry",
+        )
+
+    if len(entries) > 1:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="multiple_config_entries",
+        )
+
+    entry = entries[0]
+
+    if entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="config_entry_not_loaded",
+        )
+
+    return entry
+
+
 async def _async_append_to_sheet(call: ServiceCall) -> None:
     """Append new line of data to a Google Sheets document."""
-    entry: GoogleSheetsConfigEntry | None = call.hass.config_entries.async_get_entry(
-        call.data[DATA_CONFIG_ENTRY]
-    )
-    if not entry or not hasattr(entry, "runtime_data"):
-        raise ValueError(f"Invalid config entry: {call.data[DATA_CONFIG_ENTRY]}")
+    entry = _get_config_entry(call)
     await entry.runtime_data.async_ensure_token_valid()
     await call.hass.async_add_executor_job(_append_to_sheet, call, entry)
 
 
 async def _async_get_from_sheet(call: ServiceCall) -> ServiceResponse:
     """Get lines of data from a Google Sheets document."""
-    entry: GoogleSheetsConfigEntry | None = call.hass.config_entries.async_get_entry(
-        call.data[DATA_CONFIG_ENTRY]
-    )
-    if entry is None:
-        raise ServiceValidationError(
-            f"Invalid config entry id: {call.data[DATA_CONFIG_ENTRY]}"
-        )
-    if entry.state is not ConfigEntryState.LOADED:
-        raise HomeAssistantError(f"Config entry {entry.entry_id} is not loaded")
-
+    entry = _get_config_entry(call)
     await entry.runtime_data.async_ensure_token_valid()
     return await call.hass.async_add_executor_job(_get_from_sheet, call, entry)
 
@@ -139,13 +162,13 @@ def async_setup_services(hass: HomeAssistant) -> None:
         DOMAIN,
         SERVICE_APPEND_SHEET,
         _async_append_to_sheet,
-        schema=SHEET_SERVICE_SCHEMA,
+        schema=APPEND_SHEET_SERVICE_SCHEMA,
     )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_GET_SHEET,
         _async_get_from_sheet,
-        schema=get_SHEET_SERVICE_SCHEMA,
+        schema=GET_SHEET_SERVICE_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )

--- a/homeassistant/components/google_sheets/services.yaml
+++ b/homeassistant/components/google_sheets/services.yaml
@@ -1,10 +1,8 @@
 append_sheet:
   fields:
-    config_entry:
-      required: true
+    spreadsheet_id:
       selector:
-        config_entry:
-          integration: google_sheets
+        text:
     worksheet:
       example: "Sheet1"
       selector:
@@ -21,11 +19,9 @@ append_sheet:
         object:
 get_sheet:
   fields:
-    config_entry:
-      required: true
+    spreadsheet_id:
       selector:
-        config_entry:
-          integration: google_sheets
+        text:
     worksheet:
       example: "Sheet1"
       selector:

--- a/homeassistant/components/google_sheets/strings.json
+++ b/homeassistant/components/google_sheets/strings.json
@@ -41,6 +41,17 @@
       }
     }
   },
+  "exceptions": {
+    "config_entry_not_loaded": {
+      "message": "Config entry for Google Sheets service is not loaded"
+    },
+    "missing_config_entry": {
+      "message": "No config entry found for Google Sheets service"
+    },
+    "multiple_config_entries": {
+      "message": "Multiple config entries found for Google Sheets service"
+    }
+  },
   "services": {
     "append_sheet": {
       "description": "Appends data to a worksheet in Google Sheets.",
@@ -49,13 +60,13 @@
           "description": "Add a \"created\" column with the current date-time to the appended data.",
           "name": "Add created column"
         },
-        "config_entry": {
-          "description": "The sheet to add data to.",
-          "name": "Sheet"
-        },
         "data": {
           "description": "Data to be appended to the worksheet. This puts the values on new rows underneath the matching column (key). Any new key is placed on the top of a new column.",
           "name": "Data"
+        },
+        "spreadsheet_id": {
+          "description": "The ID of the spreadsheet to add data to. If not specified, the default spreadsheet created alongside this integration is used.",
+          "name": "Spreadsheet ID"
         },
         "worksheet": {
           "description": "Name of the worksheet. Defaults to the first one in the document.",
@@ -67,13 +78,13 @@
     "get_sheet": {
       "description": "Gets data from a worksheet in Google Sheets.",
       "fields": {
-        "config_entry": {
-          "description": "The sheet to get data from.",
-          "name": "[%key:component::google_sheets::services::append_sheet::fields::config_entry::name%]"
-        },
         "rows": {
           "description": "Maximum number of rows from the end of the worksheet to return.",
           "name": "Rows"
+        },
+        "spreadsheet_id": {
+          "description": "The ID of the spreadsheet to get data from. If not specified, the default spreadsheet created alongside this integration is used.",
+          "name": "[%key:component::google_sheets::services::append_sheet::fields::spreadsheet_id::name%]"
         },
         "worksheet": {
           "description": "[%key:component::google_sheets::services::append_sheet::fields::worksheet::description%]",

--- a/tests/components/google_sheets/test_config_flow.py
+++ b/tests/components/google_sheets/test_config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
+from homeassistant.components.google_sheets import DEFAULT_ACCESS
 from homeassistant.components.google_sheets.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -72,7 +73,7 @@ async def test_full_flow(
     assert result["url"] == (
         f"{GOOGLE_AUTH_URI}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
-        f"&state={state}&scope=https://www.googleapis.com/auth/drive.file"
+        f"&state={state}&scope={'+'.join(DEFAULT_ACCESS)}"
         "&access_type=offline&prompt=consent"
     )
 
@@ -139,7 +140,7 @@ async def test_create_sheet_error(
     assert result["url"] == (
         f"{GOOGLE_AUTH_URI}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
-        f"&state={state}&scope=https://www.googleapis.com/auth/drive.file"
+        f"&state={state}&scope={'+'.join(DEFAULT_ACCESS)}"
         "&access_type=offline&prompt=consent"
     )
 
@@ -208,7 +209,7 @@ async def test_reauth(
     assert result["url"] == (
         f"{GOOGLE_AUTH_URI}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
-        f"&state={state}&scope=https://www.googleapis.com/auth/drive.file"
+        f"&state={state}&scope={'+'.join(DEFAULT_ACCESS)}"
         "&access_type=offline&prompt=consent"
     )
     client = await hass_client_no_auth()
@@ -290,7 +291,7 @@ async def test_reauth_abort(
     assert result["url"] == (
         f"{GOOGLE_AUTH_URI}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
-        f"&state={state}&scope=https://www.googleapis.com/auth/drive.file"
+        f"&state={state}&scope={'+'.join(DEFAULT_ACCESS)}"
         "&access_type=offline&prompt=consent"
     )
     client = await hass_client_no_auth()
@@ -353,7 +354,7 @@ async def test_already_configured(
     assert result["url"] == (
         f"{GOOGLE_AUTH_URI}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
-        f"&state={state}&scope=https://www.googleapis.com/auth/drive.file"
+        f"&state={state}&scope={'+'.join(DEFAULT_ACCESS)}"
         "&access_type=offline&prompt=consent"
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `config_entry` parameter has been removed in place of a new optional `spreadsheet_id` parameter. This has been done to allow for any number of spreadsheets to be used with the integration at once.

Note: The integration is still created with a default spreadsheet whose ID is stored in the integration's config entry. This is done for both authentication validation, to provide a default spreadsheet across all actions, and to minimize migration efforts.

To migrate, replace `config_entry: <CONFIG_ENTRY_ID>` with `spreadsheet_id: <SPREADSHEET_ID>`. Alternatively, you can remove `config_entry` and exclude the `spreadsheet_id ` parameter to continue using the default spreadsheet stored in the config entry for the integration.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the ability to use any spreadsheet owned by the user with the integration. This means users can use different spreadsheets for different actions and automations.

It also means that users can easily switch which spreadsheet they write to or read from, without having to manually modify the config entry (I'm new to HA so I'm not even sure if that's possible, but if it is, this PR makes the process much simpler!).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: TODO
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
