### PR TITLE
Make velux rain sensor unavailable if update fails

### DIFF
--- a/homeassistant/components/velux/binary_sensor.py
+++ b/homeassistant/components/velux/binary_sensor.py
@@ -66,7 +66,7 @@ class VeluxRainSensor(VeluxEntity, BinarySensorEntity):
             limitation = await self.node.get_limitation()
         except (OSError, PyVLXException) as err:
             if not self._unavailable_logged:
-                LOGGER.info(
+                LOGGER.warning(
                     "Rain sensor %s is unavailable: %s",
                     self.entity_id,
                     err,

--- a/homeassistant/components/velux/binary_sensor.py
+++ b/homeassistant/components/velux/binary_sensor.py
@@ -52,7 +52,6 @@ class VeluxRainSensor(VeluxEntity, BinarySensorEntity):
         super().__init__(node, config_entry_id)
         self._attr_unique_id = f"{self._attr_unique_id}_rain_sensor"
 
-    @property
     async def async_update(self) -> None:
         """Fetch the latest state from the device."""
         try:

--- a/homeassistant/components/velux/binary_sensor.py
+++ b/homeassistant/components/velux/binary_sensor.py
@@ -45,12 +45,12 @@ class VeluxRainSensor(VeluxEntity, BinarySensorEntity):
     _attr_entity_registry_enabled_default = False
     _attr_device_class = BinarySensorDeviceClass.MOISTURE
     _attr_translation_key = "rain_sensor"
+    _unavailable_logged = False
 
     def __init__(self, node: OpeningDevice, config_entry_id: str) -> None:
         """Initialize VeluxRainSensor."""
         super().__init__(node, config_entry_id)
         self._attr_unique_id = f"{self._attr_unique_id}_rain_sensor"
-        self._unavailable_logged = False
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/velux/binary_sensor.py
+++ b/homeassistant/components/velux/binary_sensor.py
@@ -53,13 +53,6 @@ class VeluxRainSensor(VeluxEntity, BinarySensorEntity):
         self._attr_unique_id = f"{self._attr_unique_id}_rain_sensor"
 
     @property
-    def available(self) -> bool:
-        """Return if entity is available.
-
-        Rain sensor is polled, so we just use _attr_available
-        """
-        return self._attr_available
-
     async def async_update(self) -> None:
         """Fetch the latest state from the device."""
         try:

--- a/homeassistant/components/velux/binary_sensor.py
+++ b/homeassistant/components/velux/binary_sensor.py
@@ -64,7 +64,7 @@ class VeluxRainSensor(VeluxEntity, BinarySensorEntity):
         """Fetch the latest state from the device."""
         try:
             limitation = await self.node.get_limitation()
-        except PyVLXException as err:
+        except (OSError, PyVLXException) as err:
             if not self._unavailable_logged:
                 LOGGER.info(
                     "Rain sensor %s is unavailable: %s",

--- a/tests/components/velux/__init__.py
+++ b/tests/components/velux/__init__.py
@@ -28,4 +28,4 @@ async def update_polled_entities(
 
     freezer.tick(timedelta(minutes=5))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/velux/test_binary_sensor.py
+++ b/tests/components/velux/test_binary_sensor.py
@@ -4,9 +4,10 @@ from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from pyvlx.exception import PyVLXException
 
 from homeassistant.components.velux import DOMAIN
-from homeassistant.const import STATE_OFF, STATE_ON, Platform
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
@@ -22,7 +23,9 @@ def platform() -> Platform:
     return Platform.BINARY_SENSOR
 
 
-@pytest.mark.usefixtures("setup_integration")
+pytestmark = pytest.mark.usefixtures("setup_integration")
+
+
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_rain_sensor_state(
     hass: HomeAssistant,
@@ -61,7 +64,6 @@ async def test_rain_sensor_state(
     assert state.state == STATE_OFF
 
 
-@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_rain_sensor_device_association(
     hass: HomeAssistant,
@@ -98,3 +100,67 @@ async def test_rain_sensor_device_association(
     assert via_device_entry.identifiers == {
         (DOMAIN, f"gateway_{mock_config_entry.entry_id}")
     }
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_rain_sensor_unavailability(
+    hass: HomeAssistant,
+    mock_window: MagicMock,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test rain sensor becomes unavailable on errors and logs appropriately."""
+
+    test_entity_id = "binary_sensor.test_window_rain_sensor"
+
+    # Entity should be available initially
+    state = hass.states.get(test_entity_id)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+    # Simulate communication error
+    mock_window.get_limitation.side_effect = PyVLXException("Connection failed")
+    await update_polled_entities(hass, freezer)
+
+    # Entity should now be unavailable
+    state = hass.states.get(test_entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    # Verify unavailability was logged once
+    assert (
+        "Rain sensor binary_sensor.test_window_rain_sensor is unavailable"
+        in caplog.text
+    )
+    assert "Connection failed" in caplog.text
+    caplog.clear()
+
+    # Another update attempt should not log again (already logged)
+    await update_polled_entities(hass, freezer)
+    state = hass.states.get(test_entity_id)
+    assert state.state == STATE_UNAVAILABLE
+    assert "is unavailable" not in caplog.text
+    caplog.clear()
+
+    # Simulate recovery
+    mock_window.get_limitation.side_effect = None
+    mock_window.get_limitation.return_value.min_value = 95
+    await update_polled_entities(hass, freezer)
+
+    # Entity should be available again
+    state = hass.states.get(test_entity_id)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+    # Verify recovery was logged
+    assert (
+        "Rain sensor binary_sensor.test_window_rain_sensor is back online"
+        in caplog.text
+    )
+    caplog.clear()
+
+    # Another successful update should not log recovery again
+    await update_polled_entities(hass, freezer)
+    state = hass.states.get(test_entity_id)
+    assert state.state == STATE_OFF
+    assert "back online" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
This PR is part one of two, making entities unavailable if update fails. This is for the polled rain sensor. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #159523
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
