### PR TITLE
Code quality fixes for TP-Link Omada service actions

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -13,18 +13,14 @@ from tplink_omada_client.exceptions import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import (
-    ConfigEntryAuthFailed,
-    ConfigEntryNotReady,
-    HomeAssistantError,
-    ServiceValidationError,
-)
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 
 from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
 from .controller import OmadaSiteController
+from .services import async_setup_services
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -34,8 +30,16 @@ PLATFORMS: list[Platform] = [
     Platform.UPDATE,
 ]
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 type OmadaConfigEntry = ConfigEntry[OmadaSiteController]
+
+
+async def async_setup(hass: HomeAssistant, config: OmadaConfigEntry) -> bool:
+    """Set up my integration."""
+    async_setup_services(hass)
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bool:
@@ -65,19 +69,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 
     entry.runtime_data = controller
 
-    async def handle_reconnect_client(call: ServiceCall) -> None:
-        """Handle the service action to force reconnection of a network client."""
-        mac: str | None = call.data.get("mac")
-        if not mac:
-            raise ServiceValidationError("MAC address is required")
-
-        try:
-            await site_client.reconnect_client(mac)
-        except OmadaClientException as ex:
-            raise HomeAssistantError("Failed to reconnect client") from ex
-
-    hass.services.async_register(DOMAIN, "reconnect_client", handle_reconnect_client)
-
     _remove_old_devices(hass, entry, controller.devices_coordinator.data)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -87,12 +78,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 
 async def async_unload_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if not hass.config_entries.async_loaded_entries(DOMAIN):
-        # This is the last loaded instance of Omada, deregister any services
-        hass.services.async_remove(DOMAIN, "reconnect_client")
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 def _remove_old_devices(

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers.typing import ConfigType
 
 from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
@@ -35,8 +36,8 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 type OmadaConfigEntry = ConfigEntry[OmadaSiteController]
 
 
-async def async_setup(hass: HomeAssistant, config: OmadaConfigEntry) -> bool:
-    """Set up my integration."""
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up TP-Link Omada integration."""
     async_setup_services(hass)
 
     return True

--- a/homeassistant/components/tplink_omada/quality_scale.yaml
+++ b/homeassistant/components/tplink_omada/quality_scale.yaml
@@ -1,8 +1,6 @@
 rules:
   # Bronze
-  action-setup:
-    status: todo
-    comment: Actions are created in async_setup_entry, and need to be moved.
+  action-setup: done
   appropriate-polling:
     status: done
     comment: Service data APIs are polled every 5 minutes

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -29,6 +29,8 @@ def _get_controller(call: ServiceCall) -> OmadaSiteController:
     else:
         # Assume first loaded entry if none specified (for backward compatibility/99% use case)
         entries = call.hass.config_entries.async_entries(DOMAIN)
+        if len(entries) == 0:
+            raise ServiceValidationError("No active TP-Link Omada controllers found")
         entry = entries[0]
 
     entry = cast(ConfigEntry[OmadaSiteController], entry)

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -1,0 +1,75 @@
+"""Services for the TP-Link Omada integration."""
+
+from typing import cast
+
+from tplink_omada_client.exceptions import OmadaClientException
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import config_validation as cv, selector
+
+from .const import DOMAIN
+from .controller import OmadaSiteController
+
+SERVICE_RECONNECT_CLIENT = "reconnect_client"
+
+ATTR_CONFIG_ENTRY_ID = "config_entry_id"
+ATTR_MAC = "mac"
+
+
+def _get_controller(call: ServiceCall) -> OmadaSiteController:
+    if call.data.get(ATTR_CONFIG_ENTRY_ID):
+        entry = call.hass.config_entries.async_get_entry(
+            call.data[ATTR_CONFIG_ENTRY_ID]
+        )
+        if not entry:
+            raise ServiceValidationError("Entry not found")
+    else:
+        # Assume first loaded entry if none specified (for backward compatibility/99% use case)
+        entries = call.hass.config_entries.async_entries(DOMAIN)
+        entry = entries[0]
+
+    entry = cast(ConfigEntry[OmadaSiteController], entry)
+
+    if entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError("Entry not loaded")
+    return entry.runtime_data
+
+
+SCHEMA_RECONNECT_CLIENT = vol.Schema(
+    {
+        vol.Optional(ATTR_CONFIG_ENTRY_ID): selector.ConfigEntrySelector(
+            {
+                "integration": DOMAIN,
+            }
+        ),
+        vol.Required(ATTR_MAC): cv.string,
+    }
+)
+
+
+async def _handle_reconnect_client(call: ServiceCall) -> None:
+    """Handle the service action to force reconnection of a network client."""
+    controller = _get_controller(call)
+
+    mac: str = call.data[ATTR_MAC]
+
+    try:
+        await controller.omada_client.reconnect_client(mac)
+    except OmadaClientException as ex:
+        raise HomeAssistantError("Failed to reconnect client") from ex
+
+
+SERVICES = [
+    (SERVICE_RECONNECT_CLIENT, SCHEMA_RECONNECT_CLIENT, _handle_reconnect_client)
+]
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up the services for the TP-Link Omada integration."""
+
+    for service_name, schema, handler in SERVICES:
+        hass.services.async_register(DOMAIN, service_name, handler, schema=schema)

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -25,7 +25,7 @@ def _get_controller(call: ServiceCall) -> OmadaSiteController:
             call.data[ATTR_CONFIG_ENTRY_ID]
         )
         if not entry:
-            raise ServiceValidationError("Entry not found")
+            raise ServiceValidationError("Specified TP-Link Omada controller not found")
     else:
         # Assume first loaded entry if none specified (for backward compatibility/99% use case)
         entries = call.hass.config_entries.async_entries(DOMAIN)
@@ -34,7 +34,9 @@ def _get_controller(call: ServiceCall) -> OmadaSiteController:
     entry = cast(ConfigEntry[OmadaSiteController], entry)
 
     if entry.state is not ConfigEntryState.LOADED:
-        raise ServiceValidationError("Entry not loaded")
+        raise ServiceValidationError(
+            "The TP-Link Omada integration is not currently available"
+        )
     return entry.runtime_data
 
 
@@ -59,7 +61,7 @@ async def _handle_reconnect_client(call: ServiceCall) -> None:
     try:
         await controller.omada_client.reconnect_client(mac)
     except OmadaClientException as ex:
-        raise HomeAssistantError("Failed to reconnect client") from ex
+        raise HomeAssistantError(f"Failed to reconnect client with MAC {mac}") from ex
 
 
 SERVICES = [

--- a/homeassistant/components/tplink_omada/services.yaml
+++ b/homeassistant/components/tplink_omada/services.yaml
@@ -1,5 +1,9 @@
 reconnect_client:
   fields:
+    config_entry_id:
+      selector:
+        config_entry:
+          integration: tplink_omada
     mac:
       required: true
       example: "01-23-45-67-89-AB"

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -102,6 +102,10 @@
     "reconnect_client": {
       "description": "Tries to get wireless client to reconnect to Omada network.",
       "fields": {
+        "config_entry_id": {
+          "description": "The instance of the Omada integration to which the client is connected.",
+          "name": "Omada controller"
+        },
         "mac": {
           "description": "MAC address of the device.",
           "name": "MAC address"

--- a/tests/components/tplink_omada/test_services.py
+++ b/tests/components/tplink_omada/test_services.py
@@ -6,10 +6,30 @@ import pytest
 from tplink_omada_client.exceptions import OmadaClientException
 
 from homeassistant.components.tplink_omada.const import DOMAIN
+from homeassistant.components.tplink_omada.services import async_setup_services
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from tests.common import MockConfigEntry
+
+
+async def test_service_reconnect_no_config_entries(
+    hass: HomeAssistant,
+) -> None:
+    """Test reconnect service raises error when no config entries exist."""
+    # Register services directly without any config entries
+    async_setup_services(hass)
+
+    mac = "AA:BB:CC:DD:EE:FF"
+    with pytest.raises(
+        ServiceValidationError, match="No active TP-Link Omada controllers found"
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "reconnect_client",
+            {"mac": mac},
+            blocking=True,
+        )
 
 
 async def test_service_reconnect_client(

--- a/tests/components/tplink_omada/test_services.py
+++ b/tests/components/tplink_omada/test_services.py
@@ -1,0 +1,104 @@
+"""Tests for TP-Link Omada integration services."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from tplink_omada_client.exceptions import OmadaClientException
+
+from homeassistant.components.tplink_omada.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from tests.common import MockConfigEntry
+
+
+async def test_service_reconnect_client(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconnect client service."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "AA:BB:CC:DD:EE:FF"
+    await hass.services.async_call(
+        DOMAIN,
+        "reconnect_client",
+        {"config_entry_id": mock_config_entry.entry_id, "mac": mac},
+        blocking=True,
+    )
+
+    mock_omada_site_client.reconnect_client.assert_awaited_once_with(mac)
+
+
+async def test_service_reconnect_failed_with_invalid_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconnect with invalid config entry raises ServiceValidationError."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "AA:BB:CC:DD:EE:FF"
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "reconnect_client",
+            {"config_entry_id": "invalid_entry_id", "mac": mac},
+            blocking=True,
+        )
+
+
+async def test_service_reconnect_without_config_entry_id(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconnect client service without config_entry_id uses first loaded entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "AA:BB:CC:DD:EE:FF"
+    await hass.services.async_call(
+        DOMAIN,
+        "reconnect_client",
+        {"mac": mac},
+        blocking=True,
+    )
+
+    mock_omada_site_client.reconnect_client.assert_awaited_once_with(mac)
+
+
+async def test_service_reconnect_failed_raises_homeassistanterror(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconnect client service raises the right kind of exception on service failure."""
+
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "AA:BB:CC:DD:EE:FF"
+    mock_omada_site_client.reconnect_client.side_effect = OmadaClientException
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            "reconnect_client",
+            {"config_entry_id": mock_config_entry.entry_id, "mac": mac},
+            blocking=True,
+        )
+
+    mock_omada_site_client.reconnect_client.assert_awaited_once_with(mac)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Checking off quality checklist item:

## Bronze
- [x] `action-setup` - Service actions are registered in async_setup

I had to add a parameter to identify which integration instance the action was for. This defaults to the first installed integration for backward compatibility.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: [#42763](https://github.com/home-assistant/home-assistant.io/pull/42763)
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
