### PR TITLE
Add button platform for BSB-Lan integration

### DIFF
--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -36,7 +36,7 @@ from .const import CONF_PASSKEY, DOMAIN
 from .coordinator import BSBLanFastCoordinator, BSBLanSlowCoordinator
 from .services import async_setup_services
 
-PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.WATER_HEATER]
+PLATFORMS = [Platform.BUTTON, Platform.CLIMATE, Platform.SENSOR, Platform.WATER_HEATER]
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 

--- a/homeassistant/components/bsblan/button.py
+++ b/homeassistant/components/bsblan/button.py
@@ -1,0 +1,87 @@
+"""Button platform for BSB-Lan integration."""
+
+from __future__ import annotations
+
+from bsblan import BSBLANError
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from . import BSBLanConfigEntry, BSBLanData
+from .const import DOMAIN
+from .coordinator import BSBLanFastCoordinator
+from .entity import BSBLanEntity
+
+PARALLEL_UPDATES = 1
+
+BUTTON_DESCRIPTIONS: tuple[ButtonEntityDescription, ...] = (
+    ButtonEntityDescription(
+        key="sync_time",
+        translation_key="sync_time",
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: BSBLanConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up BSB-Lan button entities from a config entry."""
+    data = entry.runtime_data
+
+    async_add_entities(
+        BSBLanButtonEntity(data.fast_coordinator, data, description)
+        for description in BUTTON_DESCRIPTIONS
+    )
+
+
+class BSBLanButtonEntity(BSBLanEntity, ButtonEntity):
+    """Defines a BSB-Lan button entity."""
+
+    entity_description: ButtonEntityDescription
+
+    def __init__(
+        self,
+        coordinator: BSBLanFastCoordinator,
+        data: BSBLanData,
+        description: ButtonEntityDescription,
+    ) -> None:
+        """Initialize BSB-Lan button entity."""
+        super().__init__(coordinator, data)
+        self.entity_description = description
+        self._attr_unique_id = f"{data.device.MAC}-{description.key}"
+        self._client = data.client
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        if self.entity_description.key == "sync_time":
+            await self._async_sync_time()
+
+    async def _async_sync_time(self) -> None:
+        """Synchronize BSB-LAN device time with Home Assistant."""
+        try:
+            device_time = await self._client.time()
+            current_time = dt_util.now()
+            current_time_str = current_time.strftime("%d.%m.%Y %H:%M:%S")
+
+            # Only sync if device time differs from HA time
+            if device_time.time.value != current_time_str:
+                await self._client.set_time(current_time_str)
+        except BSBLANError as err:
+            device_name = "Unknown"
+            if self._attr_device_info:
+                device_name = str(self._attr_device_info.get("name", "Unknown"))
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sync_time_failed",
+                translation_placeholders={
+                    "device_name": device_name,
+                    "error": str(err),
+                },
+            ) from err

--- a/homeassistant/components/bsblan/button.py
+++ b/homeassistant/components/bsblan/button.py
@@ -52,12 +52,8 @@ class BSBLanButtonEntity(BSBLanEntity, ButtonEntity):
         super().__init__(coordinator, data)
         self.entity_description = description
         self._attr_unique_id = f"{data.device.MAC}-{description.key}"
-        self._client = data.client
+        self._data = data
 
     async def async_press(self) -> None:
         """Handle the button press."""
-        if self.entity_description.key == "sync_time":
-            device_name = "Unknown"
-            if self._attr_device_info:
-                device_name = str(self._attr_device_info.get("name", "Unknown"))
-            await async_sync_device_time(self._client, device_name)
+        await async_sync_device_time(self._data.client, self._data.device.name)

--- a/homeassistant/components/bsblan/helpers.py
+++ b/homeassistant/components/bsblan/helpers.py
@@ -1,0 +1,42 @@
+"""Helper functions for BSB-Lan integration."""
+
+from __future__ import annotations
+
+from bsblan import BSBLAN, BSBLANError
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+
+
+async def async_sync_device_time(client: BSBLAN, device_name: str) -> None:
+    """Synchronize BSB-LAN device time with Home Assistant.
+
+    Only updates if device time differs from Home Assistant time.
+
+    Args:
+        client: The BSB-LAN client instance.
+        device_name: The name of the device (used in error messages).
+
+    Raises:
+        HomeAssistantError: If the time sync operation fails.
+
+    """
+    try:
+        device_time = await client.time()
+        current_time = dt_util.now()
+        current_time_str = current_time.strftime("%d.%m.%Y %H:%M:%S")
+
+        # Only sync if device time differs from HA time
+        if device_time.time.value != current_time_str:
+            await client.set_time(current_time_str)
+    except BSBLANError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="sync_time_failed",
+            translation_placeholders={
+                "device_name": device_name,
+                "error": str(err),
+            },
+        ) from err

--- a/homeassistant/components/bsblan/icons.json
+++ b/homeassistant/components/bsblan/icons.json
@@ -1,4 +1,11 @@
 {
+  "entity": {
+    "button": {
+      "sync_time": {
+        "default": "mdi:timer-sync-outline"
+      }
+    }
+  },
   "services": {
     "set_hot_water_schedule": {
       "service": "mdi:calendar-clock"

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -60,6 +60,11 @@
     }
   },
   "entity": {
+    "button": {
+      "sync_time": {
+        "name": "Sync time"
+      }
+    },
     "sensor": {
       "current_temperature": {
         "name": "Current temperature"

--- a/tests/components/bsblan/snapshots/test_button.ambr
+++ b/tests/components/bsblan/snapshots/test_button.ambr
@@ -20,6 +20,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Sync time',
     'options': dict({
     }),
     'original_device_class': None,

--- a/tests/components/bsblan/snapshots/test_button.ambr
+++ b/tests/components/bsblan/snapshots/test_button.ambr
@@ -1,0 +1,49 @@
+# serializer version: 1
+# name: test_button_entity_properties[button.bsb_lan_sync_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.bsb_lan_sync_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sync time',
+    'platform': 'bsblan',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'sync_time',
+    'unique_id': '00:80:41:19:69:90-sync_time',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entity_properties[button.bsb_lan_sync_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BSB-LAN Sync time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.bsb_lan_sync_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/bsblan/test_button.py
+++ b/tests/components/bsblan/test_button.py
@@ -1,0 +1,140 @@
+"""Tests for the BSB-Lan button platform."""
+
+from unittest.mock import MagicMock
+
+from bsblan import BSBLANError, DeviceTime
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from . import setup_with_selected_platforms
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+ENTITY_SYNC_TIME = "button.bsb_lan_sync_time"
+
+
+async def test_button_entity_properties(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the button entity properties."""
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.BUTTON])
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_button_press_syncs_time(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test pressing the sync time button syncs the device time."""
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.BUTTON])
+
+    # Mock device time that differs from HA time
+    mock_bsblan.time.return_value = DeviceTime.from_json(
+        '{"time": {"name": "Time", "value": "01.01.2020 00:00:00", "unit": "", "desc": "", "dataType": 0, "readonly": 0, "error": 0}}'
+    )
+
+    # Press the button
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: ENTITY_SYNC_TIME},
+        blocking=True,
+    )
+
+    # Verify time() was called to check current device time
+    assert mock_bsblan.time.called
+
+    # Verify set_time() was called with current HA time
+    current_time_str = dt_util.now().strftime("%d.%m.%Y %H:%M:%S")
+    mock_bsblan.set_time.assert_called_once_with(current_time_str)
+
+
+async def test_button_press_no_update_when_same(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test button press doesn't update when time matches."""
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.BUTTON])
+
+    # Mock device time that matches HA time
+    current_time_str = dt_util.now().strftime("%d.%m.%Y %H:%M:%S")
+    mock_bsblan.time.return_value = DeviceTime.from_json(
+        f'{{"time": {{"name": "Time", "value": "{current_time_str}", "unit": "", "desc": "", "dataType": 0, "readonly": 0, "error": 0}}}}'
+    )
+
+    # Press the button
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: ENTITY_SYNC_TIME},
+        blocking=True,
+    )
+
+    # Verify time() was called
+    assert mock_bsblan.time.called
+
+    # Verify set_time() was NOT called since times match
+    assert not mock_bsblan.set_time.called
+
+
+async def test_button_press_error_handling(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test button press handles errors gracefully."""
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.BUTTON])
+
+    # Mock time() to raise an error
+    mock_bsblan.time.side_effect = BSBLANError("Connection failed")
+
+    # Press the button - should raise HomeAssistantError
+    with pytest.raises(HomeAssistantError, match="Failed to sync time"):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: ENTITY_SYNC_TIME},
+            blocking=True,
+        )
+
+
+async def test_button_press_set_time_error(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test button press handles set_time errors."""
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.BUTTON])
+
+    # Mock device time that differs
+    mock_bsblan.time.return_value = DeviceTime.from_json(
+        '{"time": {"name": "Time", "value": "01.01.2020 00:00:00", "unit": "", "desc": "", "dataType": 0, "readonly": 0, "error": 0}}'
+    )
+
+    # Mock set_time() to raise an error
+    mock_bsblan.set_time.side_effect = BSBLANError("Write failed")
+
+    # Press the button - should raise HomeAssistantError
+    with pytest.raises(HomeAssistantError, match="Failed to sync time"):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: ENTITY_SYNC_TIME},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request adds support for a new "Sync time" button entity to the BSB-Lan integration in Home Assistant. The button allows users to synchronize the device's time with Home Assistant, and includes all necessary platform, icon, string, and test updates.

**New button platform integration:**

* Added a new `button.py` platform for BSB-Lan, implementing a "Sync time" button entity that syncs the device's time with Home Assistant and handles errors gracefully.
* Registered the button platform in the main component setup, enabling automatic discovery and setup of button entities.

**User interface and localization:**

* Added an icon for the "Sync time" button entity (`mdi:timer-sync-outline`) in `icons.json`.
* Added a localized name ("Sync time") for the button entity in `strings.json`.

**Testing:**

* Added comprehensive tests for the button entity, including property validation, time synchronization logic, and error handling.
* Added snapshot tests to verify the entity registry and state properties for the new button entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42873
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
