### PR TITLE
Portainer polish ephemeral container ID

### DIFF
--- a/homeassistant/components/portainer/binary_sensor.py
+++ b/homeassistant/components/portainer/binary_sensor.py
@@ -164,7 +164,11 @@ class PortainerContainerSensor(PortainerContainerEntity, BinarySensorEntity):
     @property
     def available(self) -> bool:
         """Return if the device is available."""
-        return super().available and self.endpoint_id in self.coordinator.data
+        return (
+            super().available
+            and self.endpoint_id in self.coordinator.data
+            and self.device_name in self.coordinator.data[self.endpoint_id].containers
+        )
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/portainer/button.py
+++ b/homeassistant/components/portainer/button.py
@@ -113,7 +113,9 @@ class PortainerButton(PortainerContainerEntity, ButtonEntity):
         """Trigger the Portainer button press service."""
         try:
             await self.entity_description.press_action(
-                self.coordinator.portainer, self.endpoint_id, self.device_id
+                self.coordinator.portainer,
+                self.endpoint_id,
+                self.container_data.container.id,
             )
         except PortainerConnectionError as err:
             raise HomeAssistantError(

--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -233,9 +233,9 @@ class PortainerCoordinator(DataUpdateCoordinator[dict[int, PortainerCoordinatorD
 
         # Surprise, we also handle containers here :)
         current_containers = {
-            (endpoint.id, self._get_container_name(container.container.names[0]))
+            (endpoint.id, container_name)
             for endpoint in mapped_endpoints.values()
-            for container in endpoint.containers.values()
+            for container_name in endpoint.containers
         }
         new_containers = current_containers - self.known_containers
         if new_containers:

--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -233,7 +233,7 @@ class PortainerCoordinator(DataUpdateCoordinator[dict[int, PortainerCoordinatorD
 
         # Surprise, we also handle containers here :)
         current_containers = {
-            (endpoint.id, container.container.id)
+            (endpoint.id, self._get_container_name(container.container.names[0]))
             for endpoint in mapped_endpoints.values()
             for container in endpoint.containers.values()
         }

--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -171,7 +171,7 @@ class PortainerCoordinator(DataUpdateCoordinator[dict[int, PortainerCoordinatorD
                     if container.state == CONTAINER_STATE_RUNNING
                 ]
                 if running_containers:
-                    stats_by_key = dict(
+                    container_stats = dict(
                         zip(
                             (
                                 self._get_container_name(container.names[0])
@@ -191,7 +191,7 @@ class PortainerCoordinator(DataUpdateCoordinator[dict[int, PortainerCoordinatorD
                     )
 
                     # Now assign stats to the containers
-                    for container_name, stats in stats_by_key.items():
+                    for container_name, stats in container_stats.items():
                         container_map[container_name].stats = stats
             except PortainerConnectionError as err:
                 _LOGGER.exception("Connection error")

--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -154,7 +154,7 @@ class PortainerCoordinator(DataUpdateCoordinator[dict[int, PortainerCoordinatorD
                 for container in containers:
                     container_name = self._get_container_name(container.names[0])
                     prev_container = (
-                        prev_endpoint.containers.get(container_name)
+                        prev_endpoint.containers[container_name]
                         if prev_endpoint
                         else None
                     )

--- a/homeassistant/components/portainer/sensor.py
+++ b/homeassistant/components/portainer/sensor.py
@@ -52,7 +52,9 @@ CONTAINER_SENSORS: tuple[PortainerContainerSensorEntityDescription, ...] = (
     PortainerContainerSensorEntityDescription(
         key="memory_limit",
         translation_key="memory_limit",
-        value_fn=lambda data: data.stats.memory_stats.limit,
+        value_fn=lambda data: (
+            data.stats.memory_stats.limit if data.stats is not None else 0
+        ),
         device_class=SensorDeviceClass.DATA_SIZE,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.MEGABYTES,
@@ -63,7 +65,9 @@ CONTAINER_SENSORS: tuple[PortainerContainerSensorEntityDescription, ...] = (
     PortainerContainerSensorEntityDescription(
         key="memory_usage",
         translation_key="memory_usage",
-        value_fn=lambda data: data.stats.memory_stats.usage,
+        value_fn=lambda data: (
+            data.stats.memory_stats.usage if data.stats is not None else 0
+        ),
         device_class=SensorDeviceClass.DATA_SIZE,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.MEGABYTES,
@@ -76,7 +80,9 @@ CONTAINER_SENSORS: tuple[PortainerContainerSensorEntityDescription, ...] = (
         translation_key="memory_usage_percentage",
         value_fn=lambda data: (
             (data.stats.memory_stats.usage / data.stats.memory_stats.limit) * 100.0
-            if data.stats.memory_stats.limit > 0 and data.stats.memory_stats.usage > 0
+            if data.stats is not None
+            and data.stats.memory_stats.limit > 0
+            and data.stats.memory_stats.usage > 0
             else 0.0
         ),
         native_unit_of_measurement=PERCENTAGE,
@@ -89,7 +95,8 @@ CONTAINER_SENSORS: tuple[PortainerContainerSensorEntityDescription, ...] = (
         translation_key="cpu_usage_total",
         value_fn=lambda data: (
             (total_delta / system_delta) * data.stats.cpu_stats.online_cpus * 100.0
-            if (prev := data.stats_pre) is not None
+            if data.stats is not None
+            and (prev := data.stats_pre) is not None
             and (
                 system_delta := (
                     data.stats.cpu_stats.system_cpu_usage
@@ -247,7 +254,6 @@ async def async_setup_entry(
             )
             for (endpoint, container) in containers
             for entity_description in CONTAINER_SENSORS
-            if entity_description.value_fn(container) is not None
         )
 
     coordinator.new_endpoints_callbacks.append(_async_add_new_endpoints)
@@ -290,7 +296,11 @@ class PortainerContainerSensor(PortainerContainerEntity, SensorEntity):
     @property
     def available(self) -> bool:
         """Return if the device is available."""
-        return super().available and self.endpoint_id in self.coordinator.data
+        return (
+            super().available
+            and self.endpoint_id in self.coordinator.data
+            and self.device_name in self.coordinator.data[self.endpoint_id].containers
+        )
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/portainer/switch.py
+++ b/homeassistant/components/portainer/switch.py
@@ -137,13 +137,19 @@ class PortainerContainerSwitch(PortainerContainerEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Start (turn on) the container."""
         await self.entity_description.turn_on_fn(
-            "start", self.coordinator.portainer, self.endpoint_id, self.device_id
+            "start",
+            self.coordinator.portainer,
+            self.endpoint_id,
+            self.container_data.container.id,
         )
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Stop (turn off) the container."""
         await self.entity_description.turn_off_fn(
-            "stop", self.coordinator.portainer, self.endpoint_id, self.device_id
+            "stop",
+            self.coordinator.portainer,
+            self.endpoint_id,
+            self.container_data.container.id,
         )
         await self.coordinator.async_request_refresh()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR polishes two things:

1. When a container was recreated at runtime, the new container ID was not properly referenced. In the previous version the `self.device_id` was still referenced and this only get initialized in the `__init__`. Thus, during runtime the newly created container ID was not referenced anymore. This has been mitigated to use the coordinator data (which is stored in `container_data`).
2. Fix a stalemate situation where a KeyError could occur when the container was not running, due to a previous fix to not get the stats from stopped containers. This rendered stopped containers no longer being stored in the coordinator data. This is now fixed to separately merge later on container stats, only for running containers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/154312 https://github.com/home-assistant/core/issues/159504
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
