### PR TITLE
Fix IndexError in Israel Rail sensor when no departures available

### DIFF
--- a/homeassistant/components/israel_rail/sensor.py
+++ b/homeassistant/components/israel_rail/sensor.py
@@ -116,6 +116,8 @@ class IsraelRailEntitySensor(
     @property
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
+        if self.entity_description.index >= len(self.coordinator.data):
+            return None
         return self.entity_description.value_fn(
             self.coordinator.data[self.entity_description.index]
         )

--- a/tests/components/israel_rail/test_sensor.py
+++ b/tests/components/israel_rail/test_sensor.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 from freezegun.api import FrozenDateTimeFactory
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -66,3 +66,43 @@ async def test_fail_query(
     assert len(hass.states.async_entity_ids()) == 6
     departure_sensor = hass.states.get("sensor.mock_title_departure")
     assert departure_sensor.state == STATE_UNAVAILABLE
+
+
+async def test_no_departures(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_israelrail: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test handling when there are no departures available."""
+    await init_integration(hass, mock_config_entry)
+    assert len(hass.states.async_entity_ids()) == 6
+
+    # Simulate no departures (e.g., after-hours)
+    mock_israelrail.query.return_value = []
+
+    await goto_future(hass, freezer)
+
+    # All sensors should still exist
+    assert len(hass.states.async_entity_ids()) == 6
+
+    # Departure sensors should have unknown state (None)
+    departure_sensor = hass.states.get("sensor.mock_title_departure")
+    assert departure_sensor.state == STATE_UNKNOWN
+
+    departure_sensor1 = hass.states.get("sensor.mock_title_departure1")
+    assert departure_sensor1.state == STATE_UNKNOWN
+
+    departure_sensor2 = hass.states.get("sensor.mock_title_departure2")
+    assert departure_sensor2.state == STATE_UNKNOWN
+
+    # Non-departure sensors (platform, trains, train_number) also access index 0
+    # and should have unknown state when no departures available
+    platform_sensor = hass.states.get("sensor.mock_title_platform")
+    assert platform_sensor.state == STATE_UNKNOWN
+
+    trains_sensor = hass.states.get("sensor.mock_title_trains")
+    assert trains_sensor.state == STATE_UNKNOWN
+
+    train_number_sensor = hass.states.get("sensor.mock_title_train_number")
+    assert train_number_sensor.state == STATE_UNKNOWN

--- a/tests/components/israel_rail/test_sensor.py
+++ b/tests/components/israel_rail/test_sensor.py
@@ -90,11 +90,11 @@ async def test_no_departures(
     departure_sensor = hass.states.get("sensor.mock_title_departure")
     assert departure_sensor.state == STATE_UNKNOWN
 
-    departure_sensor1 = hass.states.get("sensor.mock_title_departure1")
-    assert departure_sensor1.state == STATE_UNKNOWN
+    departure_sensor_1 = hass.states.get("sensor.mock_title_departure_1")
+    assert departure_sensor_1.state == STATE_UNKNOWN
 
-    departure_sensor2 = hass.states.get("sensor.mock_title_departure2")
-    assert departure_sensor2.state == STATE_UNKNOWN
+    departure_sensor_2 = hass.states.get("sensor.mock_title_departure_2")
+    assert departure_sensor_2.state == STATE_UNKNOWN
 
     # Non-departure sensors (platform, trains, train_number) also access index 0
     # and should have unknown state when no departures available


### PR DESCRIPTION
## Summary
Fix `IndexError: list index out of range` in Israel Rail sensor when there are no more departures for a train line (e.g., after-hours).

## Problem
When there are no more departures for a particular line during the current calendar day, the `native_value` property raises an `IndexError` because `coordinator.data` returns an empty or partial list, but the sensor tries to access it by index without bounds checking.

## Solution
Add a bounds check in `native_value` property to return `None` when the index is out of range, which results in the sensor showing 'unknown' state instead of throwing an exception.

## Changes
- **homeassistant/components/israel_rail/sensor.py**: Add bounds check before accessing `coordinator.data` by index
- **tests/components/israel_rail/test_sensor.py**: Add test case for no departures scenario

## Related Issue
Fixes #160334

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] The code change is tested and works locally
- [x] Tests have been added to verify the fix
- [x] Code follows the project style guidelines