### PR TITLE
Bump ZHA to 0.0.83

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==0.0.82", "serialx==0.5.0"],
+  "requirements": ["zha==0.0.83", "serialx==0.5.0"],
   "usb": [
     {
       "description": "*2652*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3277,7 +3277,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.82
+zha==0.0.83
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2741,7 +2741,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.82
+zha==0.0.83
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.67.1


### PR DESCRIPTION
## Proposed change

This bumps ZHA to [0.0.83](https://github.com/zigpy/zha/releases/tag/0.0.83) (full diff: https://github.com/zigpy/zha/compare/0.0.82...0.0.83).
These dependency upgrades are bundled with it: 

- `bellows` [0.49.0](https://github.com/zigpy/bellows/releases/tag/0.49.0)
full diff: https://github.com/zigpy/bellows/compare/0.48.2...0.49.0

- `zigpy` [0.90.0](https://github.com/zigpy/zigpy/releases/tag/0.90.0)
full diff: https://github.com/zigpy/zigpy/compare/0.89.0...0.90.0

- `zha-quirks` [0.0.151](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.151)
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.150...0.0.151

A quick overview of the changes in this ZHA release:
- An issue is fixed when running EZSP v18 or newer unsupported versions.
- An issue is fixed with Innr SP 240 plugs showing an incorrect amount of consumed energy.
- An issue is fixed with Innr SP 240 plugs showing unnecessary entities for dimming settings.
- An issue is fixed with v2 quirks firmware filters not applying.
- Telink OTA images not following specifications are now parsed correctly and installable (mostly affected Sonoff).

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
