### PR TITLE
catch and wrap exceptions when doing pyvlx actions in velux entities

### DIFF
--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -25,7 +25,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import VeluxConfigEntry
-from .entity import VeluxEntity
+from .entity import VeluxEntity, wrap_pyvlx_call_exceptions
 
 PARALLEL_UPDATES = 1
 
@@ -113,14 +113,17 @@ class VeluxCover(VeluxEntity, CoverEntity):
         """Return if the cover is closing or not."""
         return self.node.is_closing
 
+    @wrap_pyvlx_call_exceptions
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self.node.close(wait_for_completion=False)
 
+    @wrap_pyvlx_call_exceptions
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self.node.open(wait_for_completion=False)
 
+    @wrap_pyvlx_call_exceptions
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         position_percent = 100 - kwargs[ATTR_POSITION]
@@ -129,22 +132,27 @@ class VeluxCover(VeluxEntity, CoverEntity):
             Position(position_percent=position_percent), wait_for_completion=False
         )
 
+    @wrap_pyvlx_call_exceptions
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self.node.stop(wait_for_completion=False)
 
+    @wrap_pyvlx_call_exceptions
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close cover tilt."""
         await cast(Blind, self.node).close_orientation(wait_for_completion=False)
 
+    @wrap_pyvlx_call_exceptions
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open cover tilt."""
         await cast(Blind, self.node).open_orientation(wait_for_completion=False)
 
+    @wrap_pyvlx_call_exceptions
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop cover tilt."""
         await cast(Blind, self.node).stop_orientation(wait_for_completion=False)
 
+    @wrap_pyvlx_call_exceptions
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move cover tilt to a specific position."""
         position_percent = 100 - kwargs[ATTR_TILT_POSITION]

--- a/homeassistant/components/velux/entity.py
+++ b/homeassistant/components/velux/entity.py
@@ -1,16 +1,45 @@
 """Support for VELUX KLF 200 devices."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
+from functools import wraps
 import logging
+from typing import Any, ParamSpec
 
-from pyvlx import Node
+from pyvlx import Node, PyVLXException
 
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+P = ParamSpec("P")
+
+
+def wrap_pyvlx_call_exceptions(
+    func: Callable[P, Coroutine[Any, Any, None]],
+) -> Callable[P, Coroutine[Any, Any, None]]:
+    """Decorate pyvlx calls to handle exceptions.
+
+    Catches OSError and PyVLXException and wraps them into HomeAssistantError
+    with translation support.
+    """
+
+    @wraps(func)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
+        """Wrap async function to catch exceptions thrown in pyvlx calls."""
+        try:
+            await func(*args, **kwargs)
+        except (OSError, PyVLXException) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="device_communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
+
+    return wrapper
 
 
 class VeluxEntity(Entity):

--- a/homeassistant/components/velux/light.py
+++ b/homeassistant/components/velux/light.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import VeluxConfigEntry
-from .entity import VeluxEntity
+from .entity import VeluxEntity, wrap_pyvlx_call_exceptions
 
 PARALLEL_UPDATES = 1
 
@@ -49,6 +49,7 @@ class VeluxLight(VeluxEntity, LightEntity):
         """Return true if light is on."""
         return not self.node.intensity.off and self.node.intensity.known
 
+    @wrap_pyvlx_call_exceptions
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
         if ATTR_BRIGHTNESS in kwargs:
@@ -60,6 +61,7 @@ class VeluxLight(VeluxEntity, LightEntity):
         else:
             await self.node.turn_on(wait_for_completion=True)
 
+    @wrap_pyvlx_call_exceptions
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the light to turn off."""
         await self.node.turn_off(wait_for_completion=True)

--- a/homeassistant/components/velux/quality_scale.yaml
+++ b/homeassistant/components/velux/quality_scale.yaml
@@ -22,7 +22,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: todo
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters: todo
   docs-installation-parameters: todo

--- a/homeassistant/components/velux/scene.py
+++ b/homeassistant/components/velux/scene.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import VeluxConfigEntry
 from .const import DOMAIN
+from .entity import wrap_pyvlx_call_exceptions
 
 PARALLEL_UPDATES = 1
 
@@ -51,6 +52,7 @@ class VeluxScene(Scene):
             identifiers={(DOMAIN, f"gateway_{config_entry_id}")},
         )
 
+    @wrap_pyvlx_call_exceptions
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""
         await self.scene.run(wait_for_completion=False)

--- a/homeassistant/components/velux/strings.json
+++ b/homeassistant/components/velux/strings.json
@@ -48,6 +48,9 @@
     }
   },
   "exceptions": {
+    "device_communication_error": {
+      "message": "Failed to communicate with Velux device: {error}"
+    },
     "no_gateway_loaded": {
       "message": "No loaded Velux gateway found"
     },

--- a/tests/components/velux/test_cover.py
+++ b/tests/components/velux/test_cover.py
@@ -21,6 +21,7 @@ from homeassistant.components.cover import (
 )
 from homeassistant.components.velux import DOMAIN
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     STATE_CLOSED,
     STATE_CLOSING,
     STATE_OPEN,
@@ -304,24 +305,20 @@ async def test_non_blind_has_no_tilt_position(
 
 
 @pytest.mark.parametrize(
-    ("exception_type", "exception_msg"),
-    [
-        (PyVLXException, "PyVLX error"),
-        (OSError, "OS error"),
-    ],
+    "exception",
+    [PyVLXException("PyVLX error"), OSError("OS error")],
 )
 async def test_cover_command_exception_handling(
     hass: HomeAssistant,
     mock_window: AsyncMock,
-    exception_type: type[Exception],
-    exception_msg: str,
+    exception: Exception,
 ) -> None:
     """Test that exceptions from node commands are wrapped in HomeAssistantError."""
 
     entity_id = "cover.test_window"
 
     # Make the close method raise an exception
-    mock_window.close.side_effect = exception_type(exception_msg)
+    mock_window.close.side_effect = exception
 
     with pytest.raises(
         HomeAssistantError,
@@ -330,6 +327,6 @@ async def test_cover_command_exception_handling(
         await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_CLOSE_COVER,
-            {"entity_id": entity_id},
+            {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR raises HomeAssistantErrors by using a decorator for entity actions that do not already have a dedicated wrapper (which stays untouched because we either want to keep the specific HomeAssistantError message text or is needed for unavailability tracking). 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
