### PR TITLE
Add podcast favorites support to Sonos media browser

### DIFF
--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -37,6 +37,7 @@ SONOS_RADIO = "radio"
 SONOS_SHARE = "share"
 SONOS_OTHER_ITEM = "other items"
 SONOS_AUDIO_BOOK = "audio book"
+SONOS_PODCAST = "podcast"
 
 MEDIA_TYPE_DIRECTORY = MediaClass.DIRECTORY
 
@@ -66,6 +67,7 @@ SONOS_TO_MEDIA_CLASSES = {
     SONOS_COMPOSER: MediaClass.COMPOSER,
     SONOS_GENRE: MediaClass.GENRE,
     SONOS_PLAYLISTS: MediaClass.PLAYLIST,
+    SONOS_PODCAST: MediaClass.PODCAST,
     SONOS_TRACKS: MediaClass.TRACK,
     SONOS_SHARE: MediaClass.DIRECTORY,
     "object.container": MediaClass.DIRECTORY,
@@ -75,6 +77,7 @@ SONOS_TO_MEDIA_CLASSES = {
     "object.container.person.musicArtist": MediaClass.ARTIST,
     "object.container.playlistContainer.sameArtist": MediaClass.ARTIST,
     "object.container.playlistContainer": MediaClass.PLAYLIST,
+    "object.container.podcast": MediaClass.PODCAST,
     "object.item": MediaClass.TRACK,
     "object.item.audioItem.musicTrack": MediaClass.TRACK,
     "object.item.audioItem.audioBroadcast": MediaClass.GENRE,
@@ -88,6 +91,7 @@ SONOS_TO_MEDIA_TYPES = {
     SONOS_COMPOSER: MediaType.COMPOSER,
     SONOS_GENRE: MediaType.GENRE,
     SONOS_PLAYLISTS: MediaType.PLAYLIST,
+    SONOS_PODCAST: MediaType.PODCAST,
     SONOS_TRACKS: MediaType.TRACK,
     "object.container": MEDIA_TYPE_DIRECTORY,
     "object.container.album.musicAlbum": MediaType.ALBUM,
@@ -96,6 +100,7 @@ SONOS_TO_MEDIA_TYPES = {
     "object.container.person.musicArtist": MediaType.ARTIST,
     "object.container.playlistContainer.sameArtist": MediaType.ARTIST,
     "object.container.playlistContainer": MediaType.PLAYLIST,
+    "object.container.podcast": MediaType.PODCAST,
     "object.item.audioItem.musicTrack": MediaType.TRACK,
     "object.item.audioItem.audioBook": MediaType.TRACK,
 }
@@ -125,6 +130,7 @@ SONOS_TYPES_MAPPING = {
     "object.container.person.musicArtist": SONOS_ALBUM_ARTIST,
     "object.container.playlistContainer.sameArtist": SONOS_ARTIST,
     "object.container.playlistContainer": SONOS_PLAYLISTS,
+    "object.container.podcast": SONOS_PODCAST,
     "object.item": SONOS_OTHER_ITEM,
     "object.item.audioItem.musicTrack": SONOS_TRACKS,
     "object.item.audioItem.audioBroadcast": SONOS_RADIO,
@@ -149,6 +155,7 @@ PLAYABLE_MEDIA_TYPES = [
     MediaType.CONTRIBUTING_ARTIST,
     MediaType.GENRE,
     MediaType.PLAYLIST,
+    MediaType.PODCAST,
     MediaType.TRACK,
 ]
 

--- a/tests/components/sonos/fixtures/sonos_favorites.json
+++ b/tests/components/sonos/fixtures/sonos_favorites.json
@@ -12,6 +12,23 @@
     ]
   },
   {
+    "title": "Les P'tits Bateaux",
+    "parent_id": "FV:2",
+    "item_id": "FV:2/11",
+    "album_art_uri": "https://www.radiofrance.fr/s3/cruiser-production/2023/05/67b86ee2-78c7-41a9-9d89-62c95e619036/1000x1000_sc_les-p-tits-bateaux.jpg",
+    "resource_meta_data": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"10fe206cpodcast%3A3d680a63-ec3d-11e1-a7b7-782bcb76618d\" parentID=\"10fe206cpodcast%3A3d680a63-ec3d-11e1-a7b7-782bcb76618d\" restricted=\"true\"><dc:title>Les P'tits Bateaux</dc:title><upnp:class>object.container.podcast</upnp:class><desc id=\"cdudn\" nameSpace=\"urn:schemas-rinconnetworks-com:metadata-1-0/\">SA_RINCON149767_</desc></item></DIDL-Lite>",
+    "resources": [
+      {
+        "uri": "x-rincon-cpcontainer:10fe206cpodcast%3A3d680a63-ec3d-11e1-a7b7-782bcb76618d?sid=585&flags=8300&sn=3",
+        "protocol_info": "x-rincon-cpcontainer:*:*:*"
+      }
+    ],
+    "desc": null,
+    "type": "instantPlay",
+    "description": "Radio France",
+    "favorite_nr": "10"
+  },
+  {
     "title": "James Taylor Radio",
     "parent_id": "FV:2",
     "item_id": "FV:2/13",

--- a/tests/components/sonos/snapshots/test_media_browser.ambr
+++ b/tests/components/sonos/snapshots/test_media_browser.ambr
@@ -32,6 +32,17 @@
         'can_play': False,
         'can_search': False,
         'children_media_class': None,
+        'media_class': 'podcast',
+        'media_content_id': 'object.container.podcast',
+        'media_content_type': 'favorites_folder',
+        'thumbnail': None,
+        'title': 'Podcast',
+      }),
+      dict({
+        'can_expand': True,
+        'can_play': False,
+        'can_search': False,
+        'children_media_class': None,
         'media_class': 'track',
         'media_content_id': 'object.item.audioItem.audioBook',
         'media_content_type': 'favorites_folder',
@@ -84,6 +95,33 @@
     'not_shown': 0,
     'thumbnail': None,
     'title': 'Albums',
+  })
+# ---
+# name: test_browse_media_favorites[object.container.podcast-favorites_folder]
+  dict({
+    'can_expand': True,
+    'can_play': False,
+    'can_search': False,
+    'children': list([
+      dict({
+        'can_expand': False,
+        'can_play': True,
+        'can_search': False,
+        'children_media_class': None,
+        'media_class': 'podcast',
+        'media_content_id': 'FV:2/11',
+        'media_content_type': 'favorite_item_id',
+        'thumbnail': 'https://www.radiofrance.fr/s3/cruiser-production/2023/05/67b86ee2-78c7-41a9-9d89-62c95e619036/1000x1000_sc_les-p-tits-bateaux.jpg',
+        'title': "Les P'tits Bateaux",
+      }),
+    ]),
+    'children_media_class': 'podcast',
+    'media_class': 'directory',
+    'media_content_id': '',
+    'media_content_type': 'favorites',
+    'not_shown': 0,
+    'thumbnail': None,
+    'title': 'Podcast',
   })
 # ---
 # name: test_browse_media_favorites[object.item.audioItem.audioBook-favorites_folder]

--- a/tests/components/sonos/test_media_browser.py
+++ b/tests/components/sonos/test_media_browser.py
@@ -202,6 +202,10 @@ async def test_browse_media_library_albums(
             "object.container.album.musicAlbum",
             "favorites_folder",
         ),
+        (
+            "object.container.podcast",
+            "favorites_folder",
+        ),
     ],
 )
 async def test_browse_media_favorites(


### PR DESCRIPTION
## Proposed change

Podcasts saved as Sonos favorites (from the Sonos S2 app) were not appearing in the Home Assistant media browser. This was because the `object.container.podcast` DIDL-Lite class was not mapped in the Sonos integration's type mapping dictionaries.

When browsing favorites, the `media_browser.py` groups favorites by their `item_class` (from the DIDL metadata). Only classes that exist in `SONOS_TYPES_MAPPING` are displayed. Since `object.container.podcast` was missing, podcast favorites were silently filtered out.

This change adds the missing mappings:
- `SONOS_PODCAST = "podcast"` constant
- `object.container.podcast` → `MediaClass.PODCAST` in `SONOS_TO_MEDIA_CLASSES`
- `object.container.podcast` → `MediaType.PODCAST` in `SONOS_TO_MEDIA_TYPES`
- `object.container.podcast` → `SONOS_PODCAST` in `SONOS_TYPES_MAPPING`
- `MediaType.PODCAST` added to `PLAYABLE_MEDIA_TYPES`

After this fix, podcasts appear in a new "Podcast" folder within Media Browser → Sonos → Favorites.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #138846, fixes #124811
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr