### PR TITLE
Add multi-home support to YoLink integration via UAC authentication

### DIFF
--- a/homeassistant/components/yolink/api.py
+++ b/homeassistant/components/yolink/api.py
@@ -110,38 +110,43 @@ class UACAuth(YoLinkAuthMgr):
 
     async def _token_request(self) -> dict:
         """Fetch a new access token from the YoLink OAuth2 endpoint."""
-        async with self._session.post(
-            url=OAUTH2_TOKEN,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data={
-                "grant_type": "client_credentials",
-                "scope": "create",
-                "client_id": self._client_id,
-                "client_secret": self._client_secret,
-            },
-            timeout=ClientTimeout(total=10),
-        ) as resp:
-            if resp.status >= 400:
-                try:
-                    error_response = await resp.json()
-                except ClientError, ValueError:
-                    error_response = {}
-                error_code = error_response.get("error", "unknown")
-                error_desc = error_response.get(
-                    "error_description", f"HTTP {resp.status}"
-                )
-                _LOGGER.error(
-                    "UAC token request failed (%s): %s", error_code, error_desc
-                )
-                if resp.status in (401, 403):
+        try:
+            async with self._session.post(
+                url=OAUTH2_TOKEN,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data={
+                    "grant_type": "client_credentials",
+                    "scope": "create",
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                },
+                timeout=ClientTimeout(total=10),
+            ) as resp:
+                if resp.status >= 400:
+                    try:
+                        error_response = await resp.json()
+                    except ClientError, ValueError:
+                        error_response = {}
+                    error_code = error_response.get("error", "unknown")
+                    error_desc = error_response.get(
+                        "error_description", f"HTTP {resp.status}"
+                    )
+                    _LOGGER.error(
+                        "UAC token request failed (%s): %s", error_code, error_desc
+                    )
+                    if resp.status in (401, 403):
+                        raise YoLinkAuthFailError(error_code, error_desc)
+                    raise YoLinkClientError(error_code, error_desc)
+                result = await resp.json()
+                # Token endpoint may return HTTP 200 with error in the body
+                if "access_token" not in result:
+                    error_code = result.get("code", result.get("error", "unknown"))
+                    error_desc = result.get(
+                        "desc",
+                        result.get("error_description", "Authentication failed"),
+                    )
                     raise YoLinkAuthFailError(error_code, error_desc)
-                raise YoLinkClientError(error_code, error_desc)
-            result = await resp.json()
-            # Token endpoint may return HTTP 200 with error in the body
-            if "access_token" not in result:
-                error_code = result.get("code", result.get("error", "unknown"))
-                error_desc = result.get(
-                    "desc", result.get("error_description", "Authentication failed")
-                )
-                raise YoLinkAuthFailError(error_code, error_desc)
-            return result
+                return result
+        except (ClientError, OSError) as err:
+            _LOGGER.error("UAC token request failed: %s", err)
+            raise YoLinkClientError("request_failed", str(err)) from err

--- a/homeassistant/components/yolink/api.py
+++ b/homeassistant/components/yolink/api.py
@@ -1,31 +1,147 @@
-"""API for yolink bound to Home Assistant OAuth."""
+"""API for yolink."""
 
-from aiohttp import ClientSession
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from aiohttp import ClientError, ClientSession, ClientTimeout
 from yolink.auth_mgr import YoLinkAuthMgr
+from yolink.const import OAUTH2_TOKEN
+from yolink.exception import YoLinkAuthFailError, YoLinkClientError
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
+
+_LOGGER = logging.getLogger(__name__)
+
+# Refresh token 20 seconds before expiry to account for clock skew
+CLOCK_OUT_OF_SYNC_MAX_SEC = 20
 
 
 class ConfigEntryAuth(YoLinkAuthMgr):
-    """Provide yolink authentication tied to an OAuth2 based config entry."""
+    """Provide yolink authentication tied to an OAuth2 based config entry.
+
+    Token refresh is handled by Home Assistant's OAuth2Session.
+    access_token() must be a method (not property) because the library
+    calls it as self.access_token() in http_auth_header().
+    """
 
     def __init__(
         self,
         hass: HomeAssistant,
         websession: ClientSession,
-        oauth2Session: config_entry_oauth2_flow.OAuth2Session,
+        oauth_session: OAuth2Session,
     ) -> None:
         """Initialize yolink Auth."""
-        self.hass = hass
-        self.oauth_session = oauth2Session
         super().__init__(websession)
+        self.hass = hass
+        self._oauth_session = oauth_session
 
-    def access_token(self) -> str:
-        """Return the access token."""
-        return self.oauth_session.token["access_token"]
+    def access_token(self) -> str | None:
+        """Return the current access token."""
+        return self._oauth_session.token.get("access_token")
 
     async def check_and_refresh_token(self) -> str:
-        """Check the token."""
-        await self.oauth_session.async_ensure_token_valid()
-        return self.access_token()
+        """Check and refresh the token if needed."""
+        await self._oauth_session.async_ensure_token_valid()
+        return self._oauth_session.token["access_token"]
+
+    async def async_get_access_token(self) -> str:
+        """Return a valid access token."""
+        await self._oauth_session.async_ensure_token_valid()
+        return self._oauth_session.token["access_token"]
+
+
+class UACAuth(YoLinkAuthMgr):
+    """Provide yolink authentication using UAC credentials.
+
+    Extends YoLinkAuthMgr (not YoLinkLocalAuthMgr) because the library's
+    MQTT client uses isinstance(auth_mgr, YoLinkLocalAuthMgr) to switch
+    between local-hub and cloud MQTT credential formats. UAC uses the cloud
+    broker, so we must not be an instance of YoLinkLocalAuthMgr.
+
+    Token lifecycle (fetch, expiry, locking) is modeled after
+    YoLinkLocalAuthMgr but implemented here to avoid the isinstance issue.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        websession: ClientSession,
+        uaid: str,
+        secret_key: str,
+    ) -> None:
+        """Initialize yolink UAC Auth."""
+        super().__init__(websession)
+        self.hass = hass
+        self._client_id = uaid
+        self._client_secret = secret_key
+        self._token: dict | None = None
+        self._token_lock = asyncio.Lock()
+
+    def access_token(self) -> str | None:
+        """Return the current access token."""
+        if self._token is None:
+            return None
+        return self._token["access_token"]
+
+    @property
+    def _token_valid(self) -> bool:
+        """Check if the current token is still valid."""
+        if self._token is None:
+            return False
+        return self._token["expires_at"] > time.time() + CLOCK_OUT_OF_SYNC_MAX_SEC
+
+    async def check_and_refresh_token(self) -> str:
+        """Check and refresh the token if needed."""
+        async with self._token_lock:
+            if self._token_valid and self._token is not None:
+                return self._token["access_token"]
+            new_token = await self._token_request()
+            new_token["expires_at"] = time.time() + new_token["expires_in"]
+            self._token = new_token
+            return self._token["access_token"]
+
+    async def async_get_access_token(self) -> str:
+        """Return a valid access token."""
+        return await self.check_and_refresh_token()
+
+    async def _token_request(self) -> dict:
+        """Fetch a new access token from the YoLink OAuth2 endpoint."""
+        async with self._session.post(
+            url=OAUTH2_TOKEN,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "client_credentials",
+                "scope": "create",
+                "client_id": self._client_id,
+                "client_secret": self._client_secret,
+            },
+            timeout=ClientTimeout(total=10),
+        ) as resp:
+            if resp.status >= 400:
+                try:
+                    error_response = await resp.json()
+                except ClientError, ValueError:
+                    error_response = {}
+                error_code = error_response.get("error", "unknown")
+                error_desc = error_response.get(
+                    "error_description", f"HTTP {resp.status}"
+                )
+                _LOGGER.error(
+                    "UAC token request failed (%s): %s", error_code, error_desc
+                )
+                if resp.status in (401, 403):
+                    raise YoLinkAuthFailError(error_code, error_desc)
+                raise YoLinkClientError(error_code, error_desc)
+            result = await resp.json()
+            # Token endpoint may return HTTP 200 with error in the body
+            if "access_token" not in result:
+                error_code = result.get("code", result.get("error", "unknown"))
+                error_desc = result.get(
+                    "desc", result.get("error_description", "Authentication failed")
+                )
+                raise YoLinkAuthFailError(error_code, error_desc)
+            return result

--- a/homeassistant/components/yolink/config_flow.py
+++ b/homeassistant/components/yolink/config_flow.py
@@ -79,6 +79,18 @@ class OAuth2FlowHandler(
             menu_options=["pick_implementation", "uac"],
         )
 
+    async def async_step_pick_implementation(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle selection of an OAuth implementation."""
+        if self.source != SOURCE_REAUTH and any(
+            entry.data.get(CONF_AUTH_TYPE) == AUTH_TYPE_OAUTH
+            for entry in self._async_current_entries()
+        ):
+            return self.async_abort(reason="already_configured")
+
+        return await super().async_step_pick_implementation(user_input)
+
     async def async_step_uac(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/yolink/config_flow.py
+++ b/homeassistant/components/yolink/config_flow.py
@@ -2,22 +2,61 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 import logging
 from typing import Any
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
-from homeassistant.helpers import config_entry_oauth2_flow
+import voluptuous as vol
+from yolink.device import YoLinkDevice
+from yolink.exception import YoLinkAuthFailError, YoLinkClientError
+from yolink.home_manager import YoLinkHome
+from yolink.message_listener import MessageListener
 
-from .const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
+from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
+
+from .api import UACAuth
+from .const import (
+    AUTH_TYPE_OAUTH,
+    AUTH_TYPE_UAC,
+    CONF_AUTH_TYPE,
+    CONF_HOME_ID,
+    CONF_SECRET_KEY,
+    CONF_UAID,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _NoOpMessageListener(MessageListener):
+    """No-op message listener for config flow validation."""
+
+    def on_message(self, device: YoLinkDevice, msg_data: dict[str, Any]) -> None:
+        """Do nothing with messages during validation."""
+
+
+UAC_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_UAID): str,
+        vol.Required(CONF_SECRET_KEY): str,
+    }
+)
 
 
 class OAuth2FlowHandler(
     config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN
 ):
-    """Config flow to handle yolink OAuth2 authentication."""
+    """Config flow to handle yolink OAuth2 and UAC authentication."""
 
     DOMAIN = DOMAIN
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        super().__init__()
+        self._home_id: str | None = None
+        self._home_name: str | None = None
 
     @property
     def logger(self) -> logging.Logger:
@@ -25,10 +64,102 @@ class OAuth2FlowHandler(
         return logging.getLogger(__name__)
 
     @property
-    def extra_authorize_data(self) -> dict:
+    def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
-        scopes = ["create"]
-        return {"scope": " ".join(scopes)}
+        return {"scope": "create"}
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a flow start - show menu to choose auth method."""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["pick_implementation", "uac"],
+        )
+
+    async def async_step_uac(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle UAC credential input."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                home_info = await self._async_validate_uac_credentials(
+                    user_input[CONF_UAID],
+                    user_input[CONF_SECRET_KEY],
+                )
+            except YoLinkAuthFailError:
+                errors["base"] = "invalid_auth"
+            except YoLinkClientError:
+                errors["base"] = "cannot_connect"
+            except TimeoutError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception during UAC validation")
+                errors["base"] = "unknown"
+            else:
+                home_id = home_info.get("id")
+                if not home_id:
+                    errors["base"] = "unknown"
+                else:
+                    self._home_id = home_id
+                    self._home_name = home_info.get("name", "YoLink Home")
+
+                    # Use home_id as unique identifier to allow multiple homes
+                    await self.async_set_unique_id(self._home_id)
+
+                    if self.source == SOURCE_REAUTH:
+                        self._abort_if_unique_id_mismatch(reason="wrong_account")
+                        return self.async_update_reload_and_abort(
+                            self._get_reauth_entry(),
+                            data_updates={
+                                CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+                                CONF_UAID: user_input[CONF_UAID],
+                                CONF_SECRET_KEY: user_input[CONF_SECRET_KEY],
+                                CONF_HOME_ID: self._home_id,
+                            },
+                        )
+
+                    self._abort_if_unique_id_configured()
+
+                    return self.async_create_entry(
+                        title=self._home_name,
+                        data={
+                            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+                            CONF_UAID: user_input[CONF_UAID],
+                            CONF_SECRET_KEY: user_input[CONF_SECRET_KEY],
+                            CONF_HOME_ID: self._home_id,
+                        },
+                    )
+
+        return self.async_show_form(
+            step_id="uac",
+            data_schema=UAC_SCHEMA,
+            errors=errors,
+        )
+
+    async def _async_validate_uac_credentials(
+        self, uaid: str, secret_key: str
+    ) -> dict[str, Any]:
+        """Validate UAC credentials and return home info."""
+        websession = aiohttp_client.async_get_clientsession(self.hass)
+        auth_mgr = UACAuth(self.hass, websession, uaid, secret_key)
+
+        yolink_home = YoLinkHome()
+        async with asyncio.timeout(10):
+            try:
+                await yolink_home.async_setup(auth_mgr, _NoOpMessageListener())
+                home_info = await yolink_home.async_get_home_info()
+            finally:
+                await yolink_home.async_unload()
+
+        _LOGGER.debug(
+            "Validated UAC credentials for home: id=%s, name=%s",
+            home_info.data.get("id"),
+            home_info.data.get("name"),
+        )
+        return home_info.data
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
@@ -36,25 +167,32 @@ class OAuth2FlowHandler(
         """Perform reauth upon an API authentication error."""
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(self, user_input=None) -> ConfigFlowResult:
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Dialog that informs the user that reauth is required."""
         if user_input is None:
             return self.async_show_form(step_id="reauth_confirm")
-        return await self.async_step_user()
 
-    async def async_oauth_create_entry(self, data: dict) -> ConfigFlowResult:
+        # Check auth type of existing entry and route appropriately
+        reauth_entry = self._get_reauth_entry()
+        if reauth_entry.data.get(CONF_AUTH_TYPE) == AUTH_TYPE_UAC:
+            return await self.async_step_uac()
+        # For OAuth, use the standard OAuth flow (call without user_input to start fresh)
+        return await super().async_step_user()
+
+    async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an oauth config entry or update existing entry for reauth."""
         if self.source == SOURCE_REAUTH:
             return self.async_update_reload_and_abort(
-                self._get_reauth_entry(), data_updates=data
+                self._get_reauth_entry(),
+                data_updates={**data, CONF_AUTH_TYPE: AUTH_TYPE_OAUTH},
             )
-        return self.async_create_entry(title="YoLink", data=data)
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a flow start."""
-        existing_entry = await self.async_set_unique_id(DOMAIN)
-        if existing_entry and self.source != SOURCE_REAUTH:
-            return self.async_abort(reason="already_configured")
-        return await super().async_step_user(user_input)
+        # For OAuth entries, use DOMAIN as unique_id (backwards compatible)
+        # This limits OAuth to one entry, but UAC entries are unlimited
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured()
+
+        data[CONF_AUTH_TYPE] = AUTH_TYPE_OAUTH
+        return self.async_create_entry(title="YoLink", data=data)

--- a/homeassistant/components/yolink/config_flow.py
+++ b/homeassistant/components/yolink/config_flow.py
@@ -14,7 +14,7 @@ from yolink.home_manager import YoLinkHome
 from yolink.message_listener import MessageListener
 
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
-from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
+from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow, selector
 
 from .api import UACAuth
 from .const import (
@@ -40,7 +40,9 @@ class _NoOpMessageListener(MessageListener):
 UAC_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_UAID): str,
-        vol.Required(CONF_SECRET_KEY): str,
+        vol.Required(CONF_SECRET_KEY): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+        ),
     }
 )
 

--- a/homeassistant/components/yolink/const.py
+++ b/homeassistant/components/yolink/const.py
@@ -51,3 +51,13 @@ SUPPORTED_REMOTERS = [
     DEV_MODEL_FLEX_FOB_YS3614_EC,
     DEV_MODEL_FLEX_FOB_YS3614_UC,
 ]
+
+# Authentication types
+CONF_AUTH_TYPE = "auth_type"
+AUTH_TYPE_OAUTH = "oauth"
+AUTH_TYPE_UAC = "uac"
+
+# UAC configuration
+CONF_UAID = "uaid"
+CONF_SECRET_KEY = "secret_key"
+CONF_HOME_ID = "home_id"

--- a/homeassistant/components/yolink/strings.json
+++ b/homeassistant/components/yolink/strings.json
@@ -12,10 +12,16 @@
       "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "wrong_account": "The credentials provided are for a different YoLink home than the one configured. Use the UAC credentials for the home you want to re-authenticate, or remove this integration entry and add it again if you want to change homes."
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
       "pick_implementation": {
@@ -30,6 +36,25 @@
       "reauth_confirm": {
         "description": "The YoLink integration needs to re-authenticate your account",
         "title": "[%key:common::config_flow::title::reauth%]"
+      },
+      "uac": {
+        "data": {
+          "secret_key": "Secret key",
+          "uaid": "UAID (User Access ID)"
+        },
+        "data_description": {
+          "secret_key": "The secret key associated with your UAID",
+          "uaid": "The User Access ID from your YoLink app"
+        },
+        "description": "Enter your User Access Credentials from the YoLink app.\n\nTo find these: YoLink App -> Settings -> Account -> Advanced Settings -> User Access Credentials",
+        "title": "Enter UAC credentials"
+      },
+      "user": {
+        "description": "Choose how you want to authenticate with YoLink.",
+        "menu_options": {
+          "pick_implementation": "Sign in with YoLink account",
+          "uac": "Use UAC credentials (recommended for multiple homes)"
+        }
       }
     }
   },

--- a/tests/components/yolink/conftest.py
+++ b/tests/components/yolink/conftest.py
@@ -13,7 +13,14 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
-from homeassistant.components.yolink.api import ConfigEntryAuth
+from homeassistant.components.yolink.api import ConfigEntryAuth, UACAuth
+from homeassistant.components.yolink.const import (
+    AUTH_TYPE_UAC,
+    CONF_AUTH_TYPE,
+    CONF_HOME_ID,
+    CONF_SECRET_KEY,
+    CONF_UAID,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -22,6 +29,12 @@ from tests.common import MockConfigEntry
 CLIENT_ID = "12345"
 CLIENT_SECRET = "6789"
 DOMAIN = "yolink"
+
+# UAC test credentials
+TEST_UAID = "test-uaid-12345"
+TEST_SECRET_KEY = "test-secret-key-6789"
+TEST_HOME_ID = "home_12345"
+TEST_HOME_NAME = "My Test Home"
 
 
 @pytest.fixture
@@ -76,3 +89,47 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     )
     config_entry.add_to_hass(hass)
     return config_entry
+
+
+@pytest.fixture
+def mock_uac_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Mock a UAC config entry for YoLink."""
+    config_entry = MockConfigEntry(
+        unique_id=TEST_HOME_ID,
+        domain=DOMAIN,
+        title=TEST_HOME_NAME,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: TEST_UAID,
+            CONF_SECRET_KEY: TEST_SECRET_KEY,
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+        options={},
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry
+
+
+@pytest.fixture(name="mock_uac_auth_manager")
+def mock_uac_auth_manager() -> Generator[MagicMock]:
+    """Mock the UAC authentication manager."""
+    with patch(
+        "homeassistant.components.yolink.api.UACAuth", autospec=True
+    ) as mock_auth:
+        mock_auth.return_value = MagicMock(spec=UACAuth)
+        yield mock_auth
+
+
+@pytest.fixture(name="mock_yolink_home_config_flow")
+def mock_yolink_home_config_flow() -> Generator[AsyncMock]:
+    """Mock YoLink home instance for config flow."""
+    with patch(
+        "homeassistant.components.yolink.config_flow.YoLinkHome", autospec=True
+    ) as mock_home:
+        mock_instance = AsyncMock(spec=YoLinkHome)
+        mock_home.return_value = mock_instance
+        # Set up default return for async_get_home_info
+        mock_home_info = MagicMock()
+        mock_home_info.data = {"id": TEST_HOME_ID, "name": TEST_HOME_NAME}
+        mock_instance.async_get_home_info.return_value = mock_home_info
+        yield mock_home

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -1,13 +1,22 @@
 """Test yolink config flow."""
 
 from http import HTTPStatus
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from yolink.const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from yolink.exception import YoLinkAuthFailError, YoLinkClientError
 
 from homeassistant import config_entries, setup
 from homeassistant.components import application_credentials
+from homeassistant.components.yolink.const import (
+    AUTH_TYPE_OAUTH,
+    AUTH_TYPE_UAC,
+    CONF_AUTH_TYPE,
+    CONF_HOME_ID,
+    CONF_SECRET_KEY,
+    CONF_UAID,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -21,33 +30,154 @@ CLIENT_ID = "12345"
 CLIENT_SECRET = "6789"
 DOMAIN = "yolink"
 
+# UAC test credentials
+TEST_UAID = "test-uaid-12345"
+TEST_SECRET_KEY = "test-secret-key-6789"
+TEST_HOME_ID = "home_12345"
+TEST_HOME_NAME = "My Test Home"
 
-async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
-    """Check flow abort when no configuration."""
+
+async def test_user_flow_shows_menu(
+    hass: HomeAssistant,
+) -> None:
+    """Check that user flow shows menu."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+    await application_credentials.async_import_client_credential(
+        hass,
+        DOMAIN,
+        application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
+    )
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+    assert "pick_implementation" in result["menu_options"]
+    assert "uac" in result["menu_options"]
+
+
+async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
+    """Check flow abort when no configuration and selecting OAuth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    # Menu is shown first even without credentials
+    assert result["type"] is FlowResultType.MENU
+
+    # When selecting OAuth without credentials, it should abort
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "missing_credentials"
 
 
-async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
-    """Check flow abort when an entry already exist."""
-    MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN).add_to_hass(hass)
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_oauth_alongside_uac_entries(hass: HomeAssistant) -> None:
+    """Check that OAuth entries and UAC entries can coexist."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+    await application_credentials.async_import_client_credential(
+        hass,
+        DOMAIN,
+        application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
+    )
+    # Add a UAC entry first
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: TEST_UAID,
+            CONF_SECRET_KEY: TEST_SECRET_KEY,
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    ).add_to_hass(hass)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
+    # Menu should still be shown - UAC entry doesn't block OAuth
+    assert result["type"] is FlowResultType.MENU
+
+    # Selecting OAuth should proceed to the external step (not abort)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
+    )
+    # Should show external step for OAuth (since only one implementation)
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_oauth_duplicate_entry_blocked(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Check that duplicate OAuth entries are prevented."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+    await application_credentials.async_import_client_credential(
+        hass,
+        DOMAIN,
+        application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
+    )
+    # Add existing OAuth entry
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=DOMAIN,  # OAuth uses DOMAIN as unique_id
+        data={CONF_AUTH_TYPE: AUTH_TYPE_OAUTH},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    # Menu is still shown
+    assert result["type"] is FlowResultType.MENU
+
+    # Select OAuth from menu
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
+    )
+    # External step proceeds (duplicate check happens after OAuth)
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+
+    # Complete OAuth flow
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+
+    client = await hass_client_no_auth()
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+            "scope": "create",
+        },
+    )
+
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == HTTPStatus.OK
+
+    # Now the duplicate check should abort
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
 @pytest.mark.usefixtures("current_request_with_host")
-async def test_full_flow(
+async def test_full_oauth_flow(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
-    """Check full flow."""
+    """Check full OAuth flow via menu."""
     assert await setup.async_setup_component(
         hass,
         DOMAIN,
@@ -58,9 +188,18 @@ async def test_full_flow(
         DOMAIN,
         application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
     )
+
+    # Start the flow
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
+    assert result["type"] is FlowResultType.MENU
+
+    # Select OAuth
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
+    )
+
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -99,6 +238,7 @@ async def test_full_flow(
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["data"]["auth_implementation"] == DOMAIN
+    assert result["data"][CONF_AUTH_TYPE] == AUTH_TYPE_OAUTH
 
     result["data"]["token"].pop("expires_at")
     assert result["data"]["token"] == {
@@ -116,6 +256,276 @@ async def test_full_flow(
     assert len(mock_setup.mock_calls) == 1
 
 
+async def test_uac_flow_success(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check successful UAC flow."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+
+    # Select UAC
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "uac"
+
+    # Enter credentials
+    with patch("homeassistant.components.yolink.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == TEST_HOME_NAME
+    assert result["data"] == {
+        CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+        CONF_UAID: TEST_UAID,
+        CONF_SECRET_KEY: TEST_SECRET_KEY,
+        CONF_HOME_ID: TEST_HOME_ID,
+    }
+
+
+async def test_uac_flow_invalid_auth(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check UAC flow with invalid credentials."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Make the mock raise auth error
+    mock_yolink_home_config_flow.return_value.async_setup.side_effect = (
+        YoLinkAuthFailError("000103", "Invalid credentials")
+    )
+
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter bad credentials
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: "bad-uaid", CONF_SECRET_KEY: "bad-secret"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_uac_flow_cannot_connect(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check UAC flow with connection error."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Make the mock raise connection error
+    mock_yolink_home_config_flow.return_value.async_setup.side_effect = (
+        YoLinkClientError("000201", "Connection failed")
+    )
+
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter credentials
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_uac_flow_timeout(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check UAC flow with timeout error."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Make the mock raise timeout error
+    mock_yolink_home_config_flow.return_value.async_setup.side_effect = TimeoutError()
+
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter credentials
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_uac_flow_unknown_error(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check UAC flow with unknown error."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Make the mock raise unexpected error
+    mock_yolink_home_config_flow.return_value.async_setup.side_effect = RuntimeError(
+        "Unexpected"
+    )
+
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter credentials
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_uac_flow_missing_home_id(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check UAC flow when API response is missing home id."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Return home info without an id
+    mock_home_info = MagicMock()
+    mock_home_info.data = {"name": "Some Home"}
+    mock_yolink_home_config_flow.return_value.async_get_home_info.return_value = (
+        mock_home_info
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_multiple_uac_entries_different_homes(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check that multiple UAC entries for different homes are allowed."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Add first UAC entry
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="home_11111",
+        title="First Home",
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: "first-uaid",
+            CONF_SECRET_KEY: "first-secret",
+            CONF_HOME_ID: "home_11111",
+        },
+    ).add_to_hass(hass)
+
+    # Set up mock for second home
+    mock_home_info = MagicMock()
+    mock_home_info.data = {"id": "home_22222", "name": "Second Home"}
+    mock_yolink_home_config_flow.return_value.async_get_home_info.return_value = (
+        mock_home_info
+    )
+
+    # Start the flow for second home
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter credentials for second home
+    with patch("homeassistant.components.yolink.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_UAID: "second-uaid", CONF_SECRET_KEY: "second-secret"},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Second Home"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
+
+
+async def test_uac_flow_duplicate_home(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check that duplicate UAC entries for same home are prevented."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Add existing UAC entry
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        title=TEST_HOME_NAME,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: TEST_UAID,
+            CONF_SECRET_KEY: TEST_SECRET_KEY,
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    ).add_to_hass(hass)
+
+    # Try to add same home again
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter credentials for same home
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: "new-uaid", CONF_SECRET_KEY: "new-secret"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
 @pytest.mark.usefixtures("current_request_with_host")
 async def test_abort_if_authorization_timeout(hass: HomeAssistant) -> None:
     """Check yolink authorization timeout."""
@@ -129,12 +539,18 @@ async def test_abort_if_authorization_timeout(hass: HomeAssistant) -> None:
         DOMAIN,
         application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
     )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+
     with patch(
         "homeassistant.helpers.config_entry_oauth2_flow.LocalOAuth2Implementation.async_generate_authorize_url",
         side_effect=TimeoutError,
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "pick_implementation"}
         )
 
     assert result["type"] is FlowResultType.ABORT
@@ -142,12 +558,12 @@ async def test_abort_if_authorization_timeout(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("current_request_with_host")
-async def test_reauthentication(
+async def test_oauth_reauthentication(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
-    """Test yolink reauthentication."""
+    """Test yolink OAuth reauthentication."""
     await setup.async_setup_component(
         hass,
         DOMAIN,
@@ -165,6 +581,7 @@ async def test_reauthentication(
         unique_id=DOMAIN,
         version=1,
         data={
+            CONF_AUTH_TYPE: AUTH_TYPE_OAUTH,
             "refresh_token": "outdated_fresh_token",
             "access_token": "outdated_access_token",
         },
@@ -213,3 +630,88 @@ async def test_reauthentication(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert len(mock_setup.mock_calls) == 1
+
+
+async def test_uac_reauthentication(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Test yolink UAC reauthentication."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    old_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        version=1,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: "old-uaid",
+            CONF_SECRET_KEY: "old-secret",
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    )
+    old_entry.add_to_hass(hass)
+
+    result = await old_entry.start_reauth_flow(hass)
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    # Confirm reauth
+    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "uac"
+
+    # Enter new credentials
+    with patch("homeassistant.components.yolink.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_UAID: "new-uaid", CONF_SECRET_KEY: "new-secret"},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert old_entry.data[CONF_UAID] == "new-uaid"
+    assert old_entry.data[CONF_SECRET_KEY] == "new-secret"
+
+
+async def test_uac_reauthentication_wrong_account(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Test yolink UAC reauthentication with wrong account."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    old_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        version=1,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: "old-uaid",
+            CONF_SECRET_KEY: "old-secret",
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    )
+    old_entry.add_to_hass(hass)
+
+    # Set up mock to return different home_id
+    mock_home_info = MagicMock()
+    mock_home_info.data = {"id": "different_home_id", "name": "Different Home"}
+    mock_yolink_home_config_flow.return_value.async_get_home_info.return_value = (
+        mock_home_info
+    )
+
+    result = await old_entry.start_reauth_flow(hass)
+
+    flows = hass.config_entries.flow.async_progress()
+    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
+
+    # Enter credentials for different home
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: "different-uaid", CONF_SECRET_KEY: "different-secret"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -111,10 +111,8 @@ async def test_oauth_alongside_uac_entries(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("current_request_with_host")
 async def test_oauth_duplicate_entry_blocked(
     hass: HomeAssistant,
-    hass_client_no_auth: ClientSessionGenerator,
-    aioclient_mock: AiohttpClientMocker,
 ) -> None:
-    """Check that duplicate OAuth entries are prevented."""
+    """Check that duplicate OAuth entries are prevented early."""
     await setup.async_setup_component(hass, DOMAIN, {})
     await application_credentials.async_import_client_credential(
         hass,
@@ -134,39 +132,10 @@ async def test_oauth_duplicate_entry_blocked(
     # Menu is still shown
     assert result["type"] is FlowResultType.MENU
 
-    # Select OAuth from menu
+    # Select OAuth from menu - should abort immediately
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "pick_implementation"}
     )
-    # External step proceeds (duplicate check happens after OAuth)
-    assert result["type"] is FlowResultType.EXTERNAL_STEP
-
-    # Complete OAuth flow
-    state = config_entry_oauth2_flow._encode_jwt(
-        hass,
-        {
-            "flow_id": result["flow_id"],
-            "redirect_uri": "https://example.com/auth/external/callback",
-        },
-    )
-
-    client = await hass_client_no_auth()
-    aioclient_mock.post(
-        OAUTH2_TOKEN,
-        json={
-            "refresh_token": "mock-refresh-token",
-            "access_token": "mock-access-token",
-            "type": "Bearer",
-            "expires_in": 60,
-            "scope": "create",
-        },
-    )
-
-    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
-    assert resp.status == HTTPStatus.OK
-
-    # Now the duplicate check should abort
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 

--- a/tests/components/yolink/test_init.py
+++ b/tests/components/yolink/test_init.py
@@ -1,8 +1,9 @@
 """Tests for the yolink integration."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from yolink.exception import YoLinkAuthFailError, YoLinkClientError
 
 from homeassistant.components.yolink import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -60,3 +61,86 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_auth_manager", "mock_yolink_home")
+async def test_oauth_setup_and_unload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test OAuth config entry setup and unload."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.usefixtures("mock_yolink_home")
+async def test_uac_setup_and_unload(
+    hass: HomeAssistant,
+    mock_uac_config_entry: MockConfigEntry,
+) -> None:
+    """Test UAC config entry setup and unload."""
+    with patch("homeassistant.components.yolink.api.UACAuth", autospec=True):
+        assert await hass.config_entries.async_setup(mock_uac_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_uac_config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(mock_uac_config_entry.entry_id)
+    assert mock_uac_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.usefixtures("mock_yolink_home")
+async def test_uac_setup_entry_auth_failure(
+    hass: HomeAssistant,
+    mock_uac_config_entry: MockConfigEntry,
+    mock_yolink_home: AsyncMock,
+) -> None:
+    """Test UAC setup entry with auth failure triggers reauth."""
+    mock_yolink_home.return_value.async_setup.side_effect = YoLinkAuthFailError(
+        "000103", "Invalid credentials"
+    )
+
+    with patch("homeassistant.components.yolink.api.UACAuth", autospec=True):
+        await hass.config_entries.async_setup(mock_uac_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_uac_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+@pytest.mark.usefixtures("mock_yolink_home")
+async def test_uac_setup_entry_connection_failure(
+    hass: HomeAssistant,
+    mock_uac_config_entry: MockConfigEntry,
+    mock_yolink_home: AsyncMock,
+) -> None:
+    """Test UAC setup entry with connection failure retries."""
+    mock_yolink_home.return_value.async_setup.side_effect = YoLinkClientError(
+        "000201", "Connection failed"
+    )
+
+    with patch("homeassistant.components.yolink.api.UACAuth", autospec=True):
+        await hass.config_entries.async_setup(mock_uac_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_uac_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("mock_yolink_home")
+async def test_uac_setup_entry_timeout(
+    hass: HomeAssistant,
+    mock_uac_config_entry: MockConfigEntry,
+    mock_yolink_home: AsyncMock,
+) -> None:
+    """Test UAC setup entry with timeout retries."""
+    mock_yolink_home.return_value.async_setup.side_effect = TimeoutError()
+
+    with patch("homeassistant.components.yolink.api.UACAuth", autospec=True):
+        await hass.config_entries.async_setup(mock_uac_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_uac_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds support for multiple YoLink homes in Home Assistant by introducing UAC (User Access Credentials) authentication alongside the existing OAuth2 flow.

The current integration only supports a single home per instance because OAuth2 connects only to the user's default/primary home and the integration uses `DOMAIN` as unique_id, blocking additional entries. Users with multiple YoLink homes (e.g., primary residence + vacation home) cannot access devices from secondary homes.

**Changes:**
- Menu-based authentication selection: users choose between OAuth2 or UAC credentials
- New `UACAuth` class that fetches tokens using client_credentials grant with UAID and Secret Key
- UAC entries use `home_id` as unique_id, allowing multiple home entries
- Existing OAuth2 entries continue to work unchanged
- Reauthentication support for both auth types

UAC credentials are found in YoLink App → Settings → Account → Advanced Settings → User Access Credentials. Each home has its own UAC.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #136855, fixes #96882
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr