### PR TITLE
Add basic auth support to Libre Hardware Monitor

### DIFF
--- a/homeassistant/components/libre_hardware_monitor/config_flow.py
+++ b/homeassistant/components/libre_hardware_monitor/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -9,11 +10,12 @@ from librehardwaremonitor_api import (
     LibreHardwareMonitorClient,
     LibreHardwareMonitorConnectionError,
     LibreHardwareMonitorNoDevicesError,
+    LibreHardwareMonitorUnauthorizedError,
 )
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 
 from .const import DEFAULT_HOST, DEFAULT_PORT, DOMAIN
 
@@ -23,8 +25,29 @@ CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
         vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Optional(CONF_USERNAME): str,
+        vol.Optional(CONF_PASSWORD): str,
     }
 )
+
+REAUTH_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+
+def _validate_credentials(user_input: dict[str, Any], errors: dict[str, str]) -> bool:
+    """Ensure both username and password are provided, populate errors if needed."""
+    authentication = CONF_USERNAME in user_input or CONF_PASSWORD in user_input
+    if authentication and CONF_USERNAME not in user_input:
+        errors["base"] = "username_missing"
+        return False
+    if authentication and CONF_PASSWORD not in user_input:
+        errors["base"] = "password_missing"
+        return False
+    return True
 
 
 class LibreHardwareMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -36,28 +59,85 @@ class LibreHardwareMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            self._async_abort_entries_match(user_input)
+            if _validate_credentials(user_input, errors):
+                self._async_abort_entries_match(user_input)
 
+                api = LibreHardwareMonitorClient(
+                    host=user_input[CONF_HOST],
+                    port=user_input[CONF_PORT],
+                    username=user_input.get(CONF_USERNAME),
+                    password=user_input.get(CONF_PASSWORD),
+                )
+
+                try:
+                    computer_name = (await api.get_data()).computer_name
+                except LibreHardwareMonitorConnectionError as exception:
+                    _LOGGER.error(exception)
+                    errors["base"] = "cannot_connect"
+                except LibreHardwareMonitorUnauthorizedError:
+                    errors["base"] = "invalid_auth"
+                except LibreHardwareMonitorNoDevicesError:
+                    errors["base"] = "no_devices"
+                else:
+                    return self.async_create_entry(
+                        title=f"{computer_name} ({user_input[CONF_HOST]}:{user_input[CONF_PORT]})",
+                        data=user_input,
+                    )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(CONFIG_SCHEMA, user_input),
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Perform reauthentication upon an API authentication error."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm reauthentication dialog."""
+        errors: dict[str, str] = {}
+
+        reauth_entry = self._get_reauth_entry()
+
+        if user_input:
             api = LibreHardwareMonitorClient(
-                user_input[CONF_HOST], user_input[CONF_PORT]
+                host=reauth_entry.data[CONF_HOST],
+                port=reauth_entry.data[CONF_PORT],
+                username=user_input.get(CONF_USERNAME),
+                password=user_input.get(CONF_PASSWORD),
             )
 
             try:
-                computer_name = (await api.get_data()).computer_name
+                _ = await api.get_data()
             except LibreHardwareMonitorConnectionError as exception:
                 _LOGGER.error(exception)
                 errors["base"] = "cannot_connect"
+            except LibreHardwareMonitorUnauthorizedError:
+                errors["base"] = "invalid_auth"
             except LibreHardwareMonitorNoDevicesError:
                 errors["base"] = "no_devices"
             else:
-                return self.async_create_entry(
-                    title=f"{computer_name} ({user_input[CONF_HOST]}:{user_input[CONF_PORT]})",
-                    data=user_input,
+                return self.async_update_reload_and_abort(
+                    reauth_entry, data_updates=user_input
                 )
 
         return self.async_show_form(
-            step_id="user", data_schema=CONFIG_SCHEMA, errors=errors
+            step_id="reauth_confirm",
+            data_schema=self.add_suggested_values_to_schema(
+                REAUTH_SCHEMA,
+                {
+                    CONF_USERNAME: user_input[CONF_USERNAME]
+                    if user_input is not None
+                    else reauth_entry.data.get(CONF_USERNAME)
+                },
+            ),
+            errors=errors,
         )

--- a/homeassistant/components/libre_hardware_monitor/config_flow.py
+++ b/homeassistant/components/libre_hardware_monitor/config_flow.py
@@ -108,6 +108,7 @@ class LibreHardwareMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
         """Confirm (re)authentication dialog."""
         errors: dict[str, str] = {}
 
+        # we use this step both for initial auth and for re-auth
         reauth_entry: ConfigEntry | None = None
         if self.source == SOURCE_REAUTH:
             reauth_entry = self._get_reauth_entry()

--- a/homeassistant/components/libre_hardware_monitor/config_flow.py
+++ b/homeassistant/components/libre_hardware_monitor/config_flow.py
@@ -14,7 +14,12 @@ from librehardwaremonitor_api import (
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 
 from .const import DEFAULT_HOST, DEFAULT_PORT, DOMAIN
@@ -25,8 +30,6 @@ CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
         vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-        vol.Optional(CONF_USERNAME): str,
-        vol.Optional(CONF_PASSWORD): str,
     }
 )
 
@@ -38,22 +41,28 @@ REAUTH_SCHEMA = vol.Schema(
 )
 
 
-def _validate_credentials(user_input: dict[str, Any], errors: dict[str, str]) -> bool:
-    """Ensure both username and password are provided, populate errors if needed."""
-    authentication = CONF_USERNAME in user_input or CONF_PASSWORD in user_input
-    if authentication and CONF_USERNAME not in user_input:
-        errors["base"] = "username_missing"
-        return False
-    if authentication and CONF_PASSWORD not in user_input:
-        errors["base"] = "password_missing"
-        return False
-    return True
+async def _validate_connection(user_input: dict[str, Any]) -> str:
+    """Ensure a connection can be established."""
+    api = LibreHardwareMonitorClient(
+        host=user_input[CONF_HOST],
+        port=user_input[CONF_PORT],
+        username=user_input.get(CONF_USERNAME),
+        password=user_input.get(CONF_PASSWORD),
+    )
+
+    return (await api.get_data()).computer_name
 
 
 class LibreHardwareMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for LibreHardwareMonitor."""
 
     VERSION = 2
+
+    def __init__(self) -> None:
+        """Init config flow."""
+
+        self._host: str | None = None
+        self._port: int | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -62,30 +71,24 @@ class LibreHardwareMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            if _validate_credentials(user_input, errors):
-                self._async_abort_entries_match(user_input)
+            self._async_abort_entries_match(user_input)
 
-                api = LibreHardwareMonitorClient(
-                    host=user_input[CONF_HOST],
-                    port=user_input[CONF_PORT],
-                    username=user_input.get(CONF_USERNAME),
-                    password=user_input.get(CONF_PASSWORD),
+            try:
+                computer_name = await _validate_connection(user_input)
+            except LibreHardwareMonitorConnectionError as exception:
+                _LOGGER.error(exception)
+                errors["base"] = "cannot_connect"
+            except LibreHardwareMonitorUnauthorizedError:
+                self._host = user_input[CONF_HOST]
+                self._port = user_input[CONF_PORT]
+                return await self.async_step_reauth_confirm()
+            except LibreHardwareMonitorNoDevicesError:
+                errors["base"] = "no_devices"
+            else:
+                return self.async_create_entry(
+                    title=f"{computer_name} ({user_input[CONF_HOST]}:{user_input[CONF_PORT]})",
+                    data=user_input,
                 )
-
-                try:
-                    computer_name = (await api.get_data()).computer_name
-                except LibreHardwareMonitorConnectionError as exception:
-                    _LOGGER.error(exception)
-                    errors["base"] = "cannot_connect"
-                except LibreHardwareMonitorUnauthorizedError:
-                    errors["base"] = "invalid_auth"
-                except LibreHardwareMonitorNoDevicesError:
-                    errors["base"] = "no_devices"
-                else:
-                    return self.async_create_entry(
-                        title=f"{computer_name} ({user_input[CONF_HOST]}:{user_input[CONF_PORT]})",
-                        data=user_input,
-                    )
 
         return self.async_show_form(
             step_id="user",
@@ -102,21 +105,21 @@ class LibreHardwareMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Confirm reauthentication dialog."""
+        """Confirm (re)authentication dialog."""
         errors: dict[str, str] = {}
 
-        reauth_entry = self._get_reauth_entry()
+        reauth_entry: ConfigEntry | None = None
+        if self.source == SOURCE_REAUTH:
+            reauth_entry = self._get_reauth_entry()
 
         if user_input:
-            api = LibreHardwareMonitorClient(
-                host=reauth_entry.data[CONF_HOST],
-                port=reauth_entry.data[CONF_PORT],
-                username=user_input.get(CONF_USERNAME),
-                password=user_input.get(CONF_PASSWORD),
-            )
-
+            data = {
+                CONF_HOST: reauth_entry.data[CONF_HOST] if reauth_entry else self._host,
+                CONF_PORT: reauth_entry.data[CONF_PORT] if reauth_entry else self._port,
+                **user_input,
+            }
             try:
-                _ = await api.get_data()
+                computer_name = await _validate_connection(data)
             except LibreHardwareMonitorConnectionError as exception:
                 _LOGGER.error(exception)
                 errors["base"] = "cannot_connect"
@@ -125,8 +128,15 @@ class LibreHardwareMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
             except LibreHardwareMonitorNoDevicesError:
                 errors["base"] = "no_devices"
             else:
-                return self.async_update_reload_and_abort(
-                    reauth_entry, data_updates=user_input
+                if self.source == SOURCE_REAUTH:
+                    return self.async_update_reload_and_abort(
+                        entry=reauth_entry,  # type: ignore[arg-type]
+                        data_updates=user_input,
+                    )
+                # the initial connection was unauthorized, now we can create the config entry
+                return self.async_create_entry(
+                    title=f"{computer_name} ({self._host}:{self._port})",
+                    data=data,
                 )
 
         return self.async_show_form(
@@ -137,6 +147,8 @@ class LibreHardwareMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_USERNAME: user_input[CONF_USERNAME]
                     if user_input is not None
                     else reauth_entry.data.get(CONF_USERNAME)
+                    if reauth_entry is not None
+                    else None
                 },
             ),
             errors=errors,

--- a/homeassistant/components/libre_hardware_monitor/coordinator.py
+++ b/homeassistant/components/libre_hardware_monitor/coordinator.py
@@ -9,6 +9,7 @@ from librehardwaremonitor_api import (
     LibreHardwareMonitorClient,
     LibreHardwareMonitorConnectionError,
     LibreHardwareMonitorNoDevicesError,
+    LibreHardwareMonitorUnauthorizedError,
 )
 from librehardwaremonitor_api.model import (
     DeviceId,
@@ -17,8 +18,9 @@ from librehardwaremonitor_api.model import (
 )
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -48,9 +50,12 @@ class LibreHardwareMonitorCoordinator(DataUpdateCoordinator[LibreHardwareMonitor
             update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
 
-        host = config_entry.data[CONF_HOST]
-        port = config_entry.data[CONF_PORT]
-        self._api = LibreHardwareMonitorClient(host, port)
+        self._api = LibreHardwareMonitorClient(
+            host=config_entry.data[CONF_HOST],
+            port=config_entry.data[CONF_PORT],
+            username=config_entry.data.get(CONF_USERNAME),
+            password=config_entry.data.get(CONF_PASSWORD),
+        )
         device_entries: list[DeviceEntry] = dr.async_entries_for_config_entry(
             registry=dr.async_get(self.hass), config_entry_id=config_entry.entry_id
         )
@@ -65,8 +70,11 @@ class LibreHardwareMonitorCoordinator(DataUpdateCoordinator[LibreHardwareMonitor
             lhm_data = await self._api.get_data()
         except LibreHardwareMonitorConnectionError as err:
             raise UpdateFailed(
-                "LibreHardwareMonitor connection failed, will retry", retry_after=30
+                "LibreHardwareMonitor connection failed, will retry", retry_after=25
             ) from err
+        except LibreHardwareMonitorUnauthorizedError as err:
+            _LOGGER.error("Authentication against LibreHardwareMonitor instance failed")
+            raise ConfigEntryAuthFailed("Authentication failed") from err
         except LibreHardwareMonitorNoDevicesError as err:
             raise UpdateFailed("No sensor data available, will retry") from err
 

--- a/homeassistant/components/libre_hardware_monitor/quality_scale.yaml
+++ b/homeassistant/components/libre_hardware_monitor/quality_scale.yaml
@@ -45,10 +45,7 @@ rules:
     comment: |
       Device is expected to be temporarily unavailable.
   parallel-updates: done
-  reauthentication-flow:
-    status: exempt
-    comment: |
-      This integration does not require authentication.
+  reauthentication-flow: done
   test-coverage: done
   # Gold
   devices: done

--- a/homeassistant/components/libre_hardware_monitor/strings.json
+++ b/homeassistant/components/libre_hardware_monitor/strings.json
@@ -7,9 +7,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "no_devices": "[%key:common::config_flow::abort::no_devices_found%]",
-      "password_missing": "Password is missing",
-      "username_missing": "Username is missing"
+      "no_devices": "[%key:common::config_flow::abort::no_devices_found%]"
     },
     "step": {
       "reauth_confirm": {
@@ -21,21 +19,17 @@
           "password": "The password for your Libre Hardware Monitor instance.",
           "username": "The username for your Libre Hardware Monitor instance."
         },
-        "description": "Please update your Libre Hardware Monitor credentials.",
-        "title": "Reauthenticate Libre Hardware Monitor"
+        "description": "Please provide your Libre Hardware Monitor credentials.",
+        "title": "Authenticate Libre Hardware Monitor"
       },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "port": "[%key:common::config_flow::data::port%]",
-          "username": "[%key:common::config_flow::data::username%]"
+          "port": "[%key:common::config_flow::data::port%]"
         },
         "data_description": {
           "host": "The IP address or hostname of the system running Libre Hardware Monitor.",
-          "password": "Leave blank if your system does not need authentication.",
-          "port": "The port of your Libre Hardware Monitor web server. By default 8085.",
-          "username": "Leave blank if your system does not need authentication."
+          "port": "The port of your Libre Hardware Monitor web server. By default 8085."
         }
       }
     }

--- a/homeassistant/components/libre_hardware_monitor/strings.json
+++ b/homeassistant/components/libre_hardware_monitor/strings.json
@@ -1,21 +1,41 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "no_devices": "[%key:common::config_flow::abort::no_devices_found%]"
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "no_devices": "[%key:common::config_flow::abort::no_devices_found%]",
+      "password_missing": "Password is missing",
+      "username_missing": "Username is missing"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "The password for your Libre Hardware Monitor instance.",
+          "username": "The username for your Libre Hardware Monitor instance."
+        },
+        "description": "Please update your Libre Hardware Monitor credentials.",
+        "title": "Reauthenticate Libre Hardware Monitor"
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "username": "[%key:common::config_flow::data::username%]"
         },
         "data_description": {
           "host": "The IP address or hostname of the system running Libre Hardware Monitor.",
-          "port": "The port of your Libre Hardware Monitor web server. By default 8085."
+          "password": "Leave blank if your system does not need authentication.",
+          "port": "The port of your Libre Hardware Monitor web server. By default 8085.",
+          "username": "Leave blank if your system does not need authentication."
         }
       }
     }

--- a/tests/components/libre_hardware_monitor/conftest.py
+++ b/tests/components/libre_hardware_monitor/conftest.py
@@ -13,10 +13,14 @@ from tests.common import MockConfigEntry, load_json_object_fixture
 
 VALID_CONFIG = {CONF_HOST: "192.168.0.20", CONF_PORT: 8085}
 
-VALID_CONFIG_WITH_AUTH = {
-    **VALID_CONFIG,
+AUTH_INPUT = {
     CONF_USERNAME: "lhm-user",
     CONF_PASSWORD: "lhm-password",
+}
+
+VALID_CONFIG_WITH_AUTH = {
+    **VALID_CONFIG,
+    **AUTH_INPUT,
 }
 
 REAUTH_INPUT = {
@@ -42,6 +46,18 @@ def mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         title="192.168.0.20:8085",
         data=VALID_CONFIG,
+        entry_id="test_entry_id",
+        version=2,
+    )
+
+
+@pytest.fixture
+def mock_auth_config_entry() -> MockConfigEntry:
+    """Config entry fixture."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="192.168.0.20:8085",
+        data=VALID_CONFIG_WITH_AUTH,
         entry_id="test_entry_id",
         version=2,
     )

--- a/tests/components/libre_hardware_monitor/conftest.py
+++ b/tests/components/libre_hardware_monitor/conftest.py
@@ -7,11 +7,22 @@ from librehardwaremonitor_api.parser import LibreHardwareMonitorParser
 import pytest
 
 from homeassistant.components.libre_hardware_monitor.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 
 from tests.common import MockConfigEntry, load_json_object_fixture
 
 VALID_CONFIG = {CONF_HOST: "192.168.0.20", CONF_PORT: 8085}
+
+VALID_CONFIG_WITH_AUTH = {
+    **VALID_CONFIG,
+    CONF_USERNAME: "lhm-user",
+    CONF_PASSWORD: "lhm-password",
+}
+
+REAUTH_INPUT = {
+    CONF_USERNAME: "new-username",
+    CONF_PASSWORD: "new-password",
+}
 
 
 @pytest.fixture

--- a/tests/components/libre_hardware_monitor/test_config_flow.py
+++ b/tests/components/libre_hardware_monitor/test_config_flow.py
@@ -5,24 +5,25 @@ from unittest.mock import AsyncMock
 from librehardwaremonitor_api import (
     LibreHardwareMonitorConnectionError,
     LibreHardwareMonitorNoDevicesError,
+    LibreHardwareMonitorUnauthorizedError,
 )
+import pytest
 
 from homeassistant.components.libre_hardware_monitor.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .conftest import VALID_CONFIG
+from .conftest import REAUTH_INPUT, VALID_CONFIG, VALID_CONFIG_WITH_AUTH
 
 from tests.common import MockConfigEntry
 
 
-async def test_create_entry(
+async def test_create_entry_without_auth(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_lhm_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that a complete config entry is created."""
     result = await hass.config_entries.flow.async_init(
@@ -39,21 +40,85 @@ async def test_create_entry(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id is None
 
-    mock_config_entry = result["result"]
+    created_config_entry = result["result"]
     assert (
-        mock_config_entry.title
+        created_config_entry.title
         == f"GAMING-PC ({VALID_CONFIG[CONF_HOST]}:{VALID_CONFIG[CONF_PORT]})"
     )
-    assert mock_config_entry.data == VALID_CONFIG
+    assert created_config_entry.data == VALID_CONFIG
 
     assert mock_setup_entry.call_count == 1
 
 
+async def test_create_entry_with_auth(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_lhm_client: AsyncMock,
+) -> None:
+    """Test that a complete config entry is created with authentication credentials."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=VALID_CONFIG_WITH_AUTH
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id is None
+
+    created_config_entry = result["result"]
+    assert created_config_entry.data == VALID_CONFIG_WITH_AUTH
+
+    assert mock_setup_entry.call_count == 1
+
+
+async def test_error_if_only_username_or_only_password_is_given(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_lhm_client: AsyncMock,
+) -> None:
+    """Test that either both username and password or neither are given."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    config_with_only_username = {**VALID_CONFIG, CONF_USERNAME: "test"}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=config_with_only_username
+    )
+
+    assert result["errors"] == {"base": "password_missing"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    config_with_only_password = {**VALID_CONFIG, CONF_PASSWORD: "pw123"}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=config_with_only_password
+    )
+
+    assert result["errors"] == {"base": "username_missing"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error_text"),
+    [
+        (LibreHardwareMonitorConnectionError, "cannot_connect"),
+        (LibreHardwareMonitorUnauthorizedError, "invalid_auth"),
+        (LibreHardwareMonitorNoDevicesError, "no_devices"),
+    ],
+)
 async def test_errors_and_flow_recovery(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_lhm_client: AsyncMock
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_lhm_client: AsyncMock,
+    side_effect: Exception,
+    error_text: str,
 ) -> None:
     """Test that errors are shown as expected."""
-    mock_lhm_client.get_data.side_effect = LibreHardwareMonitorConnectionError()
+    mock_lhm_client.get_data.side_effect = side_effect
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -66,17 +131,7 @@ async def test_errors_and_flow_recovery(
         result["flow_id"], user_input=VALID_CONFIG
     )
 
-    assert result["errors"] == {"base": "cannot_connect"}
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-
-    mock_lhm_client.get_data.side_effect = LibreHardwareMonitorNoDevicesError()
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=VALID_CONFIG
-    )
-
-    assert result["errors"] == {"base": "no_devices"}
+    assert result["errors"] == {"base": error_text}
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
@@ -87,7 +142,6 @@ async def test_errors_and_flow_recovery(
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-
     assert mock_setup_entry.call_count == 1
 
 
@@ -112,3 +166,102 @@ async def test_lhm_server_already_exists(
     assert result["reason"] == "already_configured"
 
     assert mock_setup_entry.call_count == 0
+
+
+async def test_reauth_no_previous_credentials(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_lhm_client: AsyncMock,
+) -> None:
+    """Test reauth flow when web server did not require auth before."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        REAUTH_INPUT,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data == {**VALID_CONFIG, **REAUTH_INPUT}
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+async def test_reauth_with_previous_credentials(
+    hass: HomeAssistant, mock_lhm_client: AsyncMock
+) -> None:
+    """Test reauth flow when web server credentials changed."""
+    mock_auth_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="192.168.0.20:8085",
+        data=VALID_CONFIG_WITH_AUTH,
+        entry_id="test_entry_id",
+        version=2,
+    )
+    mock_auth_config_entry.add_to_hass(hass)
+
+    result = await mock_auth_config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        REAUTH_INPUT,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_auth_config_entry.data == {**VALID_CONFIG, **REAUTH_INPUT}
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error_text"),
+    [
+        (LibreHardwareMonitorConnectionError, "cannot_connect"),
+        (LibreHardwareMonitorUnauthorizedError, "invalid_auth"),
+        (LibreHardwareMonitorNoDevicesError, "no_devices"),
+    ],
+)
+async def test_reauth_errors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_lhm_client: AsyncMock,
+    side_effect: Exception,
+    error_text: str,
+) -> None:
+    """Test reauth flow errors."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    mock_lhm_client.get_data.side_effect = side_effect
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        REAUTH_INPUT,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error_text}
+
+    mock_lhm_client.get_data.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        REAUTH_INPUT,
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data == {**VALID_CONFIG, **REAUTH_INPUT}
+    assert len(hass.config_entries.async_entries()) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The web server built into Libre Hardware Monitor provides optional HTTP basic auth. Previously, this was not supported in this integration, meaning it was only possible to use the integration with instances that had no auth.

This PR adds basic auth support into the integration. For new config entries, users can optionally provide username and password for their instance.

Specifically, this PR contains:
* adapted config flow
* added reauthentication flow
* extended unit tests accordingly

Docs have been adapted as well, see link below for PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42876
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
