### PR TITLE
Make Vera integration a hub for devices

### DIFF
--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -32,6 +32,7 @@ from .common import (
 )
 from .config_flow import fix_device_id_list, new_options
 from .const import CONF_CONTROLLER, DOMAIN
+from .hub import VeraHub
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -120,11 +121,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if device_type is not None:
             vera_devices[device_type].append(device)
 
+    # Create the hub device
+    hub = VeraHub(hass, controller, entry)
+    hub.async_update_device_registry()
+
     controller_data = ControllerData(
         controller=controller,
         devices=vera_devices,
         scenes=all_scenes,
         config_entry=entry,
+        hub=hub,
     )
 
     set_controller_data(hass, entry, controller_data)

--- a/homeassistant/components/vera/entity.py
+++ b/homeassistant/components/vera/entity.py
@@ -13,12 +13,13 @@ from homeassistant.const import (
     ATTR_LAST_TRIP_TIME,
     ATTR_TRIPPED,
 )
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 from homeassistant.util.dt import utc_from_timestamp
 
 from .common import ControllerData
-from .const import CONF_LEGACY_UNIQUE_ID, VERA_ID_FORMAT
+from .const import CONF_LEGACY_UNIQUE_ID, DOMAIN, VERA_ID_FORMAT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,12 +27,15 @@ _LOGGER = logging.getLogger(__name__)
 class VeraEntity[_DeviceTypeT: veraApi.VeraDevice](Entity):
     """Representation of a Vera device entity."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self, vera_device: _DeviceTypeT, controller_data: ControllerData
     ) -> None:
         """Initialize the device."""
         self.vera_device = vera_device
         self.controller = controller_data.controller
+        self.controller_data = controller_data
 
         self._name = self.vera_device.name
         # Append device id to prevent name clashes in HA.
@@ -43,6 +47,63 @@ class VeraEntity[_DeviceTypeT: veraApi.VeraDevice](Entity):
             self._unique_id = str(self.vera_device.vera_device_id)
         else:
             self._unique_id = f"vera_{controller_data.config_entry.unique_id}_{self.vera_device.vera_device_id}"
+
+        # Set up device info for device registry
+        if controller_data.hub:
+            self._attr_device_info = DeviceInfo(
+                identifiers={
+                    (
+                        DOMAIN,
+                        f"{controller_data.hub.hub_id}_{self.vera_device.vera_device_id}",
+                    )
+                },
+                name=self.vera_device.name,
+                manufacturer=self._get_manufacturer(),
+                model=self._get_model(),
+                via_device=(DOMAIN, controller_data.hub.hub_id),
+            )
+
+    def _get_manufacturer(self) -> str:
+        """Get the manufacturer name for the device."""
+        # Map Vera category to manufacturer, default to generic
+        category_manufacturers = {
+            veraApi.CATEGORY_DIMMER: "Vera",
+            veraApi.CATEGORY_SWITCH: "Vera",
+            veraApi.CATEGORY_THERMOSTAT: "Vera",
+            veraApi.CATEGORY_LOCK: "Vera",
+            veraApi.CATEGORY_CURTAIN: "Vera",
+        }
+        return category_manufacturers.get(
+            getattr(self.vera_device, "category", None), "Vera"
+        )
+
+    def _get_model(self) -> str:
+        """Get the model name for the device."""
+        # Map Vera category to a human-readable model name
+        category_models = {
+            veraApi.CATEGORY_DIMMER: "Dimmer Switch",
+            veraApi.CATEGORY_SWITCH: "On/Off Switch",
+            veraApi.CATEGORY_TEMPERATURE_SENSOR: "Temperature Sensor",
+            veraApi.CATEGORY_LIGHT_SENSOR: "Light Sensor",
+            veraApi.CATEGORY_HUMIDITY_SENSOR: "Humidity Sensor",
+            veraApi.CATEGORY_POWER_METER: "Power Meter",
+            veraApi.CATEGORY_THERMOSTAT: "Thermostat",
+            veraApi.CATEGORY_LOCK: "Door Lock",
+            veraApi.CATEGORY_CURTAIN: "Window Covering",
+            veraApi.CATEGORY_GARAGE_DOOR: "Garage Door",
+            veraApi.CATEGORY_GENERIC: "Generic Device",
+            veraApi.CATEGORY_SCENE_CONTROLLER: "Scene Controller",
+            veraApi.CATEGORY_ARMABLE: "Armable Device",
+            veraApi.CATEGORY_SENSOR: "Sensor",
+            veraApi.CATEGORY_UV_SENSOR: "UV Sensor",
+            veraApi.CATEGORY_REMOTE: "Remote Control",
+        }
+        category = getattr(self.vera_device, "category", None)
+        if category in category_models:
+            return category_models[category]
+        # Fallback to category name if available
+        category_name = getattr(self.vera_device, "category_name", None)
+        return category_name if category_name else "Vera Device"
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
@@ -64,9 +125,14 @@ class VeraEntity[_DeviceTypeT: veraApi.VeraDevice](Entity):
             self.vera_device.refresh()
 
     @property
-    def name(self) -> str:
-        """Return the name of the device."""
-        return self._name
+    def name(self) -> str | None:
+        """Return the name of the device.
+
+        When has_entity_name is True, returning None means the entity will use
+        the device name. We return None for the main entity and a specific name
+        for additional entities if needed.
+        """
+        return None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:

--- a/homeassistant/components/vera/hub.py
+++ b/homeassistant/components/vera/hub.py
@@ -1,0 +1,57 @@
+"""Vera hub implementation."""
+
+from __future__ import annotations
+
+import logging
+
+import pyvera as pv
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VeraHub:
+    """Manages a Vera controller hub."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        controller: pv.VeraController,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the Vera hub."""
+        self.hass = hass
+        self.controller = controller
+        self.config_entry = config_entry
+        self._serial_number = controller.serial_number
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the Vera controller hub."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._serial_number)},
+            manufacturer="Vera Control, Ltd",
+            model="Vera Controller",
+            name=f"Vera ({self.config_entry.data['vera_controller_url']})",
+            sw_version=None,  # Could be added if available from controller
+            configuration_url=self.config_entry.data["vera_controller_url"],
+        )
+
+    def async_update_device_registry(self) -> dr.DeviceEntry:
+        """Update device registry."""
+        device_registry = dr.async_get(self.hass)
+        return device_registry.async_get_or_create(
+            config_entry_id=self.config_entry.entry_id,
+            **self.device_info,
+        )
+
+    @property
+    def hub_id(self) -> str:
+        """Return the hub ID (serial number)."""
+        return self._serial_number

--- a/homeassistant/components/vera/strings.json
+++ b/homeassistant/components/vera/strings.json
@@ -4,16 +4,40 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "Could not connect to controller with URL {base_url}"
     },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
     "step": {
+      "devices": {
+        "data": {
+          "exclude": "Devices to exclude",
+          "lights": "Switches to treat as lights"
+        },
+        "data_description": {
+          "exclude": "Select devices to exclude from Home Assistant",
+          "lights": "Select switch devices that should appear as lights instead"
+        },
+        "description": "Found {device_count} device(s). You can optionally exclude devices or configure switches to appear as lights.",
+        "title": "Configure Vera devices"
+      },
       "user": {
         "data": {
-          "exclude": "Vera device IDs to exclude from Home Assistant.",
-          "lights": "Vera switch device IDs to treat as lights in Home Assistant.",
           "vera_controller_url": "Controller URL"
         },
         "data_description": {
-          "vera_controller_url": "It should look like this: {sample_ip}"
-        }
+          "vera_controller_url": "Enter the URL of your Vera controller (e.g., {sample_ip})"
+        },
+        "description": "Enter the URL of your Vera controller to discover connected devices."
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "energy": {
+        "name": "Energy"
+      },
+      "power": {
+        "name": "Power"
       }
     }
   },
@@ -21,8 +45,12 @@
     "step": {
       "init": {
         "data": {
-          "exclude": "[%key:component::vera::config::step::user::data::exclude%]",
-          "lights": "[%key:component::vera::config::step::user::data::lights%]"
+          "exclude": "Devices to exclude",
+          "lights": "Switches to treat as lights"
+        },
+        "data_description": {
+          "exclude": "Space-separated list of device IDs to exclude",
+          "lights": "Space-separated list of switch device IDs to treat as lights"
         },
         "description": "See the Vera documentation for details on optional parameters: {documentation_url}. Note: Any changes here require a restart of the Home Assistant server. To clear values, provide a space.",
         "title": "Vera controller options"

--- a/tests/components/vera/test_device_registry.py
+++ b/tests/components/vera/test_device_registry.py
@@ -1,0 +1,134 @@
+"""Tests for Vera device registry."""
+
+from unittest.mock import MagicMock
+
+import pyvera as pv
+
+from homeassistant.components.vera import CONF_CONTROLLER, DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .common import ComponentFactory, ConfigSource, new_simple_controller_config
+
+
+async def test_hub_device_created(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    vera_component_factory: ComponentFactory,
+) -> None:
+    """Test that a hub device is created in the device registry."""
+    vera_device1: pv.VeraBinarySensor = MagicMock(spec=pv.VeraBinarySensor)
+    vera_device1.device_id = 1
+    vera_device1.vera_device_id = vera_device1.device_id
+    vera_device1.name = "test_sensor"
+    vera_device1.is_tripped = False
+    vera_device1.category = pv.CATEGORY_SENSOR
+
+    await vera_component_factory.configure_component(
+        hass=hass,
+        controller_config=new_simple_controller_config(
+            config={CONF_CONTROLLER: "http://127.0.0.1:111"},
+            config_source=ConfigSource.CONFIG_FLOW,
+            serial_number="test_serial_123",
+            devices=(vera_device1,),
+        ),
+    )
+
+    # Verify the hub device was created
+    hub_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "test_serial_123")}
+    )
+    assert hub_device is not None
+    assert hub_device.manufacturer == "Vera Control, Ltd"
+    assert hub_device.model == "Vera Controller"
+    assert "Vera" in hub_device.name
+    assert hub_device.configuration_url == "http://127.0.0.1:111"
+
+
+async def test_entity_device_linked_to_hub(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    vera_component_factory: ComponentFactory,
+) -> None:
+    """Test that entity devices are linked to the hub via via_device."""
+    vera_device1: pv.VeraBinarySensor = MagicMock(spec=pv.VeraBinarySensor)
+    vera_device1.device_id = 1
+    vera_device1.vera_device_id = vera_device1.device_id
+    vera_device1.name = "test_sensor"
+    vera_device1.is_tripped = False
+    vera_device1.category = pv.CATEGORY_SENSOR
+
+    await vera_component_factory.configure_component(
+        hass=hass,
+        controller_config=new_simple_controller_config(
+            config={CONF_CONTROLLER: "http://127.0.0.1:111"},
+            config_source=ConfigSource.CONFIG_FLOW,
+            serial_number="test_serial_123",
+            devices=(vera_device1,),
+        ),
+    )
+
+    # Get the hub device
+    hub_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "test_serial_123")}
+    )
+    assert hub_device is not None
+
+    # Get the sensor device
+    sensor_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "test_serial_123_1")}
+    )
+    assert sensor_device is not None
+    assert sensor_device.name == "test_sensor"
+    assert sensor_device.manufacturer == "Vera"
+    assert sensor_device.model == "Sensor"
+    assert sensor_device.via_device_id == hub_device.id
+
+
+async def test_multiple_devices_under_hub(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    vera_component_factory: ComponentFactory,
+) -> None:
+    """Test that multiple entity devices are properly linked to the same hub."""
+    vera_sensor: pv.VeraSensor = MagicMock(spec=pv.VeraSensor)
+    vera_sensor.device_id = 1
+    vera_sensor.vera_device_id = vera_sensor.device_id
+    vera_sensor.name = "temperature_sensor"
+    vera_sensor.category = pv.CATEGORY_TEMPERATURE_SENSOR
+    vera_sensor.temperature = 22.5
+
+    vera_switch: pv.VeraSwitch = MagicMock(spec=pv.VeraSwitch)
+    vera_switch.device_id = 2
+    vera_switch.vera_device_id = vera_switch.device_id
+    vera_switch.name = "living_room_light"
+    vera_switch.category = pv.CATEGORY_SWITCH
+    vera_switch.is_switched_on = MagicMock(return_value=False)
+
+    await vera_component_factory.configure_component(
+        hass=hass,
+        controller_config=new_simple_controller_config(
+            config={CONF_CONTROLLER: "http://192.168.1.100:3480"},
+            config_source=ConfigSource.CONFIG_FLOW,
+            serial_number="hub_12345",
+            devices=(vera_sensor, vera_switch),
+        ),
+    )
+
+    # Get the hub device
+    hub_device = device_registry.async_get_device(identifiers={(DOMAIN, "hub_12345")})
+    assert hub_device is not None
+
+    # Get the sensor device
+    sensor_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "hub_12345_1")}
+    )
+    assert sensor_device is not None
+    assert sensor_device.via_device_id == hub_device.id
+
+    # Get the switch device
+    switch_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "hub_12345_2")}
+    )
+    assert switch_device is not None
+    assert switch_device.via_device_id == hub_device.id

--- a/tests/components/vera/test_energy_sensors.py
+++ b/tests/components/vera/test_energy_sensors.py
@@ -1,0 +1,148 @@
+"""Tests for Vera energy sensors."""
+
+from unittest.mock import MagicMock
+
+import pyvera as pv
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfEnergy, UnitOfPower
+from homeassistant.core import HomeAssistant
+
+from .common import ComponentFactory, new_simple_controller_config
+
+
+async def test_switch_with_power_sensor(
+    hass: HomeAssistant, vera_component_factory: ComponentFactory
+) -> None:
+    """Test that a switch with power creates a power sensor."""
+    vera_device: pv.VeraSwitch = MagicMock(spec=pv.VeraSwitch)
+    vera_device.device_id = 1
+    vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
+    vera_device.name = "power_switch"
+    vera_device.category = pv.CATEGORY_SWITCH
+    vera_device.is_switched_on = MagicMock(return_value=True)
+    vera_device.power = 50.5  # 50.5W
+    vera_device.energy = None  # No energy tracking
+    switch_entity_id = "switch.power_switch_1"
+    power_entity_id = "sensor.power_switch_1_power"
+
+    await vera_component_factory.configure_component(
+        hass=hass,
+        controller_config=new_simple_controller_config(devices=(vera_device,)),
+    )
+
+    # Verify switch entity exists
+    assert hass.states.get(switch_entity_id).state == "on"
+
+    # Verify power sensor was created
+    power_state = hass.states.get(power_entity_id)
+    assert power_state is not None
+    assert power_state.state == "50.5"
+    assert power_state.attributes["device_class"] == SensorDeviceClass.POWER
+    assert power_state.attributes["unit_of_measurement"] == UnitOfPower.WATT
+    assert power_state.attributes["state_class"] == SensorStateClass.MEASUREMENT
+
+
+async def test_switch_with_energy_sensor(
+    hass: HomeAssistant, vera_component_factory: ComponentFactory
+) -> None:
+    """Test that a switch with energy creates an energy sensor."""
+    vera_device: pv.VeraSwitch = MagicMock(spec=pv.VeraSwitch)
+    vera_device.device_id = 2
+    vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
+    vera_device.name = "energy_switch"
+    vera_device.category = pv.CATEGORY_SWITCH
+    vera_device.is_switched_on = MagicMock(return_value=True)
+    vera_device.power = None  # No power tracking
+    vera_device.energy = 12.345  # 12.345 kWh
+    switch_entity_id = "switch.energy_switch_2"
+    energy_entity_id = "sensor.energy_switch_2_energy"
+
+    await vera_component_factory.configure_component(
+        hass=hass,
+        controller_config=new_simple_controller_config(devices=(vera_device,)),
+    )
+
+    # Verify switch entity exists
+    assert hass.states.get(switch_entity_id).state == "on"
+
+    # Verify energy sensor was created
+    energy_state = hass.states.get(energy_entity_id)
+    assert energy_state is not None
+    assert energy_state.state == "12.345"
+    assert energy_state.attributes["device_class"] == SensorDeviceClass.ENERGY
+    assert energy_state.attributes["unit_of_measurement"] == UnitOfEnergy.KILO_WATT_HOUR
+    assert energy_state.attributes["state_class"] == SensorStateClass.TOTAL_INCREASING
+
+
+async def test_light_with_power_and_energy(
+    hass: HomeAssistant, vera_component_factory: ComponentFactory
+) -> None:
+    """Test that a light with both power and energy creates both sensors."""
+    vera_device: pv.VeraDimmer = MagicMock(spec=pv.VeraDimmer)
+    vera_device.device_id = 3
+    vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
+    vera_device.name = "smart_light"
+    vera_device.category = pv.CATEGORY_DIMMER
+    vera_device.is_switched_on = MagicMock(return_value=True)
+    vera_device.get_brightness = MagicMock(return_value=75)
+    vera_device.get_color = MagicMock(return_value=[0, 0, 0])
+    vera_device.is_dimmable = True
+    vera_device.power = 15.2  # 15.2W
+    vera_device.energy = 5.67  # 5.67 kWh
+    light_entity_id = "light.smart_light_3"
+    power_entity_id = "sensor.smart_light_3_power"
+    energy_entity_id = "sensor.smart_light_3_energy"
+
+    await vera_component_factory.configure_component(
+        hass=hass,
+        controller_config=new_simple_controller_config(devices=(vera_device,)),
+    )
+
+    # Verify light entity exists
+    assert hass.states.get(light_entity_id).state == "on"
+
+    # Verify power sensor was created
+    power_state = hass.states.get(power_entity_id)
+    assert power_state is not None
+    assert power_state.state == "15.2"
+    assert power_state.attributes["device_class"] == SensorDeviceClass.POWER
+
+    # Verify energy sensor was created
+    energy_state = hass.states.get(energy_entity_id)
+    assert energy_state is not None
+    assert energy_state.state == "5.67"
+    assert energy_state.attributes["device_class"] == SensorDeviceClass.ENERGY
+
+
+async def test_switch_without_power_no_sensor(
+    hass: HomeAssistant, vera_component_factory: ComponentFactory
+) -> None:
+    """Test that a switch without power does not create power/energy sensors."""
+    vera_device: pv.VeraSwitch = MagicMock(spec=pv.VeraSwitch)
+    vera_device.device_id = 4
+    vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
+    vera_device.name = "simple_switch"
+    vera_device.category = pv.CATEGORY_SWITCH
+    vera_device.is_switched_on = MagicMock(return_value=True)
+    vera_device.power = None
+    vera_device.energy = None
+    switch_entity_id = "switch.simple_switch_4"
+    power_entity_id = "sensor.simple_switch_4_power"
+    energy_entity_id = "sensor.simple_switch_4_energy"
+
+    await vera_component_factory.configure_component(
+        hass=hass,
+        controller_config=new_simple_controller_config(devices=(vera_device,)),
+    )
+
+    # Verify switch entity exists
+    assert hass.states.get(switch_entity_id).state == "on"
+
+    # Verify no power or energy sensors were created
+    assert hass.states.get(power_entity_id) is None
+    assert hass.states.get(energy_entity_id) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change transitions the current Vera implementation to use a hub model that allows access to multiple devices. This allows a much better behavior than the current integration with multiple entities model.
I'm planning on adding more info per device as much the pyvera library can provide, and maybe add a sub devices hierarchy if it can be retrieved from the hub.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
