### PR TITLE
Add labels to Transmission add_torrent service and events

### DIFF
--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -39,6 +39,7 @@ DEFAULT_SCAN_INTERVAL = 120
 STATE_ATTR_TORRENT_INFO = "torrent_info"
 
 ATTR_DELETE_DATA = "delete_data"
+ATTR_LABELS = "labels"
 ATTR_TORRENT = "torrent"
 ATTR_TORRENTS = "torrents"
 ATTR_DOWNLOAD_PATH = "download_path"

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -112,6 +112,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                         "name": torrent.name,
                         "id": torrent.id,
                         "download_path": torrent.download_dir,
+                        "labels": torrent.labels,
                     },
                 )
 
@@ -133,6 +134,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                         "name": torrent.name,
                         "id": torrent.id,
                         "download_path": torrent.download_dir,
+                        "labels": torrent.labels,
                     },
                 )
 
@@ -150,6 +152,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                         "name": torrent.name,
                         "id": torrent.id,
                         "download_path": torrent.download_dir,
+                        "labels": torrent.labels,
                     },
                 )
 

--- a/homeassistant/components/transmission/services.yaml
+++ b/homeassistant/components/transmission/services.yaml
@@ -15,6 +15,11 @@ add_torrent:
       example: "/path/to/download/directory"
       selector:
         text:
+    labels:
+      required: false
+      example: "Notify,Remove"
+      selector:
+        text:
 
 get_torrents:
   fields:

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -143,6 +143,10 @@
           "description": "ID of the config entry to use.",
           "name": "Transmission entry"
         },
+        "labels": {
+          "description": "Optional comma-separated list of labels to assign to the torrent.",
+          "name": "Labels"
+        },
         "torrent": {
           "description": "URL, magnet link or Base64 encoded file.",
           "name": "Torrent"

--- a/tests/components/transmission/test_services.py
+++ b/tests/components/transmission/test_services.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant.components.transmission.const import (
     ATTR_DELETE_DATA,
     ATTR_DOWNLOAD_PATH,
+    ATTR_LABELS,
     ATTR_TORRENT,
     ATTR_TORRENT_FILTER,
     ATTR_TORRENTS,
@@ -76,32 +77,48 @@ async def test_service_integration_not_found(
     ("payload", "expected_torrent", "kwargs"),
     [
         (
-            {ATTR_TORRENT: "magnet:?xt=urn:btih:test"},
+            {ATTR_TORRENT: "magnet:?xt=urn:btih:test", ATTR_LABELS: "Notify"},
             "magnet:?xt=urn:btih:test",
-            {},
+            {
+                "labels": ["Notify"],
+                "download_dir": None,
+            },
         ),
         (
             {
                 ATTR_TORRENT: "magnet:?xt=urn:btih:test",
+                ATTR_LABELS: "Movies,Notify",
                 ATTR_DOWNLOAD_PATH: "/custom/path",
             },
             "magnet:?xt=urn:btih:test",
-            {"download_dir": "/custom/path"},
+            {
+                "labels": ["Movies", "Notify"],
+                "download_dir": "/custom/path",
+            },
         ),
         (
             {ATTR_TORRENT: "http://example.com/test.torrent"},
             "http://example.com/test.torrent",
-            {},
+            {
+                "labels": None,
+                "download_dir": None,
+            },
         ),
         (
             {ATTR_TORRENT: "ftp://example.com/test.torrent"},
             "ftp://example.com/test.torrent",
-            {},
+            {
+                "labels": None,
+                "download_dir": None,
+            },
         ),
         (
             {ATTR_TORRENT: "/config/test.torrent"},
             "/config/test.torrent",
-            {},
+            {
+                "labels": None,
+                "download_dir": None,
+            },
         ),
     ],
 )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds optional labels to the add_torrent service, the add_torrent function supports None on download dir so moved to just one partial call for everything.

Add labels to event data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42742
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
