### PR TITLE
Use long service timeout for Sonos Unjoin

### DIFF
--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -212,3 +212,4 @@ BATTERY_SCAN_INTERVAL = datetime.timedelta(minutes=15)
 SCAN_INTERVAL = datetime.timedelta(seconds=10)
 DISCOVERY_INTERVAL = datetime.timedelta(seconds=60)
 SUBSCRIPTION_TIMEOUT = 1200
+LONG_SERVICE_TIMEOUT = 30.0

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -54,6 +54,7 @@ from . import media_browser
 from .const import (
     ATTR_QUEUE_POSITION,
     DOMAIN,
+    LONG_SERVICE_TIMEOUT,
     MEDIA_TYPE_DIRECTORY,
     MEDIA_TYPES_TO_SONOS,
     MODELS_LINEIN_AND_TV,
@@ -76,7 +77,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-LONG_SERVICE_TIMEOUT = 30.0
 UNJOIN_SERVICE_TIMEOUT = 0.1
 VOLUME_INCREMENT = 2
 

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -40,6 +40,7 @@ from .const import (
     AVAILABILITY_TIMEOUT,
     BATTERY_SCAN_INTERVAL,
     DOMAIN,
+    LONG_SERVICE_TIMEOUT,
     SCAN_INTERVAL,
     SONOS_CHECK_ACTIVITY,
     SONOS_CREATE_ALARM,
@@ -1067,7 +1068,7 @@ class SonosSpeaker:
         """Unjoin the player from a group."""
         if self.sonos_group == [self]:
             return
-        self.soco.unjoin()
+        self.soco.unjoin(timeout=LONG_SERVICE_TIMEOUT)
 
     @staticmethod
     async def unjoin_multi(

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -223,7 +223,6 @@ async def test_media_player_unjoin(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert len(caplog.records) == 0
-    assert soco_bedroom.unjoin.call_count == 1
     soco_bedroom.unjoin.assert_called_with(timeout=LONG_SERVICE_TIMEOUT)
     assert soco_living_room.unjoin.call_count == 0
 

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -13,6 +13,7 @@ from homeassistant.components.media_player import (
     SERVICE_JOIN,
     SERVICE_UNJOIN,
 )
+from homeassistant.components.sonos.const import LONG_SERVICE_TIMEOUT
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -223,6 +224,7 @@ async def test_media_player_unjoin(
 
     assert len(caplog.records) == 0
     assert soco_bedroom.unjoin.call_count == 1
+    soco_bedroom.unjoin.assert_called_with(timeout=LONG_SERVICE_TIMEOUT)
     assert soco_living_room.unjoin.call_count == 0
 
 


### PR DESCRIPTION
## Proposed change

Change soco unjoin api call to use LONG_SERVICE_TIMEOUT instead of default timeout.

During testing of #160011 occasionally the unjoin http request would timeout. The unjoin request was using the default timeout of 9.5 seconds. Typically the speaker responds in 1-2 seconds; but occasionally it would take 12-13 seconds. This behavior had not been seen before and may be because recent Sonos firmware updates.

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/sonos/helpers.py", line 67, in wrapper
    result = funct(self, *args, **kwargs)
  File "/usr/src/homeassistant/homeassistant/components/sonos/speaker.py", line 1005, in unjoin
    self.soco.unjoin()
  File "/usr/local/lib/python3.13/site-packages/soco/core.py", line 1740, in unjoin
    self.avTransport.BecomeCoordinatorOfStandaloneGroup([("InstanceID", 0)])
  File "/usr/local/lib/python3.13/site-packages/soco/services.py", line 208, in _dispatcher
    return self.send_command(action, *args, **kwargs)
  File "/usr/local/lib/python3.13/site-packages/soco/services.py", line 491, in send_command
    response = requests.post(
        self.base_url + self.control_url,
    ...<2 lines>...
        timeout=timeout,
    )
  File "/usr/local/lib/python3.13/site-packages/requests/api.py", line 115, in post
    return request("post", url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python3.13/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.13/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.13/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.13/site-packages/requests/adapters.py", line 713, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPConnectionPool(host='192.168.50.181', port=1400): Read timed out. (read timeout=9.5)

```



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
