### PR TITLE
Use generic DeviceWrapper in more Tuya platforms

### DIFF
--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 from tuya_sharing import CustomerDevice, Manager
 
@@ -368,7 +368,9 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         # Determine HVAC modes
         self._attr_hvac_modes: list[HVACMode] = []
         self._hvac_to_tuya = {}
-        if hvac_mode_wrapper and hvac_mode_wrapper.options is not None:
+        if hvac_mode_wrapper:
+            if TYPE_CHECKING:
+                assert hvac_mode_wrapper.options is not None
             self._attr_hvac_modes = [HVACMode.OFF]
             unknown_hvac_modes: list[str] = []
             for tuya_mode in hvac_mode_wrapper.options:

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -334,10 +334,10 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         *,
         current_humidity_wrapper: DeviceWrapper[int] | None,
         current_temperature_wrapper: DeviceWrapper[float] | None,
-        fan_mode_wrapper: DPCodeEnumWrapper | None,
-        hvac_mode_wrapper: DPCodeEnumWrapper | None,
+        fan_mode_wrapper: DeviceWrapper[str] | None,
+        hvac_mode_wrapper: DeviceWrapper[str] | None,
         set_temperature_wrapper: DPCodeIntegerWrapper | None,
-        swing_wrapper: _SwingModeWrapper | None,
+        swing_wrapper: DeviceWrapper[str] | None,
         switch_wrapper: DeviceWrapper[bool] | None,
         target_humidity_wrapper: _RoundedIntegerWrapper | None,
         temperature_unit: UnitOfTemperature,
@@ -368,7 +368,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         # Determine HVAC modes
         self._attr_hvac_modes: list[HVACMode] = []
         self._hvac_to_tuya = {}
-        if hvac_mode_wrapper:
+        if hvac_mode_wrapper and hvac_mode_wrapper.options is not None:
             self._attr_hvac_modes = [HVACMode.OFF]
             unknown_hvac_modes: list[str] = []
             for tuya_mode in hvac_mode_wrapper.options:

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Self
+from typing import Any, Self
 
 from tuya_sharing import CustomerDevice, Manager
 
@@ -368,9 +368,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         # Determine HVAC modes
         self._attr_hvac_modes: list[HVACMode] = []
         self._hvac_to_tuya = {}
-        if hvac_mode_wrapper:
-            if TYPE_CHECKING:
-                assert hvac_mode_wrapper.options is not None
+        if hvac_mode_wrapper and hvac_mode_wrapper.options is not None:
             self._attr_hvac_modes = [HVACMode.OFF]
             unknown_hvac_modes: list[str] = []
             for tuya_mode in hvac_mode_wrapper.options:

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -142,7 +142,7 @@ class TuyaHumidifierEntity(TuyaEntity, HumidifierEntity):
         description: TuyaHumidifierEntityDescription,
         *,
         current_humidity_wrapper: DeviceWrapper[int] | None = None,
-        mode_wrapper: DPCodeEnumWrapper | None = None,
+        mode_wrapper: DeviceWrapper[str] | None = None,
         switch_wrapper: DeviceWrapper[bool] | None = None,
         target_humidity_wrapper: _RoundedIntegerWrapper | None = None,
     ) -> None:

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -676,7 +676,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         *,
         brightness_wrapper: DeviceWrapper[int] | None,
         color_data_wrapper: DeviceWrapper[tuple[float, float, float]] | None,
-        color_mode_wrapper: DPCodeEnumWrapper | None,
+        color_mode_wrapper: DeviceWrapper[str] | None,
         color_temp_wrapper: DeviceWrapper[int] | None,
         switch_wrapper: DeviceWrapper[bool],
     ) -> None:
@@ -706,6 +706,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         elif (
             color_supported(color_modes)
             and color_mode_wrapper is not None
+            and color_mode_wrapper.options
             and WorkMode.WHITE in color_mode_wrapper.options
         ):
             color_modes.add(ColorMode.WHITE)

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
@@ -13,7 +15,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
-from .models import DPCodeEnumWrapper
+from .models import DeviceWrapper, DPCodeEnumWrapper
 
 # All descriptions can be found here. Mostly the Enum data types in the
 # default instructions set of each category end up being a select.
@@ -393,13 +395,15 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: SelectEntityDescription,
-        dpcode_wrapper: DPCodeEnumWrapper,
+        dpcode_wrapper: DeviceWrapper[str],
     ) -> None:
         """Init Tuya sensor."""
         super().__init__(device, device_manager)
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._dpcode_wrapper = dpcode_wrapper
+        if TYPE_CHECKING:
+            assert dpcode_wrapper.options
         self._attr_options = dpcode_wrapper.options
 
     @property

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -199,9 +199,9 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         device: CustomerDevice,
         device_manager: Manager,
         *,
-        action_wrapper: _VacuumActionWrapper | None,
-        activity_wrapper: _VacuumActivityWrapper | None,
-        fan_speed_wrapper: DPCodeEnumWrapper | None,
+        action_wrapper: DeviceWrapper[str] | None,
+        activity_wrapper: DeviceWrapper[VacuumActivity] | None,
+        fan_speed_wrapper: DeviceWrapper[str] | None,
     ) -> None:
         """Init Tuya vacuum."""
         super().__init__(device, device_manager)
@@ -227,7 +227,7 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         if activity_wrapper:
             self._attr_supported_features |= VacuumEntityFeature.STATE
 
-        if fan_speed_wrapper:
+        if fan_speed_wrapper and fan_speed_wrapper.options:
             self._attr_fan_speed_list = fan_speed_wrapper.options
             self._attr_supported_features |= VacuumEntityFeature.FAN_SPEED
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #159349

In particular, prefer generic `DeviceWrapper[str]` over `DPCodeEnumWrapper` as it shouldn't be a concern of the entity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
