### PR TITLE
Sensirion MyCO2: Disable inaccurate entities per default

### DIFF
--- a/homeassistant/components/sensirion_ble/sensor.py
+++ b/homeassistant/components/sensirion_ble/sensor.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import dataclasses
+import logging
+
 from sensor_state_data import (
     DeviceKey,
     SensorDescription,
@@ -34,6 +37,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 SENSOR_DESCRIPTIONS: dict[
     tuple[SSDSensorDeviceClass, Units | None], SensorEntityDescription
@@ -80,15 +85,57 @@ def sensor_update_to_bluetooth_data_update(
     sensor_update: SensorUpdate,
 ) -> PassiveBluetoothDataUpdate:
     """Convert a sensor update to a bluetooth data update."""
+
+    def enable_entity_by_default(device_key: DeviceKey) -> bool:
+        """Return true if the entity should be enabled by default, false otherwise.
+
+        The purpose of this function is to assist with reducing the resources spent on collecting junk data from
+        entities known to report inaccurate values.
+
+        Background:
+        The main purpose of the Sensirion MyCO2 gadget is to report CO₂ values, and it does so precisely. However,
+        the additionally reported values (humidity, temperature) are not accurate. For example, in a real world setup
+        with five pairs of each one MyCO2 gadget and a much more precise SHT43 DemoBoard, the reported humidity is off
+        by 5-8 %, and the temperature by 1.3-2.8 °C. Those inaccuracies roughly match the performance stated in the
+        data sheet of the SCD4x.
+        As the official Sensirion Android app displays neither temperature nor humidity reported by the MyCO2 gadget, we
+        should not, per default, enable those entities either.
+        """
+
+        # Bail out early if an unexpected sensor update gets passed.
+        if (count := len(sensor_update.devices)) != 1:
+            _LOGGER.warning(
+                "Expecting exactly one device in a sensor update, but got %s", count
+            )
+            return True
+
+        # Extract the first (and only) device info.
+        (device_info,) = sensor_update.devices.values()
+
+        # Values reported by devices other than the MyCO2 gadget are always enabled.
+        if device_info.model != "Sensirion MyCO2":
+            return True
+
+        # Temperature and humidity values are inaccurate and should be disabled by default.
+        if device_key.key in (
+            SensorDeviceClass.HUMIDITY,
+            SensorDeviceClass.TEMPERATURE,
+        ):
+            return False
+
+        # At this point, only the CO₂ entity of the Sensirion MyCO2 gadget should be left.
+        return True
+
     return PassiveBluetoothDataUpdate(
         devices={
             device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
         entity_descriptions={
-            _device_key_to_bluetooth_entity_key(device_key): SENSOR_DESCRIPTIONS[
-                _to_sensor_key(description)
-            ]
+            _device_key_to_bluetooth_entity_key(device_key): dataclasses.replace(
+                SENSOR_DESCRIPTIONS[_to_sensor_key(description)],
+                entity_registry_enabled_default=enable_entity_by_default(device_key),
+            )
             for device_key, description in sensor_update.entity_descriptions.items()
             if _to_sensor_key(description) in SENSOR_DESCRIPTIONS
         },

--- a/tests/components/sensirion_ble/fixtures.py
+++ b/tests/components/sensirion_ble/fixtures.py
@@ -12,7 +12,7 @@ NOT_SENSIRION_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
-SENSIRION_SERVICE_INFO = BluetoothServiceInfo(
+SENSIRION_SERVICE_INFO_MYCO2 = BluetoothServiceInfo(
     name="MyCO2",
     address="01:03:05:07:09:11",  # Ignored (the payload encodes a device ID)
     rssi=-60,
@@ -23,5 +23,5 @@ SENSIRION_SERVICE_INFO = BluetoothServiceInfo(
     service_uuids=[],
     source="local",
 )
-CONFIGURED_NAME = "MyCO2 84E3"
-CONFIGURED_PREFIX = "myco2_84e3"
+CONFIGURED_NAME_MYCO2 = "MyCO2 84E3"
+CONFIGURED_PREFIX_MYCO2 = "myco2_84e3"

--- a/tests/components/sensirion_ble/fixtures.py
+++ b/tests/components/sensirion_ble/fixtures.py
@@ -25,3 +25,17 @@ SENSIRION_SERVICE_INFO_MYCO2 = BluetoothServiceInfo(
 )
 CONFIGURED_NAME_MYCO2 = "MyCO2 84E3"
 CONFIGURED_PREFIX_MYCO2 = "myco2_84e3"
+
+SENSIRION_SERVICE_INFO_SHT43 = BluetoothServiceInfo(
+    name="SHT43 DB",
+    address="01:03:05:07:09:12",  # Ignored (the payload encodes a device ID)
+    rssi=-60,
+    manufacturer_data={
+        0x06D5: b"\x00\x06\x3a\xc2\x3c\x61\xf9\x69",
+    },
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
+CONFIGURED_NAME_SHT43 = "SHT43 DB 3AC2"
+CONFIGURED_PREFIX_SHT43 = "sht43_db_3ac2"

--- a/tests/components/sensirion_ble/test_config_flow.py
+++ b/tests/components/sensirion_ble/test_config_flow.py
@@ -11,9 +11,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from .fixtures import (
-    CONFIGURED_NAME,
+    CONFIGURED_NAME_MYCO2,
     NOT_SENSIRION_SERVICE_INFO,
-    SENSIRION_SERVICE_INFO,
+    SENSIRION_SERVICE_INFO_MYCO2,
 )
 
 from tests.common import MockConfigEntry
@@ -29,7 +29,7 @@ async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=SENSIRION_SERVICE_INFO,
+        data=SENSIRION_SERVICE_INFO_MYCO2,
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
@@ -40,8 +40,8 @@ async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
             result["flow_id"], user_input={}
         )
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == CONFIGURED_NAME
-    assert result2["result"].unique_id == SENSIRION_SERVICE_INFO.address
+    assert result2["title"] == CONFIGURED_NAME_MYCO2
+    assert result2["result"].unique_id == SENSIRION_SERVICE_INFO_MYCO2.address
 
 
 async def test_async_step_bluetooth_not_sensirion(hass: HomeAssistant) -> None:
@@ -69,7 +69,7 @@ async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.sensirion_ble.config_flow.async_discovered_service_info",
-        return_value=[SENSIRION_SERVICE_INFO],
+        return_value=[SENSIRION_SERVICE_INFO_MYCO2],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -82,18 +82,18 @@ async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"address": SENSIRION_SERVICE_INFO.address},
+            user_input={"address": SENSIRION_SERVICE_INFO_MYCO2.address},
         )
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == CONFIGURED_NAME
-    assert result2["result"].unique_id == SENSIRION_SERVICE_INFO.address
+    assert result2["title"] == CONFIGURED_NAME_MYCO2
+    assert result2["result"].unique_id == SENSIRION_SERVICE_INFO_MYCO2.address
 
 
 async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.sensirion_ble.config_flow.async_discovered_service_info",
-        return_value=[SENSIRION_SERVICE_INFO],
+        return_value=[SENSIRION_SERVICE_INFO_MYCO2],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -104,7 +104,7 @@ async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -
 
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=SENSIRION_SERVICE_INFO.address,
+        unique_id=SENSIRION_SERVICE_INFO_MYCO2.address,
     )
     entry.add_to_hass(hass)
 
@@ -113,7 +113,7 @@ async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"address": SENSIRION_SERVICE_INFO.address},
+            user_input={"address": SENSIRION_SERVICE_INFO_MYCO2.address},
         )
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
@@ -125,13 +125,13 @@ async def test_async_step_user_with_found_devices_already_setup(
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=SENSIRION_SERVICE_INFO.address,
+        unique_id=SENSIRION_SERVICE_INFO_MYCO2.address,
     )
     entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.sensirion_ble.config_flow.async_discovered_service_info",
-        return_value=[SENSIRION_SERVICE_INFO],
+        return_value=[SENSIRION_SERVICE_INFO_MYCO2],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -145,14 +145,14 @@ async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=SENSIRION_SERVICE_INFO.address,
+        unique_id=SENSIRION_SERVICE_INFO_MYCO2.address,
     )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=SENSIRION_SERVICE_INFO,
+        data=SENSIRION_SERVICE_INFO_MYCO2,
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -163,7 +163,7 @@ async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=SENSIRION_SERVICE_INFO,
+        data=SENSIRION_SERVICE_INFO_MYCO2,
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
@@ -171,7 +171,7 @@ async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=SENSIRION_SERVICE_INFO,
+        data=SENSIRION_SERVICE_INFO_MYCO2,
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_in_progress"
@@ -184,14 +184,14 @@ async def test_async_step_user_takes_precedence_over_discovery(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=SENSIRION_SERVICE_INFO,
+        data=SENSIRION_SERVICE_INFO_MYCO2,
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
 
     with patch(
         "homeassistant.components.sensirion_ble.config_flow.async_discovered_service_info",
-        return_value=[SENSIRION_SERVICE_INFO],
+        return_value=[SENSIRION_SERVICE_INFO_MYCO2],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -204,19 +204,19 @@ async def test_async_step_user_takes_precedence_over_discovery(
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"address": SENSIRION_SERVICE_INFO.address},
+            user_input={"address": SENSIRION_SERVICE_INFO_MYCO2.address},
         )
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == CONFIGURED_NAME
+    assert result2["title"] == CONFIGURED_NAME_MYCO2
     assert result2["data"] == {}
-    assert result2["result"].unique_id == SENSIRION_SERVICE_INFO.address
+    assert result2["result"].unique_id == SENSIRION_SERVICE_INFO_MYCO2.address
 
 
 async def test_user_setup_replaces_ignored_device(hass: HomeAssistant) -> None:
     """Test the user initiated form can replace an ignored device."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=SENSIRION_SERVICE_INFO.address,
+        unique_id=SENSIRION_SERVICE_INFO_MYCO2.address,
         source=SOURCE_IGNORE,
         data={},
     )
@@ -224,7 +224,7 @@ async def test_user_setup_replaces_ignored_device(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.sensirion_ble.config_flow.async_discovered_service_info",
-        return_value=[SENSIRION_SERVICE_INFO],
+        return_value=[SENSIRION_SERVICE_INFO_MYCO2],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -234,7 +234,7 @@ async def test_user_setup_replaces_ignored_device(hass: HomeAssistant) -> None:
 
     # Verify the ignored device is in the dropdown
     assert (
-        SENSIRION_SERVICE_INFO.address
+        SENSIRION_SERVICE_INFO_MYCO2.address
         in result["data_schema"].schema["address"].container
     )
 
@@ -243,9 +243,9 @@ async def test_user_setup_replaces_ignored_device(hass: HomeAssistant) -> None:
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"address": SENSIRION_SERVICE_INFO.address},
+            user_input={"address": SENSIRION_SERVICE_INFO_MYCO2.address},
         )
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == CONFIGURED_NAME
+    assert result2["title"] == CONFIGURED_NAME_MYCO2
     assert result2["data"] == {}
-    assert result2["result"].unique_id == SENSIRION_SERVICE_INFO.address
+    assert result2["result"].unique_id == SENSIRION_SERVICE_INFO_MYCO2.address

--- a/tests/components/sensirion_ble/test_sensor.py
+++ b/tests/components/sensirion_ble/test_sensor.py
@@ -37,8 +37,6 @@ from tests.components.bluetooth import inject_bluetooth_service_info
             CONFIGURED_NAME_MYCO2,
             [
                 ("carbon_dioxide", "724", "ppm", "measurement"),
-                ("humidity", "27.8", "%", "measurement"),
-                ("temperature", "20.1", "°C", "measurement"),
             ],
         ),
         (

--- a/tests/components/sensirion_ble/test_sensor.py
+++ b/tests/components/sensirion_ble/test_sensor.py
@@ -11,8 +11,11 @@ from homeassistant.core import HomeAssistant
 
 from .fixtures import (
     CONFIGURED_NAME_MYCO2,
+    CONFIGURED_NAME_SHT43,
     CONFIGURED_PREFIX_MYCO2,
+    CONFIGURED_PREFIX_SHT43,
     SENSIRION_SERVICE_INFO_MYCO2,
+    SENSIRION_SERVICE_INFO_SHT43,
 )
 
 from tests.common import MockConfigEntry
@@ -36,6 +39,15 @@ from tests.components.bluetooth import inject_bluetooth_service_info
                 ("carbon_dioxide", "724", "ppm", "measurement"),
                 ("humidity", "27.8", "%", "measurement"),
                 ("temperature", "20.1", "°C", "measurement"),
+            ],
+        ),
+        (
+            SENSIRION_SERVICE_INFO_SHT43,
+            CONFIGURED_PREFIX_SHT43,
+            CONFIGURED_NAME_SHT43,
+            [
+                ("humidity", "45.75", "%", "measurement"),
+                ("temperature", "21.47", "°C", "measurement"),
             ],
         ),
     ],

--- a/tests/components/sensirion_ble/test_sensor.py
+++ b/tests/components/sensirion_ble/test_sensor.py
@@ -9,7 +9,11 @@ from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant
 
-from .fixtures import CONFIGURED_NAME, CONFIGURED_PREFIX, SENSIRION_SERVICE_INFO
+from .fixtures import (
+    CONFIGURED_NAME_MYCO2,
+    CONFIGURED_PREFIX_MYCO2,
+    SENSIRION_SERVICE_INFO_MYCO2,
+)
 
 from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
@@ -18,7 +22,9 @@ from tests.components.bluetooth import inject_bluetooth_service_info
 @pytest.mark.usefixtures("enable_bluetooth")
 async def test_sensors(hass: HomeAssistant) -> None:
     """Test the Sensirion BLE sensors."""
-    entry = MockConfigEntry(domain=DOMAIN, unique_id=SENSIRION_SERVICE_INFO.address)
+    entry = MockConfigEntry(
+        domain=DOMAIN, unique_id=SENSIRION_SERVICE_INFO_MYCO2.address
+    )
     entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -27,7 +33,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert len(hass.states.async_all()) == 0
     inject_bluetooth_service_info(
         hass,
-        SENSIRION_SERVICE_INFO,
+        SENSIRION_SERVICE_INFO_MYCO2,
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) >= 3
@@ -37,11 +43,13 @@ async def test_sensors(hass: HomeAssistant) -> None:
         ("humidity", "27.8", "%", "measurement"),
         ("temperature", "20.1", "°C", "measurement"),
     ):
-        state = hass.states.get(f"sensor.{CONFIGURED_PREFIX}_{sensor}")
+        state = hass.states.get(f"sensor.{CONFIGURED_PREFIX_MYCO2}_{sensor}")
         assert state is not None
         assert state.state == value
         name_lower = state.attributes[ATTR_FRIENDLY_NAME].lower()
-        assert name_lower == f"{CONFIGURED_NAME} {sensor}".lower().replace("_", " ")
+        assert name_lower == f"{CONFIGURED_NAME_MYCO2} {sensor}".lower().replace(
+            "_", " "
+        )
         assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == unit
         assert state.attributes[ATTR_STATE_CLASS] == state_class
     assert await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/sensirion_ble/test_sensor.py
+++ b/tests/components/sensirion_ble/test_sensor.py
@@ -20,11 +20,35 @@ from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
-async def test_sensors(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    (
+        "sensirion_service_info",
+        "configured_prefix",
+        "configured_name",
+        "sensor_value_unit_state_class_list",
+    ),
+    [
+        (
+            SENSIRION_SERVICE_INFO_MYCO2,
+            CONFIGURED_PREFIX_MYCO2,
+            CONFIGURED_NAME_MYCO2,
+            [
+                ("carbon_dioxide", "724", "ppm", "measurement"),
+                ("humidity", "27.8", "%", "measurement"),
+                ("temperature", "20.1", "°C", "measurement"),
+            ],
+        ),
+    ],
+)
+async def test_sensors(
+    hass: HomeAssistant,
+    sensirion_service_info,
+    configured_prefix,
+    configured_name,
+    sensor_value_unit_state_class_list,
+) -> None:
     """Test the Sensirion BLE sensors."""
-    entry = MockConfigEntry(
-        domain=DOMAIN, unique_id=SENSIRION_SERVICE_INFO_MYCO2.address
-    )
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=sensirion_service_info.address)
     entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -33,23 +57,17 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert len(hass.states.async_all()) == 0
     inject_bluetooth_service_info(
         hass,
-        SENSIRION_SERVICE_INFO_MYCO2,
+        sensirion_service_info,
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) >= 3
+    assert len(hass.states.async_all()) >= len(sensor_value_unit_state_class_list)
 
-    for sensor, value, unit, state_class in (
-        ("carbon_dioxide", "724", "ppm", "measurement"),
-        ("humidity", "27.8", "%", "measurement"),
-        ("temperature", "20.1", "°C", "measurement"),
-    ):
-        state = hass.states.get(f"sensor.{CONFIGURED_PREFIX_MYCO2}_{sensor}")
+    for sensor, value, unit, state_class in sensor_value_unit_state_class_list:
+        state = hass.states.get(f"sensor.{configured_prefix}_{sensor}")
         assert state is not None
         assert state.state == value
         name_lower = state.attributes[ATTR_FRIENDLY_NAME].lower()
-        assert name_lower == f"{CONFIGURED_NAME_MYCO2} {sensor}".lower().replace(
-            "_", " "
-        )
+        assert name_lower == f"{configured_name} {sensor}".lower().replace("_", " ")
         assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == unit
         assert state.attributes[ATTR_STATE_CLASS] == state_class
     assert await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The main purpose of the Sensirion MyCO2 gadget is to report CO₂ values, and it does so precisely. However, the additionally reported values (humidity, temperature) are not accurate. For example, in a real world setup with five pairs of each one MyCO2 gadget and a much more precise SHT43 DemoBoard, the reported humidity is off by 5-8 %, and the temperature by 1.3-2.8 °C. Those inaccuracies roughly match the performance stated in the data sheet of the SCD4x.
As the official Sensirion Android app displays neither temperature nor humidity reported by the MyCO2 gadget, we should not, per default, enable those entities either.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
  - Reading "Make your PRs as small as possible." makes me feel unsure whether I am expected to split up this PR into 3 PRs (refactoring, adding the new test, adding the actual feature) or if keeping this (what I think is a concise batch of changes) in a single PR is fine. Please let me know.
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.
  - There is no generated code

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
