### PR TITLE
Fix reolink brightness scaling

### DIFF
--- a/homeassistant/components/reolink/light.py
+++ b/homeassistant/components/reolink/light.py
@@ -19,6 +19,7 @@ from homeassistant.components.light import (
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import color as color_util
 
 from .entity import (
     ReolinkChannelCoordinatorEntity,
@@ -157,16 +158,16 @@ class ReolinkLightEntity(ReolinkChannelCoordinatorEntity, LightEntity):
 
     @property
     def brightness(self) -> int | None:
-        """Return the brightness of this light between 0.255."""
+        """Return the brightness of this light between 1.255."""
         assert self.entity_description.get_brightness_fn is not None
 
         bright_pct = self.entity_description.get_brightness_fn(
             self._host.api, self._channel
         )
-        if bright_pct is None:
+        if not bright_pct:
             return None
 
-        return round(255 * bright_pct / 100.0)
+        return color_util.value_to_brightness((1, 100), bright_pct)
 
     @property
     def color_temp_kelvin(self) -> int | None:
@@ -189,7 +190,7 @@ class ReolinkLightEntity(ReolinkChannelCoordinatorEntity, LightEntity):
         if (
             brightness := kwargs.get(ATTR_BRIGHTNESS)
         ) is not None and self.entity_description.set_brightness_fn is not None:
-            brightness_pct = int(brightness / 255.0 * 100)
+            brightness_pct = round(color_util.brightness_to_value((1, 100), brightness))
             await self.entity_description.set_brightness_fn(
                 self._host.api, self._channel, brightness_pct
             )

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -185,6 +185,7 @@ def _init_host_mock(host_mock: MagicMock) -> None:
     host_mock.baichuan.smart_ai_type_list.return_value = ["people"]
     host_mock.baichuan.smart_ai_index.return_value = 1
     host_mock.baichuan.smart_ai_name.return_value = "zone1"
+    host_mock.whiteled_brightness.return_value = None
 
     def ai_detect_type(channel: int, object_type: str) -> str | None:
         if object_type == "people":

--- a/tests/components/reolink/test_light.py
+++ b/tests/components/reolink/test_light.py
@@ -74,6 +74,7 @@ async def test_light_turn_off(
 ) -> None:
     """Test light turn off service."""
     reolink_host.whiteled_color_temperature.return_value = 3000
+    reolink_host.whiteled_brightness.return_value = 75
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.LIGHT]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -81,6 +82,8 @@ async def test_light_turn_off(
     assert config_entry.state is ConfigEntryState.LOADED
 
     entity_id = f"{Platform.LIGHT}.{TEST_CAM_NAME}_floodlight"
+    state = hass.states.get(entity_id)
+    assert state and state.attributes.get(ATTR_BRIGHTNESS) == 191
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -107,6 +110,7 @@ async def test_light_turn_on(
 ) -> None:
     """Test light turn on service."""
     reolink_host.whiteled_color_temperature.return_value = 3000
+    reolink_host.whiteled_brightness.return_value = None
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.LIGHT]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a Reolink light is turned on, to scale the brightness to a 1-100 scale the value should be rounded. To ensure proper scaling the built in scaling utils are used. Also it is ensured no zero brightness is reported.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #160083
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
