### PR TITLE
fix HVAC mode ordering in LG ThinQ climate entity

### DIFF
--- a/homeassistant/components/lg_thinq/climate.py
+++ b/homeassistant/components/lg_thinq/climate.py
@@ -57,6 +57,17 @@ STR_TO_HVAC: dict[str, HVACMode] = {
 
 HVAC_TO_STR = {v: k for k, v in STR_TO_HVAC.items()}
 
+# Standard ordering for HVAC modes to ensure consistent UI display
+HVAC_MODE_ORDER: tuple[HVACMode, ...] = (
+    HVACMode.AUTO,
+    HVACMode.HEAT_COOL,
+    HVACMode.HEAT,
+    HVACMode.COOL,
+    HVACMode.DRY,
+    HVACMode.FAN_ONLY,
+    HVACMode.OFF,
+)
+
 THINQ_PRESET_MODE: list[str] = ["air_clean", "aroma", "energy_saving"]
 
 STR_TO_SWING = {
@@ -130,6 +141,9 @@ class ThinQClimateEntity(ThinQEntity, ClimateEntity):
             elif mode in THINQ_PRESET_MODE:
                 self._attr_preset_modes.append(mode)
                 self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
+
+        # Sort HVAC modes for consistent UI display order.
+        self._attr_hvac_modes.sort(key=HVAC_MODE_ORDER.index)
 
         # Set up fan modes.
         self._attr_fan_modes = [

--- a/tests/components/lg_thinq/snapshots/test_climate.ambr
+++ b/tests/components/lg_thinq/snapshots/test_climate.ambr
@@ -11,9 +11,9 @@
         'medium',
       ]),
       'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
+        <HVACMode.OFF: 'off'>,
       ]),
       'max_temp': 86,
       'min_temp': 64,
@@ -73,9 +73,9 @@
       ]),
       'friendly_name': 'Test air conditioner',
       'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
+        <HVACMode.OFF: 'off'>,
       ]),
       'max_temp': 86,
       'min_temp': 64,


### PR DESCRIPTION
## Proposed change

Fix inconsistent HVAC mode ordering in the LG ThinQ climate entity UI. Previously, HVAC modes (heat, cool, auto, etc.) would appear in different positions each time the UI was opened, causing confusion for users. This change sorts the HVAC modes in a consistent, logical order (Auto → Heat/Cool → Heat → Cool → Dry → Fan Only → Off) matching the frontend's expected display order.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure