### PR TITLE
vesync switch to async_write_ha_state

### DIFF
--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -198,7 +198,7 @@ class VeSyncFanHA(VeSyncBaseEntity, FanEntity):
                     "An error occurred while turning off: "
                     + self.device.last_response.message
                 )
-            self.schedule_update_ha_state()
+            self.async_write_ha_state()
             return
 
         # If the fan is off, turn it on first
@@ -226,7 +226,7 @@ class VeSyncFanHA(VeSyncBaseEntity, FanEntity):
                 + self.device.last_response.message
             )
 
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of device."""
@@ -254,7 +254,7 @@ class VeSyncFanHA(VeSyncBaseEntity, FanEntity):
         if not success:
             raise HomeAssistantError(self.device.last_response.message)
 
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_turn_on(
         self,
@@ -270,7 +270,7 @@ class VeSyncFanHA(VeSyncBaseEntity, FanEntity):
             success = await self.device.turn_on()
             if not success:
                 raise HomeAssistantError(self.device.last_response.message)
-            self.schedule_update_ha_state()
+            self.async_write_ha_state()
         else:
             await self.async_set_percentage(percentage)
 
@@ -279,11 +279,11 @@ class VeSyncFanHA(VeSyncBaseEntity, FanEntity):
         success = await self.device.turn_off()
         if not success:
             raise HomeAssistantError(self.device.last_response.message)
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Set oscillation."""
         success = await self.device.toggle_oscillation(oscillating)
         if not success:
             raise HomeAssistantError(self.device.last_response.message)
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()

--- a/homeassistant/components/vesync/humidifier.py
+++ b/homeassistant/components/vesync/humidifier.py
@@ -178,7 +178,7 @@ class VeSyncHumidifierHA(VeSyncBaseEntity, HumidifierEntity):
         if not success:
             raise HomeAssistantError(self.device.last_response.message)
 
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
@@ -186,7 +186,7 @@ class VeSyncHumidifierHA(VeSyncBaseEntity, HumidifierEntity):
         if not success:
             raise HomeAssistantError(self.device.last_response.message)
 
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -145,10 +145,12 @@ class VeSyncBaseLightHA(VeSyncBaseEntity, LightEntity):
             return
         # send turn_on command to pyvesync api
         await self.device.turn_on()
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self.device.turn_off()
+        self.async_write_ha_state()
 
 
 class VeSyncDimmableLightHA(VeSyncBaseLightHA, LightEntity):

--- a/homeassistant/components/vesync/number.py
+++ b/homeassistant/components/vesync/number.py
@@ -125,4 +125,4 @@ class VeSyncNumberEntity(VeSyncBaseEntity, NumberEntity):
         """Set new value."""
         if not await self.entity_description.set_value_fn(self.device, value):
             raise HomeAssistantError(self.device.last_response.message)
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()

--- a/homeassistant/components/vesync/select.py
+++ b/homeassistant/components/vesync/select.py
@@ -169,4 +169,4 @@ class VeSyncSelectEntity(VeSyncBaseEntity, SelectEntity):
         """Set an option."""
         if not await self.entity_description.select_option_fn(self.device, option):
             raise HomeAssistantError(self.device.last_response.message)
-        await self.coordinator.async_request_refresh()
+        self.async_write_ha_state()

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -135,11 +135,11 @@ class VeSyncSwitchEntity(SwitchEntity, VeSyncBaseEntity):
         if not await self.entity_description.off_fn(self.device):
             raise HomeAssistantError(self.device.last_response.message)
 
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         if not await self.entity_description.on_fn(self.device):
             raise HomeAssistantError(self.device.last_response.message)
 
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()

--- a/tests/components/vesync/test_fan.py
+++ b/tests/components/vesync/test_fan.py
@@ -80,7 +80,7 @@ async def test_turn_on_off_success(
         patch(command, new_callable=AsyncMock, return_value=True) as method_mock,
     ):
         with patch(
-            "homeassistant.components.vesync.fan.VeSyncFanHA.schedule_update_ha_state"
+            "homeassistant.components.vesync.fan.VeSyncFanHA.async_write_ha_state"
         ) as update_mock:
             await hass.services.async_call(
                 FAN_DOMAIN,
@@ -169,7 +169,7 @@ async def test_set_preset_mode(
         ) as method_mock,
     ):
         with patch(
-            "homeassistant.components.vesync.fan.VeSyncFanHA.schedule_update_ha_state"
+            "homeassistant.components.vesync.fan.VeSyncFanHA.async_write_ha_state"
         ) as update_mock:
             await hass.services.async_call(
                 FAN_DOMAIN,
@@ -214,7 +214,7 @@ async def test_oscillation_success(
         ) as method_mock,
     ):
         with patch(
-            "homeassistant.components.vesync.fan.VeSyncFanHA.schedule_update_ha_state"
+            "homeassistant.components.vesync.fan.VeSyncFanHA.async_write_ha_state"
         ) as update_mock:
             await hass.services.async_call(
                 FAN_DOMAIN,

--- a/tests/components/vesync/test_humidifier.py
+++ b/tests/components/vesync/test_humidifier.py
@@ -182,7 +182,7 @@ async def test_turn_on(
         ) as method_mock,
     ):
         with patch(
-            "homeassistant.components.vesync.humidifier.VeSyncHumidifierHA.schedule_update_ha_state"
+            "homeassistant.components.vesync.humidifier.VeSyncHumidifierHA.async_write_ha_state"
         ) as update_mock:
             await hass.services.async_call(
                 HUMIDIFIER_DOMAIN,
@@ -218,7 +218,7 @@ async def test_turn_off(
         ) as method_mock,
     ):
         with patch(
-            "homeassistant.components.vesync.humidifier.VeSyncHumidifierHA.schedule_update_ha_state"
+            "homeassistant.components.vesync.humidifier.VeSyncHumidifierHA.async_write_ha_state"
         ) as update_mock:
             await hass.services.async_call(
                 HUMIDIFIER_DOMAIN,

--- a/tests/components/vesync/test_switch.py
+++ b/tests/components/vesync/test_switch.py
@@ -88,7 +88,7 @@ async def test_turn_on_off_display_success(
             return_value=True,
         ) as method_mock,
         patch(
-            "homeassistant.components.vesync.switch.VeSyncSwitchEntity.schedule_update_ha_state"
+            "homeassistant.components.vesync.switch.VeSyncSwitchEntity.async_write_ha_state"
         ) as update_mock,
     ):
         await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Switch to async_write_ha_state.   The risk of this change is if any device class in the library isn't optimistic.  They all should be.  If reports come in will handle it then.   This may assist with #155633 as it would actually slow the API call, allowing it to become consistent. 

Submitting related to this: https://github.com/home-assistant/core/pull/156663/files#r2569609342

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
