### PR TITLE
Refactor Tuya event platform to use DeviceWrapper

### DIFF
--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -21,6 +21,7 @@ from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
 from .models import (
+    DeviceWrapper,
     DPCodeEnumWrapper,
     DPCodeRawWrapper,
     DPCodeStringWrapper,
@@ -28,73 +29,58 @@ from .models import (
 )
 
 
-class _DPCodeEventWrapper(DPCodeTypeInformationWrapper):
-    """Base class for Tuya event wrappers."""
+class _EventEnumWrapper(DPCodeEnumWrapper):
+    """Wrapper for event enum DP codes."""
+
+    def read_device_status(self, device: CustomerDevice) -> tuple[str, None] | None:
+        """Return the event details."""
+        if (raw_value := super().read_device_status(device)) is None:
+            return None
+        return (raw_value, None)
+
+
+class _AlarmMessageWrapper(DPCodeStringWrapper):
+    """Wrapper for a STRING message on DPCode.ALARM_MESSAGE."""
 
     def __init__(self, dpcode: str, type_information: Any) -> None:
-        """Init _DPCodeEventWrapper."""
+        """Init _AlarmMessageWrapper."""
         super().__init__(dpcode, type_information)
         self.options = ["triggered"]
 
-    def get_event_type(
-        self, device: CustomerDevice, updated_status_properties: list[str] | None
-    ) -> str | None:
-        """Return the event type."""
-        if (
-            updated_status_properties is None
-            or self.dpcode not in updated_status_properties
-        ):
-            return None
-        return "triggered"
-
-    def get_event_attributes(self, device: CustomerDevice) -> dict[str, Any] | None:
-        """Return the event attributes."""
-        return None
-
-
-class _EventEnumWrapper(DPCodeEnumWrapper, _DPCodeEventWrapper):
-    """Wrapper for event enum DP codes."""
-
-    def get_event_type(
-        self, device: CustomerDevice, updated_status_properties: list[str] | None
-    ) -> str | None:
-        """Return the triggered event type."""
-        if (
-            updated_status_properties is None
-            or self.dpcode not in updated_status_properties
-        ):
-            return None
-        return self.read_device_status(device)
-
-
-class _AlarmMessageWrapper(DPCodeStringWrapper, _DPCodeEventWrapper):
-    """Wrapper for a STRING message on DPCode.ALARM_MESSAGE."""
-
-    def get_event_attributes(self, device: CustomerDevice) -> dict[str, Any] | None:
+    def read_device_status(
+        self, device: CustomerDevice
+    ) -> tuple[str, dict[str, Any]] | None:
         """Return the event attributes for the alarm message."""
-        if (raw_value := device.status.get(self.dpcode)) is None:
+        if (raw_value := super().read_device_status(device)) is None:
             return None
-        return {"message": b64decode(raw_value).decode("utf-8")}
+        return ("triggered", {"message": b64decode(raw_value).decode("utf-8")})
 
 
-class _DoorbellPicWrapper(DPCodeRawWrapper, _DPCodeEventWrapper):
+class _DoorbellPicWrapper(DPCodeRawWrapper):
     """Wrapper for a RAW message on DPCode.DOORBELL_PIC.
 
     It is expected that the RAW data is base64/utf8 encoded URL of the picture.
     """
 
-    def get_event_attributes(self, device: CustomerDevice) -> dict[str, Any] | None:
+    def __init__(self, dpcode: str, type_information: Any) -> None:
+        """Init _DoorbellPicWrapper."""
+        super().__init__(dpcode, type_information)
+        self.options = ["triggered"]
+
+    def read_device_status(
+        self, device: CustomerDevice
+    ) -> tuple[str, dict[str, Any]] | None:
         """Return the event attributes for the doorbell picture."""
         if (status := super().read_device_status(device)) is None:
             return None
-        return {"message": status.decode("utf-8")}
+        return ("triggered", {"message": status.decode("utf-8")})
 
 
 @dataclass(frozen=True)
 class TuyaEventEntityDescription(EventEntityDescription):
     """Describe a Tuya Event entity."""
 
-    wrapper_class: type[_DPCodeEventWrapper] = _EventEnumWrapper
+    wrapper_class: type[DPCodeTypeInformationWrapper] = _EventEnumWrapper
 
 
 # All descriptions can be found here. Mostly the Enum data types in the
@@ -191,11 +177,14 @@ async def async_setup_entry(
             if descriptions := EVENTS.get(device.category):
                 entities.extend(
                     TuyaEventEntity(
-                        device, manager, description, dpcode_wrapper=dpcode_wrapper
+                        device,
+                        manager,
+                        description,
+                        event_wrapper=event_wrapper,
                     )
                     for description in descriptions
                     if (
-                        dpcode_wrapper := description.wrapper_class.find_dpcode(
+                        event_wrapper := description.wrapper_class.find_dpcode(
                             device, description.key
                         )
                     )
@@ -220,29 +209,26 @@ class TuyaEventEntity(TuyaEntity, EventEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: EventEntityDescription,
-        dpcode_wrapper: _DPCodeEventWrapper,
+        *,
+        event_wrapper: DeviceWrapper[tuple[str, dict[str, Any] | None]],
     ) -> None:
         """Init Tuya event entity."""
         super().__init__(device, device_manager)
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
-        self._dpcode_wrapper = dpcode_wrapper
-        self._attr_event_types = dpcode_wrapper.options
+        self._event_wrapper = event_wrapper
+        self._attr_event_types = event_wrapper.options
 
     async def _handle_state_update(
         self,
         updated_status_properties: list[str] | None,
         dp_timestamps: dict | None = None,
     ) -> None:
-        if (
-            event_type := self._dpcode_wrapper.get_event_type(
-                self.device, updated_status_properties
-            )
-        ) is None:
+        if self._event_wrapper.skip_update(
+            self.device, updated_status_properties
+        ) or not (event_data := self._event_wrapper.read_device_status(self.device)):
             return
 
-        self._trigger_event(
-            event_type,
-            self._dpcode_wrapper.get_event_attributes(self.device),
-        )
+        event_type, event_attributes = event_data
+        self._trigger_event(event_type, event_attributes)
         self.async_write_ha_state()

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -33,7 +33,10 @@ class DeviceWrapper[T]:
     def skip_update(
         self, device: CustomerDevice, updated_status_properties: list[str] | None
     ) -> bool:
-        """Determine if the wrapper should skip an update."""
+        """Determine if the wrapper should skip an update.
+
+        The default is to always skip, unless overridden in subclasses.
+        """
         return True
 
     def read_device_status(self, device: CustomerDevice) -> T | None:
@@ -61,7 +64,11 @@ class DPCodeWrapper(DeviceWrapper):
     def skip_update(
         self, device: CustomerDevice, updated_status_properties: list[str] | None
     ) -> bool:
-        """Determine if the wrapper should skip an update."""
+        """Determine if the wrapper should skip an update.
+
+        By default, skip if updated_status_properties is given and
+        does not include this dpcode.
+        """
         return (
             updated_status_properties is None
             or self.dpcode not in updated_status_properties

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -30,6 +30,12 @@ class DeviceWrapper[T]:
 
     options: list[str]
 
+    def skip_update(
+        self, device: CustomerDevice, updated_status_properties: list[str] | None
+    ) -> bool:
+        """Determine if the wrapper should skip an update."""
+        return True
+
     def read_device_status(self, device: CustomerDevice) -> T | None:
         """Read device status and convert to a Home Assistant value."""
         raise NotImplementedError
@@ -51,6 +57,15 @@ class DPCodeWrapper(DeviceWrapper):
     def __init__(self, dpcode: str) -> None:
         """Init DPCodeWrapper."""
         self.dpcode = dpcode
+
+    def skip_update(
+        self, device: CustomerDevice, updated_status_properties: list[str] | None
+    ) -> bool:
+        """Determine if the wrapper should skip an update."""
+        return (
+            updated_status_properties is None
+            or self.dpcode not in updated_status_properties
+        )
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
         """Convert a Home Assistant value back to a raw device value.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is the last platform not using the `DeviceWrapper`:
- Add `skip_update` method to base `DeviceWrapper` - this allows the wrapper to indicate whether to trigger an event based on the list of updated properties sent by the Tuya SDK
- Merge `get_event_type` and `get_event_attributes` methods to use single `read_device_status` with `tuple[str, dict[str, Any] | None]`
- Remove now unnecessary intermediate `_DPCodeEventWrapper` base class

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
