### PR TITLE
Byrant Evolution hvac_action Attribute Support for Multi-Zone Systems

### DIFF
--- a/homeassistant/components/bryant_evolution/climate.py
+++ b/homeassistant/components/bryant_evolution/climate.py
@@ -168,54 +168,25 @@ class BryantEvolutionClimate(ClimateEntity):
         if not is_active:
             return HVACAction.OFF
         match mode.upper():
-             # For HEAT and COOL, compare the current temp and setpoint to determine
-             # if this ZONE is HEATING or COOLING.  
-             # MODE only shows trhat the SYSTEM is running, not individual ZONES
             case "HEAT":
-                if (
-                    self.current_temperature is not None
-                    and self.target_temperature is not None
-                ):
-                    if self.target_temperature > self.current_temperature:
-                       return HVACAction.HEATING
-                    else:
-                       return HVACAction.OFF
+                return HVACAction.HEATING
             case "COOL":
-                if (
-                    self.current_temperature is not None
-                    and self.target_temperature is not None
-                ):
-                    if self.target_temperature < self.current_temperature:
-                       return HVACAction.COOLING
-                    else:
-                       return HVACAction.OFF                
+                return HVACAction.COOLING
             case "OFF":
                 return HVACAction.OFF
             case "AUTO":
-                # For AUTO, we need to figure out whether we're heating, cooling, or
-                # neither for this Zone based on the current temperature and the setpoints,
-                # and given that while the system itself is running in some zone(s), it may
-                # or may not be running in this one.
+                # In AUTO, we need to figure out what the actual action is
+                # based on the setpoints.
                 if (
                     self.current_temperature is not None
                     and self.target_temperature_low is not None
-                    and self.target_temperature_high is not None
                 ):
                     if self.current_temperature > self.target_temperature_low:
-                       # If the system is running and the current_temperature is
-                       # higher than the setpoint at which cooling would stop,
-                       # then the zone must be cooling.
-                       return HVACAction.COOLING
-                    elif self.current_temperature < self.target_temperature_high:
-                       # Or, conversely, heating
-                       return HVACAction.HEATING
-                    else:
-                       # Othewise, set the current zone to OFF because the current_temperature is
-                       # within the _high - _low temperature band, inclusive of both bounds. That is,
-                       # neither cooling, nor heating is required in this zone.
-                       # (By implication, some other zone(s) must be running (heating or cooling)
-                       return HVACAction.OFF
-
+                        # If the system is on and the current temperature is
+                        # higher than the point at which heating would activate,
+                        # then we must be cooling.
+                        return HVACAction.COOLING
+                    return HVACAction.HEATING
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="failed_to_parse_hvac_action",

--- a/homeassistant/components/bryant_evolution/climate.py
+++ b/homeassistant/components/bryant_evolution/climate.py
@@ -168,25 +168,54 @@ class BryantEvolutionClimate(ClimateEntity):
         if not is_active:
             return HVACAction.OFF
         match mode.upper():
+             # For HEAT and COOL, compare the current temp and setpoint to determine
+             # if this ZONE is HEATING or COOLING.  
+             # MODE only shows trhat the SYSTEM is running, not individual ZONES
             case "HEAT":
-                return HVACAction.HEATING
+                if (
+                    self.current_temperature is not None
+                    and self.target_temperature is not None
+                ):
+                    if self.target_temperature > self.current_temperature:
+                       return HVACAction.HEATING
+                    else:
+                       return HVACAction.OFF
             case "COOL":
-                return HVACAction.COOLING
+                if (
+                    self.current_temperature is not None
+                    and self.target_temperature is not None
+                ):
+                    if self.target_temperature < self.current_temperature:
+                       return HVACAction.COOLING
+                    else:
+                       return HVACAction.OFF                
             case "OFF":
                 return HVACAction.OFF
             case "AUTO":
-                # In AUTO, we need to figure out what the actual action is
-                # based on the setpoints.
+                # For AUTO, we need to figure out whether we're heating, cooling, or
+                # neither for this Zone based on the current temperature and the setpoints,
+                # and given that while the system itself is running in some zone(s), it may
+                # or may not be running in this one.
                 if (
                     self.current_temperature is not None
                     and self.target_temperature_low is not None
+                    and self.target_temperature_high is not None
                 ):
                     if self.current_temperature > self.target_temperature_low:
-                        # If the system is on and the current temperature is
-                        # higher than the point at which heating would activate,
-                        # then we must be cooling.
-                        return HVACAction.COOLING
-                    return HVACAction.HEATING
+                       # If the system is running and the current_temperature is
+                       # higher than the setpoint at which cooling would stop,
+                       # then the zone must be cooling.
+                       return HVACAction.COOLING
+                    elif self.current_temperature < self.target_temperature_high:
+                       # Or, conversely, heating
+                       return HVACAction.HEATING
+                    else:
+                       # Othewise, set the current zone to OFF because the current_temperature is
+                       # within the _high - _low temperature band, inclusive of both bounds. That is,
+                       # neither cooling, nor heating is required in this zone.
+                       # (By implication, some other zone(s) must be running (heating or cooling)
+                       return HVACAction.OFF
+
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="failed_to_parse_hvac_action",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add logic to determine if individual zones are heating or cooling.  Don't rely on the system-wide operating mode that does not contain zonal status information.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Logic is added to determine hvac_action based on current temperature and setpoint(s) in addition to the operating MODE

- This PR fixes or closes issue: fixes #160148
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
