### PR TITLE
Refactor Actron Air climate and switch entities to inherit from a new base entity class

### DIFF
--- a/homeassistant/components/actron_air/climate.py
+++ b/homeassistant/components/actron_air/climate.py
@@ -17,10 +17,10 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import ActronAirConfigEntry, ActronAirSystemCoordinator
+from .entity import ActronAirEntity
 
 PARALLEL_UPDATES = 0
 
@@ -56,8 +56,7 @@ async def async_setup_entry(
 
     for coordinator in system_coordinators.values():
         status = coordinator.data
-        name = status.ac_system.system_name
-        entities.append(ActronSystemClimate(coordinator, name))
+        entities.append(ActronSystemClimate(coordinator))
 
         entities.extend(
             ActronZoneClimate(coordinator, zone)
@@ -68,10 +67,9 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class BaseClimateEntity(CoordinatorEntity[ActronAirSystemCoordinator], ClimateEntity):
+class ActronAirClimateEntity(ActronAirEntity, ClimateEntity):
     """Base class for Actron Air climate entities."""
 
-    _attr_has_entity_name = True
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE
@@ -83,43 +81,17 @@ class BaseClimateEntity(CoordinatorEntity[ActronAirSystemCoordinator], ClimateEn
     _attr_fan_modes = list(FAN_MODE_MAPPING_ACTRONAIR_TO_HA.values())
     _attr_hvac_modes = list(HVAC_MODE_MAPPING_ACTRONAIR_TO_HA.values())
 
+
+class ActronSystemClimate(ActronAirClimateEntity):
+    """Representation of the Actron Air system."""
+
     def __init__(
         self,
         coordinator: ActronAirSystemCoordinator,
-        name: str,
     ) -> None:
         """Initialize an Actron Air unit."""
         super().__init__(coordinator)
-        self._serial_number = coordinator.serial_number
-
-
-class ActronSystemClimate(BaseClimateEntity):
-    """Representation of the Actron Air system."""
-
-    _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.FAN_MODE
-        | ClimateEntityFeature.TURN_ON
-        | ClimateEntityFeature.TURN_OFF
-    )
-
-    def __init__(
-        self,
-        coordinator: ActronAirSystemCoordinator,
-        name: str,
-    ) -> None:
-        """Initialize an Actron Air unit."""
-        super().__init__(coordinator, name)
-        serial_number = coordinator.serial_number
-        self._attr_unique_id = serial_number
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, serial_number)},
-            name=self._status.ac_system.system_name,
-            manufacturer="Actron Air",
-            model_id=self._status.ac_system.master_wc_model,
-            sw_version=self._status.ac_system.master_wc_firmware_version,
-            serial_number=serial_number,
-        )
+        self._attr_unique_id = self._serial_number
 
     @property
     def min_temp(self) -> float:
@@ -168,7 +140,7 @@ class ActronSystemClimate(BaseClimateEntity):
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set a new fan mode."""
-        api_fan_mode = FAN_MODE_MAPPING_HA_TO_ACTRONAIR.get(fan_mode.lower())
+        api_fan_mode = FAN_MODE_MAPPING_HA_TO_ACTRONAIR.get(fan_mode)
         await self._status.user_aircon_settings.set_fan_mode(api_fan_mode)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
@@ -182,7 +154,7 @@ class ActronSystemClimate(BaseClimateEntity):
         await self._status.user_aircon_settings.set_temperature(temperature=temp)
 
 
-class ActronZoneClimate(BaseClimateEntity):
+class ActronZoneClimate(ActronAirClimateEntity):
     """Representation of a zone within the Actron Air system."""
 
     _attr_supported_features = (
@@ -197,17 +169,16 @@ class ActronZoneClimate(BaseClimateEntity):
         zone: ActronAirZone,
     ) -> None:
         """Initialize an Actron Air unit."""
-        super().__init__(coordinator, zone.title)
-        serial_number = coordinator.serial_number
+        super().__init__(coordinator)
         self._zone_id: int = zone.zone_id
-        self._attr_unique_id: str = f"{serial_number}_zone_{zone.zone_id}"
+        self._attr_unique_id: str = f"{self._serial_number}_zone_{zone.zone_id}"
         self._attr_device_info: DeviceInfo = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
             name=zone.title,
             manufacturer="Actron Air",
             model="Zone",
             suggested_area=zone.title,
-            via_device=(DOMAIN, serial_number),
+            via_device=(DOMAIN, self._serial_number),
         )
 
     @property
@@ -256,4 +227,4 @@ class ActronZoneClimate(BaseClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the temperature."""
-        await self._zone.set_temperature(temperature=kwargs["temperature"])
+        await self._zone.set_temperature(temperature=kwargs.get(ATTR_TEMPERATURE))

--- a/homeassistant/components/actron_air/coordinator.py
+++ b/homeassistant/components/actron_air/coordinator.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from actron_neo_api import (
     ActronAirACSystem,
     ActronAirAPI,
+    ActronAirAPIError,
     ActronAirAuthError,
     ActronAirStatus,
 )
@@ -15,7 +16,7 @@ from actron_neo_api import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .const import _LOGGER, DOMAIN
@@ -69,6 +70,12 @@ class ActronAirSystemCoordinator(DataUpdateCoordinator[ActronAirACSystem]):
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="auth_error",
+            ) from err
+        except ActronAirAPIError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_error",
+                translation_placeholders={"error": repr(err)},
             ) from err
 
         self.status = self.api.state_manager.get_status(self.serial_number)

--- a/homeassistant/components/actron_air/entity.py
+++ b/homeassistant/components/actron_air/entity.py
@@ -1,5 +1,7 @@
 """Base entity classes for Actron Air integration."""
 
+from actron_neo_api import ActronAirZone
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -7,7 +9,7 @@ from .const import DOMAIN
 from .coordinator import ActronAirSystemCoordinator
 
 
-class ActronAirEntity(CoordinatorEntity[ActronAirSystemCoordinator]):
+class ActronAirAcEntity(CoordinatorEntity[ActronAirSystemCoordinator]):
     """Base class for Actron Air entities."""
 
     _attr_has_entity_name = True
@@ -30,3 +32,25 @@ class ActronAirEntity(CoordinatorEntity[ActronAirSystemCoordinator]):
     def available(self) -> bool:
         """Return True if entity is available."""
         return not self.coordinator.is_device_stale()
+
+
+class ActronAirZoneEntity(ActronAirAcEntity):
+    """Base class for Actron Air zone entities."""
+
+    def __init__(
+        self,
+        coordinator: ActronAirSystemCoordinator,
+        zone: ActronAirZone,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._zone_id: int = zone.zone_id
+        self._zone_identifier = f"{self._serial_number}_zone_{zone.zone_id}"
+        self._attr_device_info: DeviceInfo = DeviceInfo(
+            identifiers={(DOMAIN, self._zone_identifier)},
+            name=zone.title,
+            manufacturer="Actron Air",
+            model="Zone",
+            suggested_area=zone.title,
+            via_device=(DOMAIN, self._serial_number),
+        )

--- a/homeassistant/components/actron_air/entity.py
+++ b/homeassistant/components/actron_air/entity.py
@@ -1,0 +1,32 @@
+"""Base entity classes for Actron Air integration."""
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import ActronAirSystemCoordinator
+
+
+class ActronAirEntity(CoordinatorEntity[ActronAirSystemCoordinator]):
+    """Base class for Actron Air entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: ActronAirSystemCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._serial_number = coordinator.serial_number
+
+        self._attr_device_info: DeviceInfo = DeviceInfo(
+            identifiers={(DOMAIN, self._serial_number)},
+            name=coordinator.data.ac_system.system_name,
+            manufacturer="Actron Air",
+            model_id=coordinator.data.ac_system.master_wc_model,
+            sw_version=coordinator.data.ac_system.master_wc_firmware_version,
+            serial_number=self._serial_number,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return not self.coordinator.is_device_stale()

--- a/homeassistant/components/actron_air/entity.py
+++ b/homeassistant/components/actron_air/entity.py
@@ -31,7 +31,7 @@ class ActronAirAcEntity(ActronAirEntity):
     def __init__(self, coordinator: ActronAirSystemCoordinator) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
-        self._attr_device_info: DeviceInfo = DeviceInfo(
+        self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._serial_number)},
             name=coordinator.data.ac_system.system_name,
             manufacturer="Actron Air",
@@ -53,7 +53,7 @@ class ActronAirZoneEntity(ActronAirEntity):
         super().__init__(coordinator)
         self._zone_id: int = zone.zone_id
         self._zone_identifier = f"{self._serial_number}_zone_{zone.zone_id}"
-        self._attr_device_info: DeviceInfo = DeviceInfo(
+        self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._zone_identifier)},
             name=zone.title,
             manufacturer="Actron Air",

--- a/homeassistant/components/actron_air/entity.py
+++ b/homeassistant/components/actron_air/entity.py
@@ -9,7 +9,7 @@ from .const import DOMAIN
 from .coordinator import ActronAirSystemCoordinator
 
 
-class ActronAirAcEntity(CoordinatorEntity[ActronAirSystemCoordinator]):
+class ActronAirEntity(CoordinatorEntity[ActronAirSystemCoordinator]):
     """Base class for Actron Air entities."""
 
     _attr_has_entity_name = True
@@ -19,6 +19,18 @@ class ActronAirAcEntity(CoordinatorEntity[ActronAirSystemCoordinator]):
         super().__init__(coordinator)
         self._serial_number = coordinator.serial_number
 
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return not self.coordinator.is_device_stale()
+
+
+class ActronAirAcEntity(ActronAirEntity):
+    """Base class for Actron Air entities."""
+
+    def __init__(self, coordinator: ActronAirSystemCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
         self._attr_device_info: DeviceInfo = DeviceInfo(
             identifiers={(DOMAIN, self._serial_number)},
             name=coordinator.data.ac_system.system_name,
@@ -28,13 +40,8 @@ class ActronAirAcEntity(CoordinatorEntity[ActronAirSystemCoordinator]):
             serial_number=self._serial_number,
         )
 
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return not self.coordinator.is_device_stale()
 
-
-class ActronAirZoneEntity(ActronAirAcEntity):
+class ActronAirZoneEntity(ActronAirEntity):
     """Base class for Actron Air zone entities."""
 
     def __init__(

--- a/homeassistant/components/actron_air/quality_scale.yaml
+++ b/homeassistant/components/actron_air/quality_scale.yaml
@@ -34,7 +34,7 @@ rules:
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: done
+  log-when-unavailable: todo
   parallel-updates: done
   reauthentication-flow: done
   test-coverage: todo

--- a/homeassistant/components/actron_air/quality_scale.yaml
+++ b/homeassistant/components/actron_air/quality_scale.yaml
@@ -34,7 +34,7 @@ rules:
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: todo
+  log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
   test-coverage: todo

--- a/homeassistant/components/actron_air/strings.json
+++ b/homeassistant/components/actron_air/strings.json
@@ -51,6 +51,9 @@
   "exceptions": {
     "auth_error": {
       "message": "Authentication failed, please reauthenticate"
+    },
+    "update_error": {
+      "message": "An error occurred while retrieving data from the Actron Air API: {error}"
     }
   }
 }

--- a/homeassistant/components/actron_air/switch.py
+++ b/homeassistant/components/actron_air/switch.py
@@ -7,12 +7,10 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
 from .coordinator import ActronAirConfigEntry, ActronAirSystemCoordinator
+from .entity import ActronAirEntity
 
 PARALLEL_UPDATES = 0
 
@@ -74,10 +72,9 @@ async def async_setup_entry(
     )
 
 
-class ActronAirSwitch(CoordinatorEntity[ActronAirSystemCoordinator], SwitchEntity):
+class ActronAirSwitch(ActronAirEntity, SwitchEntity):
     """Actron Air switch."""
 
-    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
     entity_description: ActronAirSwitchEntityDescription
 
@@ -90,11 +87,6 @@ class ActronAirSwitch(CoordinatorEntity[ActronAirSystemCoordinator], SwitchEntit
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.serial_number}_{description.key}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.serial_number)},
-            manufacturer="Actron Air",
-            name=coordinator.data.ac_system.system_name,
-        )
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/actron_air/switch.py
+++ b/homeassistant/components/actron_air/switch.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import ActronAirConfigEntry, ActronAirSystemCoordinator
-from .entity import ActronAirEntity
+from .entity import ActronAirAcEntity
 
 PARALLEL_UPDATES = 0
 
@@ -72,7 +72,7 @@ async def async_setup_entry(
     )
 
 
-class ActronAirSwitch(ActronAirEntity, SwitchEntity):
+class ActronAirSwitch(ActronAirAcEntity, SwitchEntity):
     """Actron Air switch."""
 
     _attr_entity_category = EntityCategory.CONFIG


### PR DESCRIPTION
## Proposed change
This PR implements a new base entity class in entity.py, and implements that in climate.py and switch.py. 
Implements log-when-unavailable per copilot recommendation as this was marked implemented incorrectly. 


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
