### PR TITLE
Update integration lightwave - Add unique_id options for switch and lights

### DIFF
--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -22,6 +22,7 @@ CONF_PROXY_IP = "proxy_ip"
 CONF_PROXY_PORT = "proxy_port"
 CONF_TRV = "trv"
 CONF_TRVS = "trvs"
+CONF_UNIQUE_ID = "unique_id"
 DEFAULT_PROXY_PORT = 7878
 DOMAIN = "lightwave"
 LIGHTWAVE_LINK = f"{DOMAIN}_link"
@@ -39,10 +40,20 @@ CONFIG_SCHEMA = vol.Schema(
                 {
                     vol.Required(CONF_HOST): cv.string,
                     vol.Optional(CONF_LIGHTS, default={}): {
-                        cv.string: vol.Schema({vol.Required(CONF_NAME): cv.string})
+                        cv.string: vol.Schema(
+                            {
+                                vol.Required(CONF_NAME): cv.string,
+                                vol.Optional(CONF_UNIQUE_ID): cv.string,
+                            }
+                        )
                     },
                     vol.Optional(CONF_SWITCHES, default={}): {
-                        cv.string: vol.Schema({vol.Required(CONF_NAME): cv.string})
+                        cv.string: vol.Schema(
+                            {
+                                vol.Required(CONF_NAME): cv.string,
+                                vol.Optional(CONF_UNIQUE_ID): cv.string,
+                            }
+                        )
                     },
                     vol.Optional(CONF_TRV, default={}): {
                         vol.Optional(

--- a/homeassistant/components/lightwave/light.py
+++ b/homeassistant/components/lightwave/light.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import LIGHTWAVE_LINK
+from . import CONF_UNIQUE_ID, LIGHTWAVE_LINK
 
 MAX_BRIGHTNESS = 255
 
@@ -30,7 +30,8 @@ async def async_setup_platform(
 
     for device_id, device_config in discovery_info.items():
         name = device_config[CONF_NAME]
-        lights.append(LWRFLight(name, device_id, lwlink))
+        unique_id = device_config.get(CONF_UNIQUE_ID)
+        lights.append(LWRFLight(name, device_id, lwlink, unique_id))
 
     async_add_entities(lights)
 
@@ -42,12 +43,14 @@ class LWRFLight(LightEntity):
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
     _attr_should_poll = False
 
-    def __init__(self, name, device_id, lwlink):
+    def __init__(self, name, device_id, lwlink, unique_id=None):
         """Initialize LWRFLight entity."""
         self._attr_name = name
         self._device_id = device_id
         self._attr_brightness = MAX_BRIGHTNESS
         self._lwlink = lwlink
+        if unique_id:
+            self._attr_unique_id = unique_id
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the LightWave light on."""

--- a/homeassistant/components/lightwave/switch.py
+++ b/homeassistant/components/lightwave/switch.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import LIGHTWAVE_LINK
+from . import CONF_UNIQUE_ID, LIGHTWAVE_LINK
 
 
 async def async_setup_platform(
@@ -28,7 +28,8 @@ async def async_setup_platform(
 
     for device_id, device_config in discovery_info.items():
         name = device_config[CONF_NAME]
-        switches.append(LWRFSwitch(name, device_id, lwlink))
+        unique_id = device_config.get(CONF_UNIQUE_ID)
+        switches.append(LWRFSwitch(name, device_id, lwlink, unique_id))
 
     async_add_entities(switches)
 
@@ -38,11 +39,13 @@ class LWRFSwitch(SwitchEntity):
 
     _attr_should_poll = False
 
-    def __init__(self, name, device_id, lwlink):
+    def __init__(self, name, device_id, lwlink, unique_id=None):
         """Initialize LWRFSwitch entity."""
         self._attr_name = name
         self._device_id = device_id
         self._lwlink = lwlink
+        if unique_id:
+            self._attr_unique_id = unique_id
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the LightWave switch on."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This update allows the legacy `lightwave` RF integration to make use of `unique_id` in the `configuration.yaml`. At present there is no unique ID, meaning it's impossible to give the entities another name in the UI, and also to give it aliases to prevent to Assist.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42716
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
