### PR TITLE
Support more attribute overrides for universal media player

### DIFF
--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import copy
+import datetime
 from typing import Any
 
 import voluptuous as vol
@@ -79,6 +80,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.util import dt as dt_util
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv
@@ -315,7 +317,15 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     @property
     def assumed_state(self) -> bool:
         """Return True if unable to access real state of the entity."""
-        return self._child_attr(ATTR_ASSUMED_STATE)
+        attr = self._override_or_child_attr(ATTR_ASSUMED_STATE)
+
+        if isinstance(attr, bool):
+            return attr
+
+        if isinstance(attr, str):
+            return attr.strip().lower() in ("true", STATE_ON)
+
+        return False
 
     @property
     def state(self):
@@ -348,19 +358,22 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         return self._override_or_child_attr(ATTR_MEDIA_VOLUME_MUTED) in [True, STATE_ON]
 
     @property
-    def media_content_id(self):
+    def media_content_id(self) -> str | None:
         """Return the content ID of current playing media."""
-        return self._child_attr(ATTR_MEDIA_CONTENT_ID)
+        return self._override_or_child_attr(ATTR_MEDIA_CONTENT_ID)
 
     @property
-    def media_content_type(self):
+    def media_content_type(self) -> MediaType | str | None:
         """Return the content type of current playing media."""
-        return self._child_attr(ATTR_MEDIA_CONTENT_TYPE)
+        return self._override_or_child_attr(ATTR_MEDIA_CONTENT_TYPE)
 
     @property
-    def media_duration(self):
+    def media_duration(self) -> int | None:
         """Return the duration of current playing media in seconds."""
-        return self._child_attr(ATTR_MEDIA_DURATION)
+        try:
+            return int(self._override_or_child_attr(ATTR_MEDIA_DURATION))
+        except (TypeError, ValueError):
+            return None
 
     @property
     def media_image_url(self):
@@ -378,64 +391,67 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         return self.media_image_url
 
     @property
-    def media_title(self):
+    def media_title(self) -> str | None:
         """Title of current playing media."""
-        return self._child_attr(ATTR_MEDIA_TITLE)
+        return self._override_or_child_attr(ATTR_MEDIA_TITLE)
 
     @property
-    def media_artist(self):
+    def media_artist(self) -> str | None:
         """Artist of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ARTIST)
+        return self._override_or_child_attr(ATTR_MEDIA_ARTIST)
 
     @property
-    def media_album_name(self):
+    def media_album_name(self) -> str | None:
         """Album name of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ALBUM_NAME)
+        return self._override_or_child_attr(ATTR_MEDIA_ALBUM_NAME)
 
     @property
-    def media_album_artist(self):
+    def media_album_artist(self) -> str | None:
         """Album artist of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ALBUM_ARTIST)
+        return self._override_or_child_attr(ATTR_MEDIA_ALBUM_ARTIST)
 
     @property
-    def media_track(self):
+    def media_track(self) -> int | None:
         """Track number of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_TRACK)
+        try:
+            return int(self._override_or_child_attr(ATTR_MEDIA_TRACK))
+        except (TypeError, ValueError):
+            return None
 
     @property
-    def media_series_title(self):
+    def media_series_title(self) -> str | None:
         """Return the title of the series of current playing media (TV)."""
-        return self._child_attr(ATTR_MEDIA_SERIES_TITLE)
+        return self._override_or_child_attr(ATTR_MEDIA_SERIES_TITLE)
 
     @property
-    def media_season(self):
+    def media_season(self) -> str | None:
         """Season of current playing media (TV Show only)."""
-        return self._child_attr(ATTR_MEDIA_SEASON)
+        return self._override_or_child_attr(ATTR_MEDIA_SEASON)
 
     @property
-    def media_episode(self):
+    def media_episode(self) -> str | None:
         """Episode of current playing media (TV Show only)."""
-        return self._child_attr(ATTR_MEDIA_EPISODE)
+        return self._override_or_child_attr(ATTR_MEDIA_EPISODE)
 
     @property
-    def media_channel(self):
+    def media_channel(self) -> str | None:
         """Channel currently playing."""
-        return self._child_attr(ATTR_MEDIA_CHANNEL)
+        return self._override_or_child_attr(ATTR_MEDIA_CHANNEL)
 
     @property
-    def media_playlist(self):
+    def media_playlist(self) -> str | None:
         """Title of Playlist currently playing."""
-        return self._child_attr(ATTR_MEDIA_PLAYLIST)
+        return self._override_or_child_attr(ATTR_MEDIA_PLAYLIST)
 
     @property
-    def app_id(self):
+    def app_id(self) -> str | None:
         """ID of the current running app."""
-        return self._child_attr(ATTR_APP_ID)
+        return self._override_or_child_attr(ATTR_APP_ID)
 
     @property
-    def app_name(self):
+    def app_name(self) -> str | None:
         """Name of the current running app."""
-        return self._child_attr(ATTR_APP_NAME)
+        return self._override_or_child_attr(ATTR_APP_NAME)
 
     @property
     def sound_mode(self):
@@ -539,14 +555,39 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         return {ATTR_ACTIVE_CHILD: active_child.entity_id} if active_child else {}
 
     @property
-    def media_position(self):
+    def media_position(self) -> int | None:
         """Position of current playing media in seconds."""
-        return self._child_attr(ATTR_MEDIA_POSITION)
+        try:
+            return int(self._override_or_child_attr(ATTR_MEDIA_POSITION))
+        except (TypeError, ValueError):
+            return None
 
     @property
-    def media_position_updated_at(self):
+    def media_position_updated_at(self) -> datetime.datetime | None:
         """When was the position of the current playing media valid."""
-        return self._child_attr(ATTR_MEDIA_POSITION_UPDATED_AT)
+        attr = self._override_or_child_attr(ATTR_MEDIA_POSITION_UPDATED_AT)
+
+        if isinstance(attr, datetime.datetime):
+            return dt_util.as_utc(attr)
+
+        if isinstance(attr, str):
+            try:
+                parsed = dt_util.parse_datetime(attr)
+            except ValueError:
+                return None
+
+            if parsed is None:
+                return None
+
+            return dt_util.as_utc(parsed)
+
+        if isinstance(attr, (int, float)):
+            try:
+                return dt_util.utc_from_timestamp(attr)
+            except (OSError, OverflowError, ValueError):
+                return None
+
+        return None
 
     async def async_turn_on(self) -> None:
         """Turn the media player on."""

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -1,5 +1,6 @@
 """The tests for the Universal Media player platform."""
 
+import datetime
 from copy import copy
 from unittest.mock import Mock, patch
 
@@ -27,7 +28,6 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityPlatformState
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
-
 from tests.common import MockEntityPlatform, async_mock_service, get_fixture_path
 
 CONFIG_CHILDREN_ONLY = {
@@ -268,6 +268,65 @@ async def mock_states(hass: HomeAssistant) -> Mock:
 
     result.mock_media_image_url_id = f"{input_select.DOMAIN}.entity_picture"
     hass.states.async_set(result.mock_media_image_url_id, "/local/picture.png")
+
+    result.mock_assumed_state_id = switch.ENTITY_ID_FORMAT.format("assumed_state")
+    hass.states.async_set(result.mock_assumed_state_id, True)
+
+    result.mock_media_content_id_id = f"{input_select.DOMAIN}.media_content_id"
+    hass.states.async_set(result.mock_media_content_id_id, "spotify:track:123")
+
+    result.mock_media_content_type_id = f"{input_select.DOMAIN}.media_content_type"
+    hass.states.async_set(result.mock_media_content_type_id, "music")
+
+    result.mock_media_duration_id = f"{input_number.DOMAIN}.media_duration"
+    hass.states.async_set(result.mock_media_duration_id, 180)
+
+    result.mock_media_title_id = f"{input_select.DOMAIN}.media_title"
+    hass.states.async_set(result.mock_media_title_id, "Song Title")
+
+    result.mock_media_artist_id = f"{input_select.DOMAIN}.media_artist"
+    hass.states.async_set(result.mock_media_artist_id, "Artist Name")
+
+    result.mock_media_album_name_id = f"{input_select.DOMAIN}.media_album_name"
+    hass.states.async_set(result.mock_media_album_name_id, "Album Name")
+
+    result.mock_media_album_artist_id = f"{input_select.DOMAIN}.media_album_artist"
+    hass.states.async_set(result.mock_media_album_artist_id, "Album Artist")
+
+    result.mock_media_track_id = f"{input_number.DOMAIN}.media_track"
+    hass.states.async_set(result.mock_media_track_id, 5)
+
+    result.mock_media_series_title_id = f"{input_select.DOMAIN}.media_series_title"
+    hass.states.async_set(result.mock_media_series_title_id, "Series Title")
+
+    result.mock_media_season_id = f"{input_number.DOMAIN}.media_season"
+    hass.states.async_set(result.mock_media_season_id, "2nd season")
+
+    result.mock_media_episode_id = f"{input_number.DOMAIN}.media_episode"
+    hass.states.async_set(result.mock_media_episode_id, "Episode 10")
+
+    result.mock_media_channel_id = f"{input_select.DOMAIN}.media_channel"
+    hass.states.async_set(result.mock_media_channel_id, "BBC One")
+
+    result.mock_media_playlist_id = f"{input_select.DOMAIN}.media_playlist"
+    hass.states.async_set(result.mock_media_playlist_id, "My Playlist")
+
+    result.mock_app_id_id = f"{input_select.DOMAIN}.app_id"
+    hass.states.async_set(result.mock_app_id_id, "com.spotify.music")
+
+    result.mock_app_name_id = f"{input_select.DOMAIN}.app_name"
+    hass.states.async_set(result.mock_app_name_id, "Spotify")
+
+    result.mock_media_position_id = f"{input_number.DOMAIN}.media_position"
+    hass.states.async_set(result.mock_media_position_id, 45)
+
+    result.mock_media_position_updated_at_id = (
+        f"{input_select.DOMAIN}.media_position_updated_at"
+    )
+    hass.states.async_set(
+        result.mock_media_position_updated_at_id, "2023-01-01T12:00:00Z"
+    )
+
     return result
 
 
@@ -282,8 +341,24 @@ def config_children_and_attr(mock_states):
             media_player.ENTITY_ID_FORMAT.format("mock2"),
         ],
         "attributes": {
+            "assumed_state": mock_states.mock_assumed_state_id,
             "is_volume_muted": mock_states.mock_mute_switch_id,
             "volume_level": mock_states.mock_volume_id,
+            "media_content_id": mock_states.mock_media_content_id_id,
+            "media_content_type": mock_states.mock_media_content_type_id,
+            "media_duration": mock_states.mock_media_duration_id,
+            "media_title": mock_states.mock_media_title_id,
+            "media_artist": mock_states.mock_media_artist_id,
+            "media_album_name": mock_states.mock_media_album_name_id,
+            "media_album_artist": mock_states.mock_media_album_artist_id,
+            "media_track": mock_states.mock_media_track_id,
+            "media_series_title": mock_states.mock_media_series_title_id,
+            "media_season": mock_states.mock_media_season_id,
+            "media_episode": mock_states.mock_media_episode_id,
+            "media_channel": mock_states.mock_media_channel_id,
+            "media_playlist": mock_states.mock_media_playlist_id,
+            "app_id": mock_states.mock_app_id_id,
+            "app_name": mock_states.mock_app_name_id,
             "source": mock_states.mock_source_id,
             "source_list": mock_states.mock_source_list_id,
             "state": mock_states.mock_state_switch_id,
@@ -292,6 +367,8 @@ def config_children_and_attr(mock_states):
             "sound_mode_list": mock_states.mock_sound_mode_list_id,
             "sound_mode": mock_states.mock_sound_mode_id,
             "entity_picture": mock_states.mock_media_image_url_id,
+            "media_position": mock_states.mock_media_position_id,
+            "media_position_updated_at": mock_states.mock_media_position_updated_at_id,
         },
     }
 
@@ -673,6 +750,20 @@ async def test_volume_level_children_and_attr(
     assert ump.volume_level == 100
 
 
+async def test_assumed_state_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test assumed_state property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.assumed_state is True
+
+    hass.states.async_set(mock_states.mock_assumed_state_id, False)
+    assert ump.assumed_state is False
+
+
 async def test_is_volume_muted_children_and_attr(
     hass: HomeAssistant, config_children_and_attr, mock_states
 ) -> None:
@@ -685,6 +776,250 @@ async def test_is_volume_muted_children_and_attr(
 
     hass.states.async_set(mock_states.mock_mute_switch_id, STATE_ON)
     assert ump.is_volume_muted
+
+
+async def test_media_content_id_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_content_id property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_content_id == "spotify:track:123"
+
+    hass.states.async_set(mock_states.mock_media_content_id_id, "spotify:track:456")
+    assert ump.media_content_id == "spotify:track:456"
+
+
+async def test_media_content_type_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_content_type property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_content_type == "music"
+
+    hass.states.async_set(mock_states.mock_media_content_type_id, "podcast")
+    assert ump.media_content_type == "podcast"
+
+
+async def test_media_duration_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_duration property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_duration == 180
+
+    hass.states.async_set(mock_states.mock_media_duration_id, 240)
+    assert ump.media_duration == 240
+
+
+async def test_media_title_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_title property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_title == "Song Title"
+
+    hass.states.async_set(mock_states.mock_media_title_id, "Another Song")
+    assert ump.media_title == "Another Song"
+
+
+async def test_media_artist_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_artist property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_artist == "Artist Name"
+
+    hass.states.async_set(mock_states.mock_media_artist_id, "Other Artist")
+    assert ump.media_artist == "Other Artist"
+
+
+async def test_media_album_name_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_album_name property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_album_name == "Album Name"
+
+    hass.states.async_set(mock_states.mock_media_album_name_id, "Other Album")
+    assert ump.media_album_name == "Other Album"
+
+
+async def test_media_album_artist_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_album_artist property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_album_artist == "Album Artist"
+
+    hass.states.async_set(mock_states.mock_media_album_artist_id, "Other Album Artist")
+    assert ump.media_album_artist == "Other Album Artist"
+
+
+async def test_media_track_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_track property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_track == 5
+
+    hass.states.async_set(mock_states.mock_media_track_id, 10)
+    assert ump.media_track == 10
+
+
+async def test_media_series_title_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_series_title property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_series_title == "Series Title"
+
+    hass.states.async_set(mock_states.mock_media_series_title_id, "Other Series")
+    assert ump.media_series_title == "Other Series"
+
+
+async def test_media_season_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_season property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_season == "2nd season"
+
+    hass.states.async_set(mock_states.mock_media_season_id, "3rd season")
+    assert ump.media_season == "3rd season"
+
+
+async def test_media_episode_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_episode property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_episode == "Episode 10"
+
+    hass.states.async_set(mock_states.mock_media_episode_id, "Episode 8")
+    assert ump.media_episode == "Episode 8"
+
+
+async def test_media_channel_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_channel property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_channel == "BBC One"
+
+    hass.states.async_set(mock_states.mock_media_channel_id, "BBC Two")
+    assert ump.media_channel == "BBC Two"
+
+
+async def test_media_playlist_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_playlist property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_playlist == "My Playlist"
+
+    hass.states.async_set(mock_states.mock_media_playlist_id, "Other Playlist")
+    assert ump.media_playlist == "Other Playlist"
+
+
+async def test_app_id_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test app_id property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.app_id == "com.spotify.music"
+
+    hass.states.async_set(mock_states.mock_app_id_id, "com.youtube.tv")
+    assert ump.app_id == "com.youtube.tv"
+
+
+async def test_app_name_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test app_name property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.app_name == "Spotify"
+
+    hass.states.async_set(mock_states.mock_app_name_id, "YouTube")
+    assert ump.app_name == "YouTube"
+
+
+async def test_media_position_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_position property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_position == 45
+
+    hass.states.async_set(mock_states.mock_media_position_id, 60)
+    assert ump.media_position == 60
+
+
+async def test_media_position_updated_at_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
+    """Test media_position_updated_at property w/ children and attrs."""
+    config = validate_config(config_children_and_attr)
+
+    ump = universal.UniversalMediaPlayer(hass, config)
+
+    assert ump.media_position_updated_at == datetime.datetime(
+        2023, 1, 1, 12, 0, 0, tzinfo=datetime.UTC
+    )
+
+    hass.states.async_set(
+        mock_states.mock_media_position_updated_at_id, "2023-01-02T12:00:00Z"
+    )
+    assert ump.media_position_updated_at == datetime.datetime(
+        2023, 1, 2, 12, 0, 0, tzinfo=datetime.UTC
+    )
 
 
 async def test_supported_features_children_only(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Support more attribute overrides for the universal media player.
Some attributes cannot currently be overridden, and this PR enables overriding additional attributes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

There was a PR (#24903) made similar changes without unit tests and was eventually closed without merging.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
