### PR TITLE
Move async_setup_services to async_setup for netgear_lte

### DIFF
--- a/homeassistant/components/netgear_lte/__init__.py
+++ b/homeassistant/components/netgear_lte/__init__.py
@@ -61,6 +61,7 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Netgear LTE component."""
     hass.data[DATA_HASS_CONFIG] = config
+    async_setup_services(hass)
 
     return True
 
@@ -96,8 +97,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearLTEConfigEntry) -
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
-    async_setup_services(hass)
-
     await discovery.async_load_platform(
         hass,
         Platform.NOTIFY,
@@ -118,7 +117,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: NetgearLTEConfigEntry) 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if not hass.config_entries.async_loaded_entries(DOMAIN):
         hass.data.pop(DOMAIN, None)
-        for service_name in hass.services.async_services()[DOMAIN]:
-            hass.services.async_remove(DOMAIN, service_name)
 
     return unload_ok

--- a/homeassistant/components/netgear_lte/services.py
+++ b/homeassistant/components/netgear_lte/services.py
@@ -51,9 +51,8 @@ async def _service_handler(call: ServiceCall) -> None:
     host = call.data.get(ATTR_HOST)
 
     entry: NetgearLTEConfigEntry | None = None
-    for candidate in call.hass.config_entries.async_loaded_entries(DOMAIN):
-        if not host or candidate.data.get(CONF_HOST) == host:
-            entry = candidate
+    for entry in call.hass.config_entries.async_loaded_entries(DOMAIN):
+        if entry.data.get(CONF_HOST) == host:
             break
 
     if not entry or not (modem := entry.runtime_data.modem).token:

--- a/homeassistant/components/netgear_lte/strings.json
+++ b/homeassistant/components/netgear_lte/strings.json
@@ -71,6 +71,11 @@
       }
     }
   },
+  "exceptions": {
+    "config_entry_not_found": {
+      "message": "Failed to perform action \"{service}\". Config entry for target not found"
+    }
+  },
   "services": {
     "connect_lte": {
       "description": "Asks the modem to establish the LTE connection.",

--- a/tests/components/netgear_lte/test_services.py
+++ b/tests/components/netgear_lte/test_services.py
@@ -58,6 +58,10 @@ async def test_set_option(hass: HomeAssistant, setup_integration: None) -> None:
         )
     assert len(mock_client.mock_calls) == 1
 
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
     with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             DOMAIN,

--- a/tests/components/netgear_lte/test_services.py
+++ b/tests/components/netgear_lte/test_services.py
@@ -2,9 +2,12 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components.netgear_lte.const import DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 
 from .conftest import HOST
 
@@ -54,3 +57,11 @@ async def test_set_option(hass: HomeAssistant, setup_integration: None) -> None:
             blocking=True,
         )
     assert len(mock_client.mock_calls) == 1
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "delete_sms",
+            {CONF_HOST: "no-match", "sms_id": 1},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Modernize `async_setup_services()` as requested in #146107

<s>Also fixes a bug in the `host` field matching so `ServiceValidationError` is always raised when needed.</s>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #146107
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
