### PR TITLE
Bump tuya-device-sharing-sdk to 0.2.8

### DIFF
--- a/homeassistant/components/tuya/manifest.json
+++ b/homeassistant/components/tuya/manifest.json
@@ -43,5 +43,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["tuya_sharing"],
-  "requirements": ["tuya-device-sharing-sdk==0.2.7"]
+  "requirements": ["tuya-device-sharing-sdk==0.2.8"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3060,7 +3060,7 @@ ttls==1.8.3
 ttn_client==1.2.3
 
 # homeassistant.components.tuya
-tuya-device-sharing-sdk==0.2.7
+tuya-device-sharing-sdk==0.2.8
 
 # homeassistant.components.twentemilieu
 twentemilieu==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2551,7 +2551,7 @@ ttls==1.8.3
 ttn_client==1.2.3
 
 # homeassistant.components.tuya
-tuya-device-sharing-sdk==0.2.7
+tuya-device-sharing-sdk==0.2.8
 
 # homeassistant.components.twentemilieu
 twentemilieu==2.2.1


### PR DESCRIPTION
## Breaking change

_None_

## Proposed change

Bump `tuya-device-sharing-sdk` from 0.2.7 to 0.2.8.

This update adds the `report_type` attribute to `DeviceStatusRange`, which is required for proper handling of different energy reporting mechanisms in Tuya devices.

https://github.com/tuya/tuya-device-sharing-sdk/compare/0.2.7...0.2.8

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
#160285
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

**SDK Changes:** [tuya-device-sharing-sdk 0.2.7 → 0.2.8](https://github.com/tuya/tuya-device-sharing-sdk/tree/dev)
To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.