### PR TITLE
Improve Sonos wait to unjoin timeout

### DIFF
--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -959,10 +959,8 @@ class SonosSpeaker:
                 return
 
             # Clear coordinator on speakers that are no longer in this group
-            old_members = (
-                set(self.sonos_group[1:]) if len(self.sonos_group) > 1 else set()
-            )
-            new_members = set(sonos_group[1:]) if len(sonos_group) > 1 else set()
+            old_members = set(self.sonos_group[1:])
+            new_members = set(sonos_group[1:])
             removed_members = old_members - new_members
             for removed_speaker in removed_members:
                 # Only clear if this speaker was coordinated by self and in the same group

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -971,16 +971,7 @@ class SonosSpeaker:
                         removed_speaker.zone_name,
                         self.zone_name,
                     )
-                    removed_speaker.coordinator = None
-                    removed_speaker.sonos_group = [removed_speaker]
-                    removed_speaker_entity_id = cast(
-                        str,
-                        entity_registry.async_get_entity_id(
-                            MP_DOMAIN, DOMAIN, removed_speaker.uid
-                        ),
-                    )
-                    removed_speaker.sonos_group_entities = [removed_speaker_entity_id]
-                    removed_speaker.async_write_entity_states()
+                    removed_speaker.clear_coordinator()
 
             self.coordinator = None
             self.sonos_group = sonos_group
@@ -1013,6 +1004,19 @@ class SonosSpeaker:
                     self.data.topology_condition.notify_all()
 
         return _async_handle_group_event(event)
+
+    @callback
+    def clear_coordinator(self) -> None:
+        """Clear coordinator without updating group members."""
+        entity_registry = er.async_get(self.hass)
+        self.coordinator = None
+        self.sonos_group = [self]
+        speaker_entity_id = cast(
+            str,
+            entity_registry.async_get_entity_id(MP_DOMAIN, DOMAIN, self.uid),
+        )
+        self.sonos_group_entities = [speaker_entity_id]
+        self.async_write_entity_states()
 
     @soco_error()
     def join(self, speakers: list[SonosSpeaker]) -> list[SonosSpeaker]:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -1070,7 +1070,6 @@ class SonosSpeaker:
         if self.sonos_group == [self]:
             return
         self.soco.unjoin()
-        # Coordinator will be cleared when the topology change is confirmed via ZGS event
 
     @staticmethod
     async def unjoin_multi(

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -965,7 +965,11 @@ class SonosSpeaker:
             new_members = set(sonos_group[1:]) if len(sonos_group) > 1 else set()
             removed_members = old_members - new_members
             for removed_speaker in removed_members:
-                if removed_speaker.coordinator == self:
+                # Only clear if this speaker was coordinated by self and in the same group
+                if (
+                    removed_speaker.coordinator == self
+                    and removed_speaker.sonos_group is self.sonos_group
+                ):
                     _LOGGER.debug(
                         "Zone %s Cleared coordinator [%s] (removed from group)",
                         removed_speaker.zone_name,
@@ -1007,10 +1011,10 @@ class SonosSpeaker:
 
     @callback
     def clear_coordinator(self) -> None:
-        """Clear coordinator without updating group members."""
-        entity_registry = er.async_get(self.hass)
+        """Clear coordinator from speaker."""
         self.coordinator = None
         self.sonos_group = [self]
+        entity_registry = er.async_get(self.hass)
         speaker_entity_id = cast(
             str,
             entity_registry.async_get_entity_id(MP_DOMAIN, DOMAIN, self.uid),

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -980,7 +980,6 @@ class SonosSpeaker:
                         ),
                     )
                     removed_speaker.sonos_group_entities = [removed_speaker_entity_id]
-                    sonos_group_entities.append(entity_id)
                     removed_speaker.async_write_entity_states()
 
             self.coordinator = None

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -255,7 +255,7 @@ async def test_unjoin_completes_when_coordinator_receives_event_first(
     sonos_setup_two_speakers: list[MockSoCo],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that unjoin completes even when only coordinator receives ZGS event first (delayed member event)."""
+    """Test that unjoin completes even when only coordinator receives ZGS event."""
     soco_living_room = sonos_setup_two_speakers[0]
     soco_bedroom = sonos_setup_two_speakers[1]
 
@@ -281,7 +281,7 @@ async def test_unjoin_completes_when_coordinator_receives_event_first(
         )
         await unjoin_complete_event.wait()
 
-        # Fire ZGS event to living room first (coordinator)
+        # Fire ZGS event to living room (coordinator)
         ungroup_event = create_zgs_sonos_event(
             "zgs_two_single.xml",
             soco_living_room,
@@ -296,57 +296,6 @@ async def test_unjoin_completes_when_coordinator_receives_event_first(
     # Should complete without warnings or timeout errors
     assert len(caplog.records) == 0
     assert soco_bedroom.unjoin.call_count == 1
-    state = hass.states.get("media_player.living_room")
-    assert state.attributes["group_members"] == ["media_player.living_room"]
-    state = hass.states.get("media_player.bedroom")
-    assert state.attributes["group_members"] == ["media_player.bedroom"]
-
-
-async def test_unjoin_completes_when_speaker_receives_event_first(
-    hass: HomeAssistant,
-    sonos_setup_two_speakers: list[MockSoCo],
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that unjoin completes even when only coordinator receives ZGS event first (delayed member event)."""
-    soco_living_room = sonos_setup_two_speakers[0]
-    soco_bedroom = sonos_setup_two_speakers[1]
-
-    # First, group the speakers together
-    group_speakers(soco_living_room, soco_bedroom)
-    await hass.async_block_till_done(wait_background_tasks=True)
-
-    # Now test unjoin with delayed event scenario
-    unjoin_complete_event = asyncio.Event()
-
-    def mock_unjoin(*args, **kwargs) -> None:
-        hass.loop.call_soon_threadsafe(unjoin_complete_event.set)
-
-    soco_bedroom.unjoin = Mock(side_effect=mock_unjoin)
-
-    with caplog.at_level(logging.WARNING):
-        caplog.clear()
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_UNJOIN,
-            {"entity_id": "media_player.bedroom"},
-            blocking=False,
-        )
-        await unjoin_complete_event.wait()
-
-        # Fire ZGS event to living room first (coordinator)
-        ungroup_event = create_zgs_sonos_event(
-            "zgs_two_single.xml",
-            soco_living_room,
-            soco_bedroom,
-            create_uui_ds_in_group=False,
-        )
-        soco_bedroom.zoneGroupTopology.subscribe.return_value._callback(ungroup_event)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    # Should complete without warnings or timeout errors
-    assert len(caplog.records) == 0
-    assert soco_bedroom.unjoin.call_count == 1
-
     state = hass.states.get("media_player.living_room")
     assert state.attributes["group_members"] == ["media_player.living_room"]
     state = hass.states.get("media_player.bedroom")

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -296,6 +296,10 @@ async def test_unjoin_completes_when_coordinator_receives_event_first(
     # Should complete without warnings or timeout errors
     assert len(caplog.records) == 0
     assert soco_bedroom.unjoin.call_count == 1
+    state = hass.states.get("media_player.living_room")
+    assert state.attributes["group_members"] == ["media_player.living_room"]
+    state = hass.states.get("media_player.bedroom")
+    assert state.attributes["group_members"] == ["media_player.bedroom"]
 
 
 async def test_unjoin_completes_when_speaker_receives_event_first(
@@ -342,3 +346,8 @@ async def test_unjoin_completes_when_speaker_receives_event_first(
     # Should complete without warnings or timeout errors
     assert len(caplog.records) == 0
     assert soco_bedroom.unjoin.call_count == 1
+
+    state = hass.states.get("media_player.living_room")
+    assert state.attributes["group_members"] == ["media_player.living_room"]
+    state = hass.states.get("media_player.bedroom")
+    assert state.attributes["group_members"] == ["media_player.bedroom"]

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -286,7 +286,7 @@ async def test_unjoin_completes_when_coordinator_receives_event_first(
         await hass.services.async_call(
             MP_DOMAIN,
             SERVICE_UNJOIN,
-            {"entity_id": "media_player.bedroom"},
+            {ATTR_ENTITY_ID: "media_player.bedroom"},
             blocking=False,
         )
         await unjoin_complete_event.wait()

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -262,8 +262,17 @@ async def test_unjoin_completes_when_coordinator_receives_event_first(
     # First, group the speakers together
     group_speakers(soco_living_room, soco_bedroom)
     await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get("media_player.living_room")
+    assert state.attributes["group_members"] == [
+        "media_player.living_room",
+        "media_player.bedroom",
+    ]
+    state = hass.states.get("media_player.bedroom")
+    assert state.attributes["group_members"] == [
+        "media_player.living_room",
+        "media_player.bedroom",
+    ]
 
-    # Now test unjoin with delayed event scenario
     unjoin_complete_event = asyncio.Event()
 
     def mock_unjoin(*args, **kwargs) -> None:
@@ -281,7 +290,7 @@ async def test_unjoin_completes_when_coordinator_receives_event_first(
         )
         await unjoin_complete_event.wait()
 
-        # Fire ZGS event to living room (coordinator)
+        # Fire ZGS event to living room (coordinator) after unjoin is called
         ungroup_event = create_zgs_sonos_event(
             "zgs_two_single.xml",
             soco_living_room,

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -262,16 +262,17 @@ async def test_unjoin_completes_when_coordinator_receives_event_first(
     # First, group the speakers together
     group_speakers(soco_living_room, soco_bedroom)
     await hass.async_block_till_done(wait_background_tasks=True)
-    state = hass.states.get("media_player.living_room")
-    assert state.attributes["group_members"] == [
-        "media_player.living_room",
-        "media_player.bedroom",
-    ]
-    state = hass.states.get("media_player.bedroom")
-    assert state.attributes["group_members"] == [
-        "media_player.living_room",
-        "media_player.bedroom",
-    ]
+
+    # Verify initial grouped state
+    expected_group = ["media_player.living_room", "media_player.bedroom"]
+    assert (
+        hass.states.get("media_player.living_room").attributes["group_members"]
+        == expected_group
+    )
+    assert (
+        hass.states.get("media_player.bedroom").attributes["group_members"]
+        == expected_group
+    )
 
     unjoin_complete_event = asyncio.Event()
 
@@ -290,7 +291,7 @@ async def test_unjoin_completes_when_coordinator_receives_event_first(
         )
         await unjoin_complete_event.wait()
 
-        # Fire ZGS event to living room (coordinator) after unjoin is called
+        # Fire ZGS event only to coordinator to test clearing of bedroom speaker
         ungroup_event = create_zgs_sonos_event(
             "zgs_two_single.xml",
             soco_living_room,

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MockSoCo, group_speakers, ungroup_speakers
+from .conftest import MockSoCo, create_zgs_sonos_event, group_speakers, ungroup_speakers
 
 
 async def test_media_player_join(
@@ -131,8 +131,9 @@ async def test_media_player_join_timeout(
 
     expected = (
         "Timeout while waiting for Sonos player to join the "
-        "group ['Living Room: Living Room, Bedroom']"
+        "group Living Room: Living Room, Bedroom"
     )
+
     with (
         patch(
             "homeassistant.components.sonos.speaker.asyncio.timeout", instant_timeout
@@ -215,3 +216,58 @@ async def test_media_player_unjoin_already_unjoined(
     # Should not have called unjoin, since the speakers are already unjoined.
     assert soco_bedroom.unjoin.call_count == 0
     assert soco_living_room.unjoin.call_count == 0
+
+
+async def test_unjoin_completes_when_coordinator_receives_event_first(
+    hass: HomeAssistant,
+    sonos_setup_two_speakers: list[MockSoCo],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that unjoin completes even when only coordinator receives ZGS event first (delayed member event)."""
+    soco_living_room = sonos_setup_two_speakers[0]
+    soco_bedroom = sonos_setup_two_speakers[1]
+
+    # First, group the speakers together
+    group_speakers(soco_living_room, soco_bedroom)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Now test unjoin with delayed event scenario
+    unjoin_complete_event = asyncio.Event()
+
+    def mock_unjoin(*args, **kwargs) -> None:
+        hass.loop.call_soon_threadsafe(unjoin_complete_event.set)
+
+    soco_bedroom.unjoin = Mock(side_effect=mock_unjoin)
+
+    with caplog.at_level(logging.WARNING):
+        caplog.clear()
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_UNJOIN,
+            {"entity_id": "media_player.bedroom"},
+            blocking=False,
+        )
+        await unjoin_complete_event.wait()
+
+        # Fire ZGS event to living room first (coordinator)
+        ungroup_event = create_zgs_sonos_event(
+            "zgs_two_single.xml",
+            soco_living_room,
+            soco_bedroom,
+            create_uui_ds_in_group=False,
+        )
+        soco_living_room.zoneGroupTopology.subscribe.return_value._callback(
+            ungroup_event
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        # Small delay, then fire event to bedroom
+        await asyncio.sleep(0.1)
+        soco_bedroom.zoneGroupTopology.subscribe.return_value._callback(ungroup_event)
+
+        # The unjoin should complete successfully
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Should complete without warnings or timeout errors
+    assert len(caplog.records) == 0
+    assert soco_bedroom.unjoin.call_count == 1


### PR DESCRIPTION
## Proposed change

When a speaker is joined / unjoined; the Sonos group coordinator sends its notification first. The integration processes group additions immediately; but was not processing group removals. This change adds logic to process the speaker removals when this update is received.

In  the reported issue the unjoined speaker was taking 30.5 seconds to report being unjoined (and we have a 30 second timeout); whereas the group coordinator reported the change in 15 seconds.

The log showed the following timeline:

09:43:48.546: Unjoin command sent to Bedroom
09:44:03.653: ZGS update arrives at Sonos Move showing Bedroom is standalone 
09:44:03.672: ZGS update arrives at Office showing Office+Bathroom (without Bedroom)  <--- Office is coordinator
09:44:18.838: ZGS update finally arrives at Bedroom itself showing it's standalone (15 seconds later)
09:44:18.847: async_regroup Bedroom called, coordinator cleared, notify_all() triggered
09:44:18.852: Regrouped Bedroom: ['media_player.bedroom']

With this change; the unjoin command will only wait until the update at 09:44:03.672 was received.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #159512
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
