### PR TITLE
Fix schema validation error in Telegram

### DIFF
--- a/homeassistant/components/telegram/notify.py
+++ b/homeassistant/components/telegram/notify.py
@@ -80,10 +80,6 @@ class TelegramNotificationService(BaseNotificationService):
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
         service_data = {ATTR_TARGET: kwargs.get(ATTR_TARGET, self._chat_id)}
-        if ATTR_TITLE in kwargs:
-            service_data.update({ATTR_TITLE: kwargs.get(ATTR_TITLE)})
-        if message:
-            service_data.update({ATTR_MESSAGE: message})
         data = kwargs.get(ATTR_DATA)
 
         # Set message tag
@@ -161,6 +157,12 @@ class TelegramNotificationService(BaseNotificationService):
             )
 
         # Send message
+
+        if ATTR_TITLE in kwargs:
+            service_data.update({ATTR_TITLE: kwargs.get(ATTR_TITLE)})
+        if message:
+            service_data.update({ATTR_MESSAGE: message})
+
         _LOGGER.debug(
             "TELEGRAM NOTIFIER calling %s.send_message with %s",
             TELEGRAM_BOT_DOMAIN,

--- a/tests/components/telegram/test_notify.py
+++ b/tests/components/telegram/test_notify.py
@@ -1,12 +1,14 @@
 """The tests for the telegram.notify platform."""
 
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import AsyncMock, call, patch
 
 from homeassistant import config as hass_config
 from homeassistant.components import notify
+from homeassistant.components.notify import ATTR_DATA, ATTR_MESSAGE, ATTR_TITLE
 from homeassistant.components.telegram import DOMAIN
 from homeassistant.const import SERVICE_RELOAD
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceRegistry
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
@@ -54,3 +56,108 @@ async def test_reload_notify(
         issue_id="migrate_notify",
     )
     assert len(issue_registry.issues) == 1
+
+
+async def test_notify(hass: HomeAssistant) -> None:
+    """Test notify."""
+
+    assert await async_setup_component(
+        hass,
+        notify.DOMAIN,
+        {
+            notify.DOMAIN: [
+                {
+                    "name": DOMAIN,
+                    "platform": DOMAIN,
+                    "chat_id": 1,
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    original_call = ServiceRegistry.async_call
+    with patch(
+        "homeassistant.core.ServiceRegistry.async_call", new_callable=AsyncMock
+    ) as mock_service_call:
+        # setup mock
+
+        async def call_service(*args, **kwargs) -> Any:
+            if args[0] == notify.DOMAIN:
+                return await original_call(
+                    hass.services, args[0], args[1], args[2], kwargs["blocking"]
+                )
+            return AsyncMock()
+
+        mock_service_call.side_effect = call_service
+
+        # test send message
+
+        data: dict[str, Any] = {"title": "mock title", "message": "mock message"}
+        await hass.services.async_call(
+            notify.DOMAIN,
+            DOMAIN,
+            {ATTR_TITLE: "mock title", ATTR_MESSAGE: "mock message"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert mock_service_call.mock_calls == [
+            call(
+                "notify",
+                "telegram",
+                data,
+                blocking=True,
+            ),
+            call(
+                "telegram_bot",
+                "send_message",
+                {"target": 1, "title": "mock title", "message": "mock message"},
+                False,
+                None,
+                None,
+                False,
+            ),
+        ]
+
+        mock_service_call.reset_mock()
+
+        # test send file
+
+        data = {
+            ATTR_TITLE: "mock title",
+            ATTR_MESSAGE: "mock message",
+            ATTR_DATA: {
+                "photo": {"url": "https://mock/photo.jpg", "caption": "mock caption"}
+            },
+        }
+
+        await hass.services.async_call(
+            notify.DOMAIN,
+            DOMAIN,
+            data,
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert mock_service_call.mock_calls == [
+            call(
+                "notify",
+                "telegram",
+                data,
+                blocking=True,
+            ),
+            call(
+                "telegram_bot",
+                "send_photo",
+                {
+                    "target": 1,
+                    "url": "https://mock/photo.jpg",
+                    "caption": "mock caption",
+                },
+                False,
+                None,
+                None,
+                False,
+            ),
+        ]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bug fix for 2026.1 beta.

Telegram is a legacy notify service scheduled for deprecation in 2026.5.
This fix allows users to continue to use the legacy service until its deprecation.

The recent PR https://github.com/home-assistant/core/pull/158886 introduced a code quality improvement which removed `ALLOW_EXTRA` in the schema and resulted in a "extra keys not allowed @ data['message']" error when using the legacy service.
The error happens because the legacy service simply passes all its parameters - including those not defined in the Telegram bot schema - and calls the corresponding Telegram bot service.

This PR ensures that the `title` and `message` parameters are only passed to the relevant `send_message` action.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #160278
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
