### PR TITLE
Fix allowlist dir requirement in download file handling for Telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -1053,14 +1053,6 @@ class TelegramNotificationService:
         """Download a file from Telegram."""
         if not directory_path:
             directory_path = self.hass.config.path(DOMAIN)
-        if not await self.hass.async_add_executor_job(
-            self.hass.config.is_allowed_path, directory_path
-        ):
-            raise ServiceValidationError(
-                "File path has not been configured in allowlist_external_dirs.",
-                translation_domain=DOMAIN,
-                translation_key="allowlist_external_dirs_error",
-            )
         file: File = await self._send_msg(
             self.bot.get_file,
             "Error getting file",

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -1762,12 +1762,10 @@ async def test_download_file_no_custom_dir(
     await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    allowlist_dir = hass.config.path(DOMAIN)
+    download_dir = hass.config.path(DOMAIN)
     expected_path = expected_download_path(hass)
     # verify dir exists, if not create it
-    await hass.async_add_executor_job(os.makedirs, allowlist_dir, 0o777, True)
-
-    hass.config.allowlist_external_dirs.add(allowlist_dir)
+    await hass.async_add_executor_job(os.makedirs, download_dir, 0o777, True)
 
     file_id = schema_request[ATTR_FILE_ID]
     telegram_file = File(
@@ -1839,11 +1837,8 @@ async def test_download_file_custom_dir(
     await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    allowlist_dir = tmp_path.as_posix()
-    schema_request[ATTR_DIRECTORY_PATH] = allowlist_dir
+    schema_request[ATTR_DIRECTORY_PATH] = tmp_path.as_posix()
     expected_path = expected_download_path(tmp_path.as_posix())
-
-    hass.config.allowlist_external_dirs.add(allowlist_dir)
 
     file_id = schema_request[ATTR_FILE_ID]
     telegram_file = File(
@@ -1886,9 +1881,7 @@ async def test_download_file_directory_created_successfully(
     await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    allowlist_dir = tmp_path.as_posix()
-    hass.config.allowlist_external_dirs.add(allowlist_dir)
-    download_path = os.path.join(allowlist_dir, "download_dir")
+    download_path = os.path.join(tmp_path.as_posix(), "download_dir")
 
     schema_request = {
         ATTR_FILE_ID: "file-id-for-new-dir",
@@ -1935,9 +1928,6 @@ async def test_download_file_when_bot_failed_to_get_file(
     await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    allowlist_dir = tmp_path.as_posix()
-    hass.config.allowlist_external_dirs.add(allowlist_dir)
-
     schema_request = {
         ATTR_FILE_ID: "some-file-id",
         ATTR_DIRECTORY_PATH: tmp_path.as_posix(),
@@ -1961,37 +1951,6 @@ async def test_download_file_when_bot_failed_to_get_file(
     assert err.value.translation_key == "action_failed"
 
 
-async def test_download_file_when_dir_not_allowed(
-    tmp_path: Path,
-    hass: HomeAssistant,
-    mock_broadcast_config_entry: MockConfigEntry,
-    mock_external_calls: None,
-) -> None:
-    """Test download file when bot failed to get file."""
-    mock_broadcast_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
-    await hass.async_block_till_done()
-    telegram_file_name = "some_file.jpg"
-
-    schema_request = {
-        ATTR_FILE_ID: "some-file-id",
-        ATTR_DIRECTORY_PATH: tmp_path.as_posix(),
-        ATTR_FILE_NAME: telegram_file_name,
-    }
-
-    with pytest.raises(ServiceValidationError) as err:
-        await hass.services.async_call(
-            DOMAIN,
-            "download_file",
-            schema_request,
-            blocking=True,
-            return_response=True,
-        )
-
-    await hass.async_block_till_done()
-    assert err.value.translation_key == "allowlist_external_dirs_error"
-
-
 async def test_download_file_when_empty_file_path(
     tmp_path: Path,
     hass: HomeAssistant,
@@ -2002,9 +1961,6 @@ async def test_download_file_when_empty_file_path(
     mock_broadcast_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
     await hass.async_block_till_done()
-
-    allowlist_dir = tmp_path.as_posix()
-    hass.config.allowlist_external_dirs.add(allowlist_dir)
 
     schema_request = {
         ATTR_FILE_ID: "some-file-id",
@@ -2048,9 +2004,6 @@ async def test_download_file_when_error_when_downloading(
     mock_broadcast_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
     await hass.async_block_till_done()
-
-    allowlist_dir = tmp_path.as_posix()
-    hass.config.allowlist_external_dirs.add(allowlist_dir)
 
     schema_request = {
         ATTR_FILE_ID: "some-file-id",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Nope


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix unnecessary constraint https://github.com/home-assistant/core/pull/154625#discussion_r2641420404


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
