### PR TITLE
kostal_plenticore: Add DcCheck state

### DIFF
--- a/homeassistant/components/kostal_plenticore/helper.py
+++ b/homeassistant/components/kostal_plenticore/helper.py
@@ -31,6 +31,7 @@ class PlenticoreDataFormatter:
         15: "Shutdown",
         16: "ImproperDcVoltage",
         17: "ESB",
+        18: "DcCheck",
     }
 
     EM_STATES = {


### PR DESCRIPTION
## Proposed change
Just watched my Kostal PlentiCore G3 L inverter report an "Unknown" state in Home Assistant. I queried the inverter state code via Modbus TCP and watched the Kostal web interface simultaneously, which allowed me to match State ID 18 to "DC Check":

<img width="1969" height="1141" alt="grafik" src="https://github.com/user-attachments/assets/0adf0dfc-6e03-46b8-b951-24e3a6eef0a1" />

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.