### PR TITLE
Implement shorter default update_interval for Plugwise P1

### DIFF
--- a/homeassistant/components/plugwise/const.py
+++ b/homeassistant/components/plugwise/const.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-
 from datetime import timedelta
 import logging
 from typing import Final, Literal

--- a/homeassistant/components/plugwise/const.py
+++ b/homeassistant/components/plugwise/const.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
 import logging
 from typing import Final, Literal
 
@@ -71,11 +70,6 @@ type SelectOptionsType = Literal[
 DEFAULT_MAX_TEMP: Final = 30
 DEFAULT_MIN_TEMP: Final = 4
 DEFAULT_PORT: Final = 80
-DEFAULT_SCAN_INTERVAL: Final[dict[str, timedelta]] = {
-    "power": timedelta(seconds=10),
-    "stretch": timedelta(seconds=60),
-    "thermostat": timedelta(seconds=60),
-}
 DEFAULT_USERNAME: Final = "smile"
 
 MASTER_THERMOSTATS: Final[list[str]] = [

--- a/homeassistant/components/plugwise/const.py
+++ b/homeassistant/components/plugwise/const.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+
+from datetime import timedelta
 import logging
 from typing import Final, Literal
 
@@ -70,7 +72,9 @@ type SelectOptionsType = Literal[
 DEFAULT_MAX_TEMP: Final = 30
 DEFAULT_MIN_TEMP: Final = 4
 DEFAULT_PORT: Final = 80
+DEFAULT_UPDATE_INTERVAL = timedelta(seconds=60)
 DEFAULT_USERNAME: Final = "smile"
+P1_UPDATE_INTERVAL = timedelta(seconds=10)
 
 MASTER_THERMOSTATS: Final[list[str]] = [
     "thermostat",

--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -1,7 +1,5 @@
 """DataUpdateCoordinator for Plugwise."""
 
-from datetime import timedelta
-
 from packaging.version import Version
 from plugwise import GwEntityData, Smile
 from plugwise.exceptions import (

--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -23,7 +23,14 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DEFAULT_PORT, DEFAULT_USERNAME, DOMAIN, LOGGER
+from .const import (
+    DEFAULT_PORT,
+    DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_USERNAME,
+    DOMAIN,
+    LOGGER,
+    P1_UPDATE_INTERVAL,
+)
 
 type PlugwiseConfigEntry = ConfigEntry[PlugwiseDataUpdateCoordinator]
 
@@ -45,7 +52,7 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, GwEntityData
             LOGGER,
             config_entry=config_entry,
             name=DOMAIN,
-            update_interval=timedelta(seconds=60),
+            update_interval=DEFAULT_UPDATE_INTERVAL,
             # Don't refresh immediately, give the device time to process
             # the change in state before we query it.
             request_refresh_debouncer=Debouncer(
@@ -75,7 +82,7 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, GwEntityData
         version = await self.api.connect()
         self._connected = isinstance(version, Version)
         if self._connected and self.api.smile.type == "power":
-            self.update_interval = timedelta(seconds=10)
+            self.update_interval = P1_UPDATE_INTERVAL
 
     async def _async_setup(self) -> None:
         """Initialize the update_data process."""

--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -38,19 +38,14 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, GwEntityData
 
     config_entry: PlugwiseConfigEntry
 
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        config_entry: PlugwiseConfigEntry,
-        update_interval: timedelta = timedelta(seconds=60),
-    ) -> None:
+    def __init__(self, hass: HomeAssistant, config_entry: PlugwiseConfigEntry) -> None:
         """Initialize the coordinator."""
         super().__init__(
             hass,
             LOGGER,
             config_entry=config_entry,
             name=DOMAIN,
-            update_interval=update_interval,
+            update_interval=timedelta(seconds=60),
             # Don't refresh immediately, give the device time to process
             # the change in state before we query it.
             request_refresh_debouncer=Debouncer(

--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DEFAULT_SCAN_INTERVAL, DEFAULT_PORT, DEFAULT_USERNAME, DOMAIN, LOGGER
+from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_USERNAME, DOMAIN, LOGGER
 
 type PlugwiseConfigEntry = ConfigEntry[PlugwiseDataUpdateCoordinator]
 

--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_USERNAME, DOMAIN, LOGGER
+from .const import DEFAULT_PORT, DEFAULT_USERNAME, DOMAIN, LOGGER
 
 type PlugwiseConfigEntry = ConfigEntry[PlugwiseDataUpdateCoordinator]
 
@@ -74,10 +74,8 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, GwEntityData
         """
         version = await self.api.connect()
         self._connected = isinstance(version, Version)
-        if self._connected:
-            self.update_interval = DEFAULT_SCAN_INTERVAL.get(
-                self.api.smile.type, timedelta(seconds=60)
-            )
+        if self._connected and self.api.smile.type == "power":
+            self.update_interval = timedelta(seconds=10)
 
     async def _async_setup(self) -> None:
         """Initialize the update_data process."""

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -15,7 +15,11 @@ from plugwise.exceptions import (
 )
 import pytest
 
-from homeassistant.components.plugwise.const import DOMAIN
+from homeassistant.components.plugwise.const import (
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    P1_UPDATE_INTERVAL,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -23,8 +27,6 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-DEFAULT_UPDATE_INTERVAL = timedelta(seconds=60)
-P1_UPDATE_INTERVAL = timedelta(seconds=10)
 HA_PLUGWISE_SMILE_ASYNC_UPDATE = (
     "homeassistant.components.plugwise.coordinator.Smile.async_update"
 )

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -402,7 +402,7 @@ async def test_update_interval_p1(
     mock_smile_p1: MagicMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test Adam update interval."""
+    """Test Smile P1 update interval."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -382,7 +382,9 @@ async def test_update_interval_adam(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert mock_smile_adam_heat_cool.async_update.call_count == 1
 
-    assert DEFAULT_SCAN_INTERVAL[mock_smile_adam_heat_cool.smile.type] == timedelta(seconds=60)
+    assert DEFAULT_SCAN_INTERVAL[mock_smile_adam_heat_cool.smile.type] == timedelta(
+        seconds=60
+    )
     freezer.tick(DEFAULT_SCAN_INTERVAL[mock_smile_adam_heat_cool.smile.type])
     async_fire_time_changed(hass)
     await hass.async_block_till_done()

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -15,7 +15,7 @@ from plugwise.exceptions import (
 )
 import pytest
 
-from homeassistant.components.plugwise.const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from homeassistant.components.plugwise.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -23,6 +23,8 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
+DEFAULT_UPDATE_INTERVAL = timedelta(seconds=60)
+P1_UPDATE_INTERVAL = timedelta(seconds=10)
 HA_PLUGWISE_SMILE_ASYNC_UPDATE = (
     "homeassistant.components.plugwise.coordinator.Smile.async_update"
 )
@@ -382,10 +384,7 @@ async def test_update_interval_adam(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert mock_smile_adam_heat_cool.async_update.call_count == 1
 
-    assert DEFAULT_SCAN_INTERVAL[mock_smile_adam_heat_cool.smile.type] == timedelta(
-        seconds=60
-    )
-    freezer.tick(DEFAULT_SCAN_INTERVAL[mock_smile_adam_heat_cool.smile.type])
+    freezer.tick(DEFAULT_UPDATE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -410,8 +409,7 @@ async def test_update_interval_p1(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert mock_smile_p1.async_update.call_count == 1
 
-    assert DEFAULT_SCAN_INTERVAL[mock_smile_p1.smile.type] == timedelta(seconds=10)
-    freezer.tick(DEFAULT_SCAN_INTERVAL[mock_smile_p1.smile.type])
+    freezer.tick(P1_UPDATE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -15,7 +15,7 @@ from plugwise.exceptions import (
 )
 import pytest
 
-from homeassistant.components.plugwise.const import DOMAIN
+from homeassistant.components.plugwise.const import DEFAULT_SCAN_INTERVAL, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -364,3 +364,53 @@ async def test_delete_removed_device(
     for device_entry in device_registry.devices.values():
         item_list.extend(x[1] for x in device_entry.identifiers)
     assert "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6" not in item_list
+
+
+@pytest.mark.parametrize("chosen_env", ["m_adam_heating"], indirect=True)
+@pytest.mark.parametrize("cooling_present", [False], indirect=True)
+async def test_update_interval_adam(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smile_adam_heat_cool: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test Adam update interval."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_smile_adam_heat_cool.async_update.call_count == 1
+
+    assert DEFAULT_SCAN_INTERVAL[mock_smile_adam_heat_cool.smile.type] == timedelta(seconds=60)
+    freezer.tick(DEFAULT_SCAN_INTERVAL[mock_smile_adam_heat_cool.smile.type])
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_smile_adam_heat_cool.async_update.call_count == 2
+
+
+@pytest.mark.parametrize("chosen_env", ["p1v4_442_single"], indirect=True)
+@pytest.mark.parametrize(
+    "gateway_id", ["a455b61e52394b2db5081ce025a430f3"], indirect=True
+)
+async def test_update_interval_p1(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smile_p1: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test Adam update interval."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_smile_p1.async_update.call_count == 1
+
+    assert DEFAULT_SCAN_INTERVAL[mock_smile_p1.smile.type] == timedelta(seconds=10)
+    freezer.tick(DEFAULT_SCAN_INTERVAL[mock_smile_p1.smile.type])
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_smile_p1.async_update.call_count == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Somehow this functionality become lost over time, re-adding it via this PR.
The default `update_interval`'s should be 60 sec for Anna, Adam and Stretch, and 10 sec for the P1.
At present it is 60 sec for everything.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
