### PR TITLE
Fix JSON serialization of time objects in anthropic tool results

### DIFF
--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -69,6 +69,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, llm
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.json import json_dumps
 from homeassistant.util import slugify
 
 from . import AnthropicConfigEntry
@@ -193,7 +194,7 @@ def _convert_content(
                 tool_result_block = ToolResultBlockParam(
                     type="tool_result",
                     tool_use_id=content.tool_call_id,
-                    content=json.dumps(content.tool_result),
+                    content=json_dumps(content.tool_result),
                 )
                 external_tool = False
             if not messages or messages[-1]["role"] != (

--- a/tests/components/anthropic/snapshots/test_conversation.ambr
+++ b/tests/components/anthropic/snapshots/test_conversation.ambr
@@ -309,12 +309,12 @@
           'type': 'text',
         }),
         dict({
-          'content': '{"success": true, "response": "Lights are off."}',
+          'content': '{"success":true,"response":"Lights are off."}',
           'tool_use_id': 'mock-tool-call-id',
           'type': 'tool_result',
         }),
         dict({
-          'content': '{"success": false, "response": "Not enough milk."}',
+          'content': '{"success":false,"response":"Not enough milk."}',
           'tool_use_id': 'mock-tool-call-id-2',
           'type': 'tool_result',
         }),
@@ -442,6 +442,62 @@
             
             Those are the main headlines making news today.
           ''',
+          'type': 'text',
+        }),
+      ]),
+      'role': 'assistant',
+    }),
+    dict({
+      'content': 'Are you sure?',
+      'role': 'user',
+    }),
+    dict({
+      'content': list([
+        dict({
+          'text': 'Yes, I am sure!',
+          'type': 'text',
+        }),
+      ]),
+      'role': 'assistant',
+    }),
+  ])
+# ---
+# name: test_history_conversion[content6]
+  list([
+    dict({
+      'content': 'What time is it?',
+      'role': 'user',
+    }),
+    dict({
+      'content': list([
+        dict({
+          'text': 'Let me check the time for you.',
+          'type': 'text',
+        }),
+        dict({
+          'id': 'mock-tool-call-id',
+          'input': dict({
+          }),
+          'name': 'GetCurrentTime',
+          'type': 'tool_use',
+        }),
+      ]),
+      'role': 'assistant',
+    }),
+    dict({
+      'content': list([
+        dict({
+          'content': '{"speech_slots":{"time":"14:30:00"},"message":"Current time retrieved"}',
+          'tool_use_id': 'mock-tool-call-id',
+          'type': 'tool_result',
+        }),
+      ]),
+      'role': 'user',
+    }),
+    dict({
+      'content': list([
+        dict({
+          'text': 'It is currently 2:30 PM.',
           'type': 'text',
         }),
       ]),

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -1,5 +1,6 @@
 """Tests for the Anthropic integration."""
 
+import datetime
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -317,7 +318,7 @@ async def test_function_exception(
         "role": "user",
         "content": [
             {
-                "content": '{"error": "HomeAssistantError", "error_text": "Test tool exception"}',
+                "content": '{"error":"HomeAssistantError","error_text":"Test tool exception"}',
                 "tool_use_id": "toolu_0123456789AbCdEfGhIjKlM",
                 "type": "tool_result",
             }
@@ -891,6 +892,34 @@ async def test_web_search(
                         ),
                     ],
                 ),
+            ),
+        ],
+        [
+            conversation.chat_log.SystemContent("You are a helpful assistant."),
+            conversation.chat_log.UserContent("What time is it?"),
+            conversation.chat_log.AssistantContent(
+                agent_id="conversation.claude_conversation",
+                content="Let me check the time for you.",
+                tool_calls=[
+                    llm.ToolInput(
+                        id="mock-tool-call-id",
+                        tool_name="GetCurrentTime",
+                        tool_args={},
+                    ),
+                ],
+            ),
+            conversation.chat_log.ToolResultContent(
+                agent_id="conversation.claude_conversation",
+                tool_call_id="mock-tool-call-id",
+                tool_name="GetCurrentTime",
+                tool_result={
+                    "speech_slots": {"time": datetime.time(14, 30, 0)},
+                    "message": "Current time retrieved",
+                },
+            ),
+            conversation.chat_log.AssistantContent(
+                agent_id="conversation.claude_conversation",
+                content="It is currently 2:30 PM.",
             ),
         ],
     ],


### PR DESCRIPTION
This fixes the immediate json serialization failure of time objects.

The actual underlying problem is however, that when 'Prefer handling commands locally' is on, then we use the local current time handler `GetCurrentTimeHandler`. This classes' async_handle function does the following:
```python
response.async_set_speech_slots({"date": dt_util.now().date()})
```
and this time object bubbles up into the `ChatLog` as a raw datetime object and nothing that an be json serialized.

cc @Shulyaka
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #160078
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
