### PR TITLE
Add schema validation for set_hot_water_schedule service

### DIFF
--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -7,11 +7,12 @@ import logging
 from typing import TYPE_CHECKING
 
 from bsblan import BSBLANError, DaySchedule, DHWSchedule, TimeSlot
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 
 from .const import DOMAIN
 
@@ -31,6 +32,29 @@ ATTR_SUNDAY_SLOTS = "sunday_slots"
 
 # Service name
 SERVICE_SET_HOT_WATER_SCHEDULE = "set_hot_water_schedule"
+
+
+# Schema for a single time slot
+_SLOT_SCHEMA = vol.Schema(
+    {
+        vol.Required("start_time"): vol.Any(cv.time, cv.string),
+        vol.Required("end_time"): vol.Any(cv.time, cv.string),
+    }
+)
+
+
+SERVICE_SET_HOT_WATER_SCHEDULE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
+        vol.Optional(ATTR_MONDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+        vol.Optional(ATTR_TUESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+        vol.Optional(ATTR_WEDNESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+        vol.Optional(ATTR_THURSDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+        vol.Optional(ATTR_FRIDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+        vol.Optional(ATTR_SATURDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+        vol.Optional(ATTR_SUNDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    }
+)
 
 
 def _parse_time_value(value: time | str) -> time:
@@ -214,4 +238,5 @@ def async_setup_services(hass: HomeAssistant) -> None:
         DOMAIN,
         SERVICE_SET_HOT_WATER_SCHEDULE,
         set_hot_water_schedule,
+        schema=SERVICE_SET_HOT_WATER_SCHEDULE_SCHEMA,
     )

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -1,17 +1,16 @@
 """Tests for BSB-LAN services."""
 
 from datetime import time
-from typing import Any, cast
+from typing import Any
 from unittest.mock import MagicMock
 
 from bsblan import BSBLANError, DaySchedule, TimeSlot
 import pytest
+import voluptuous as vol
 
 from homeassistant.components.bsblan.const import DOMAIN
 from homeassistant.components.bsblan.services import (
     SERVICE_SET_HOT_WATER_SCHEDULE,
-    _convert_time_slots_to_day_schedule,
-    _parse_time_value,
     async_setup_services,
 )
 from homeassistant.core import HomeAssistant
@@ -200,9 +199,7 @@ async def test_no_config_entry_for_device(
             SERVICE_SET_HOT_WATER_SCHEDULE,
             {
                 "device_id": device_entry.id,
-                "monday_slots": [
-                    {"start_time": time(6, 0), "end_time": time(8, 0)},
-                ],
+                "monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}],
             },
             blocking=True,
         )
@@ -276,14 +273,10 @@ async def test_api_error(
     [
         (time(13, 0), time(11, 0), "end_time_before_start_time"),
         ("13:00", "11:00", "end_time_before_start_time"),
-        ("invalid", "08:00", "invalid_time_format"),
-        ("06:00", "not-a-time", "invalid_time_format"),
     ],
     ids=[
         "time_objects_end_before_start",
         "strings_end_before_start",
-        "invalid_start_time_format",
-        "invalid_end_time_format",
     ],
 )
 async def test_time_validation_errors(
@@ -397,23 +390,19 @@ async def test_non_standard_time_types(
     device_entry: dr.DeviceEntry,
 ) -> None:
     """Test service with non-standard time types raises error."""
-    # Test with integer time values (shouldn't happen but need coverage)
-
-
-def test_non_standard_time_types_helper() -> None:
-    """Test helper with non-standard time types raises error.
-
-    Use the internal helper directly instead of exercising the Home
-    Assistant service layer; this avoids testing HA internals and keeps
-    the unit test focused on parsing/validation logic.
-    """
-    # Provide non-standard types (integers) to the converter
-    with pytest.raises(ServiceValidationError) as exc_info:
-        _convert_time_slots_to_day_schedule(
-            cast(Any, [{"start_time": 600, "end_time": 800}])
+    # Test with integer time values - schema validation will reject these
+    with pytest.raises(vol.MultipleInvalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HOT_WATER_SCHEDULE,
+            {
+                "device_id": device_entry.id,
+                "monday_slots": [
+                    {"start_time": 600, "end_time": 800},
+                ],
+            },
+            blocking=True,
         )
-
-    assert exc_info.value.translation_key == "invalid_time_format"
 
 
 async def test_async_setup_services(
@@ -432,19 +421,3 @@ async def test_async_setup_services(
 
     # Verify service is now registered
     assert hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
-
-
-def test_parse_time_value_with_non_string_non_time() -> None:
-    """Directly test _parse_time_value with a non-string, non-time value."""
-
-    # Use an arbitrary object that's neither a time nor a string
-    class Foo:
-        pass
-
-    # Call the imported function from the module-level import
-    with pytest.raises(ServiceValidationError) as exc_info:
-        # Cast to Any to intentionally pass an invalid type and satisfy static
-        # type checkers (Pylance/mypy)
-        _parse_time_value(cast(Any, Foo()))
-
-    assert exc_info.value.translation_key == "invalid_time_format"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request refactors the hot water schedule service in the `bsblan` Home Assistant integration to use strict schema validation for time slots, replacing manual parsing and validation. This change improves reliability by ensuring that only valid time objects are accepted and simplifies the code by removing custom parsing logic. The associated tests are updated to reflect the new validation approach.

**Service schema and validation improvements:**

* Introduced a `voluptuous` schema (`SERVICE_SET_HOT_WATER_SCHEDULE_SCHEMA`) for the `set_hot_water_schedule` service, enforcing that `start_time` and `end_time` are valid time objects and removing the need for manual parsing. (`homeassistant/components/bsblan/services.py`) [[1]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225L36-R56) [[2]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225R10-R15) [[3]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225R213)
* Removed the `_parse_time_value` function and updated the schedule conversion logic to assume validated time objects, simplifying the code and error handling. (`homeassistant/components/bsblan/services.py`) [[1]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225L36-R56) [[2]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225L80-R81)
* Updated the docstring in `_convert_time_slots_to_day_schedule` to clarify that time objects are expected after schema validation. (`homeassistant/components/bsblan/services.py`)

**Test updates for new validation:**

* Adjusted tests to expect `voluptuous` schema validation errors (`vol.MultipleInvalid`) instead of custom `ServiceValidationError` for invalid time types, and removed tests for string-based invalid time formats, as these are now caught by the schema. (`tests/components/bsblan/test_services.py`) [[1]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L398-L413) [[2]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L277-L284)
* Minor test cleanups for formatting and imports to align with the new validation approach. (`tests/components/bsblan/test_services.py`) [[1]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582R9) [[2]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L201-R202)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/156112
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
