### PR TITLE
Add support to configure KNX time exposes from the UI

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -27,7 +27,7 @@ from .const import (
     SUPPORTED_PLATFORMS_UI,
     SUPPORTED_PLATFORMS_YAML,
 )
-from .expose import create_knx_exposure
+from .expose import create_and_register_knx_exposure
 from .knx_module import KNXModule
 from .project import STORAGE_KEY as PROJECT_STORAGE_KEY
 from .schema import (
@@ -123,8 +123,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if CONF_KNX_EXPOSE in config:
         for expose_config in config[CONF_KNX_EXPOSE]:
             knx_module.exposures.append(
-                create_knx_exposure(hass, knx_module.xknx, expose_config)
+                create_and_register_knx_exposure(hass, knx_module.xknx, expose_config)
             )
+    for address, data in knx_module.config_store.get_expose_entries().items():
+        exposure = create_and_register_knx_exposure(hass, knx_module.xknx, data)
+        knx_module.ui_exposures[address] = exposure
     configured_platforms_yaml = {
         platform for platform in SUPPORTED_PLATFORMS_YAML if platform in config
     }

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -139,6 +139,12 @@ class FanZeroMode(StrEnum):
     OFF = FAN_OFF
     AUTO = FAN_AUTO
 
+class ExposeType(StrEnum):
+    """A type of expose configuration."""
+    TIME = "time"
+    DATE = "date"
+    DATETIME = "datetime"
+
 
 SUPPORTED_PLATFORMS_YAML: Final = {
     Platform.BINARY_SENSOR,

--- a/homeassistant/components/knx/knx_module.py
+++ b/homeassistant/components/knx/knx_module.py
@@ -75,6 +75,7 @@ class KNXModule:
         self.connected = False
         self.exposures: list[KNXExposeSensor | KNXExposeTime] = []
         self.service_exposures: dict[str, KNXExposeSensor | KNXExposeTime] = {}
+        self.ui_exposures: dict[str, KNXExposeSensor | KNXExposeTime] = {}
         self.entry = entry
 
         self.project = KNXProject(hass=hass, entry=entry)

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -59,10 +59,12 @@ from .const import (
     ClimateConf,
     ColorTempModes,
     CoverConf,
+    ExposeType,
     FanConf,
     FanZeroMode,
     SceneConf,
 )
+from .storage.knx_selector import GASelector
 from .validation import (
     backwards_compatible_xknx_climate_enum_member,
     dpt_base_type_validator,
@@ -539,17 +541,14 @@ class ExposeSchema(KNXPlatformSchema):
     CONF_KNX_EXPOSE_BINARY = "binary"
     CONF_KNX_EXPOSE_COOLDOWN = "cooldown"
     CONF_KNX_EXPOSE_DEFAULT = "default"
-    CONF_TIME = "time"
-    CONF_DATE = "date"
-    CONF_DATETIME = "datetime"
-    EXPOSE_TIME_TYPES: Final = [CONF_TIME, CONF_DATE, CONF_DATETIME]
+    EXPOSE_TIME_TYPES: Final = [ExposeType.TIME, ExposeType.DATE, ExposeType.DATETIME]
 
     EXPOSE_TIME_SCHEMA = vol.Schema(
         {
             vol.Required(CONF_KNX_EXPOSE_TYPE): vol.All(
                 cv.string, str.lower, vol.In(EXPOSE_TIME_TYPES)
             ),
-            vol.Required(KNX_ADDRESS): ga_validator,
+            vol.Required(KNX_ADDRESS): vol.Union(ga_validator, GASelector(state=False, passive=False, write_required=True)),
         }
     )
     EXPOSE_SENSOR_SCHEMA = vol.Schema(
@@ -559,7 +558,7 @@ class ExposeSchema(KNXPlatformSchema):
             vol.Required(CONF_KNX_EXPOSE_TYPE): vol.Any(
                 CONF_KNX_EXPOSE_BINARY, sensor_type_validator
             ),
-            vol.Required(KNX_ADDRESS): ga_validator,
+            vol.Required(KNX_ADDRESS): vol.Union(ga_validator, GASelector(state=False, passive=False, write_required=True)),
             vol.Required(CONF_ENTITY_ID): cv.entity_id,
             vol.Optional(CONF_KNX_EXPOSE_ATTRIBUTE): cv.string,
             vol.Optional(CONF_KNX_EXPOSE_DEFAULT): cv.match_all,

--- a/homeassistant/components/knx/services.py
+++ b/homeassistant/components/knx/services.py
@@ -31,7 +31,7 @@ from .const import (
     SERVICE_KNX_READ,
     SERVICE_KNX_SEND,
 )
-from .expose import create_knx_exposure
+from .expose import create_and_register_knx_exposure
 from .schema import ExposeSchema, dpt_base_type_validator, ga_validator
 
 if TYPE_CHECKING:
@@ -196,7 +196,7 @@ async def service_exposure_register_modify(call: ServiceCall) -> None:
             replaced_exposure.device.name,
         )
         replaced_exposure.async_remove()
-    exposure = create_knx_exposure(knx_module.hass, knx_module.xknx, call.data)
+    exposure = create_and_register_knx_exposure(knx_module.hass, knx_module.xknx, call.data)
     knx_module.service_exposures[group_address] = exposure
     _LOGGER.debug(
         "Service exposure_register registered exposure for '%s' - %s",

--- a/homeassistant/components/knx/storage/expose_store_schema.py
+++ b/homeassistant/components/knx/storage/expose_store_schema.py
@@ -1,0 +1,30 @@
+"""KNX expose store schema."""
+
+import voluptuous as vol
+
+from homeassistant.components.knx.const import KNX_ADDRESS, ExposeType
+from homeassistant.helpers.typing import VolDictType
+
+from .. import ExposeSchema
+from .knx_selector import GASelector
+
+EXPOSE_TIME_SCHEMA: VolDictType = {
+    vol.Required(ExposeSchema.CONF_KNX_EXPOSE_TYPE): ExposeType.TIME.value,
+    vol.Required(KNX_ADDRESS): GASelector(state=False, passive=False, write_required=True, valid_dpt="10.001"),
+}
+
+EXPOSE_DATE_SCHEMA: VolDictType = {
+    vol.Required(ExposeSchema.CONF_KNX_EXPOSE_TYPE): ExposeType.DATE.value,
+    vol.Required(KNX_ADDRESS): GASelector(state=False, passive=False, write_required=True, valid_dpt="11.001"),
+}
+
+EXPOSE_DATETIME_SCHEMA: VolDictType = {
+    vol.Required(ExposeSchema.CONF_KNX_EXPOSE_TYPE): ExposeType.DATETIME.value,
+    vol.Required(KNX_ADDRESS): GASelector(state=False, passive=False, write_required=True, valid_dpt="19.001"),
+}
+
+KNX_SCHEMA_FOR_TYPE = {
+    ExposeType.TIME: EXPOSE_TIME_SCHEMA,
+    ExposeType.DATE: EXPOSE_DATE_SCHEMA,
+    ExposeType.DATETIME: EXPOSE_DATETIME_SCHEMA,
+}

--- a/homeassistant/components/knx/storage/expose_store_validation.py
+++ b/homeassistant/components/knx/storage/expose_store_validation.py
@@ -1,0 +1,72 @@
+"""KNX expose store validation."""
+
+from typing import Literal, TypedDict
+
+import voluptuous as vol
+
+from ..expose import ExposeSchema
+
+
+class _ErrorDescription(TypedDict):
+    path: list[str] | None
+    error_message: str
+    error_class: str
+
+
+class ExposeStoreValidationError(TypedDict):
+    """Negative expose store validation result."""
+
+    success: Literal[False]
+    error_base: str
+    errors: list[_ErrorDescription]
+
+
+class ExposeStoreValidationSuccess(TypedDict):
+    """Positive expose store validation result."""
+
+    success: Literal[True]
+    expose_address: str
+
+
+def parse_invalid(exc: vol.Invalid) -> _ErrorDescription:
+    """Parse a vol.Invalid exception."""
+    return _ErrorDescription(
+        path=[str(path) for path in exc.path],  # exc.path: str | vol.Required
+        error_message=exc.msg,
+        error_class=type(exc).__name__,
+    )
+
+
+def validate_expose_data(expose_data: dict) -> dict:
+    """Validate expose data.
+
+    Return validated data or raise ExposeStoreValidationException.
+    """
+    try:
+        # return so defaults are applied
+        return ExposeSchema.ENTITY_SCHEMA(expose_data)  # type: ignore[no-any-return]
+    except vol.MultipleInvalid as exc:
+        raise ExposeStoreValidationException(
+            validation_error={
+                "success": False,
+                "error_base": str(exc),
+                "errors": [parse_invalid(invalid) for invalid in exc.errors],
+            }
+        ) from exc
+    except vol.Invalid as exc:
+        raise ExposeStoreValidationException(
+            validation_error={
+                "success": False,
+                "error_base": str(exc),
+                "errors": [parse_invalid(exc)],
+            }
+        ) from exc
+
+
+class ExposeStoreValidationException(Exception):
+    """Expose store validation exception."""
+
+    def __init__(self, validation_error: ExposeStoreValidationError) -> None:
+        """Initialize."""
+        super().__init__(validation_error)
+        self.validation_error = validation_error

--- a/homeassistant/components/knx/storage/serialize.py
+++ b/homeassistant/components/knx/storage/serialize.py
@@ -8,7 +8,9 @@ from voluptuous_serialize import UNSUPPORTED, UnsupportedType, convert
 from homeassistant.const import Platform
 from homeassistant.helpers import selector
 
+from ..const import ExposeType
 from .entity_store_schema import KNX_SCHEMA_FOR_PLATFORM
+from .expose_store_schema import KNX_SCHEMA_FOR_TYPE
 from .knx_selector import AllSerializeFirst, GroupSelectSchema, KNXSelectorBase
 
 
@@ -43,5 +45,12 @@ def get_serialized_schema(
 ) -> dict[str, Any] | list[dict[str, Any]] | None:
     """Get the schema for a specific platform."""
     if knx_schema := KNX_SCHEMA_FOR_PLATFORM.get(platform):
+        return convert(knx_schema, custom_serializer=knx_serializer)
+    return None
+
+
+def get_serialized_expose_schema(typ: ExposeType) -> dict[str, Any] | list[dict[str, Any]] | None:
+    """Get the schema for a specific expose type."""
+    if knx_schema := KNX_SCHEMA_FOR_TYPE.get(typ):
         return convert(knx_schema, custom_serializer=knx_serializer)
     return None

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -891,6 +891,10 @@
       "description": "Add and manage KNX entities",
       "title": "Entities"
     },
+    "expose": {
+      "description": "Add and manage KNX exposed entries",
+      "title": "Expose"
+    },
     "group_monitor": {
       "description": "Monitor KNX group communication",
       "title": "Group monitor"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow to configure KNX expose entries from the UI. For now, only add support for time, date and datetime exposes.

For now this is still WIP, tests are still missing. This is mostly to get some feedback on the approach from @farmio.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: TODO
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/XKNX/knx-frontend/pull/307

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
