### PR TITLE
Add delay_on and delay_off when configuring a binary sensor template helpers

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -269,7 +269,10 @@ class StateBinarySensorEntity(TemplateEntity, AbstractTemplateBinarySensor):
         def _set_state(_):
             """Set state of template binary sensor."""
             self._attr_is_on = state
-            self.async_write_ha_state()
+            if self._preview_callback:
+                self._async_preview_update()
+            else:
+                self.async_write_ha_state()
 
         delay = (self._delay_on if state else self._delay_off).total_seconds()
         # state with delay. Cancelled if template result changes.

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -57,7 +57,11 @@ from .alarm_control_panel import (
     TemplateCodeFormat,
     async_create_preview_alarm_control_panel,
 )
-from .binary_sensor import async_create_preview_binary_sensor
+from .binary_sensor import (
+    CONF_DELAY_OFF,
+    CONF_DELAY_ON,
+    async_create_preview_binary_sensor,
+)
 from .const import (
     CONF_ADVANCED_OPTIONS,
     CONF_AVAILABILITY,
@@ -420,14 +424,23 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
             vol.Optional(CONF_FORECAST_HOURLY): selector.TemplateSelector(),
         }
 
+    advanced_schema: dict[vol.Marker, Any] = {
+        vol.Optional(CONF_AVAILABILITY): selector.TemplateSelector(),
+    }
+    if domain == Platform.BINARY_SENSOR:
+        advanced_schema |= {
+            vol.Optional(CONF_DELAY_ON): selector.DurationSelector(
+                selector.DurationSelectorConfig(allow_negative=False)
+            ),
+            vol.Optional(CONF_DELAY_OFF): selector.DurationSelector(
+                selector.DurationSelectorConfig(allow_negative=False)
+            ),
+        }
+
     schema |= {
         vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
         vol.Optional(CONF_ADVANCED_OPTIONS): section(
-            vol.Schema(
-                {
-                    vol.Optional(CONF_AVAILABILITY): selector.TemplateSelector(),
-                }
-            ),
+            vol.Schema(advanced_schema),
             {"collapsed": True},
         ),
     }

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -6,6 +6,10 @@
     "code_format": "Code format",
     "device_class": "Device class",
     "device_id_description": "Select a device to link to this entity.",
+    "delay_on": "Delay on",
+    "delay_on_description": "The amount of time the template state must be met before this sensor switches to `on`.",
+    "delay_off": "Delay off",
+    "delay_off_description": "The amount of time the template state must not be met before this sensor switches to `off`.",
     "state": "State",
     "turn_off": "Actions on turn off",
     "turn_on": "Actions on turn on",
@@ -44,10 +48,14 @@
         "sections": {
           "advanced_options": {
             "data": {
-              "availability": "[%key:component::template::common::availability%]"
+              "availability": "[%key:component::template::common::availability%]",
+              "delay_on": "[%key:component::template::common::delay_on%]",
+              "delay_off": "[%key:component::template::common::delay_off%]"
             },
             "data_description": {
-              "availability": "[%key:component::template::common::availability_description%]"
+              "availability": "[%key:component::template::common::availability_description%]",
+              "delay_on": "[%key:component::template::common::delay_on_description%]",
+              "delay_off": "[%key:component::template::common::delay_off_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }
@@ -68,10 +76,14 @@
         "sections": {
           "advanced_options": {
             "data": {
-              "availability": "[%key:component::template::common::availability%]"
+              "availability": "[%key:component::template::common::availability%]",
+              "delay_on": "[%key:component::template::common::delay_on%]",
+              "delay_off": "[%key:component::template::common::delay_off%]"
             },
             "data_description": {
-              "availability": "[%key:component::template::common::availability_description%]"
+              "availability": "[%key:component::template::common::availability_description%]",
+              "delay_on": "[%key:component::template::common::delay_on_description%]",
+              "delay_off": "[%key:component::template::common::delay_off_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }
@@ -92,10 +104,14 @@
         "sections": {
           "advanced_options": {
             "data": {
-              "availability": "[%key:component::template::common::availability%]"
+              "availability": "[%key:component::template::common::availability%]",
+              "delay_on": "[%key:component::template::common::delay_on%]",
+              "delay_off": "[%key:component::template::common::delay_off%]"
             },
             "data_description": {
-              "availability": "[%key:component::template::common::availability_description%]"
+              "availability": "[%key:component::template::common::availability_description%]",
+              "delay_on": "[%key:component::template::common::delay_on_description%]",
+              "delay_off": "[%key:component::template::common::delay_off_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }
@@ -126,10 +142,14 @@
         "sections": {
           "advanced_options": {
             "data": {
-              "availability": "[%key:component::template::common::availability%]"
+              "availability": "[%key:component::template::common::availability%]",
+              "delay_on": "[%key:component::template::common::delay_on%]",
+              "delay_off": "[%key:component::template::common::delay_off%]"
             },
             "data_description": {
-              "availability": "[%key:component::template::common::availability_description%]"
+              "availability": "[%key:component::template::common::availability_description%]",
+              "delay_on": "[%key:component::template::common::delay_on_description%]",
+              "delay_off": "[%key:component::template::common::delay_off_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }
@@ -618,10 +638,14 @@
         "sections": {
           "advanced_options": {
             "data": {
-              "availability": "[%key:component::template::common::availability%]"
+              "availability": "[%key:component::template::common::availability%]",
+              "delay_on": "[%key:component::template::common::delay_on%]",
+              "delay_off": "[%key:component::template::common::delay_off%]"
             },
             "data_description": {
-              "availability": "[%key:component::template::common::availability_description%]"
+              "availability": "[%key:component::template::common::availability_description%]",
+              "delay_on": "[%key:component::template::common::delay_on_description%]",
+              "delay_off": "[%key:component::template::common::delay_off_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -48,14 +48,10 @@
         "sections": {
           "advanced_options": {
             "data": {
-              "availability": "[%key:component::template::common::availability%]",
-              "delay_off": "[%key:component::template::common::delay_off%]",
-              "delay_on": "[%key:component::template::common::delay_on%]"
+              "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
-              "availability": "[%key:component::template::common::availability_description%]",
-              "delay_off": "[%key:component::template::common::delay_off_description%]",
-              "delay_on": "[%key:component::template::common::delay_on_description%]"
+              "availability": "[%key:component::template::common::availability_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }
@@ -104,14 +100,10 @@
         "sections": {
           "advanced_options": {
             "data": {
-              "availability": "[%key:component::template::common::availability%]",
-              "delay_off": "[%key:component::template::common::delay_off%]",
-              "delay_on": "[%key:component::template::common::delay_on%]"
+              "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
-              "availability": "[%key:component::template::common::availability_description%]",
-              "delay_off": "[%key:component::template::common::delay_off_description%]",
-              "delay_on": "[%key:component::template::common::delay_on_description%]"
+              "availability": "[%key:component::template::common::availability_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }
@@ -142,14 +134,10 @@
         "sections": {
           "advanced_options": {
             "data": {
-              "availability": "[%key:component::template::common::availability%]",
-              "delay_off": "[%key:component::template::common::delay_off%]",
-              "delay_on": "[%key:component::template::common::delay_on%]"
+              "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
-              "availability": "[%key:component::template::common::availability_description%]",
-              "delay_off": "[%key:component::template::common::delay_off_description%]",
-              "delay_on": "[%key:component::template::common::delay_on_description%]"
+              "availability": "[%key:component::template::common::availability_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -4,12 +4,12 @@
     "availability": "Availability template",
     "availability_description": "Defines a template to get the `available` state of the entity. If the template either fails to render or returns `True`, `\"1\"`, `\"true\"`, `\"yes\"`, `\"on\"`, `\"enable\"`, or a non-zero number, the entity will be `available`. If the template returns any other value, the entity will be `unavailable`. If not configured, the entity will always be `available`. Note that the string comparison is not case sensitive; `\"TrUe\"` and `\"yEs\"` are allowed.",
     "code_format": "Code format",
-    "device_class": "Device class",
-    "device_id_description": "Select a device to link to this entity.",
-    "delay_on": "Delay on",
-    "delay_on_description": "The amount of time the template state must be met before this sensor switches to `on`.",
     "delay_off": "Delay off",
     "delay_off_description": "The amount of time the template state must not be met before this sensor switches to `off`.",
+    "delay_on": "Delay on",
+    "delay_on_description": "The amount of time the template state must be met before this sensor switches to `on`.",
+    "device_class": "Device class",
+    "device_id_description": "Select a device to link to this entity.",
     "state": "State",
     "turn_off": "Actions on turn off",
     "turn_on": "Actions on turn on",
@@ -49,13 +49,13 @@
           "advanced_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]",
-              "delay_on": "[%key:component::template::common::delay_on%]",
-              "delay_off": "[%key:component::template::common::delay_off%]"
+              "delay_off": "[%key:component::template::common::delay_off%]",
+              "delay_on": "[%key:component::template::common::delay_on%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]",
-              "delay_on": "[%key:component::template::common::delay_on_description%]",
-              "delay_off": "[%key:component::template::common::delay_off_description%]"
+              "delay_off": "[%key:component::template::common::delay_off_description%]",
+              "delay_on": "[%key:component::template::common::delay_on_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }
@@ -77,13 +77,13 @@
           "advanced_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]",
-              "delay_on": "[%key:component::template::common::delay_on%]",
-              "delay_off": "[%key:component::template::common::delay_off%]"
+              "delay_off": "[%key:component::template::common::delay_off%]",
+              "delay_on": "[%key:component::template::common::delay_on%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]",
-              "delay_on": "[%key:component::template::common::delay_on_description%]",
-              "delay_off": "[%key:component::template::common::delay_off_description%]"
+              "delay_off": "[%key:component::template::common::delay_off_description%]",
+              "delay_on": "[%key:component::template::common::delay_on_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }
@@ -105,13 +105,13 @@
           "advanced_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]",
-              "delay_on": "[%key:component::template::common::delay_on%]",
-              "delay_off": "[%key:component::template::common::delay_off%]"
+              "delay_off": "[%key:component::template::common::delay_off%]",
+              "delay_on": "[%key:component::template::common::delay_on%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]",
-              "delay_on": "[%key:component::template::common::delay_on_description%]",
-              "delay_off": "[%key:component::template::common::delay_off_description%]"
+              "delay_off": "[%key:component::template::common::delay_off_description%]",
+              "delay_on": "[%key:component::template::common::delay_on_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }
@@ -143,13 +143,13 @@
           "advanced_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]",
-              "delay_on": "[%key:component::template::common::delay_on%]",
-              "delay_off": "[%key:component::template::common::delay_off%]"
+              "delay_off": "[%key:component::template::common::delay_off%]",
+              "delay_on": "[%key:component::template::common::delay_on%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]",
-              "delay_on": "[%key:component::template::common::delay_on_description%]",
-              "delay_off": "[%key:component::template::common::delay_off_description%]"
+              "delay_off": "[%key:component::template::common::delay_off_description%]",
+              "delay_on": "[%key:component::template::common::delay_on_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }
@@ -639,13 +639,13 @@
           "advanced_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]",
-              "delay_on": "[%key:component::template::common::delay_on%]",
-              "delay_off": "[%key:component::template::common::delay_off%]"
+              "delay_off": "[%key:component::template::common::delay_off%]",
+              "delay_on": "[%key:component::template::common::delay_on%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]",
-              "delay_on": "[%key:component::template::common::delay_on_description%]",
-              "delay_off": "[%key:component::template::common::delay_off_description%]"
+              "delay_off": "[%key:component::template::common::delay_off_description%]",
+              "delay_on": "[%key:component::template::common::delay_on_description%]"
             },
             "name": "[%key:component::template::common::advanced_options%]"
           }

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -386,13 +386,24 @@ class TemplateEntity(AbstractTemplateEntity):
             self._preview_callback(None, None, None, str(errors[-1]))
             return
 
+        self._async_preview_update()
+
+    @callback
+    def _async_preview_update(self) -> None:
+        """Send an updated state to the preview callback."""
+        if not self._preview_callback:
+            return
+
+        if not self._template_result_info:
+            self._preview_callback(None, None, None, "Preview not ready")
+            return
+
         try:
             calculated_state = self._async_calculate_state()
             validate_state(calculated_state.state)
         except Exception as err:  # noqa: BLE001
             self._preview_callback(None, None, None, str(err))
         else:
-            assert self._template_result_info
             self._preview_callback(
                 calculated_state.state,
                 calculated_state.attributes,

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Switch config flow."""
 
+from datetime import timedelta
 from typing import Any
 from unittest.mock import patch
 
@@ -13,8 +14,13 @@ from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
+from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, get_schema_suggested_value
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    get_schema_suggested_value,
+)
 from tests.typing import WebSocketGenerator
 
 SWITCH_BEFORE_OPTIONS = {
@@ -1089,6 +1095,66 @@ async def test_config_flow_preview(
     }
 
     assert len(hass.states.async_all()) == 3
+
+
+async def test_config_flow_preview_binary_sensor_delay(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the config flow preview with a delayed binary sensor."""
+    client = await hass_ws_client(hass)
+
+    hass.states.async_set("binary_sensor.available", "on")
+    hass.states.async_set("binary_sensor.one", "off")
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"next_step_id": "binary_sensor"},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "binary_sensor"
+    assert result["preview"] == "template"
+
+    await client.send_json_auto_id(
+        {
+            "type": "template/start_preview",
+            "flow_id": result["flow_id"],
+            "flow_type": "config_flow",
+            "user_input": {
+                "name": "My template",
+                "state": "{{ is_state('binary_sensor.one', 'on') }}",
+                "advanced_options": {
+                    "availability": "{{ True }}",
+                    "delay_on": {"seconds": 1},
+                },
+            },
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] is None
+
+    msg = await client.receive_json()
+    assert msg["event"]["state"] == "off"
+
+    hass.states.async_set("binary_sensor.one", "on")
+    await hass.async_block_till_done()
+
+    msg = await client.receive_json()
+    assert msg["event"]["state"] == "off"
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    msg = await client.receive_json()
+    assert msg["event"]["state"] == "on"
 
 
 EARLY_END_ERROR = "invalid template (TemplateSyntaxError: unexpected 'end of template')"

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -423,7 +423,11 @@ async def test_config_flow_binary_sensor_delay_options(
         "state": "{{ true }}",
         "advanced_options": expected_advanced_options,
     }
-    assert hass.states.get("binary_sensor.my_template").state == "on"
+    state = hass.states.get("binary_sensor.my_template")
+    if "delay_on" in expected_advanced_options:
+        assert state.state == "unknown"
+    else:
+        assert state.state == "on"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

⚠️ Huge caveat: This PR has been made using Codex, and it's my first experiment using agentic coding.
I did not lie while filling the checkboxes of the `Checklist`, which means some are unfortunately unticked.

`delay_on` and `delay_off` are two advanced options of the binary sensor template helpers that are available in YAML.

This PR makes them available in the UI under an advanced option section to avoid overcrowding the UI for something fairly advanced.

<img width="732" height="679" alt="CleanShot 2026-01-06 at 21 57 57" src="https://github.com/user-attachments/assets/10496445-20b4-4b02-90c0-ae7cf6a9b59a" />

The YAML options allow templating. The UI only allows fixed values using our time selector.

The preview of the template when creating (and editing) the entity was initially failing.

Here is a video of the options in action. Preview and "final" sensor:

https://github.com/user-attachments/assets/1e8bc440-c011-4d67-bf56-af493aa4839e



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
