### PR TITLE
Permission restriction for workflows

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -18,14 +18,15 @@ env:
   BASE_IMAGE_VERSION: "2026.01.0"
   ARCHITECTURES: '["amd64", "aarch64"]'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   init:
     name: Initialize build
     if: github.repository_owner == 'home-assistant'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
       channel: ${{ steps.version.outputs.channel }}
@@ -313,6 +314,8 @@ jobs:
     if: github.repository_owner == 'home-assistant'
     needs: ["init", "build_machine"]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -18,6 +18,9 @@ env:
   BASE_IMAGE_VERSION: "2026.01.0"
   ARCHITECTURES: '["amd64", "aarch64"]'
 
+permissions:
+  contents: read
+
 jobs:
   init:
     name: Initialize build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   info:
     name: Collect information & changes data

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: "0 * * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+
 jobs:
   lock:
     if: github.repository_owner == 'home-assistant'

--- a/.github/workflows/restrict-task-creation.yml
+++ b/.github/workflows/restrict-task-creation.yml
@@ -5,6 +5,10 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-authorization:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,12 @@ on:
     - cron: "0 * * * *"
   workflow_dispatch:
 
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+  contents: read   # Set to write if delete-branch option will be used
+
 jobs:
   stale:
     if: github.repository_owner == 'home-assistant'

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -12,6 +12,9 @@ on:
 env:
   DEFAULT_PYTHON: "3.14.2"
 
+permissions:
+  contents: read
+
 jobs:
   upload:
     name: Upload

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   init:
     name: Initialize wheels builder


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
--

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR introduces the explicit setting (and thereby restricting) of permissions for GitHub Action workflows. Some of the existing jobs inside of workflows did already set permissions, but only sporadically.
Setting explicit permissions for a workflow is important to enforce the principle of least privilege, ensuring that the workflow only has access to the resources and actions it truly needs. This minimizes the risk of unauthorized access or misuse in case of a vulnerability or compromise within the workflow.

1. [Details on Github Action Permissions in a concise format](https://www.graphite.com/guides/github-actions-permissions)
1. [Official Docs on Github Action Permissions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)
1. Nice to know: [persist-credentials](https://github.com/actions/checkout/issues/485) being written to git config was finally fixed in [actions/checkout 6.X](https://github.com/actions/checkout/releases) and is therefore not included in this PR anymore, as I initially planned.

Testing Note:

Complex GitHub Action workflows are not trivial to test on local systems due to the lack of access to all required environment variables and secrets.

**Important for Maintainers: Since this PR modifies workflow files I assume the tests will not run automatically for security reasons. You will need to manually approve and trigger the tests to validate these changes.** If you want to take my changes to your own internal branch directly to do that instead, feel free.

If you have already [restricted the permissions on organization level](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#setting-the-permissions-of-the-github_token-for-your-organization) this PR might or might not be useful, depending on your settings there.

--- 
Idea: For the future I suggest to add a workflow with [Zizmor](https://docs.zizmor.sh/) or a similar SAST tool for these GitHub Actions. They still have some issues with [YAML Anchors](https://docs.zizmor.sh/troubleshooting/#cant-access-orgrepo-missing-or-you-have-no-access) but I am sure that could be resolved. If that is something of interest in the future, let me know. The SARIF report for those could be added to the other testing documentation/upload.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
