### PR TITLE
Fix ElevenLabs STT auto-detect language

### DIFF
--- a/homeassistant/components/elevenlabs/stt.py
+++ b/homeassistant/components/elevenlabs/stt.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterable
 from io import BytesIO
 import logging
+from typing import Any
 
 from elevenlabs import AsyncElevenLabs
 from elevenlabs.core import ApiError
@@ -180,15 +181,17 @@ class ElevenLabsSTTEntity(SpeechToTextEntity):
         )
 
         try:
-            response = await self._client.speech_to_text.convert(
-                file=BytesIO(audio),
-                file_format=file_format,
-                model_id=self._stt_model,
-                language_code=lang_code,
-                tag_audio_events=False,
-                num_speakers=1,
-                diarize=False,
-            )
+            kwargs: dict[str, Any] = {
+                "file": BytesIO(audio),
+                "file_format": file_format,
+                "model_id": self._stt_model,
+                "tag_audio_events": False,
+                "num_speakers": 1,
+                "diarize": False,
+            }
+            if lang_code is not None:
+                kwargs["language_code"] = lang_code
+            response = await self._client.speech_to_text.convert(**kwargs)
         except ApiError as exc:
             _LOGGER.error("Error during processing of STT request: %s", exc)
             return stt.SpeechResult(None, SpeechResultState.ERROR)

--- a/tests/components/elevenlabs/test_stt.py
+++ b/tests/components/elevenlabs/test_stt.py
@@ -156,6 +156,26 @@ async def test_stt_transcription_success_auto_language(
     assert result.result == stt.SpeechResultState.SUCCESS
     assert result.text == "hello world"
     entity._client.speech_to_text.convert.assert_called_once()
+    # Verify language_code is NOT passed when auto-detect is enabled
+    call_kwargs = entity._client.speech_to_text.convert.call_args.kwargs
+    assert "language_code" not in call_kwargs
+
+
+async def test_stt_transcription_passes_language_code(
+    hass: HomeAssistant,
+    setup: AsyncMock,
+    default_metadata: stt.SpeechMetadata,
+    simple_stream,
+) -> None:
+    """Test that language_code is passed when auto-detect is disabled."""
+    entity = stt.async_get_speech_to_text_engine(hass, "stt.elevenlabs_speech_to_text")
+    assert entity is not None
+    assert not entity._auto_detect_language
+    result = await entity.async_process_audio_stream(default_metadata, simple_stream())
+    assert result.result == stt.SpeechResultState.SUCCESS
+    # Verify language_code IS passed when auto-detect is disabled
+    call_kwargs = entity._client.speech_to_text.convert.call_args.kwargs
+    assert call_kwargs["language_code"] == "en"
 
 
 # === ERROR CASES (PARAMETRIZED) ===


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes the ElevenLabs speech-to-text auto-detect language feature.

When auto-detect language is enabled in the ElevenLabs integration options, the code was passing `language_code=None` to the API. The ElevenLabs SDK serializes `None` as an empty string `''` in multipart form data, causing the API to reject it with:

```
Invalid language code received: ''. Please use None if you want us to automatically detect the language...
```

The fix omits `language_code` entirely when auto-detecting, letting the SDK use its default `OMIT` sentinel which excludes the parameter from the request - triggering the API's auto-detect behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code I am submitting and can explain how it works.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr