### PR TITLE
Bump reolink_aio to 0.18.0

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -20,5 +20,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.17.1"]
+  "requirements": ["reolink-aio==0.18.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2732,7 +2732,7 @@ renault-api==0.5.2
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.17.1
+reolink-aio==0.18.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2292,7 +2292,7 @@ renault-api==0.5.2
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.17.1
+reolink-aio==0.18.0
 
 # homeassistant.components.rflink
 rflink==0.0.67


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink_aio to 0.18.0:
**Breaking changes:**
- [Depricate HDR_on method](https://github.com/starkillerOG/reolink_aio/commit/5208b9cc077f0c777231b4afc203629d8d969490)

**Additions:**
- [Implement baichuan snapshots](https://github.com/starkillerOG/reolink_aio/commit/c1ab98e5dcc9464a19e0471d24ee211cab4777ce)
  - [Baichuan snapshot supported flag](https://github.com/starkillerOG/reolink_aio/commit/a6610ccffa2d6c0c334f1aba0d6b0ca106389699)
  - [Use last empty push cmd_id 109 for snapshot end instead of imageSize](https://github.com/starkillerOG/reolink_aio/commit/2f940a248b621a1cbb31fa4536bbde7ff46c4cef)
  - [Improve message_id handeling during snapshots](https://github.com/starkillerOG/reolink_aio/commit/c9ed5e9c95406c7386118e62d13c741381e481ef)
  - [Ensure only 1 snapshot per channel simultaniously](https://github.com/starkillerOG/reolink_aio/commit/90666afeee7436d571451b5d98b75e58983c1b3a)
- [Use incrementing message ID for baichuan protocol](https://github.com/starkillerOG/reolink_aio/commit/caf582abb212fa07608da854a1e8c1060df3f5b4)
  - [Fix baichuan retries with new message id](https://github.com/starkillerOG/reolink_aio/commit/42c6d6294ceda299b87232229b294a5ca5f62564)
  - [Allow simultanious cmd_id to same channel using full_mess_id](https://github.com/starkillerOG/reolink_aio/commit/5e4a582c39d8ca8f3fe53a0e36a78b01916f2076)
- [Baichuan fallback for GetIsp](https://github.com/starkillerOG/reolink_aio/commit/955af13aaaea568aa40dc52e274f517771f87760)
- [Baichuan fallback for SetIsp](https://github.com/starkillerOG/reolink_aio/commit/63a24beadc63029af369f637b5a5467161464a10)
- [Improve baichuan detection of dayNightThreshold and day_night_state support](https://github.com/starkillerOG/reolink_aio/commit/8c9b28f21a0a465395220c983d93c4c723c91366)
- [Improve Baichuan isp capability detection](https://github.com/starkillerOG/reolink_aio/commit/29d1c64b8c34e47f5b833810af1947d51602aead)
- [Support parsing of payload_offset in baichuan message](https://github.com/starkillerOG/reolink_aio/commit/f5c327ccd43c2181afbc50edc6632ff6631a4f31)

**Bug fixes:**
- [Use push callback if baichuan receive future is already set](https://github.com/starkillerOG/reolink_aio/commit/cb553fe7359f00479fe00ad475b630445ae11ce1)

**Optimizations:**
- [Remove "Isp" form internal self._isp_settings cache](https://github.com/starkillerOG/reolink_aio/commit/65191b3d30d9ff9c6d3408ba4e35061453ea70fe)
- [Debug log cancelled error for baichuan cmd](https://github.com/starkillerOG/reolink_aio/commit/daf96fb2a538b93c76599c30b2eafe39cb1bd671)
- [Fix VOD_file.size returning string when types say it's int](https://github.com/starkillerOG/reolink_aio/pull/149)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.17.1...0.18.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/152127
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
