### PR TITLE
Remove default in Tuya DeviceWrapper options

### DIFF
--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -183,13 +183,12 @@ class TuyaAlarmEntity(TuyaEntity, AlarmControlPanelEntity):
         self._state_wrapper = state_wrapper
 
         # Determine supported modes
-        if action_wrapper.options:
-            if "arm_home" in action_wrapper.options:
-                self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
-            if "arm_away" in action_wrapper.options:
-                self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_AWAY
-            if "trigger" in action_wrapper.options:
-                self._attr_supported_features |= AlarmControlPanelEntityFeature.TRIGGER
+        if "arm_home" in action_wrapper.options:
+            self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
+        if "arm_away" in action_wrapper.options:
+            self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_AWAY
+        if "trigger" in action_wrapper.options:
+            self._attr_supported_features |= AlarmControlPanelEntityFeature.TRIGGER
 
     @property
     def alarm_state(self) -> AlarmControlPanelState | None:

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -368,7 +368,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         # Determine HVAC modes
         self._attr_hvac_modes: list[HVACMode] = []
         self._hvac_to_tuya = {}
-        if hvac_mode_wrapper and hvac_mode_wrapper.options is not None:
+        if hvac_mode_wrapper:
             self._attr_hvac_modes = [HVACMode.OFF]
             unknown_hvac_modes: list[str] = []
             for tuya_mode in hvac_mode_wrapper.options:

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -351,7 +351,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         self._set_position = set_position
         self._tilt_position = tilt_position
 
-        if instruction_wrapper and instruction_wrapper.options:
+        if instruction_wrapper:
             if "open" in instruction_wrapper.options:
                 self._attr_supported_features |= CoverEntityFeature.OPEN
             if "close" in instruction_wrapper.options:

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -424,11 +424,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        if (
-            self._instruction_wrapper
-            and (options := self._instruction_wrapper.options)
-            and "stop" in options
-        ):
+        if self._instruction_wrapper and "stop" in self._instruction_wrapper.options:
             await self._async_send_wrapper_updates(self._instruction_wrapper, "stop")
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -31,8 +31,6 @@ from .models import (
 class _DPCodeEventWrapper(DPCodeTypeInformationWrapper):
     """Base class for Tuya event wrappers."""
 
-    options: list[str]
-
     def __init__(self, dpcode: str, type_information: Any) -> None:
         """Init _DPCodeEventWrapper."""
         super().__init__(dpcode, type_information)

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -198,7 +198,7 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
 
         if speed_wrapper:
             self._attr_supported_features |= FanEntityFeature.SET_SPEED
-            if speed_wrapper.options is not None:
+            if hasattr(speed_wrapper, "options"):
                 self._attr_speed_count = len(speed_wrapper.options)
 
         if oscillate_wrapper:

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -198,6 +198,8 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
 
         if speed_wrapper:
             self._attr_supported_features |= FanEntityFeature.SET_SPEED
+            # if speed is from an enum, set speed count from options
+            # else keep entity default 100
             if hasattr(speed_wrapper, "options"):
                 self._attr_speed_count = len(speed_wrapper.options)
 

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -706,7 +706,6 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         elif (
             color_supported(color_modes)
             and color_mode_wrapper is not None
-            and color_mode_wrapper.options
             and WorkMode.WHITE in color_mode_wrapper.options
         ):
             color_modes.add(ColorMode.WHITE)

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -22,12 +22,13 @@ class DeviceWrapper[T]:
     """Base device wrapper."""
 
     native_unit: str | None = None
-    options: list[str] | None = None
     suggested_unit: str | None = None
 
     max_value: float
     min_value: float
     value_step: float
+
+    options: list[str]
 
     def read_device_status(self, device: CustomerDevice) -> T | None:
         """Read device status and convert to a Home Assistant value."""
@@ -138,7 +139,6 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
     """Simple wrapper for EnumTypeInformation values."""
 
     _DPTYPE = EnumTypeInformation
-    options: list[str]
 
     def __init__(self, dpcode: str, type_information: EnumTypeInformation) -> None:
         """Init DPCodeEnumWrapper."""

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
@@ -402,8 +400,6 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._dpcode_wrapper = dpcode_wrapper
-        if TYPE_CHECKING:
-            assert dpcode_wrapper.options
         self._attr_options = dpcode_wrapper.options
 
     @property

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -212,7 +212,7 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         self._attr_fan_speed_list = []
         self._attr_supported_features = VacuumEntityFeature.SEND_COMMAND
 
-        if action_wrapper and action_wrapper.options:
+        if action_wrapper:
             if "pause" in action_wrapper.options:
                 self._attr_supported_features |= VacuumEntityFeature.PAUSE
             if "return_to_base" in action_wrapper.options:
@@ -227,7 +227,7 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         if activity_wrapper:
             self._attr_supported_features |= VacuumEntityFeature.STATE
 
-        if fan_speed_wrapper and fan_speed_wrapper.options:
+        if fan_speed_wrapper:
             self._attr_fan_speed_list = fan_speed_wrapper.options
             self._attr_supported_features |= VacuumEntityFeature.FAN_SPEED
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust from `options: list[str] | None = None` to `options: list[str]` to reduce need for type-specific checks (`if TYPE_CHECKING` and similar)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
