### PR TITLE
Add report_type to Tuya diagnostic

### DIFF
--- a/homeassistant/components/tuya/diagnostics.py
+++ b/homeassistant/components/tuya/diagnostics.py
@@ -123,6 +123,7 @@ def _async_device_as_dict(
         data["status_range"][status_range.code] = {
             "type": status_range.type,
             "value": status_range.values,
+            "report_type": status_range.report_type,
         }
 
     # Gather information how this Tuya device is represented in Home Assistant

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -194,6 +194,7 @@ async def _create_device(hass: HomeAssistant, mock_device_code: str) -> Customer
     device.status_range = {
         key: DeviceStatusRange(
             code=key,
+            report_type=value.get("report_type"),
             type=value["type"],
             values=(
                 values

--- a/tests/components/tuya/fixtures/cz_guitoc9iylae4axs.json
+++ b/tests/components/tuya/fixtures/cz_guitoc9iylae4axs.json
@@ -3,6 +3,7 @@
   "mqtt_connected": true,
   "disabled_by": null,
   "disabled_polling": false,
+
   "name": "HA Socket Delta Test",
   "category": "cz",
   "product_id": "guitoc9iylae4axs",
@@ -34,6 +35,10 @@
         "range": ["power_off", "power_on", "last"]
       }
     },
+    "overcharge_switch": {
+      "type": "Boolean",
+      "value": {}
+    },
     "light_mode": {
       "type": "Enum",
       "value": {
@@ -42,6 +47,18 @@
     },
     "child_lock": {
       "type": "Boolean",
+      "value": {}
+    },
+    "cycle_time": {
+      "type": "String",
+      "value": {}
+    },
+    "random_time": {
+      "type": "String",
+      "value": {}
+    },
+    "switch_inching": {
+      "type": "String",
       "value": {}
     }
   },
@@ -100,6 +117,42 @@
         "step": 1
       }
     },
+    "voltage_coe": {
+      "type": "Integer",
+      "value": {
+        "min": 0,
+        "max": 1000000,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "electric_coe": {
+      "type": "Integer",
+      "value": {
+        "min": 0,
+        "max": 1000000,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "power_coe": {
+      "type": "Integer",
+      "value": {
+        "min": 0,
+        "max": 1000000,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "electricity_coe": {
+      "type": "Integer",
+      "value": {
+        "min": 0,
+        "max": 1000000,
+        "scale": 0,
+        "step": 1
+      }
+    },
     "fault": {
       "type": "Bitmap",
       "value": {
@@ -112,6 +165,10 @@
         "range": ["power_off", "power_on", "last"]
       }
     },
+    "overcharge_switch": {
+      "type": "Boolean",
+      "value": {}
+    },
     "light_mode": {
       "type": "Enum",
       "value": {
@@ -121,19 +178,39 @@
     "child_lock": {
       "type": "Boolean",
       "value": {}
+    },
+    "cycle_time": {
+      "type": "String",
+      "value": {}
+    },
+    "random_time": {
+      "type": "String",
+      "value": {}
+    },
+    "switch_inching": {
+      "type": "String",
+      "value": {}
     }
   },
   "status": {
-    "switch_1": false,
+    "switch_1": true,
     "countdown_1": 0,
-    "add_ele": 100,
-    "cur_current": 0,
-    "cur_power": 0,
-    "cur_voltage": 0,
+    "add_ele": 84,
+    "cur_current": 304,
+    "cur_power": 54,
+    "cur_voltage": 2240,
+    "voltage_coe": 0,
+    "electric_coe": 0,
+    "power_coe": 0,
+    "electricity_coe": 0,
     "fault": 0,
     "relay_status": "power_off",
+    "overcharge_switch": false,
     "light_mode": "relay",
-    "child_lock": false
+    "child_lock": false,
+    "cycle_time": "",
+    "random_time": "",
+    "switch_inching": ""
   },
   "set_up": true,
   "support_local": true

--- a/tests/components/tuya/fixtures/cz_guitoc9iylae4axs.json
+++ b/tests/components/tuya/fixtures/cz_guitoc9iylae4axs.json
@@ -1,0 +1,140 @@
+{
+  "endpoint": "https://apigw.tuyacn.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "HA Socket Delta Test",
+  "category": "cz",
+  "product_id": "guitoc9iylae4axs",
+  "product_name": "10A Metering Socket",
+  "online": true,
+  "sub": false,
+  "time_zone": "+8:00",
+  "active_time": "2025-12-15T05:51:26+00:00",
+  "create_time": "2025-12-15T05:51:26+00:00",
+  "update_time": "2025-12-15T05:51:26+00:00",
+  "function": {
+    "switch_1": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "countdown_1": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 86400,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "relay_status": {
+      "type": "Enum",
+      "value": {
+        "range": ["power_off", "power_on", "last"]
+      }
+    },
+    "light_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["relay", "pos", "none"]
+      }
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": {}
+    }
+  },
+  "status_range": {
+    "switch_1": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "countdown_1": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 86400,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "add_ele": {
+      "type": "Integer",
+      "value": {
+        "min": 0,
+        "max": 50000,
+        "scale": 3,
+        "step": 100
+      },
+      "report_type": "sum"
+    },
+    "cur_current": {
+      "type": "Integer",
+      "value": {
+        "unit": "mA",
+        "min": 0,
+        "max": 30000,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "cur_power": {
+      "type": "Integer",
+      "value": {
+        "unit": "W",
+        "min": 0,
+        "max": 80000,
+        "scale": 1,
+        "step": 1
+      }
+    },
+    "cur_voltage": {
+      "type": "Integer",
+      "value": {
+        "unit": "V",
+        "min": 0,
+        "max": 5000,
+        "scale": 1,
+        "step": 1
+      }
+    },
+    "fault": {
+      "type": "Bitmap",
+      "value": {
+        "label": ["ov_cr", "ov_vol", "ov_pwr", "ls_cr", "ls_vol", "ls_pow"]
+      }
+    },
+    "relay_status": {
+      "type": "Enum",
+      "value": {
+        "range": ["power_off", "power_on", "last"]
+      }
+    },
+    "light_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["relay", "pos", "none"]
+      }
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": {}
+    }
+  },
+  "status": {
+    "switch_1": false,
+    "countdown_1": 0,
+    "add_ele": 100,
+    "cur_current": 0,
+    "cur_power": 0,
+    "cur_voltage": 0,
+    "fault": 0,
+    "relay_status": "power_off",
+    "light_mode": "relay",
+    "child_lock": false
+  },
+  "set_up": true,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_diagnostics.ambr
+++ b/tests/components/tuya/snapshots/test_diagnostics.ambr
@@ -226,70 +226,87 @@
     }),
     'status_range': dict({
       'alarm_delay_time': dict({
+        'report_type': None,
         'type': 'Integer',
         'value': '{"unit":"s","min":0,"max":999,"scale":0,"step":1}',
       }),
       'alarm_msg': dict({
+        'report_type': None,
         'type': 'Raw',
         'value': '{}',
       }),
       'alarm_time': dict({
+        'report_type': None,
         'type': 'Integer',
         'value': '{"unit":"min","min":0,"max":999,"scale":0,"step":1}',
       }),
       'delay_set': dict({
+        'report_type': None,
         'type': 'Integer',
         'value': '{"unit":"s","min":0,"max":999,"scale":0,"step":1}',
       }),
       'master_mode': dict({
+        'report_type': None,
         'type': 'Enum',
         'value': '{"range":["disarmed","arm","home","sos"]}',
       }),
       'master_state': dict({
+        'report_type': None,
         'type': 'Enum',
         'value': '{"range":["normal","alarm"]}',
       }),
       'muffling': dict({
+        'report_type': None,
         'type': 'Boolean',
         'value': '{}',
       }),
       'sub_admin': dict({
+        'report_type': None,
         'type': 'Raw',
         'value': '{}',
       }),
       'sub_class': dict({
+        'report_type': None,
         'type': 'Enum',
         'value': '{"range":["remote_controller","detector"]}',
       }),
       'sub_state': dict({
+        'report_type': None,
         'type': 'Enum',
         'value': '{"range":["normal","alarm","fault","others"]}',
       }),
       'switch_alarm_light': dict({
+        'report_type': None,
         'type': 'Boolean',
         'value': '{}',
       }),
       'switch_alarm_propel': dict({
+        'report_type': None,
         'type': 'Boolean',
         'value': '{}',
       }),
       'switch_alarm_sound': dict({
+        'report_type': None,
         'type': 'Boolean',
         'value': '{}',
       }),
       'switch_kb_light': dict({
+        'report_type': None,
         'type': 'Boolean',
         'value': '{}',
       }),
       'switch_kb_sound': dict({
+        'report_type': None,
         'type': 'Boolean',
         'value': '{}',
       }),
       'switch_mode_sound': dict({
+        'report_type': None,
         'type': 'Boolean',
         'value': '{}',
       }),
       'telnet_state': dict({
+        'report_type': None,
         'type': 'Enum',
         'value': '{"range":["normal","network_no","phone_no","sim_card_no","network_search","signal_level_1","signal_level_2","signal_level_3","signal_level_4","signal_level_5"]}',
       }),
@@ -387,26 +404,32 @@
     }),
     'status_range': dict({
       'alarm_time': dict({
+        'report_type': None,
         'type': 'Integer',
         'value': '{"unit":"s","min":0,"max":3600,"scale":0,"step":1}',
       }),
       'checking_result': dict({
+        'report_type': None,
         'type': 'Enum',
         'value': '{"range":["checking","check_success","check_failure","others"]}',
       }),
       'gas_sensor_status': dict({
+        'report_type': None,
         'type': 'Enum',
         'value': '{"range":["alarm","normal"]}',
       }),
       'gas_sensor_value': dict({
+        'report_type': None,
         'type': 'Integer',
         'value': '{"unit":"ppm","min":0,"max":999,"scale":0,"step":1}',
       }),
       'muffling': dict({
+        'report_type': None,
         'type': 'Boolean',
         'value': '{}',
       }),
       'self_checking': dict({
+        'report_type': None,
         'type': 'Boolean',
         'value': '{}',
       }),
@@ -534,38 +557,47 @@
     }),
     'status_range': dict({
       'countdown_1': dict({
+        'report_type': None,
         'type': 'Integer',
         'value': '{"unit":"s","min":0,"max":86400,"scale":0,"step":1}',
       }),
       'cycle_time': dict({
+        'report_type': None,
         'type': 'String',
         'value': '{"maxlen":255}',
       }),
       'random_time': dict({
+        'report_type': None,
         'type': 'String',
         'value': '{"maxlen":255}',
       }),
       'relay_status': dict({
+        'report_type': None,
         'type': 'Enum',
         'value': '{"range":["0","1","2"]}',
       }),
       'remote_add': dict({
+        'report_type': None,
         'type': 'Raw',
         'value': '{}',
       }),
       'remote_list': dict({
+        'report_type': None,
         'type': 'Raw',
         'value': '{}',
       }),
       'switch_1': dict({
+        'report_type': None,
         'type': 'Boolean',
         'value': '{}',
       }),
       'switch_inching': dict({
+        'report_type': None,
         'type': 'String',
         'value': '{"maxlen":255}',
       }),
       'switch_type': dict({
+        'report_type': None,
         'type': 'Enum',
         'value': '{"range":["flip","sync","button"]}',
       }),
@@ -663,26 +695,32 @@
         }),
         'status_range': dict({
           'alarm_time': dict({
+            'report_type': None,
             'type': 'Integer',
             'value': '{"unit":"s","min":0,"max":3600,"scale":0,"step":1}',
           }),
           'checking_result': dict({
+            'report_type': None,
             'type': 'Enum',
             'value': '{"range":["checking","check_success","check_failure","others"]}',
           }),
           'gas_sensor_status': dict({
+            'report_type': None,
             'type': 'Enum',
             'value': '{"range":["alarm","normal"]}',
           }),
           'gas_sensor_value': dict({
+            'report_type': None,
             'type': 'Integer',
             'value': '{"unit":"ppm","min":0,"max":999,"scale":0,"step":1}',
           }),
           'muffling': dict({
+            'report_type': None,
             'type': 'Boolean',
             'value': '{}',
           }),
           'self_checking': dict({
+            'report_type': None,
             'type': 'Boolean',
             'value': '{}',
           }),

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -7284,6 +7284,37 @@
     'via_device_id': None,
   })
 # ---
+# name: test_device_registry[sxa4ealyi9cotiugzc]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tuya',
+        'sxa4ealyi9cotiugzc',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Tuya',
+    'model': '10A Metering Socket',
+    'model_id': 'guitoc9iylae4axs',
+    'name': 'HA Socket Delta Test',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_device_registry[t5zosev6h6wmwyrajbwy]
   DeviceRegistryEntrySnapshot({
     'area_id': None,

--- a/tests/components/tuya/snapshots/test_select.ambr
+++ b/tests/components/tuya/snapshots/test_select.ambr
@@ -2886,6 +2886,124 @@
     'state': 'cancel',
   })
 # ---
+# name: test_platform_setup_and_discovery[select.ha_socket_delta_test_indicator_light_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'relay',
+        'pos',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.ha_socket_delta_test_indicator_light_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Indicator light mode',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'light_mode',
+    'unique_id': 'tuya.sxa4ealyi9cotiugzclight_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[select.ha_socket_delta_test_indicator_light_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'HA Socket Delta Test Indicator light mode',
+      'options': list([
+        'relay',
+        'pos',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.ha_socket_delta_test_indicator_light_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'relay',
+  })
+# ---
+# name: test_platform_setup_and_discovery[select.ha_socket_delta_test_power_on_behavior-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'power_off',
+        'power_on',
+        'last',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.ha_socket_delta_test_power_on_behavior',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Power on behavior',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_status',
+    'unique_id': 'tuya.sxa4ealyi9cotiugzcrelay_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[select.ha_socket_delta_test_power_on_behavior-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'HA Socket Delta Test Power on behavior',
+      'options': list([
+        'power_off',
+        'power_on',
+        'last',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.ha_socket_delta_test_power_on_behavior',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'power_off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[select.hoover_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -8597,7 +8597,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': '0.304',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.ha_socket_delta_test_power-entry]
@@ -8653,7 +8653,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': '5.4',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.ha_socket_delta_test_total_energy-entry]
@@ -8704,7 +8704,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.1',
+    'state': '0.084',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.ha_socket_delta_test_voltage-entry]
@@ -8763,7 +8763,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': '224.0',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.hl400_pm2_5-entry]

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -8541,6 +8541,231 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_platform_setup_and_discovery[sensor.ha_socket_delta_test_current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ha_socket_delta_test_current',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current',
+    'unique_id': 'tuya.sxa4ealyi9cotiugzccur_current',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.ha_socket_delta_test_current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'HA Socket Delta Test Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ha_socket_delta_test_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.ha_socket_delta_test_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ha_socket_delta_test_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Power',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power',
+    'unique_id': 'tuya.sxa4ealyi9cotiugzccur_power',
+    'unit_of_measurement': 'W',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.ha_socket_delta_test_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'HA Socket Delta Test Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'W',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ha_socket_delta_test_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.ha_socket_delta_test_total_energy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ha_socket_delta_test_total_energy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Total energy',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'total_energy',
+    'unique_id': 'tuya.sxa4ealyi9cotiugzcadd_ele',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.ha_socket_delta_test_total_energy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'HA Socket Delta Test Total energy',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ha_socket_delta_test_total_energy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.1',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.ha_socket_delta_test_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ha_socket_delta_test_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage',
+    'unique_id': 'tuya.sxa4ealyi9cotiugzccur_voltage',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.ha_socket_delta_test_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'HA Socket Delta Test Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ha_socket_delta_test_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sensor.hl400_pm2_5-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -4600,6 +4600,103 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[switch.ha_socket_delta_test_child_lock-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ha_socket_delta_test_child_lock',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Child lock',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'child_lock',
+    'unique_id': 'tuya.sxa4ealyi9cotiugzcchild_lock',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.ha_socket_delta_test_child_lock-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'HA Socket Delta Test Child lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ha_socket_delta_test_child_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.ha_socket_delta_test_socket_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.ha_socket_delta_test_socket_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.OUTLET: 'outlet'>,
+    'original_icon': None,
+    'original_name': 'Socket 1',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indexed_socket',
+    'unique_id': 'tuya.sxa4ealyi9cotiugzcswitch_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.ha_socket_delta_test_socket_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'outlet',
+      'friendly_name': 'HA Socket Delta Test Socket 1',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ha_socket_delta_test_socket_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[switch.hl400_child_lock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -4694,7 +4694,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'on',
   })
 # ---
 # name: test_platform_setup_and_discovery[switch.hl400_child_lock-entry]


### PR DESCRIPTION
## Breaking change

<!-- This PR is NOT a breaking change, removing this section -->

## Proposed change

Add a new test fixture `cz_guitoc9iylae4axs.json` for a Tuya socket device that has `report_type='sum'` on the `add_ele` (total energy) status. This fixture represents a real-world device that reports incremental energy values.

Also update `conftest.py` to parse the `report_type` field from fixture files into `DeviceStatusRange`, enabling future tests to verify behavior based on this field.

This is a preparation PR for upcoming delta report sensor support.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: #160285
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.