### PR TITLE
Exceptions during Sonos Unjoin action results in hung script

### DIFF
--- a/homeassistant/components/sonos/helpers.py
+++ b/homeassistant/components/sonos/helpers.py
@@ -15,6 +15,7 @@ from soco.exceptions import SoCoException, SoCoUPnPException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import SONOS_SPEAKER_ACTIVITY
@@ -135,6 +136,7 @@ class UnjoinData:
 
     speakers: list[SonosSpeaker] = field(default_factory=list)
     event: asyncio.Event = field(default_factory=asyncio.Event)
+    exception: HomeAssistantError | OSError | SoCoException | None = None
 
 
 @dataclass

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -15,6 +15,7 @@ from soco.core import (
     PLAY_MODES,
 )
 from soco.data_structures import DidlFavorite, DidlMusicTrack
+from soco.exceptions import SoCoException
 from soco.ms_data_structures import MusicServiceItem
 from sonos_websocket.exception import SonosWebsocketError
 
@@ -853,9 +854,12 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
             _LOGGER.debug(
                 "Processing unjoins for %s", [x.zone_name for x in unjoin_data.speakers]
             )
-            await SonosSpeaker.unjoin_multi(
-                self.hass, self.config_entry, unjoin_data.speakers
-            )
+            try:
+                await SonosSpeaker.unjoin_multi(
+                    self.hass, self.config_entry, unjoin_data.speakers
+                )
+            except (HomeAssistantError, SoCoException, OSError) as err:
+                unjoin_data.exception = err
             unjoin_data.event.set()
 
         if unjoin_data := sonos_data.unjoin_data.get(household_id):
@@ -868,3 +872,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
 
         _LOGGER.debug("Requesting unjoin for %s", self.speaker.zone_name)
         await unjoin_data.event.wait()
+
+        # Re-raise any exception that occurred during processing
+        if unjoin_data.exception:
+            raise unjoin_data.exception

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -860,7 +860,8 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
                 )
             except (HomeAssistantError, SoCoException, OSError) as err:
                 unjoin_data.exception = err
-            unjoin_data.event.set()
+            finally:
+                unjoin_data.event.set()
 
         if unjoin_data := sonos_data.unjoin_data.get(household_id):
             unjoin_data.speakers.append(self.speaker)

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -1063,7 +1063,7 @@ class SonosSpeaker:
                 hass,
                 config_entry,
                 [[s] for s in speakers],
-                operation="unjoin",
+                action="unjoin",
             )
 
     @soco_error()
@@ -1207,7 +1207,7 @@ class SonosSpeaker:
         hass: HomeAssistant,
         config_entry: SonosConfigEntry,
         groups: list[list[SonosSpeaker]],
-        operation: str = "join",
+        action: str = "join",
     ) -> None:
         """Wait until all groups are present, or timeout."""
 
@@ -1241,7 +1241,7 @@ class SonosSpeaker:
                 translation_key="timeout_join",
                 translation_placeholders={
                     "group_description": group_description,
-                    "operation": operation,
+                    "action": action,
                 },
             ) from TimeoutError
         any_speaker = next(iter(config_entry.runtime_data.discovered.values()))

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -1060,7 +1060,10 @@ class SonosSpeaker:
         async with config_entry.runtime_data.topology_condition:
             await hass.async_add_executor_job(_unjoin_all, speakers)
             await SonosSpeaker.wait_for_groups(
-                hass, config_entry, [[s] for s in speakers]
+                hass,
+                config_entry,
+                [[s] for s in speakers],
+                operation="unjoin",
             )
 
     @soco_error()
@@ -1204,6 +1207,7 @@ class SonosSpeaker:
         hass: HomeAssistant,
         config_entry: SonosConfigEntry,
         groups: list[list[SonosSpeaker]],
+        operation: str = "join",
     ) -> None:
         """Wait until all groups are present, or timeout."""
 
@@ -1228,14 +1232,17 @@ class SonosSpeaker:
                 while not _test_groups(groups):
                     await config_entry.runtime_data.topology_condition.wait()
         except TimeoutError:
-            group_description = [
+            group_description = "; ".join(
                 f"{group[0].zone_name}: {', '.join(speaker.zone_name for speaker in group)}"
                 for group in groups
-            ]
+            )
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="timeout_join",
-                translation_placeholders={"group_description": str(group_description)},
+                translation_placeholders={
+                    "group_description": group_description,
+                    "operation": operation,
+                },
             ) from TimeoutError
         any_speaker = next(iter(config_entry.runtime_data.discovered.values()))
         any_speaker.soco.zone_group_state.clear_cache()

--- a/homeassistant/components/sonos/strings.json
+++ b/homeassistant/components/sonos/strings.json
@@ -125,7 +125,7 @@
       "message": "{entity_id} is not a known Sonos speaker."
     },
     "timeout_join": {
-      "message": "Timeout while waiting for Sonos player to join the group {group_description}"
+      "message": "Timeout while waiting for Sonos player to {operation} the group {group_description}"
     }
   },
   "issues": {

--- a/homeassistant/components/sonos/strings.json
+++ b/homeassistant/components/sonos/strings.json
@@ -125,7 +125,7 @@
       "message": "{entity_id} is not a known Sonos speaker."
     },
     "timeout_join": {
-      "message": "Timeout while waiting for Sonos player to {operation} the group {group_description}"
+      "message": "Timeout while waiting for Sonos player to {action} the group {group_description}"
     }
   },
   "issues": {

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -131,7 +131,7 @@ async def test_media_player_join_timeout(
 
     expected = (
         "Timeout while waiting for Sonos player to join the "
-        "group ['Living Room: Living Room, Bedroom']"
+        "group Living Room: Living Room, Bedroom"
     )
     with (
         patch(
@@ -168,7 +168,7 @@ async def test_media_player_unjoin_timeout(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     expected = (
-        "Timeout while waiting for Sonos player to join the group ['Bedroom: Bedroom']"
+        "Timeout while waiting for Sonos player to unjoin the group Bedroom: Bedroom"
     )
     with (
         patch(

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -153,6 +153,38 @@ async def test_media_player_join_timeout(
     assert soco_living_room.join.call_count == 0
 
 
+async def test_media_player_unjoin_timeout(
+    hass: HomeAssistant,
+    sonos_setup_two_speakers: list[MockSoCo],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test unjoining of speaker with timeout error."""
+
+    soco_living_room = sonos_setup_two_speakers[0]
+    soco_bedroom = sonos_setup_two_speakers[1]
+
+    # First group the speakers together
+    group_speakers(soco_living_room, soco_bedroom)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    expected = (
+        "Timeout while waiting for Sonos player to join the group ['Bedroom: Bedroom']"
+    )
+    with (
+        patch(
+            "homeassistant.components.sonos.speaker.asyncio.timeout", instant_timeout
+        ),
+        pytest.raises(HomeAssistantError, match=re.escape(expected)),
+    ):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_UNJOIN,
+            {"entity_id": "media_player.bedroom"},
+            blocking=True,
+        )
+    assert soco_bedroom.unjoin.call_count == 1
+
+
 async def test_media_player_unjoin(
     hass: HomeAssistant,
     sonos_setup_two_speakers: list[MockSoCo],

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -13,6 +13,7 @@ from homeassistant.components.media_player import (
     SERVICE_JOIN,
     SERVICE_UNJOIN,
 )
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -156,7 +157,6 @@ async def test_media_player_join_timeout(
 async def test_media_player_unjoin_timeout(
     hass: HomeAssistant,
     sonos_setup_two_speakers: list[MockSoCo],
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test unjoining of speaker with timeout error."""
 
@@ -174,12 +174,12 @@ async def test_media_player_unjoin_timeout(
         patch(
             "homeassistant.components.sonos.speaker.asyncio.timeout", instant_timeout
         ),
-        pytest.raises(HomeAssistantError, match=re.escape(expected)),
+        pytest.raises(HomeAssistantError, match=expected),
     ):
         await hass.services.async_call(
             MP_DOMAIN,
             SERVICE_UNJOIN,
-            {"entity_id": "media_player.bedroom"},
+            {ATTR_ENTITY_ID: "media_player.bedroom"},
             blocking=True,
         )
     assert soco_bedroom.unjoin.call_count == 1

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -174,7 +174,7 @@ async def test_media_player_unjoin_timeout(
         patch(
             "homeassistant.components.sonos.speaker.asyncio.timeout", instant_timeout
         ),
-        pytest.raises(HomeAssistantError, match=expected),
+        pytest.raises(HomeAssistantError, match=re.escape(expected)),
     ):
         await hass.services.async_call(
             MP_DOMAIN,


### PR DESCRIPTION
## Proposed change

Exceptions during an Unjoin action were not propagated back to Home Assistant. This change properly handles the exceptions and propagates them back to the automation.

The integration coalesces multiple unjoin actions into a single operation by using a worker thread and a combines all calls within 0.1 seconds into a single call. When the worker thread completes it sets an event to notify the action(s) the processing is complete.

a) Exceptions in the worker thread were not handled. This resulted in the event not being sent and the actions not completing; aw well as an unhandled task exception in the log.
b) Under some circumstances the construction on the timeout error message could cause an exception.
c) The error message for an "unjoin" action did not have the correct action name.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #159512
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
