### PR TITLE
Replace openevse backend library

### DIFF
--- a/homeassistant/components/html5/manifest.json
+++ b/homeassistant/components/html5/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/html5",
   "iot_class": "cloud_push",
   "loggers": ["http_ece", "py_vapid", "pywebpush"],
-  "requirements": ["pywebpush==1.14.1"],
+  "requirements": ["pywebpush==1.14.1", "py-vapid==1.9.2"],
   "single_config_entry": true
 }

--- a/homeassistant/components/html5/manifest.json
+++ b/homeassistant/components/html5/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/html5",
   "iot_class": "cloud_push",
   "loggers": ["http_ece", "py_vapid", "pywebpush"],
-  "requirements": ["pywebpush==1.14.1", "py-vapid==1.9.2"],
+  "requirements": ["pywebpush==1.14.1"],
   "single_config_entry": true
 }

--- a/homeassistant/components/openevse/__init__.py
+++ b/homeassistant/components/openevse/__init__.py
@@ -17,7 +17,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenEVSEConfigEntry) -> 
 
     entry.runtime_data = OpenEVSE(entry.data[CONF_HOST])
     try:
-        await entry.runtime_data.update()
+        await entry.runtime_data.test_and_get()
     except TimeoutError as ex:
         raise ConfigEntryError("Unable to connect to charger") from ex
 

--- a/homeassistant/components/openevse/__init__.py
+++ b/homeassistant/components/openevse/__init__.py
@@ -2,23 +2,23 @@
 
 from __future__ import annotations
 
-import openevsewifi
+from openevsehttp.__main__ import OpenEVSE
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 
-type OpenEVSEConfigEntry = ConfigEntry[openevsewifi.Charger]
+type OpenEVSEConfigEntry = ConfigEntry[OpenEVSE]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: OpenEVSEConfigEntry) -> bool:
     """Set up openevse from a config entry."""
 
-    entry.runtime_data = openevsewifi.Charger(entry.data[CONF_HOST])
+    entry.runtime_data = OpenEVSE(entry.data[CONF_HOST])
     try:
-        await hass.async_add_executor_job(entry.runtime_data.getStatus)
-    except AttributeError as ex:
+        await entry.runtime_data.update()
+    except TimeoutError as ex:
         raise ConfigEntryError("Unable to connect to charger") from ex
 
     await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])

--- a/homeassistant/components/openevse/config_flow.py
+++ b/homeassistant/components/openevse/config_flow.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-import openevsewifi
+from openevsehttp.__main__ import OpenEVSE
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -20,13 +20,13 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
     async def check_status(self, host: str) -> bool:
         """Check if we can connect to the OpenEVSE charger."""
 
-        charger = openevsewifi.Charger(host)
+        charger = OpenEVSE(host)
         try:
-            result = await self.hass.async_add_executor_job(charger.getStatus)
-        except AttributeError:
+            await charger.update()
+        except TimeoutError:
             return False
         else:
-            return result is not None
+            return True
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/openevse/config_flow.py
+++ b/homeassistant/components/openevse/config_flow.py
@@ -22,7 +22,7 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
 
         charger = OpenEVSE(host)
         try:
-            await charger.update()
+            await charger.test_and_get()
         except TimeoutError:
             return False
         else:

--- a/homeassistant/components/openevse/manifest.json
+++ b/homeassistant/components/openevse/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/openevse",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "loggers": ["openevsewifi"],
+  "loggers": ["openevsehttp"],
   "quality_scale": "legacy",
-  "requirements": ["openevsewifi==1.1.2"]
+  "requirements": ["python-openevse-http==0.1.91"]
 }

--- a/homeassistant/components/openevse/manifest.json
+++ b/homeassistant/components/openevse/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["openevsehttp"],
   "quality_scale": "legacy",
-  "requirements": ["python-openevse-http==0.1.91"]
+  "requirements": ["python-openevse-http==0.2.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1833,9 +1833,6 @@ py-sucks==0.9.11
 # homeassistant.components.synology_dsm
 py-synologydsm-api==2.7.3
 
-# homeassistant.components.html5
-py-vapid==1.9.2
-
 # homeassistant.components.atome
 pyAtome==0.1.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1662,9 +1662,6 @@ openai==2.11.0
 # homeassistant.components.openerz
 openerz-api==0.3.0
 
-# homeassistant.components.openevse
-openevsewifi==1.1.2
-
 # homeassistant.components.openhome
 openhomedevice==2.2.0
 
@@ -2557,6 +2554,9 @@ python-open-router==0.3.3
 
 # homeassistant.components.swiss_public_transport
 python-opendata-transport==0.5.0
+
+# homeassistant.components.openevse
+python-openevse-http==0.1.91
 
 # homeassistant.components.opensky
 python-opensky==1.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2559,7 +2559,7 @@ python-open-router==0.3.3
 python-opendata-transport==0.5.0
 
 # homeassistant.components.openevse
-python-openevse-http==0.1.91
+python-openevse-http==0.2.1
 
 # homeassistant.components.opensky
 python-opensky==1.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1833,6 +1833,9 @@ py-sucks==0.9.11
 # homeassistant.components.synology_dsm
 py-synologydsm-api==2.7.3
 
+# homeassistant.components.html5
+py-vapid==1.9.2
+
 # homeassistant.components.atome
 pyAtome==0.1.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1573,6 +1573,9 @@ py-sucks==0.9.11
 # homeassistant.components.synology_dsm
 py-synologydsm-api==2.7.3
 
+# homeassistant.components.html5
+py-vapid==1.9.2
+
 # homeassistant.components.hdmi_cec
 pyCEC==0.5.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1573,9 +1573,6 @@ py-sucks==0.9.11
 # homeassistant.components.synology_dsm
 py-synologydsm-api==2.7.3
 
-# homeassistant.components.html5
-py-vapid==1.9.2
-
 # homeassistant.components.hdmi_cec
 pyCEC==0.5.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1445,9 +1445,6 @@ openai==2.11.0
 # homeassistant.components.openerz
 openerz-api==0.3.0
 
-# homeassistant.components.openevse
-openevsewifi==1.1.2
-
 # homeassistant.components.openhome
 openhomedevice==2.2.0
 
@@ -2147,6 +2144,9 @@ python-open-router==0.3.3
 
 # homeassistant.components.swiss_public_transport
 python-opendata-transport==0.5.0
+
+# homeassistant.components.openevse
+python-openevse-http==0.1.91
 
 # homeassistant.components.opensky
 python-opensky==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2149,7 +2149,7 @@ python-open-router==0.3.3
 python-opendata-transport==0.5.0
 
 # homeassistant.components.openevse
-python-openevse-http==0.1.91
+python-openevse-http==0.2.1
 
 # homeassistant.components.opensky
 python-opensky==1.0.1

--- a/tests/components/openevse/conftest.py
+++ b/tests/components/openevse/conftest.py
@@ -16,22 +16,23 @@ def mock_charger() -> Generator[MagicMock]:
     """Create a mock OpenEVSE charger."""
     with (
         patch(
-            "homeassistant.components.openevse.openevsewifi.Charger",
+            "homeassistant.components.openevse.OpenEVSE",
             autospec=True,
         ) as mock,
         patch(
-            "homeassistant.components.openevse.config_flow.openevsewifi.Charger",
+            "homeassistant.components.openevse.config_flow.OpenEVSE",
             new=mock,
         ),
     ):
         charger = mock.return_value
-        charger.getStatus.return_value = "Charging"
-        charger.getChargeTimeElapsed.return_value = 3600  # 60 minutes in seconds
-        charger.getAmbientTemperature.return_value = 25.5
-        charger.getIRTemperature.return_value = 30.2
-        charger.getRTCTemperature.return_value = 28.7
-        charger.getUsageSession.return_value = 15000  # 15 kWh in Wh
-        charger.getUsageTotal.return_value = 500000  # 500 kWh in Wh
+        charger.update = AsyncMock()
+        charger.status = "Charging"
+        charger.charge_time_elapsed = 3600  # 60 minutes in seconds
+        charger.ambient_temperature = 25.5
+        charger.ir_temperature = 30.2
+        charger.rtc_temperature = 28.7
+        charger.usage_session = 15000  # 15 kWh in Wh
+        charger.usage_total = 500000  # 500 kWh in Wh
         charger.charging_current = 32.0
         yield charger
 

--- a/tests/components/openevse/test_config_flow.py
+++ b/tests/components/openevse/test_config_flow.py
@@ -45,7 +45,7 @@ async def test_user_flow_flaky(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    mock_charger.getStatus.side_effect = AttributeError
+    mock_charger.update.side_effect = TimeoutError
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_HOST: "10.0.0.131"},
@@ -54,7 +54,7 @@ async def test_user_flow_flaky(
     assert result["step_id"] == "user"
     assert result["errors"] == {"host": "cannot_connect"}
 
-    mock_charger.getStatus.side_effect = "Charging"
+    mock_charger.update.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_HOST: "10.0.0.131"},
@@ -112,7 +112,7 @@ async def test_import_flow_bad(
     mock_setup_entry: AsyncMock,
 ) -> None:
     """Test import flow with bad charger."""
-    mock_charger.getStatus.side_effect = AttributeError
+    mock_charger.update.side_effect = TimeoutError
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_HOST: "10.0.0.131"}

--- a/tests/components/openevse/test_config_flow.py
+++ b/tests/components/openevse/test_config_flow.py
@@ -45,7 +45,7 @@ async def test_user_flow_flaky(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    mock_charger.update.side_effect = TimeoutError
+    mock_charger.test_and_get.side_effect = TimeoutError
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_HOST: "10.0.0.131"},
@@ -54,7 +54,7 @@ async def test_user_flow_flaky(
     assert result["step_id"] == "user"
     assert result["errors"] == {"host": "cannot_connect"}
 
-    mock_charger.update.side_effect = None
+    mock_charger.test_and_get.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_HOST: "10.0.0.131"},
@@ -112,7 +112,7 @@ async def test_import_flow_bad(
     mock_setup_entry: AsyncMock,
 ) -> None:
     """Test import flow with bad charger."""
-    mock_charger.update.side_effect = TimeoutError
+    mock_charger.test_and_get.side_effect = TimeoutError
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_HOST: "10.0.0.131"}


### PR DESCRIPTION
This allows us to get serial number (and be fully async)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This switches us to a more modern library, which contains serial number (so in a later PR, we can correctly identify devices). This also simplifies some of the async code, since the underlying library is async.

Changelog - https://github.com/firstof9/python-openevse-http/releases (Although for notes, we're switching the whole library - the substance of the changes is 1) this is fully async and uses aiohttp under the hood, 2) this uses json, and not the weird hybrid json xml thing the previous dependency used, and 3) it supports a lot more information, as well as push actions, 4) we're not using it fully but this partly switches us to local pushing instead of polling, another PR to finish that).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
