### PR TITLE
Bump python-roborock to 4.2.0

### DIFF
--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -20,7 +20,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==4.1.0",
+    "python-roborock==4.2.0",
     "vacuum-map-parser-roborock==0.1.4"
   ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2581,7 +2581,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==4.1.0
+python-roborock==4.2.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.46

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2165,7 +2165,7 @@ python-pooldose==0.8.1
 python-rabbitair==0.0.8
 
 # homeassistant.components.roborock
-python-roborock==4.1.0
+python-roborock==4.2.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.46


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Bump `python-roborock` to 4.2.0 to fix setup failing for Roborock B01 Q7 devices (for example `B01_7`).

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #159656
- Link to changelog or diff between library versions: https://github.com/roborock/python-roborock/compare/v4.1.0...v4.2.0

Tests: `pytest -q tests/components/roborock`
