### PR TITLE
Fixing state_class for ecowitt rain sensors

### DIFF
--- a/homeassistant/components/ecowitt/sensor.py
+++ b/homeassistant/components/ecowitt/sensor.py
@@ -302,7 +302,7 @@ async def async_setup_entry(
             name=sensor.name,
         )
 
-        # Only total rain needs state class for long-term statistics
+        # Rain sensors with cumulative values need state class for long-term statistics
         if sensor.key in RAIN_TOTAL_INCREASING_SENSOR_KEYS:
             description = dataclasses.replace(
                 description,

--- a/homeassistant/components/ecowitt/sensor.py
+++ b/homeassistant/components/ecowitt/sensor.py
@@ -257,6 +257,23 @@ ECOWITT_SENSORS_MAPPING: Final = {
     ),
 }
 
+RAIN_TOTAL_INCREASING_SENSOR_KEYS: Final = (
+    "totalrainin",
+    "eventrainin",
+    "hourlyrainin",
+    "dailyrainin",
+    "weeklyrainin",
+    "monthlyrainin",
+    "yearlyrainin",
+    "totalrainmm",
+    "eventrainmm",
+    "hourlyrainmm",
+    "dailyrainmm",
+    "weeklyrainmm",
+    "monthlyrainmm",
+    "yearlyrainmm",
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -286,10 +303,7 @@ async def async_setup_entry(
         )
 
         # Only total rain needs state class for long-term statistics
-        if sensor.key in (
-            "totalrainin",
-            "totalrainmm",
-        ):
+        if sensor.key in RAIN_TOTAL_INCREASING_SENSOR_KEYS:
             description = dataclasses.replace(
                 description,
                 state_class=SensorStateClass.TOTAL_INCREASING,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Fixes [#159188](https://github.com/home-assistant/core/issues/159188)

PR #155812 removed state class from accumulating rain sensor (weekly, hourly, last 24h, ....) because they are moving windows. However the truth is that not all rain sensor are moving windows - "last 24h" is, but not others - daily, hourly, yearly, etc.
This causes the error described in the issue.
This PR extends the list of sensor keys that are considered as "TOTAL_INCREASING", as they are not moving windows.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: Fixes [#159188](https://github.com/home-assistant/core/issues/159188)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
