### PR TITLE
Use WATER device_class for Hydrawise sensors

### DIFF
--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -67,21 +67,21 @@ FLOW_CONTROLLER_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
     HydrawiseSensorEntityDescription(
         key="daily_total_water_use",
         translation_key="daily_total_water_use",
-        device_class=SensorDeviceClass.VOLUME,
+        device_class=SensorDeviceClass.WATER,
         suggested_display_precision=1,
         value_fn=lambda sensor: _get_water_use(sensor).total_use,
     ),
     HydrawiseSensorEntityDescription(
         key="daily_active_water_use",
         translation_key="daily_active_water_use",
-        device_class=SensorDeviceClass.VOLUME,
+        device_class=SensorDeviceClass.WATER,
         suggested_display_precision=1,
         value_fn=lambda sensor: _get_water_use(sensor).total_active_use,
     ),
     HydrawiseSensorEntityDescription(
         key="daily_inactive_water_use",
         translation_key="daily_inactive_water_use",
-        device_class=SensorDeviceClass.VOLUME,
+        device_class=SensorDeviceClass.WATER,
         suggested_display_precision=1,
         value_fn=lambda sensor: _get_water_use(sensor).total_inactive_use,
     ),
@@ -91,7 +91,7 @@ FLOW_ZONE_SENSORS: tuple[SensorEntityDescription, ...] = (
     HydrawiseSensorEntityDescription(
         key="daily_active_water_use",
         translation_key="daily_active_water_use",
-        device_class=SensorDeviceClass.VOLUME,
+        device_class=SensorDeviceClass.WATER,
         suggested_display_precision=1,
         value_fn=lambda sensor: float(
             _get_water_use(sensor).active_use_by_zone_id.get(sensor.zone.id, 0.0)
@@ -204,7 +204,7 @@ class HydrawiseSensor(HydrawiseEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit_of_measurement of the sensor."""
-        if self.entity_description.device_class != SensorDeviceClass.VOLUME:
+        if self.entity_description.device_class != SensorDeviceClass.WATER:
             return self.entity_description.native_unit_of_measurement
         return (
             UnitOfVolume.GALLONS
@@ -217,7 +217,7 @@ class HydrawiseSensor(HydrawiseEntity, SensorEntity):
         """Icon of the entity based on the value."""
         if (
             self.entity_description.key in FLOW_MEASUREMENT_KEYS
-            and self.entity_description.device_class == SensorDeviceClass.VOLUME
+            and self.entity_description.device_class == SensorDeviceClass.WATER
             and round(self.state, 2) == 0.0
         ):
             return "mdi:water-outline"

--- a/tests/components/hydrawise/snapshots/test_sensor.ambr
+++ b/tests/components/hydrawise/snapshots/test_sensor.ambr
@@ -28,7 +28,7 @@
         'suggested_unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.VOLUME: 'volume'>,
+    'original_device_class': <SensorDeviceClass.WATER: 'water'>,
     'original_icon': None,
     'original_name': 'Daily active water use',
     'platform': 'hydrawise',
@@ -44,7 +44,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by hydrawise.com',
-      'device_class': 'volume',
+      'device_class': 'water',
       'friendly_name': 'Home Controller Daily active water use',
       'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
     }),
@@ -139,7 +139,7 @@
         'suggested_unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.VOLUME: 'volume'>,
+    'original_device_class': <SensorDeviceClass.WATER: 'water'>,
     'original_icon': None,
     'original_name': 'Daily inactive water use',
     'platform': 'hydrawise',
@@ -155,7 +155,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by hydrawise.com',
-      'device_class': 'volume',
+      'device_class': 'water',
       'friendly_name': 'Home Controller Daily inactive water use',
       'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
     }),
@@ -196,7 +196,7 @@
         'suggested_unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.VOLUME: 'volume'>,
+    'original_device_class': <SensorDeviceClass.WATER: 'water'>,
     'original_icon': None,
     'original_name': 'Daily total water use',
     'platform': 'hydrawise',
@@ -212,7 +212,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by hydrawise.com',
-      'device_class': 'volume',
+      'device_class': 'water',
       'friendly_name': 'Home Controller Daily total water use',
       'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
     }),
@@ -253,7 +253,7 @@
         'suggested_unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.VOLUME: 'volume'>,
+    'original_device_class': <SensorDeviceClass.WATER: 'water'>,
     'original_icon': None,
     'original_name': 'Daily active water use',
     'platform': 'hydrawise',
@@ -269,7 +269,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by hydrawise.com',
-      'device_class': 'volume',
+      'device_class': 'water',
       'friendly_name': 'Zone One Daily active water use',
       'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
     }),
@@ -464,7 +464,7 @@
         'suggested_unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.VOLUME: 'volume'>,
+    'original_device_class': <SensorDeviceClass.WATER: 'water'>,
     'original_icon': 'mdi:water-outline',
     'original_name': 'Daily active water use',
     'platform': 'hydrawise',
@@ -480,7 +480,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by hydrawise.com',
-      'device_class': 'volume',
+      'device_class': 'water',
       'friendly_name': 'Zone Two Daily active water use',
       'icon': 'mdi:water-outline',
       'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update Hydrawise water usage sensors to use the `WATER` device class instead of `VOLUME` so they can be used in water usage dashboards.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #159958
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
