### PR TITLE
Reorganize CLAUDE.md into modular skills and docs

### DIFF
--- a/.claude/docs/README.md
+++ b/.claude/docs/README.md
@@ -1,0 +1,45 @@
+# Home Assistant Integration Development Documentation
+
+This directory contains reference documentation for developing Home Assistant integrations. These docs are loaded on-demand when needed for specific tasks.
+
+## Available Documentation
+
+### Core Patterns
+| Document | Description | When to use |
+|----------|-------------|-------------|
+| [async-patterns.md](async-patterns.md) | Async programming, executors, coordinators | Working with async code, data fetching |
+| [entity-patterns.md](entity-patterns.md) | Entity development, unique IDs, availability | Creating or modifying entities |
+| [config-flow-patterns.md](config-flow-patterns.md) | Config flow implementation examples | Adding or fixing config flows |
+
+### Discovery & Connectivity
+| Document | Description | When to use |
+|----------|-------------|-------------|
+| [discovery-patterns.md](discovery-patterns.md) | Zeroconf, SSDP, Bluetooth, DHCP | Implementing device discovery |
+| [services-patterns.md](services-patterns.md) | Service registration and actions | Adding integration services |
+
+### Device & State Management
+| Document | Description | When to use |
+|----------|-------------|-------------|
+| [device-management.md](device-management.md) | Device registry, DeviceInfo | Managing device entries |
+| [diagnostics-repairs.md](diagnostics-repairs.md) | Diagnostics and repair issues | Adding diagnostics or repairs |
+| [translations.md](translations.md) | Entity, exception, icon translations | Internationalizing integrations |
+
+### Testing & Quality
+| Document | Description | When to use |
+|----------|-------------|-------------|
+| [testing-patterns.md](testing-patterns.md) | Fixtures, mocks, snapshots | Writing or fixing tests |
+| [anti-patterns.md](anti-patterns.md) | Common mistakes and solutions | Code review, debugging issues |
+
+## Usage
+
+These documents are loaded by Claude when executing skills or when specific context is needed. You can also reference them directly in conversations:
+
+```
+Read .claude/docs/entity-patterns.md for entity development guidance
+```
+
+## Related Resources
+
+- **Skills**: See `.claude/skills/` for workflow-based guidance
+- **Agents**: See `.claude/agents/` for specialized verification agents
+- **CLAUDE.md**: Essential quick reference always loaded

--- a/.claude/docs/README.md
+++ b/.claude/docs/README.md
@@ -9,6 +9,7 @@ This directory contains reference documentation for developing Home Assistant in
 |----------|-------------|-------------|
 | [async-patterns.md](async-patterns.md) | Async programming, executors, coordinators | Working with async code, data fetching |
 | [entity-patterns.md](entity-patterns.md) | Entity development, unique IDs, availability | Creating or modifying entities |
+| [advanced-entity-patterns.md](advanced-entity-patterns.md) | Type casting, multi-coordinator, custom descriptions | Complex integrations with typed libraries |
 | [config-flow-patterns.md](config-flow-patterns.md) | Config flow implementation examples | Adding or fixing config flows |
 
 ### Discovery & Connectivity

--- a/.claude/docs/advanced-entity-patterns.md
+++ b/.claude/docs/advanced-entity-patterns.md
@@ -1,0 +1,203 @@
+# Advanced Entity Patterns
+
+Patterns for complex integrations with typed library objects and multiple data sources.
+
+## Custom EntityDescription Fields
+
+Extend descriptions with domain-specific callables:
+
+```python
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+
+from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.helpers.typing import StateType
+
+
+@dataclass(frozen=True, kw_only=True)
+class MySensorDescription(
+    MyBaseDescription,
+    SensorEntityDescription,
+):
+    """Sensor description with custom fields."""
+
+    value_fn: Callable[[MyDataType], StateType | datetime | None]
+    supported_fn: Callable[[MyCoordinator], bool] = lambda _: True
+    available_fn: Callable[[MyCoordinator], bool] = lambda _: True
+```
+
+## Type-Safe Library Object Access
+
+When accessing typed library objects, use `cast` for type safety:
+
+```python
+from typing import cast
+from mylib.models import DeviceStatus, BoilerState
+from mylib.const import WidgetType
+
+# Access nested typed data with cast
+value_fn=lambda data: cast(
+    DeviceStatus, data[WidgetType.STATUS]
+).temperature
+
+# Check key exists before access
+value_fn=lambda data: (
+    cast(BoilerState, data[WidgetType.BOILER]).ready_time
+    if WidgetType.BOILER in data
+    else None
+)
+
+# With fallback default
+value_fn=lambda data: cast(
+    BoilerState,
+    data.get(WidgetType.BOILER, BoilerState(status="off")),
+).status
+```
+
+## Widget/Dict Access Pattern
+
+For APIs returning dict-like structures with typed values:
+
+```python
+from mylib.models import BaseWidgetOutput
+
+# Define value_fn signature matching the data structure
+value_fn: Callable[[dict[WidgetType, BaseWidgetOutput]], StateType | None]
+
+# In native_value, pass the correct data level
+@property
+def native_value(self) -> StateType | None:
+    """Return the sensor value."""
+    return self.entity_description.value_fn(
+        self.coordinator.device.dashboard.config  # Pass the dict, not device
+    )
+```
+
+## Coordinator Data vs Device Object
+
+Choose the right pattern for your data structure:
+
+```python
+# Pattern 1: Coordinator stores data directly (simple integrations)
+# coordinator.data is a dict or dataclass
+value_fn: Callable[[dict[str, Any]], StateType]
+
+@property
+def native_value(self) -> StateType:
+    return self.entity_description.value_fn(self.coordinator.data)
+
+
+# Pattern 2: Coordinator stores device/client reference (complex integrations)
+# coordinator.device is a library object with nested state
+value_fn: Callable[[dict[WidgetType, BaseWidget]], StateType]
+
+@property
+def native_value(self) -> StateType:
+    return self.entity_description.value_fn(
+        self.coordinator.device.dashboard.config
+    )
+```
+
+## Entity Subclasses for Different Data Sources
+
+When entities need different coordinators or data access patterns:
+
+```python
+class MyBaseEntity(CoordinatorEntity[MyCoordinator]):
+    """Base entity for the integration."""
+
+    _attr_has_entity_name = True
+
+
+class MyConfigEntity(MyBaseEntity):
+    """Entity using config/dashboard data (real-time updates)."""
+
+    @property
+    def native_value(self) -> StateType | datetime | None:
+        """Return the sensor value from dashboard config."""
+        return self.entity_description.value_fn(
+            self.coordinator.device.dashboard.config
+        )
+
+
+class MyStatisticEntity(MyBaseEntity):
+    """Entity using statistics data (periodic updates)."""
+
+    _unavailable_when_machine_off = False  # Stats available when device is off
+
+    @property
+    def native_value(self) -> StateType | None:
+        """Return the sensor value from statistics."""
+        return self.entity_description.value_fn(
+            self.coordinator.device.statistics.widgets
+        )
+```
+
+## Reusing EntityDescription Across Entity Types
+
+When config and statistic entities share the same description structure:
+
+```python
+# Single description type for both
+@dataclass(frozen=True, kw_only=True)
+class MySensorDescription(LaMarzoccoEntityDescription, SensorEntityDescription):
+    value_fn: Callable[[dict[WidgetType, BaseWidgetOutput]], StateType | None]
+
+# Config sensors
+CONFIG_SENSORS: tuple[MySensorDescription, ...] = (...)
+
+# Statistic sensors (same type, different data source)
+STATISTIC_SENSORS: tuple[MySensorDescription, ...] = (...)
+
+# Different entity classes handle data access
+class MyConfigSensor(MyEntity, SensorEntity):
+    @property
+    def native_value(self):
+        return self.entity_description.value_fn(
+            self.coordinator.device.dashboard.config
+        )
+
+class MyStatisticSensor(MyConfigSensor):
+    _unavailable_when_machine_off = False
+
+    @property
+    def native_value(self):
+        return self.entity_description.value_fn(
+            self.coordinator.device.statistics.widgets
+        )
+```
+
+## Availability with Machine State
+
+Check device state for availability:
+
+```python
+from typing import cast
+from mylib.const import MachineState, WidgetType
+from mylib.models import MachineStatus
+
+class MyEntity(CoordinatorEntity[MyCoordinator]):
+    _unavailable_when_machine_off = True
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if not super().available:
+            return False
+
+        # Check machine state from typed widget
+        machine_state = (
+            cast(
+                MachineStatus,
+                self.coordinator.device.dashboard.config[WidgetType.MACHINE_STATUS],
+            ).status
+            if WidgetType.MACHINE_STATUS in self.coordinator.device.dashboard.config
+            else MachineState.OFF
+        )
+
+        if self._unavailable_when_machine_off and machine_state is MachineState.OFF:
+            return False
+
+        return True
+```

--- a/.claude/docs/anti-patterns.md
+++ b/.claude/docs/anti-patterns.md
@@ -1,0 +1,213 @@
+# Anti-Patterns and Best Practices
+
+## Blocking Operations
+
+```python
+# ❌ Bad - blocks event loop
+data = requests.get(url)
+time.sleep(5)
+
+# ✅ Good - async operations
+data = await hass.async_add_executor_job(requests.get, url)
+await asyncio.sleep(5)
+```
+
+## BleakClient Reuse
+
+```python
+# ❌ Bad - reusing client
+self.client = BleakClient(address)
+await self.client.connect()
+# Later...
+await self.client.connect()  # Don't reuse!
+
+# ✅ Good - fresh instance
+client = BleakClient(address)
+await client.connect()
+```
+
+## Hardcoded Strings
+
+```python
+# ❌ Bad - not translatable
+self._attr_name = "Temperature Sensor"
+
+# ✅ Good - translatable
+_attr_translation_key = "temperature_sensor"
+```
+
+## Missing Error Handling
+
+```python
+# ❌ Bad - no exception handling
+data = await self.api.get_data()
+
+# ✅ Good - proper handling
+try:
+    data = await self.api.get_data()
+except ApiException as err:
+    raise UpdateFailed(f"API error: {err}") from err
+```
+
+## Sensitive Data in Diagnostics
+
+```python
+# ❌ Bad - exposes secrets
+return {"api_key": entry.data[CONF_API_KEY]}
+
+# ✅ Good - redacted
+return async_redact_data(data, {"api_key", "password"})
+```
+
+## Accessing hass.data in Tests
+
+```python
+# ❌ Bad - direct access
+coordinator = hass.data[DOMAIN][entry.entry_id]
+
+# ✅ Good - proper fixture setup
+@pytest.fixture
+async def init_integration(hass, mock_config_entry, mock_api):
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+```
+
+## User-Configurable Polling
+
+```python
+# ❌ Bad - user controls interval
+vol.Optional("scan_interval", default=60): cv.positive_int
+update_interval = timedelta(minutes=entry.data.get("scan_interval", 1))
+
+# ✅ Good - integration determines interval
+SCAN_INTERVAL = timedelta(minutes=5)
+interval = timedelta(minutes=1) if client.is_local else SCAN_INTERVAL
+```
+
+## User-Configurable Names
+
+```python
+# ❌ Bad - user sets name in config flow (non-helper)
+vol.Optional("name", default="My Device"): cv.string
+
+# ✅ Good - names auto-generated or set in UI later
+# Don't add name field to config flow
+```
+
+## Too Much in Try Block
+
+```python
+# ❌ Bad - processing inside try
+try:
+    response = await client.get_data()
+    temperature = response["temperature"] / 10
+    self._attr_native_value = temperature
+except ClientError:
+    _LOGGER.error("Failed to fetch data")
+
+# ✅ Good - minimal try block
+try:
+    response = await client.get_data()
+except ClientError:
+    _LOGGER.error("Failed to fetch data")
+    return
+
+temperature = response["temperature"] / 10
+self._attr_native_value = temperature
+```
+
+## Bare Exceptions
+
+```python
+# ❌ Bad - in regular code
+try:
+    value = await sensor.read_value()
+except Exception:
+    _LOGGER.error("Failed to read sensor")
+
+# ✅ OK - in config flow (for robustness)
+async def async_step_user(self, user_input=None):
+    try:
+        await self._test_connection(user_input)
+    except Exception:
+        errors["base"] = "unknown"
+
+# ✅ OK - in background tasks
+async def _background_refresh():
+    try:
+        await coordinator.async_refresh()
+    except Exception:
+        _LOGGER.exception("Unexpected error in background task")
+```
+
+## Logging Anti-Patterns
+
+```python
+# ❌ Bad
+_LOGGER.debug("Processing data.")  # No period
+_LOGGER.debug("[my_integration] Processing")  # No domain prefix
+_LOGGER.debug("API key: %s", api_key)  # No sensitive data
+_LOGGER.debug("Processing data: " + str(data))  # Use lazy logging
+
+# ✅ Good
+_LOGGER.debug("Processing data: %s", data)
+```
+
+## Entity Lifecycle
+
+```python
+# ❌ Bad - subscribing in __init__
+def __init__(self):
+    self.client.subscribe(self._handle_event)
+
+# ✅ Good - subscribing in async_added_to_hass
+async def async_added_to_hass(self) -> None:
+    self.async_on_remove(
+        self.client.subscribe(self._handle_event)
+    )
+```
+
+## State Values
+
+```python
+# ❌ Bad - string for unknown
+self._attr_native_value = "unknown"
+
+# ✅ Good - None for unknown
+self._attr_native_value = None
+```
+
+## Unique ID Sources
+
+```python
+# ❌ Bad - unstable identifiers
+self._attr_unique_id = device.ip_address
+self._attr_unique_id = device.name
+self._attr_unique_id = user.email
+
+# ✅ Good - stable identifiers
+self._attr_unique_id = device.serial_number
+self._attr_unique_id = format_mac(device.mac)
+self._attr_unique_id = f"{entry.entry_id}-battery"  # Last resort
+```
+
+## Coordinator Setup
+
+```python
+# ❌ Bad - missing config_entry
+super().__init__(
+    hass,
+    logger=LOGGER,
+    name=DOMAIN,
+    update_interval=timedelta(minutes=5),
+)
+
+# ✅ Good - pass config_entry
+super().__init__(
+    hass,
+    logger=LOGGER,
+    name=DOMAIN,
+    update_interval=timedelta(minutes=5),
+    config_entry=config_entry,
+)
+```

--- a/.claude/docs/async-patterns.md
+++ b/.claude/docs/async-patterns.md
@@ -1,0 +1,77 @@
+# Async Programming Patterns
+
+## Core Principles
+
+- All external I/O operations must be async
+- Avoid sleeping in loops
+- Avoid awaiting in loops - use `gather` instead
+- No blocking calls
+- Group executor jobs when possible - switching between event loop and executor is expensive
+
+## Blocking Operations
+
+Use executor for blocking I/O operations:
+```python
+result = await hass.async_add_executor_job(blocking_function, args)
+```
+
+**Never block the event loop**:
+- Avoid file operations without executor
+- No `time.sleep()` - use `asyncio.sleep()` instead
+- No blocking HTTP calls
+
+## Thread Safety
+
+Use `@callback` decorator for event loop safe functions:
+```python
+@callback
+def async_update_callback(self, event):
+    """Safe to run in event loop."""
+    self.async_write_ha_state()
+```
+
+- Sync APIs from threads: Use sync versions when calling from non-event loop threads
+- Registry changes: Must be done in event loop thread
+
+## Data Update Coordinator
+
+Standard pattern for efficient data management:
+```python
+class MyCoordinator(DataUpdateCoordinator[MyData]):
+    def __init__(self, hass: HomeAssistant, client: MyClient, config_entry: ConfigEntry) -> None:
+        super().__init__(
+            hass,
+            logger=LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(minutes=5),
+            config_entry=config_entry,  # Always pass config_entry
+        )
+        self.client = client
+
+    async def _async_update_data(self) -> MyData:
+        try:
+            return await self.client.fetch_data()
+        except ApiError as err:
+            raise UpdateFailed(f"API communication error: {err}") from err
+```
+
+**Error types**:
+- `UpdateFailed`: For API errors
+- `ConfigEntryAuthFailed`: For authentication issues
+
+## WebSession Injection (Platinum)
+
+Pass web sessions to dependencies:
+```python
+async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
+    """Set up integration from config entry."""
+    client = MyClient(entry.data[CONF_HOST], async_get_clientsession(hass))
+```
+
+For cookies:
+- aiohttp: Use `async_create_clientsession`
+- httpx: Use `create_async_httpx_client`
+
+## Async Dependencies (Platinum)
+
+All dependencies must use asyncio for efficient task handling without thread context switching.

--- a/.claude/docs/config-flow-patterns.md
+++ b/.claude/docs/config-flow-patterns.md
@@ -1,0 +1,200 @@
+# Config Flow Patterns
+
+## Basic Structure
+
+```python
+class MyConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow."""
+
+    VERSION = 1
+    MINOR_VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                await self._test_connection(user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # Allowed in config flow
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(user_input[CONF_HOST])
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=user_input[CONF_HOST],
+                    data=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({
+                vol.Required(CONF_HOST): str,
+                vol.Required(CONF_API_KEY): str,
+            }),
+            errors=errors,
+        )
+```
+
+## Unique ID Management
+
+```python
+# Set unique ID and abort if already configured
+await self.async_set_unique_id(device_unique_id)
+self._abort_if_unique_id_configured()
+
+# Or match on specific data
+self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+```
+
+## Reauthentication Flow
+
+```python
+async def async_step_reauth(
+    self, entry_data: Mapping[str, Any]
+) -> ConfigFlowResult:
+    """Handle reauthentication."""
+    return await self.async_step_reauth_confirm()
+
+async def async_step_reauth_confirm(
+    self, user_input: dict[str, Any] | None = None
+) -> ConfigFlowResult:
+    """Handle reauthentication confirmation."""
+    errors: dict[str, str] = {}
+
+    if user_input is not None:
+        try:
+            user_id = await self._validate_credentials(user_input)
+        except InvalidAuth:
+            errors["base"] = "invalid_auth"
+        else:
+            await self.async_set_unique_id(user_id)
+            self._abort_if_unique_id_mismatch(reason="wrong_account")
+            return self.async_update_reload_and_abort(
+                self._get_reauth_entry(),
+                data_updates={CONF_API_TOKEN: user_input[CONF_API_TOKEN]}
+            )
+
+    return self.async_show_form(
+        step_id="reauth_confirm",
+        data_schema=vol.Schema({
+            vol.Required(CONF_API_TOKEN): str,
+        }),
+        errors=errors,
+    )
+```
+
+## Reconfiguration Flow
+
+```python
+async def async_step_reconfigure(
+    self, user_input: dict[str, Any] | None = None
+) -> ConfigFlowResult:
+    """Handle reconfiguration."""
+    errors: dict[str, str] = {}
+    reconfigure_entry = self._get_reconfigure_entry()
+
+    if user_input is not None:
+        # Prevent changing underlying account
+        self._abort_if_unique_id_mismatch()
+        return self.async_update_reload_and_abort(
+            reconfigure_entry,
+            data_updates=user_input,
+        )
+
+    return self.async_show_form(
+        step_id="reconfigure",
+        data_schema=vol.Schema({
+            vol.Required(CONF_HOST, default=reconfigure_entry.data[CONF_HOST]): str,
+        }),
+        errors=errors,
+    )
+```
+
+## Discovery Flow (Zeroconf Example)
+
+```python
+async def async_step_zeroconf(
+    self, discovery_info: ZeroconfServiceInfo
+) -> ConfigFlowResult:
+    """Handle zeroconf discovery."""
+    await self.async_set_unique_id(discovery_info.properties["serialno"])
+    self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
+
+    self._discovered_host = discovery_info.host
+    self._discovered_name = discovery_info.name
+
+    return await self.async_step_discovery_confirm()
+
+async def async_step_discovery_confirm(
+    self, user_input: dict[str, Any] | None = None
+) -> ConfigFlowResult:
+    """Confirm discovery."""
+    if user_input is not None:
+        return self.async_create_entry(
+            title=self._discovered_name,
+            data={CONF_HOST: self._discovered_host},
+        )
+
+    self._set_confirm_only()
+    return self.async_show_form(
+        step_id="discovery_confirm",
+        description_placeholders={"name": self._discovered_name},
+    )
+```
+
+## Options Flow
+
+```python
+class MyOptionsFlow(OptionsFlow):
+    """Handle options flow."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({
+                vol.Optional(
+                    CONF_SCAN_INTERVAL,
+                    default=self.config_entry.options.get(CONF_SCAN_INTERVAL, 60),
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=300)),
+            }),
+        )
+```
+
+## Error Handling
+
+Define errors in `strings.json`:
+```json
+{
+  "config": {
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured",
+      "wrong_account": "Wrong account"
+    }
+  }
+}
+```
+
+## Key Rules
+
+- **Version control**: Always set `VERSION = 1` and `MINOR_VERSION = 1`
+- **Config entry naming**: Do NOT allow users to set names in config flows (exception: helper integrations)
+- **Connection testing**: Always test connection during config flow
+- **Duplicate prevention**: Use unique ID or data matching

--- a/.claude/docs/device-management.md
+++ b/.claude/docs/device-management.md
@@ -1,0 +1,118 @@
+# Device Management Patterns
+
+## Device Registry
+
+Create devices to group related entities:
+
+```python
+_attr_device_info = DeviceInfo(
+    connections={(CONNECTION_NETWORK_MAC, device.mac)},
+    identifiers={(DOMAIN, device.id)},
+    name=device.name,
+    manufacturer="My Company",
+    model="My Sensor",
+    sw_version=device.version,
+)
+```
+
+For services, add entry type:
+```python
+_attr_device_info = DeviceInfo(
+    identifiers={(DOMAIN, entry.entry_id)},
+    name="My Service",
+    entry_type=DeviceEntryType.SERVICE,
+)
+```
+
+## Device Info Fields
+
+| Field | Description | Required |
+|-------|-------------|----------|
+| `identifiers` | Set of (domain, id) tuples | Yes |
+| `connections` | Set of (type, value) tuples | Optional |
+| `name` | Device name | Yes |
+| `manufacturer` | Manufacturer name | Recommended |
+| `model` | Model name | Recommended |
+| `sw_version` | Software/firmware version | Optional |
+| `hw_version` | Hardware version | Optional |
+| `serial_number` | Serial number | Optional |
+| `via_device` | Parent device identifier | Optional |
+| `configuration_url` | URL to device config | Optional |
+
+## Dynamic Device Addition
+
+Auto-detect new devices after initial setup:
+
+```python
+def _check_device() -> None:
+    """Check for new devices."""
+    current_devices = set(coordinator.data)
+    new_devices = current_devices - known_devices
+    if new_devices:
+        known_devices.update(new_devices)
+        async_add_entities([
+            MySensor(coordinator, device_id)
+            for device_id in new_devices
+        ])
+
+entry.async_on_unload(coordinator.async_add_listener(_check_device))
+```
+
+## Stale Device Removal
+
+Auto-remove when devices disappear from hub/account:
+
+```python
+device_registry = dr.async_get(hass)
+device_registry.async_update_device(
+    device_id=device.id,
+    remove_config_entry_id=self.config_entry.entry_id,
+)
+```
+
+## Manual Device Deletion
+
+Implement `async_remove_config_entry_device` when users should be able to manually remove devices:
+
+```python
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    device_entry: DeviceEntry,
+) -> bool:
+    """Remove a device from the integration."""
+    # Return True to allow removal, False to prevent
+    device_id = next(
+        identifier[1]
+        for identifier in device_entry.identifiers
+        if identifier[0] == DOMAIN
+    )
+    # Check if device is still connected
+    if device_id in config_entry.runtime_data.devices:
+        return False  # Don't allow removal of connected devices
+    return True
+```
+
+## Via Device (Hub Relationship)
+
+For devices connected through a hub:
+
+```python
+_attr_device_info = DeviceInfo(
+    identifiers={(DOMAIN, device.id)},
+    name=device.name,
+    via_device=(DOMAIN, hub.id),  # Reference to parent device
+)
+```
+
+## Configuration URL
+
+Provide link to device's web interface:
+
+```python
+_attr_device_info = DeviceInfo(
+    identifiers={(DOMAIN, device.id)},
+    name=device.name,
+    configuration_url=f"http://{device.host}",
+)
+```

--- a/.claude/docs/diagnostics-repairs.md
+++ b/.claude/docs/diagnostics-repairs.md
@@ -1,0 +1,152 @@
+# Diagnostics and Repairs
+
+## Integration Diagnostics
+
+Implement diagnostic data collection for debugging:
+
+```python
+from homeassistant.components.diagnostics import async_redact_data
+
+TO_REDACT = [CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_PASSWORD]
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: MyConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    return {
+        "entry_data": async_redact_data(entry.data, TO_REDACT),
+        "entry_options": async_redact_data(entry.options, TO_REDACT),
+        "data": entry.runtime_data.data,
+    }
+```
+
+**Security**: Never expose passwords, tokens, API keys, or sensitive coordinates.
+
+## Device Diagnostics
+
+For per-device diagnostics:
+
+```python
+async def async_get_device_diagnostics(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    device: DeviceEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a device."""
+    device_id = next(
+        identifier[1]
+        for identifier in device.identifiers
+        if identifier[0] == DOMAIN
+    )
+    return {
+        "device_info": async_redact_data(device_data, TO_REDACT),
+    }
+```
+
+## Repair Issues
+
+All repair issues must be actionable for end users.
+
+**Implementation**:
+```python
+from homeassistant.helpers import issue_registry as ir
+
+ir.async_create_issue(
+    hass,
+    DOMAIN,
+    "outdated_version",
+    is_fixable=False,
+    issue_domain=DOMAIN,
+    severity=ir.IssueSeverity.ERROR,
+    translation_key="outdated_version",
+    translation_placeholders={
+        "current_version": current_version,
+        "min_version": MIN_VERSION,
+    },
+)
+```
+
+## Issue Content Requirements
+
+**strings.json must include**:
+- What the problem is
+- Why it matters
+- Exact steps to resolve (numbered list when multiple steps)
+- What to expect after following the steps
+
+```json
+{
+  "issues": {
+    "outdated_version": {
+      "title": "Device firmware is outdated",
+      "description": "Your device firmware version {current_version} is below the minimum required version {min_version}. To fix this issue: 1) Open the manufacturer's mobile app, 2) Navigate to device settings, 3) Select 'Update Firmware', 4) Wait for the update to complete, then 5) Restart Home Assistant."
+    }
+  }
+}
+```
+
+**Avoid vague instructions**: Don't just say "update firmware" - provide specific steps.
+
+## Severity Guidelines
+
+| Severity | Use case |
+|----------|----------|
+| `CRITICAL` | Reserved for extreme scenarios only |
+| `ERROR` | Requires immediate user attention |
+| `WARNING` | Indicates future potential breakage |
+
+## Additional Attributes
+
+```python
+ir.async_create_issue(
+    hass, DOMAIN, "issue_id",
+    breaks_in_ha_version="2024.1.0",  # When it will break
+    is_fixable=True,                   # Can be fixed via repair flow
+    is_persistent=True,                # Survives restart
+    severity=ir.IssueSeverity.ERROR,
+    translation_key="issue_description",
+)
+```
+
+## Fixable Issues
+
+For issues that can be resolved through a repair flow:
+
+```python
+ir.async_create_issue(
+    hass, DOMAIN, "auth_expired",
+    is_fixable=True,
+    severity=ir.IssueSeverity.ERROR,
+    translation_key="auth_expired",
+)
+```
+
+Then implement the repair flow:
+```python
+class MyRepairFlow(RepairsFlow):
+    """Handle repair flow."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the repair step."""
+        if user_input is not None:
+            # Handle the fix
+            return self.async_create_entry(data={})
+
+        return self.async_show_form(step_id="init")
+```
+
+## Deleting Issues
+
+When the issue is resolved:
+```python
+ir.async_delete_issue(hass, DOMAIN, "issue_id")
+```
+
+## Best Practices
+
+- Only create issues for problems users can potentially resolve
+- Use friendly, helpful language
+- Include relevant context (device names, error details)
+- Test that the resolution steps actually work

--- a/.claude/docs/discovery-patterns.md
+++ b/.claude/docs/discovery-patterns.md
@@ -1,0 +1,126 @@
+# Discovery Patterns
+
+## Manifest Configuration
+
+Add discovery method to `manifest.json`:
+```json
+{
+  "zeroconf": ["_mydevice._tcp.local."],
+  "ssdp": [{"st": "urn:schemas-upnp-org:device:Basic:1"}],
+  "dhcp": [{"hostname": "mydevice*", "macaddress": "AABBCC*"}],
+  "bluetooth": [{"service_uuid": "example-uuid"}]
+}
+```
+
+## Zeroconf/mDNS
+
+Use async instances:
+```python
+aiozc = await zeroconf.async_get_async_instance(hass)
+```
+
+Config flow handler:
+```python
+async def async_step_zeroconf(
+    self, discovery_info: ZeroconfServiceInfo
+) -> ConfigFlowResult:
+    """Handle zeroconf discovery."""
+    await self.async_set_unique_id(discovery_info.properties["serialno"])
+    self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
+
+    self._discovered_host = discovery_info.host
+    return await self.async_step_discovery_confirm()
+```
+
+## SSDP Discovery
+
+Register callbacks with cleanup:
+```python
+entry.async_on_unload(
+    ssdp.async_register_callback(
+        hass, _async_discovered_device,
+        {"st": "urn:schemas-upnp-org:device:ZonePlayer:1"}
+    )
+)
+```
+
+## DHCP Discovery
+
+```python
+async def async_step_dhcp(
+    self, discovery_info: DhcpServiceInfo
+) -> ConfigFlowResult:
+    """Handle DHCP discovery."""
+    await self.async_set_unique_id(
+        format_mac(discovery_info.macaddress)
+    )
+    self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
+
+    return await self.async_step_discovery_confirm()
+```
+
+## Bluetooth Integration
+
+**Manifest dependencies**:
+```json
+{
+  "dependencies": ["bluetooth_adapters"],
+  "bluetooth": [
+    {"service_uuid": "example-uuid", "connectable": true}
+  ]
+}
+```
+
+**Scanner usage** - always use shared instance:
+```python
+scanner = bluetooth.async_get_scanner()
+entry.async_on_unload(
+    bluetooth.async_register_callback(
+        hass, _async_discovered_device,
+        {"service_uuid": "example_uuid"},
+        bluetooth.BluetoothScanningMode.ACTIVE
+    )
+)
+```
+
+**Connection handling**:
+- Never reuse `BleakClient` instances
+- Use 10+ second timeouts
+
+```python
+# Create fresh client each time
+client = BleakClient(address)
+async with client:
+    await client.read_gatt_char(CHARACTERISTIC_UUID)
+```
+
+## Network Updates via Discovery
+
+Use discovery to update dynamic IP addresses:
+```python
+self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
+```
+
+This updates the host in the existing config entry if the device is already configured.
+
+## USB Discovery
+
+```json
+{
+  "usb": [
+    {"vid": "10C4", "pid": "EA60", "description": "*MyDevice*"}
+  ]
+}
+```
+
+```python
+async def async_step_usb(
+    self, discovery_info: UsbServiceInfo
+) -> ConfigFlowResult:
+    """Handle USB discovery."""
+    await self.async_set_unique_id(discovery_info.serial_number)
+    self._abort_if_unique_id_configured()
+
+    self._discovered_device = discovery_info.device
+    return await self.async_step_discovery_confirm()
+```

--- a/.claude/docs/entity-patterns.md
+++ b/.claude/docs/entity-patterns.md
@@ -1,0 +1,148 @@
+# Entity Development Patterns
+
+## Unique IDs
+
+Every entity must have a unique ID for registry tracking.
+
+**Requirements**:
+- Must be unique per platform (not per integration)
+- Don't include integration domain or platform in ID
+
+**Implementation**:
+```python
+class MySensor(SensorEntity):
+    def __init__(self, device_id: str) -> None:
+        self._attr_unique_id = f"{device_id}_temperature"
+```
+
+**Acceptable ID sources**:
+- Device serial numbers
+- MAC addresses (use `format_mac` from device registry)
+- Physical identifiers (printed/EEPROM)
+- Config entry ID as last resort: `f"{entry.entry_id}-battery"`
+
+**Never use**:
+- IP addresses, hostnames, URLs
+- Device names
+- Email addresses, usernames
+
+## Entity Naming
+
+Use `has_entity_name` for proper naming:
+```python
+class MySensor(SensorEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, device: Device, field: str) -> None:
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.id)},
+            name=device.name,
+        )
+        self._attr_name = field  # e.g., "temperature", "humidity"
+```
+
+For the device itself, set `_attr_name = None`.
+
+## Entity Availability
+
+Mark entities unavailable when data cannot be fetched:
+
+**Coordinator pattern**:
+```python
+@property
+def available(self) -> bool:
+    """Return if entity is available."""
+    return super().available and self.identifier in self.coordinator.data
+```
+
+**Direct update pattern**:
+```python
+async def async_update(self) -> None:
+    """Update entity."""
+    try:
+        data = await self.client.get_data()
+    except MyException:
+        self._attr_available = False
+    else:
+        self._attr_available = True
+        self._attr_native_value = data.value
+```
+
+## Event Lifecycle Management
+
+Subscribe in `async_added_to_hass`:
+```python
+async def async_added_to_hass(self) -> None:
+    """Subscribe to events."""
+    self.async_on_remove(
+        self.client.events.subscribe("my_event", self._handle_event)
+    )
+```
+
+- Unsubscribe in `async_will_remove_from_hass` if not using `async_on_remove`
+- Never subscribe in `__init__` or other methods
+
+## State Handling
+
+- Unknown values: Use `None` (not "unknown" or "unavailable")
+- Availability: Implement `available` property instead of using "unavailable" state
+
+## Entity Descriptions
+
+For multiline lambdas, wrap in parentheses:
+```python
+SensorEntityDescription(
+    key="temperature",
+    name="Temperature",
+    value_fn=lambda data: (
+        round(data["temp_value"] * 1.8 + 32, 1)
+        if data.get("temp_value") is not None
+        else None
+    ),
+)
+```
+
+## Extra State Attributes
+
+- All attribute keys must always be present
+- Unknown values: Use `None`
+- Provide descriptive attributes
+
+## Entity Categories
+
+Set `_attr_entity_category` for proper categorization:
+```python
+class MySensor(SensorEntity):
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+```
+
+## Device Classes
+
+Use when available for proper context:
+```python
+class MyTemperatureSensor(SensorEntity):
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+```
+
+Provides: unit conversion, voice control, UI representation
+
+## Disabled by Default
+
+Disable noisy or less popular entities:
+```python
+class MySignalStrengthSensor(SensorEntity):
+    _attr_entity_registry_enabled_default = False
+```
+
+## Performance Optimization
+
+```python
+# Use __slots__ for memory efficiency
+class MySensor(SensorEntity):
+    __slots__ = ("_attr_native_value", "_attr_available")
+
+    @property
+    def should_poll(self) -> bool:
+        """Disable polling when using coordinator."""
+        return False
+```

--- a/.claude/docs/services-patterns.md
+++ b/.claude/docs/services-patterns.md
@@ -1,0 +1,136 @@
+# Service Patterns
+
+## Registration Location
+
+Register all service actions in `async_setup`, NOT in `async_setup_entry`:
+
+```python
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the integration."""
+
+    async def service_action(call: ServiceCall) -> ServiceResponse:
+        """Handle service call."""
+        if not (entry := hass.config_entries.async_get_entry(
+            call.data[ATTR_CONFIG_ENTRY_ID]
+        )):
+            raise ServiceValidationError("Entry not found")
+        if entry.state is not ConfigEntryState.LOADED:
+            raise ServiceValidationError("Entry not loaded")
+
+        # Service logic here
+        return {"result": "success"}
+
+    hass.services.async_register(
+        DOMAIN,
+        "my_service",
+        service_action,
+        schema=SERVICE_SCHEMA,
+    )
+
+    return True
+```
+
+## Service Schema
+
+Always validate input:
+```python
+SERVICE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
+    vol.Required("parameter"): cv.string,
+    vol.Optional("timeout", default=30): cv.positive_int,
+})
+```
+
+## Entity Services
+
+Register on platform setup:
+```python
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up platform."""
+    platform = async_get_current_platform()
+    platform.async_register_entity_service(
+        "my_entity_service",
+        {vol.Required("parameter"): cv.string},
+        "handle_service_method"
+    )
+```
+
+Entity method:
+```python
+class MyEntity(Entity):
+    async def handle_service_method(self, parameter: str) -> None:
+        """Handle the service call."""
+        await self.device.do_something(parameter)
+```
+
+## Exception Handling
+
+```python
+async def service_action(call: ServiceCall) -> ServiceResponse:
+    """Handle service call."""
+    # For invalid input
+    if call.data["end_date"] < call.data["start_date"]:
+        raise ServiceValidationError("End date must be after start date")
+
+    # For service errors
+    try:
+        await client.set_schedule(
+            call.data["start_date"],
+            call.data["end_date"]
+        )
+    except MyConnectionError as err:
+        raise HomeAssistantError("Could not connect to the schedule") from err
+```
+
+## Services File
+
+Create `services.yaml` with descriptions:
+```yaml
+my_service:
+  name: My service
+  description: Does something useful
+  fields:
+    parameter:
+      name: Parameter
+      description: The parameter to use
+      required: true
+      example: "value"
+      selector:
+        text:
+    timeout:
+      name: Timeout
+      description: Timeout in seconds
+      default: 30
+      selector:
+        number:
+          min: 1
+          max: 300
+          unit_of_measurement: seconds
+```
+
+## Service Response (returning data)
+
+```python
+async def service_action(call: ServiceCall) -> ServiceResponse:
+    """Handle service call with response."""
+    result = await client.get_data()
+    return {
+        "status": "success",
+        "data": result,
+    }
+```
+
+Register with `supports_response`:
+```python
+hass.services.async_register(
+    DOMAIN,
+    "my_service",
+    service_action,
+    schema=SERVICE_SCHEMA,
+    supports_response=SupportsResponse.OPTIONAL,
+)
+```

--- a/.claude/docs/testing-patterns.md
+++ b/.claude/docs/testing-patterns.md
@@ -1,0 +1,178 @@
+# Testing Patterns
+
+## Test Location
+
+Tests go in `tests/components/{domain}/`.
+
+## Coverage Requirement
+
+Above 95% test coverage for all modules.
+
+## Modern Fixture Setup
+
+```python
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        title="My Integration",
+        domain=DOMAIN,
+        data={CONF_HOST: "127.0.0.1", CONF_API_KEY: "test_key"},
+        unique_id="device_unique_id",
+    )
+
+@pytest.fixture
+def mock_device_api() -> Generator[MagicMock]:
+    """Return a mocked device API."""
+    with patch(
+        "homeassistant.components.my_integration.MyDeviceAPI",
+        autospec=True
+    ) as api_mock:
+        api = api_mock.return_value
+        api.get_data.return_value = MyDeviceData.from_json(
+            load_fixture("device_data.json", DOMAIN)
+        )
+        yield api
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return PLATFORMS
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_device_api: MagicMock,
+    platforms: list[Platform],
+) -> MockConfigEntry:
+    """Set up the integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.my_integration.PLATFORMS", platforms):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    return mock_config_entry
+```
+
+## Config Flow Testing
+
+100% coverage required for all config flow paths:
+
+```python
+async def test_user_flow_success(hass: HomeAssistant, mock_api: MagicMock) -> None:
+    """Test successful user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=TEST_USER_INPUT
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My Device"
+    assert result["data"] == TEST_USER_INPUT
+
+async def test_flow_connection_error(
+    hass: HomeAssistant, mock_api_error: MagicMock
+) -> None:
+    """Test connection error handling."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=TEST_USER_INPUT
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+```
+
+## Entity Testing with Snapshots
+
+```python
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Overridden fixture to specify platforms to test."""
+    return [Platform.SENSOR]
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the sensor entities."""
+    await snapshot_platform(
+        hass, entity_registry, snapshot, mock_config_entry.entry_id
+    )
+
+    # Verify entities are assigned to device
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "device_unique_id")}
+    )
+    assert device_entry
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    for entity_entry in entity_entries:
+        assert entity_entry.device_id == device_entry.id
+```
+
+## Snapshot Updates
+
+```bash
+# Update snapshots
+pytest ./tests/components/<domain> --snapshot-update
+
+# Always run again without flag to verify
+pytest ./tests/components/<domain>
+```
+
+## Testing Commands
+
+```bash
+# Integration-specific tests with coverage
+pytest ./tests/components/<domain> \
+  --cov=homeassistant.components.<domain> \
+  --cov-report term-missing \
+  --durations-min=1 \
+  --durations=0 \
+  --numprocesses=auto
+
+# Quick test of changed files
+pytest --timeout=10 --picked
+```
+
+## Mock Patterns
+
+**Never access `hass.data` directly** - use fixtures and proper setup instead.
+
+**Use fixtures with realistic JSON data**:
+```python
+api.get_data.return_value = MyDeviceData.from_json(
+    load_fixture("device_data.json", DOMAIN)
+)
+```
+
+## Debug Logging in Tests
+
+```python
+async def test_something(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
+    """Test with logging."""
+    caplog.set_level(logging.DEBUG, logger="homeassistant.components.my_integration")
+    # ... test code
+    assert "Expected log message" in caplog.text
+```
+
+## Testing Best Practices
+
+- Test through integration setup, not entities in isolation
+- Mock all external dependencies
+- Use snapshots for complex data structures
+- Follow existing test patterns in the codebase
+- Verify registries (entity and device)

--- a/.claude/docs/translations.md
+++ b/.claude/docs/translations.md
@@ -1,0 +1,201 @@
+# Translation Patterns
+
+## Entity Translations
+
+Required with `has_entity_name` for international users:
+
+```python
+class MySensor(SensorEntity):
+    _attr_has_entity_name = True
+    _attr_translation_key = "phase_voltage"
+```
+
+In `strings.json`:
+```json
+{
+  "entity": {
+    "sensor": {
+      "phase_voltage": {
+        "name": "Phase voltage"
+      }
+    }
+  }
+}
+```
+
+## State Translations
+
+For entities with enumerated states:
+
+```json
+{
+  "entity": {
+    "sensor": {
+      "status": {
+        "name": "Status",
+        "state": {
+          "idle": "Idle",
+          "running": "Running",
+          "error": "Error"
+        }
+      }
+    }
+  }
+}
+```
+
+## Exception Translations (Gold)
+
+Use translation keys for user-facing exceptions:
+
+```python
+raise ServiceValidationError(
+    translation_domain=DOMAIN,
+    translation_key="end_date_before_start_date",
+)
+```
+
+In `strings.json`:
+```json
+{
+  "exceptions": {
+    "end_date_before_start_date": {
+      "message": "The end date cannot be before the start date."
+    }
+  }
+}
+```
+
+With placeholders:
+```python
+raise ServiceValidationError(
+    translation_domain=DOMAIN,
+    translation_key="invalid_value",
+    translation_placeholders={"value": str(value), "min": "0", "max": "100"},
+)
+```
+
+```json
+{
+  "exceptions": {
+    "invalid_value": {
+      "message": "The value {value} is invalid. Must be between {min} and {max}."
+    }
+  }
+}
+```
+
+## Icon Translations (Gold)
+
+### State-based Icons
+
+```json
+{
+  "entity": {
+    "sensor": {
+      "tree_pollen": {
+        "default": "mdi:tree",
+        "state": {
+          "low": "mdi:tree",
+          "medium": "mdi:tree",
+          "high": "mdi:tree-outline"
+        }
+      }
+    }
+  }
+}
+```
+
+### Range-based Icons (numeric values)
+
+```json
+{
+  "entity": {
+    "sensor": {
+      "battery_level": {
+        "default": "mdi:battery-unknown",
+        "range": {
+          "0": "mdi:battery-outline",
+          "10": "mdi:battery-10",
+          "20": "mdi:battery-20",
+          "30": "mdi:battery-30",
+          "40": "mdi:battery-40",
+          "50": "mdi:battery-50",
+          "60": "mdi:battery-60",
+          "70": "mdi:battery-70",
+          "80": "mdi:battery-80",
+          "90": "mdi:battery-90",
+          "100": "mdi:battery"
+        }
+      }
+    }
+  }
+}
+```
+
+## Config Flow Translations
+
+```json
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to device",
+        "description": "Enter the connection details for your device.",
+        "data": {
+          "host": "Host",
+          "api_key": "API key"
+        },
+        "data_description": {
+          "host": "The IP address or hostname of your device",
+          "api_key": "Found in the device settings"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  }
+}
+```
+
+## Options Flow Translations
+
+```json
+{
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options",
+        "data": {
+          "scan_interval": "Update interval"
+        }
+      }
+    }
+  }
+}
+```
+
+## Service Translations
+
+In `services.yaml` (auto-translated from strings.json):
+```yaml
+my_service:
+  name: My service
+  description: Does something useful
+  fields:
+    parameter:
+      name: Parameter
+      description: The parameter to use
+```
+
+## Update Translations Command
+
+After modifying `strings.json`:
+```bash
+python -m script.translations develop --all
+```

--- a/.claude/skills/add-config-flow.md
+++ b/.claude/skills/add-config-flow.md
@@ -1,0 +1,261 @@
+# Skill: Add Config Flow
+
+Use this skill when implementing or extending config flows for a Home Assistant integration.
+
+## Workflow
+
+### Step 1: Set up manifest
+
+In `manifest.json`:
+```json
+{
+  "config_flow": true
+}
+```
+
+### Step 2: Create config_flow.py
+
+```python
+"""Config flow for My Integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_API_KEY
+
+from .const import DOMAIN
+
+
+class MyConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for My Integration."""
+
+    VERSION = 1
+    MINOR_VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                # Test connection
+                client = MyClient(user_input[CONF_HOST], user_input[CONF_API_KEY])
+                info = await client.get_info()
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # Allowed in config flow
+                errors["base"] = "unknown"
+            else:
+                # Set unique ID and check for duplicates
+                await self.async_set_unique_id(info.serial)
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=info.name,
+                    data=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({
+                vol.Required(CONF_HOST): str,
+                vol.Required(CONF_API_KEY): str,
+            }),
+            errors=errors,
+        )
+```
+
+### Step 3: Add strings.json
+
+```json
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to device",
+        "description": "Enter the connection details.",
+        "data": {
+          "host": "Host",
+          "api_key": "API key"
+        },
+        "data_description": {
+          "host": "IP address or hostname",
+          "api_key": "Found in device settings"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  }
+}
+```
+
+### Step 4: Add reauthentication (Silver+)
+
+```python
+async def async_step_reauth(
+    self, entry_data: Mapping[str, Any]
+) -> ConfigFlowResult:
+    """Handle reauthentication."""
+    return await self.async_step_reauth_confirm()
+
+async def async_step_reauth_confirm(
+    self, user_input: dict[str, Any] | None = None
+) -> ConfigFlowResult:
+    """Confirm reauthentication."""
+    errors: dict[str, str] = {}
+
+    if user_input is not None:
+        reauth_entry = self._get_reauth_entry()
+        try:
+            client = MyClient(
+                reauth_entry.data[CONF_HOST],
+                user_input[CONF_API_KEY]
+            )
+            info = await client.get_info()
+        except InvalidAuth:
+            errors["base"] = "invalid_auth"
+        else:
+            await self.async_set_unique_id(info.serial)
+            self._abort_if_unique_id_mismatch(reason="wrong_account")
+            return self.async_update_reload_and_abort(
+                reauth_entry,
+                data_updates={CONF_API_KEY: user_input[CONF_API_KEY]},
+            )
+
+    return self.async_show_form(
+        step_id="reauth_confirm",
+        data_schema=vol.Schema({
+            vol.Required(CONF_API_KEY): str,
+        }),
+        errors=errors,
+    )
+```
+
+### Step 5: Add reconfiguration (Silver+)
+
+```python
+async def async_step_reconfigure(
+    self, user_input: dict[str, Any] | None = None
+) -> ConfigFlowResult:
+    """Handle reconfiguration."""
+    errors: dict[str, str] = {}
+    reconfigure_entry = self._get_reconfigure_entry()
+
+    if user_input is not None:
+        try:
+            client = MyClient(user_input[CONF_HOST], reconfigure_entry.data[CONF_API_KEY])
+            info = await client.get_info()
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        else:
+            await self.async_set_unique_id(info.serial)
+            self._abort_if_unique_id_mismatch()
+            return self.async_update_reload_and_abort(
+                reconfigure_entry,
+                data_updates={CONF_HOST: user_input[CONF_HOST]},
+            )
+
+    return self.async_show_form(
+        step_id="reconfigure",
+        data_schema=vol.Schema({
+            vol.Required(CONF_HOST, default=reconfigure_entry.data[CONF_HOST]): str,
+        }),
+        errors=errors,
+    )
+```
+
+### Step 6: Add discovery (optional)
+
+For zeroconf discovery, add to manifest:
+```json
+{
+  "zeroconf": ["_mydevice._tcp.local."]
+}
+```
+
+Add discovery handler:
+```python
+async def async_step_zeroconf(
+    self, discovery_info: ZeroconfServiceInfo
+) -> ConfigFlowResult:
+    """Handle zeroconf discovery."""
+    await self.async_set_unique_id(discovery_info.properties["serial"])
+    self._abort_if_unique_id_configured(
+        updates={CONF_HOST: str(discovery_info.ip_address)}
+    )
+
+    self._discovered_host = str(discovery_info.ip_address)
+    self._discovered_name = discovery_info.name.removesuffix("._mydevice._tcp.local.")
+
+    return await self.async_step_discovery_confirm()
+
+async def async_step_discovery_confirm(
+    self, user_input: dict[str, Any] | None = None
+) -> ConfigFlowResult:
+    """Confirm discovery."""
+    if user_input is not None:
+        return self.async_create_entry(
+            title=self._discovered_name,
+            data={
+                CONF_HOST: self._discovered_host,
+                CONF_API_KEY: user_input[CONF_API_KEY],
+            },
+        )
+
+    self._set_confirm_only()
+    return self.async_show_form(
+        step_id="discovery_confirm",
+        data_schema=vol.Schema({
+            vol.Required(CONF_API_KEY): str,
+        }),
+        description_placeholders={"name": self._discovered_name},
+    )
+```
+
+### Step 7: Write tests (100% coverage required)
+
+Test all flow paths:
+- User flow success
+- User flow errors (connect, auth, unknown)
+- Already configured abort
+- Reauth flow
+- Reconfigure flow
+- Discovery flow (if applicable)
+
+See `.claude/docs/testing-patterns.md` for test examples.
+
+### Step 8: Validate
+
+```bash
+pre-commit run --all-files
+pytest ./tests/components/<domain>/test_config_flow.py -v
+python -m script.hassfest
+python -m script.translations develop --all
+```
+
+## Key Rules
+
+- **VERSION = 1, MINOR_VERSION = 1** always
+- **No user-configurable names** (except helper integrations)
+- **Test connection** before creating entry
+- **Prevent duplicates** with unique ID or data matching
+- **Bare exceptions allowed** in config flow for robustness
+
+## Reference
+
+For detailed patterns, see `.claude/docs/config-flow-patterns.md`.

--- a/.claude/skills/add-entity.md
+++ b/.claude/skills/add-entity.md
@@ -2,6 +2,17 @@
 
 Use this skill when adding new entity types to a Home Assistant integration.
 
+## Pre-Implementation Checklist
+
+Before creating entities, analyze the existing integration and verify:
+
+- [ ] **EntityCategory**: Is this `DIAGNOSTIC` (stats/health/counters) or primary (user-facing measurement)?
+- [ ] **supported_fn**: Does this entity exist on all device models, or only specific ones?
+- [ ] **available_fn**: When should this entity be unavailable beyond coordinator failure?
+- [ ] **value_fn signature**: What data type does the lambda receive? (dict, dataclass, library object)
+- [ ] **Multiple coordinators**: Does this data come from a different update source (config vs statistics)?
+- [ ] **Existing patterns**: Check other entity files in the integration for established patterns
+
 ## Workflow
 
 ### Step 1: Choose entity platform
@@ -209,4 +220,5 @@ MySensorEntityDescription(
 
 ## Reference
 
-For detailed patterns, see `.claude/docs/entity-patterns.md`.
+- Basic patterns: `.claude/docs/entity-patterns.md`
+- Advanced patterns (casting, multi-coordinator): `.claude/docs/advanced-entity-patterns.md`

--- a/.claude/skills/add-entity.md
+++ b/.claude/skills/add-entity.md
@@ -1,0 +1,212 @@
+# Skill: Add Entity
+
+Use this skill when adding new entity types to a Home Assistant integration.
+
+## Workflow
+
+### Step 1: Choose entity platform
+
+Common platforms:
+- `sensor` - Read-only values (temperature, humidity, power)
+- `binary_sensor` - On/off states (motion, door, connectivity)
+- `switch` - Controllable on/off (outlets, toggles)
+- `button` - Trigger actions (restart, identify)
+- `number` - Adjustable numeric values (brightness, volume)
+- `select` - Dropdown selections (modes, presets)
+- `climate` - HVAC controls
+- `light` - Light controls
+- `cover` - Blinds, garage doors
+
+### Step 2: Create or update platform file
+
+Create `homeassistant/components/<domain>/<platform>.py`:
+
+```python
+"""Sensor platform for My Integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import MyCoordinator
+from .entity import MyEntity
+
+# Use type alias for config entry
+from . import MyConfigEntry
+
+
+@dataclass(frozen=True, kw_only=True)
+class MySensorEntityDescription(SensorEntityDescription):
+    """Describe a sensor entity."""
+
+    value_fn: Callable[[MyData], float | None]
+
+
+SENSORS: tuple[MySensorEntityDescription, ...] = (
+    MySensorEntityDescription(
+        key="temperature",
+        translation_key="temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda data: data.temperature,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MyConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up sensors from a config entry."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        MySensor(coordinator, description)
+        for description in SENSORS
+    )
+
+
+class MySensor(MyEntity, SensorEntity):
+    """Representation of a sensor."""
+
+    entity_description: MySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: MyCoordinator,
+        description: MySensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.device_id}_{description.key}"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the sensor value."""
+        return self.entity_description.value_fn(self.coordinator.data)
+```
+
+### Step 3: Create base entity class
+
+Create `homeassistant/components/<domain>/entity.py`:
+
+```python
+"""Base entity for My Integration."""
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import MyCoordinator
+
+
+class MyEntity(CoordinatorEntity[MyCoordinator]):
+    """Base entity for My Integration."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: MyCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.device_id)},
+            name=coordinator.device_name,
+            manufacturer="My Company",
+            model=coordinator.device_model,
+            sw_version=coordinator.device_version,
+        )
+```
+
+### Step 4: Register platform
+
+Add to `PLATFORMS` in `__init__.py`:
+```python
+from homeassistant.const import Platform
+
+PLATFORMS = [Platform.SENSOR]  # Add new platform here
+```
+
+### Step 5: Add translations
+
+In `strings.json`:
+```json
+{
+  "entity": {
+    "sensor": {
+      "temperature": {
+        "name": "Temperature"
+      }
+    }
+  }
+}
+```
+
+### Step 6: Write tests
+
+```python
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Test sensors only."""
+    return [Platform.SENSOR]
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_sensors(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test sensor entities."""
+    await snapshot_platform(
+        hass, entity_registry, snapshot, mock_config_entry.entry_id
+    )
+```
+
+### Step 7: Validate
+
+```bash
+pre-commit run --all-files
+pytest ./tests/components/<domain> --cov=homeassistant.components.<domain>
+python -m script.hassfest
+python -m script.translations develop --all
+```
+
+## Key Reminders
+
+- **Always use `_attr_has_entity_name = True`**
+- **Set `translation_key`** for entity name translations
+- **Use `device_class`** when available
+- **Unique ID format**: `{device_id}_{entity_key}`
+- **Coordinator pattern** for data updates
+
+## Entity Description Pattern
+
+For multiline value functions:
+```python
+MySensorEntityDescription(
+    key="power",
+    value_fn=lambda data: (
+        round(data.power / 1000, 2)
+        if data.power is not None
+        else None
+    ),
+)
+```
+
+## Reference
+
+For detailed patterns, see `.claude/docs/entity-patterns.md`.

--- a/.claude/skills/improve-integration.md
+++ b/.claude/skills/improve-integration.md
@@ -1,0 +1,106 @@
+# Skill: Improve Integration
+
+Use this skill when improving an existing Home Assistant integration toward a higher quality scale level.
+
+## Workflow
+
+### Step 1: Analyze current state
+
+1. Read `manifest.json` to find current `quality_scale` target (Bronze/Silver/Gold/Platinum)
+2. Read `quality_scale.yaml` to see rule statuses:
+   - `done`: Already implemented
+   - `todo`: Needs implementation
+   - `exempt`: Doesn't apply (check comment for reason)
+3. List all rules marked as `todo`
+
+### Step 2: Understand the rules
+
+For each `todo` rule, fetch the official documentation:
+```
+https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/<rule-name>/
+```
+
+The rule documentation explains:
+- What the rule requires
+- How to implement it
+- Examples
+
+### Step 3: Prioritize improvements
+
+Order by impact and complexity:
+
+**High priority (user-visible)**:
+- `entity-unavailable` - Proper availability handling
+- `entity-translations` - Internationalization
+- `reauthentication-flow` - Credential updates
+- `reconfiguration-flow` - Config updates
+
+**Medium priority (quality)**:
+- `parallel-updates` - Specify concurrent update limit
+- `diagnostics` - Debug data collection
+- `devices` - Device registry integration
+
+**Lower priority (technical)**:
+- `strict-typing` - Full type hints
+- `async-dependency` - Async-only dependencies
+
+### Step 4: Implement each improvement
+
+For each rule:
+
+1. **Read relevant documentation**:
+   - Entity issues → `.claude/docs/entity-patterns.md`
+   - Config flow issues → `.claude/docs/config-flow-patterns.md`
+   - Testing issues → `.claude/docs/testing-patterns.md`
+   - Diagnostics → `.claude/docs/diagnostics-repairs.md`
+   - Translations → `.claude/docs/translations.md`
+
+2. **Make the changes** following the patterns
+
+3. **Update `quality_scale.yaml`**: Change `todo` to `done`
+
+4. **Add/update tests** if needed (>95% coverage required)
+
+### Step 5: Validate changes
+
+```bash
+# Run linters
+pre-commit run --all-files
+
+# Run integration tests
+pytest ./tests/components/<domain> \
+  --cov=homeassistant.components.<domain> \
+  --cov-report term-missing
+
+# Validate project structure
+python -m script.hassfest
+
+# Update translations if strings.json changed
+python -m script.translations develop --all
+```
+
+### Step 6: Update manifest if needed
+
+When all rules for a tier are `done`, consider updating the `quality_scale` in `manifest.json` to target the next tier.
+
+## Key Reminders
+
+- **Don't skip tests**: All changes need test coverage
+- **Check exemptions**: Some rules may legitimately not apply
+- **One rule at a time**: Implement and verify each rule before moving on
+- **Follow patterns**: Use the docs for consistent implementation
+
+## Common Quality Scale Rules
+
+| Rule | What it requires |
+|------|------------------|
+| `config-flow` | UI-based configuration |
+| `entity-unique-id` | Stable unique IDs for all entities |
+| `entity-unavailable` | Mark entities unavailable when data fetch fails |
+| `parallel-updates` | Set `PARALLEL_UPDATES` constant |
+| `reauthentication-flow` | Allow credential updates |
+| `reconfiguration-flow` | Allow config updates |
+| `diagnostics` | Implement diagnostic data collection |
+| `devices` | Register devices in device registry |
+| `entity-translations` | Translate entity names |
+| `strict-typing` | Full type hints with typed config entry |

--- a/.claude/skills/test-integration.md
+++ b/.claude/skills/test-integration.md
@@ -1,0 +1,189 @@
+# Skill: Test Integration
+
+Use this skill when writing or fixing tests for a Home Assistant integration.
+
+## Workflow
+
+### Step 1: Understand test structure
+
+Tests are located in `tests/components/<domain>/`:
+```
+tests/components/<domain>/
+├── __init__.py
+├── conftest.py          # Shared fixtures
+├── test_config_flow.py  # Config flow tests (100% coverage required)
+├── test_sensor.py       # Platform-specific tests
+├── test_init.py         # Setup/unload tests
+├── test_diagnostics.py  # Diagnostics tests
+└── snapshots/           # Snapshot files
+```
+
+### Step 2: Set up fixtures in conftest.py
+
+```python
+import pytest
+from unittest.mock import MagicMock, patch
+from collections.abc import Generator
+
+from homeassistant.const import CONF_HOST, CONF_API_KEY
+from homeassistant.core import HomeAssistant
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .const import DOMAIN
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        title="Test Device",
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100", CONF_API_KEY: "test_key"},
+        unique_id="test_unique_id",
+    )
+
+@pytest.fixture
+def mock_api() -> Generator[MagicMock]:
+    """Return a mocked API client."""
+    with patch(
+        "homeassistant.components.<domain>.Client",
+        autospec=True
+    ) as mock:
+        client = mock.return_value
+        client.get_data.return_value = {"temperature": 22.5}
+        yield client
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Platforms to load for tests."""
+    return PLATFORMS
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: MagicMock,
+    platforms: list[Platform],
+) -> MockConfigEntry:
+    """Set up the integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.<domain>.PLATFORMS", platforms):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+    return mock_config_entry
+```
+
+### Step 3: Write config flow tests
+
+**Must cover 100% of config flow paths:**
+
+```python
+async def test_user_flow_success(hass: HomeAssistant, mock_api: MagicMock) -> None:
+    """Test successful user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "192.168.1.100", CONF_API_KEY: "key"},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+async def test_user_flow_cannot_connect(
+    hass: HomeAssistant, mock_api: MagicMock
+) -> None:
+    """Test connection error."""
+    mock_api.get_data.side_effect = ConnectionError()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "192.168.1.100", CONF_API_KEY: "key"},
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+async def test_user_flow_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test duplicate config."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "192.168.1.100", CONF_API_KEY: "key"},
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+```
+
+### Step 4: Write entity tests with snapshots
+
+```python
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Test only sensors."""
+    return [Platform.SENSOR]
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_sensors(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test sensor entities."""
+    await snapshot_platform(
+        hass, entity_registry, snapshot, mock_config_entry.entry_id
+    )
+```
+
+### Step 5: Run tests
+
+```bash
+# Run with coverage
+pytest ./tests/components/<domain> \
+  --cov=homeassistant.components.<domain> \
+  --cov-report term-missing \
+  --numprocesses=auto
+
+# Update snapshots if needed
+pytest ./tests/components/<domain> --snapshot-update
+
+# Verify snapshots (run again without update flag)
+pytest ./tests/components/<domain>
+```
+
+## Key Reminders
+
+- **Never access `hass.data` directly** - use fixtures
+- **Mock all external calls** - no real network/device access
+- **Use `load_fixture()`** for realistic JSON data
+- **Snapshot testing** for entity states and attributes
+- **Test error paths** not just happy paths
+
+## Common Test Patterns
+
+| Scenario | Pattern |
+|----------|---------|
+| Test entities | `@pytest.mark.usefixtures("init_integration")` |
+| Mock API error | `mock_api.method.side_effect = Exception()` |
+| Time-based tests | `freezegun.freeze_time()` or `async_fire_time_changed()` |
+| State changes | `hass.states.async_set()` then `await hass.async_block_till_done()` |
+
+## Debug Tips
+
+```python
+# Enable debug logging
+caplog.set_level(logging.DEBUG, logger="homeassistant.components.<domain>")
+
+# Check logs
+assert "Expected message" in caplog.text
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -139,6 +139,7 @@ Detailed patterns available in `.claude/docs/`:
 |----------|---------|
 | `async-patterns.md` | Async programming, executors, coordinators |
 | `entity-patterns.md` | Entity development, availability, lifecycle |
+| `advanced-entity-patterns.md` | Custom descriptions, type casting, multi-coordinator |
 | `config-flow-patterns.md` | Config flow implementation |
 | `discovery-patterns.md` | Zeroconf, SSDP, Bluetooth, DHCP |
 | `testing-patterns.md` | Fixtures, mocks, snapshots |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1184 +1,151 @@
-# GitHub Copilot & Claude Code Instructions
+# Home Assistant Core Development
 
 This repository contains the core of Home Assistant, a Python 3 based home automation application.
-
-## Integration Quality Scale
-
-Home Assistant uses an Integration Quality Scale to ensure code quality and consistency. The quality level determines which rules apply:
-
-### Quality Scale Levels
-- **Bronze**: Basic requirements (ALL Bronze rules are mandatory)
-- **Silver**: Enhanced functionality 
-- **Gold**: Advanced features
-- **Platinum**: Highest quality standards
-
-### How Rules Apply
-1. **Check `manifest.json`**: Look for `"quality_scale"` key to determine integration level
-2. **Bronze Rules**: Always required for any integration with quality scale
-3. **Higher Tier Rules**: Only apply if integration targets that tier or higher
-4. **Rule Status**: Check `quality_scale.yaml` in integration folder for:
-   - `done`: Rule implemented
-   - `exempt`: Rule doesn't apply (with reason in comment)
-   - `todo`: Rule needs implementation
-
-### Example `quality_scale.yaml` Structure
-```yaml
-rules:
-  # Bronze (mandatory)
-  config-flow: done
-  entity-unique-id: done
-  action-setup:
-    status: exempt
-    comment: Integration does not register custom actions.
-  
-  # Silver (if targeting Silver+)
-  entity-unavailable: done
-  parallel-updates: done
-  
-  # Gold (if targeting Gold+)
-  devices: done
-  diagnostics: done
-  
-  # Platinum (if targeting Platinum)
-  strict-typing: done
-```
-
-**When Reviewing/Creating Code**: Always check the integration's quality scale level and exemption status before applying rules.
-
-## Code Review Guidelines
-
-**When reviewing code, do NOT comment on:**
-- **Missing imports** - We use static analysis tooling to catch that
-- **Code formatting** - We have ruff as a formatting tool that will catch those if needed (unless specifically instructed otherwise in these instructions)
-
-**Git commit practices during review:**
-- **Do NOT amend, squash, or rebase commits after review has started** - Reviewers need to see what changed since their last review
 
 ## Python Requirements
 
 - **Compatibility**: Python 3.13+
-- **Language Features**: Use the newest features when possible:
-  - Pattern matching
-  - Type hints
-  - f-strings (preferred over `%` or `.format()`)
-  - Dataclasses
-  - Walrus operator
+- **Language**: American English for all code, comments, and documentation
+- **Features**: Use newest features (pattern matching, type hints, f-strings, dataclasses, walrus operator)
 
-### Strict Typing (Platinum)
-- **Comprehensive Type Hints**: Add type hints to all functions, methods, and variables
-- **Custom Config Entry Types**: When using runtime_data:
-  ```python
-  type MyIntegrationConfigEntry = ConfigEntry[MyClient]
-  ```
-- **Library Requirements**: Include `py.typed` file for PEP-561 compliance
+## File Locations
 
-## Code Quality Standards
+- **Integration code**: `homeassistant/components/<domain>/`
+- **Integration tests**: `tests/components/<domain>/`
+- **Shared constants**: `homeassistant/const.py`
+- **Quality scale rules**: `homeassistant/components/<domain>/quality_scale.yaml`
+
+## Code Quality Tools
 
 - **Formatting**: Ruff
 - **Linting**: PyLint and Ruff
-- **Type Checking**: MyPy
-- **Lint/Type/Format Fixes**: Always prefer addressing the underlying issue (e.g., import the typed source, update shared stubs, align with Ruff expectations, or correct formatting at the source) before disabling a rule, adding `# type: ignore`, or skipping a formatter. Treat suppressions and `noqa` comments as a last resort once no compliant fix exists
-- **Testing**: pytest with plain functions and fixtures
-- **Language**: American English for all code, comments, and documentation (use sentence case, including titles)
+- **Type checking**: MyPy
+- **Testing**: pytest with >95% coverage
 
-### Writing Style Guidelines
-- **Tone**: Friendly and informative
-- **Perspective**: Use second-person ("you" and "your") for user-facing messages
-- **Inclusivity**: Use objective, non-discriminatory language
-- **Clarity**: Write for non-native English speakers
-- **Formatting in Messages**:
-  - Use backticks for: file paths, filenames, variable names, field entries
-  - Use sentence case for titles and messages (capitalize only the first word and proper nouns)
-  - Avoid abbreviations when possible
+**Always address underlying issues** before adding `# type: ignore`, `noqa`, or suppressions.
 
-## Code Organization
+## Quality Scale
 
-### Core Locations
-- Shared constants: `homeassistant/const.py` (use these instead of hardcoding)
-- Integration structure:
-  - `homeassistant/components/{domain}/const.py` - Constants
-  - `homeassistant/components/{domain}/models.py` - Data models
-  - `homeassistant/components/{domain}/coordinator.py` - Update coordinator
-  - `homeassistant/components/{domain}/config_flow.py` - Configuration flow
-  - `homeassistant/components/{domain}/{platform}.py` - Platform implementations
+Check `manifest.json` for `quality_scale` target (Bronze/Silver/Gold/Platinum).
+Check `quality_scale.yaml` for rule status: `done`, `todo`, or `exempt`.
 
-### Common Modules
-- **coordinator.py**: Centralize data fetching logic
-  ```python
-  class MyCoordinator(DataUpdateCoordinator[MyData]):
-      def __init__(self, hass: HomeAssistant, client: MyClient, config_entry: ConfigEntry) -> None:
-          super().__init__(
-              hass, 
-              logger=LOGGER, 
-              name=DOMAIN, 
-              update_interval=timedelta(minutes=1),
-              config_entry=config_entry,  # ✅ Pass config_entry - it's accepted and recommended
-          )
-  ```
-- **entity.py**: Base entity definitions to reduce duplication
-  ```python
-  class MyEntity(CoordinatorEntity[MyCoordinator]):
-      _attr_has_entity_name = True
-  ```
-
-### Runtime Data Storage
-- **Use ConfigEntry.runtime_data**: Store non-persistent runtime data
-  ```python
-  type MyIntegrationConfigEntry = ConfigEntry[MyClient]
-  
-  async def async_setup_entry(hass: HomeAssistant, entry: MyIntegrationConfigEntry) -> bool:
-      client = MyClient(entry.data[CONF_HOST])
-      entry.runtime_data = client
-  ```
-
-### Manifest Requirements
-- **Required Fields**: `domain`, `name`, `codeowners`, `integration_type`, `documentation`, `requirements`
-- **Integration Types**: `device`, `hub`, `service`, `system`, `helper`
-- **IoT Class**: Always specify connectivity method (e.g., `cloud_polling`, `local_polling`, `local_push`)
-- **Discovery Methods**: Add when applicable: `zeroconf`, `dhcp`, `bluetooth`, `ssdp`, `usb`
-- **Dependencies**: Include platform dependencies (e.g., `application_credentials`, `bluetooth_adapters`)
-
-### Config Flow Patterns
-- **Version Control**: Always set `VERSION = 1` and `MINOR_VERSION = 1`
-- **Unique ID Management**:
-  ```python
-  await self.async_set_unique_id(device_unique_id)
-  self._abort_if_unique_id_configured()
-  ```
-- **Error Handling**: Define errors in `strings.json` under `config.error`
-- **Step Methods**: Use standard naming (`async_step_user`, `async_step_discovery`, etc.)
-
-### Integration Ownership
-- **manifest.json**: Add GitHub usernames to `codeowners`:
-  ```json
-  {
-    "domain": "my_integration",
-    "name": "My Integration",
-    "codeowners": ["@me"]
-  }
-  ```
-
-### Documentation Standards
-- **File Headers**: Short and concise
-  ```python
-  """Integration for Peblar EV chargers."""
-  ```
-- **Method/Function Docstrings**: Required for all
-  ```python
-  async def async_setup_entry(hass: HomeAssistant, entry: PeblarConfigEntry) -> bool:
-      """Set up Peblar from a config entry."""
-  ```
-- **Comment Style**:
-  - Use clear, descriptive comments
-  - Explain the "why" not just the "what"
-  - Keep code block lines under 80 characters when possible
-  - Use progressive disclosure (simple explanation first, complex details later)
-
-## Async Programming
-
-- All external I/O operations must be async
-- **Best Practices**:
-  - Avoid sleeping in loops
-  - Avoid awaiting in loops - use `gather` instead
-  - No blocking calls
-  - Group executor jobs when possible - switching between event loop and executor is expensive
-
-### Async Dependencies (Platinum)
-- **Requirement**: All dependencies must use asyncio
-- Ensures efficient task handling without thread context switching
-
-### WebSession Injection (Platinum)
-- **Pass WebSession**: Support passing web sessions to dependencies
-  ```python
-  async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
-      """Set up integration from config entry."""
-      client = MyClient(entry.data[CONF_HOST], async_get_clientsession(hass))
-  ```
-- For cookies: Use `async_create_clientsession` (aiohttp) or `create_async_httpx_client` (httpx)
-
-### Blocking Operations
-- **Use Executor**: For blocking I/O operations
-  ```python
-  result = await hass.async_add_executor_job(blocking_function, args)
-  ```
-- **Never Block Event Loop**: Avoid file operations, `time.sleep()`, blocking HTTP calls
-- **Replace with Async**: Use `asyncio.sleep()` instead of `time.sleep()`
-
-### Thread Safety
-- **@callback Decorator**: For event loop safe functions
-  ```python
-  @callback
-  def async_update_callback(self, event):
-      """Safe to run in event loop."""
-      self.async_write_ha_state()
-  ```
-- **Sync APIs from Threads**: Use sync versions when calling from non-event loop threads
-- **Registry Changes**: Must be done in event loop thread
-
-### Data Update Coordinator
-- **Standard Pattern**: Use for efficient data management
-  ```python
-  class MyCoordinator(DataUpdateCoordinator):
-      def __init__(self, hass: HomeAssistant, client: MyClient, config_entry: ConfigEntry) -> None:
-          super().__init__(
-              hass,
-              logger=LOGGER,
-              name=DOMAIN,
-              update_interval=timedelta(minutes=5),
-              config_entry=config_entry,  # ✅ Pass config_entry - it's accepted and recommended
-          )
-          self.client = client
-      
-      async def _async_update_data(self):
-          try:
-              return await self.client.fetch_data()
-          except ApiError as err:
-              raise UpdateFailed(f"API communication error: {err}")
-  ```
-- **Error Types**: Use `UpdateFailed` for API errors, `ConfigEntryAuthFailed` for auth issues
-- **Config Entry**: Always pass `config_entry` parameter to coordinator - it's accepted and recommended
-
-## Integration Guidelines
-
-### Configuration Flow
-- **UI Setup Required**: All integrations must support configuration via UI
-- **Manifest**: Set `"config_flow": true` in `manifest.json`
-- **Data Storage**:
-  - Connection-critical config: Store in `ConfigEntry.data`
-  - Non-critical settings: Store in `ConfigEntry.options`
-- **Validation**: Always validate user input before creating entries
-- **Config Entry Naming**: 
-  - ❌ Do NOT allow users to set config entry names in config flows
-  - Names are automatically generated or can be customized later in UI
-  - ✅ Exception: Helper integrations MAY allow custom names in config flow
-- **Connection Testing**: Test device/service connection during config flow:
-  ```python
-  try:
-      await client.get_data()
-  except MyException:
-      errors["base"] = "cannot_connect"
-  ```
-- **Duplicate Prevention**: Prevent duplicate configurations:
-  ```python
-  # Using unique ID
-  await self.async_set_unique_id(identifier)
-  self._abort_if_unique_id_configured()
-  
-  # Using unique data
-  self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
-  ```
-
-### Reauthentication Support
-- **Required Method**: Implement `async_step_reauth` in config flow
-- **Credential Updates**: Allow users to update credentials without re-adding
-- **Validation**: Verify account matches existing unique ID:
-  ```python
-  await self.async_set_unique_id(user_id)
-  self._abort_if_unique_id_mismatch(reason="wrong_account")
-  return self.async_update_reload_and_abort(
-      self._get_reauth_entry(),
-      data_updates={CONF_API_TOKEN: user_input[CONF_API_TOKEN]}
-  )
-  ```
-
-### Reconfiguration Flow
-- **Purpose**: Allow configuration updates without removing device
-- **Implementation**: Add `async_step_reconfigure` method
-- **Validation**: Prevent changing underlying account with `_abort_if_unique_id_mismatch`
-
-### Device Discovery
-- **Manifest Configuration**: Add discovery method (zeroconf, dhcp, etc.)
-  ```json
-  {
-    "zeroconf": ["_mydevice._tcp.local."]
-  }
-  ```
-- **Discovery Handler**: Implement appropriate `async_step_*` method:
-  ```python
-  async def async_step_zeroconf(self, discovery_info):
-      """Handle zeroconf discovery."""
-      await self.async_set_unique_id(discovery_info.properties["serialno"])
-      self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
-  ```
-- **Network Updates**: Use discovery to update dynamic IP addresses
-
-### Network Discovery Implementation
-- **Zeroconf/mDNS**: Use async instances
-  ```python
-  aiozc = await zeroconf.async_get_async_instance(hass)
-  ```
-- **SSDP Discovery**: Register callbacks with cleanup
-  ```python
-  entry.async_on_unload(
-      ssdp.async_register_callback(
-          hass, _async_discovered_device, 
-          {"st": "urn:schemas-upnp-org:device:ZonePlayer:1"}
-      )
-  )
-  ```
-
-### Bluetooth Integration
-- **Manifest Dependencies**: Add `bluetooth_adapters` to dependencies
-- **Connectable**: Set `"connectable": true` for connection-required devices
-- **Scanner Usage**: Always use shared scanner instance
-  ```python
-  scanner = bluetooth.async_get_scanner()
-  entry.async_on_unload(
-      bluetooth.async_register_callback(
-          hass, _async_discovered_device,
-          {"service_uuid": "example_uuid"},
-          bluetooth.BluetoothScanningMode.ACTIVE
-      )
-  )
-  ```
-- **Connection Handling**: Never reuse `BleakClient` instances, use 10+ second timeouts
-
-### Setup Validation
-- **Test Before Setup**: Verify integration can be set up in `async_setup_entry`
-- **Exception Handling**:
-  - `ConfigEntryNotReady`: Device offline or temporary failure
-  - `ConfigEntryAuthFailed`: Authentication issues
-  - `ConfigEntryError`: Unresolvable setup problems
-
-### Config Entry Unloading
-- **Required**: Implement `async_unload_entry` for runtime removal/reload
-- **Platform Unloading**: Use `hass.config_entries.async_unload_platforms`
-- **Cleanup**: Register callbacks with `entry.async_on_unload`:
-  ```python
-  async def async_unload_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
-      """Unload a config entry."""
-      if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-          entry.runtime_data.listener()  # Clean up resources
-      return unload_ok
-  ```
-
-### Service Actions
-- **Registration**: Register all service actions in `async_setup`, NOT in `async_setup_entry`
-- **Validation**: Check config entry existence and loaded state:
-  ```python
-  async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-      async def service_action(call: ServiceCall) -> ServiceResponse:
-          if not (entry := hass.config_entries.async_get_entry(call.data[ATTR_CONFIG_ENTRY_ID])):
-              raise ServiceValidationError("Entry not found")
-          if entry.state is not ConfigEntryState.LOADED:
-              raise ServiceValidationError("Entry not loaded")
-  ```
-- **Exception Handling**: Raise appropriate exceptions:
-  ```python
-  # For invalid input
-  if end_date < start_date:
-      raise ServiceValidationError("End date must be after start date")
-  
-  # For service errors
-  try:
-      await client.set_schedule(start_date, end_date)
-  except MyConnectionError as err:
-      raise HomeAssistantError("Could not connect to the schedule") from err
-  ```
-
-### Service Registration Patterns
-- **Entity Services**: Register on platform setup
-  ```python
-  platform.async_register_entity_service(
-      "my_entity_service",
-      {vol.Required("parameter"): cv.string},
-      "handle_service_method"
-  )
-  ```
-- **Service Schema**: Always validate input
-  ```python
-  SERVICE_SCHEMA = vol.Schema({
-      vol.Required("entity_id"): cv.entity_ids,
-      vol.Required("parameter"): cv.string,
-      vol.Optional("timeout", default=30): cv.positive_int,
-  })
-  ```
-- **Services File**: Create `services.yaml` with descriptions and field definitions
-
-### Polling
-- Use update coordinator pattern when possible
-- **Polling intervals are NOT user-configurable**: Never add scan_interval, update_interval, or polling frequency options to config flows or config entries
-- **Integration determines intervals**: Set `update_interval` programmatically based on integration logic, not user input
-- **Minimum Intervals**:
-  - Local network: 5 seconds
-  - Cloud services: 60 seconds
-- **Parallel Updates**: Specify number of concurrent updates:
-  ```python
-  PARALLEL_UPDATES = 1  # Serialize updates to prevent overwhelming device
-  # OR
-  PARALLEL_UPDATES = 0  # Unlimited (for coordinator-based or read-only)
-  ```
-
-### Error Handling
-- **Exception Types**: Choose most specific exception available
-  - `ServiceValidationError`: User input errors (preferred over `ValueError`)
-  - `HomeAssistantError`: Device communication failures
-  - `ConfigEntryNotReady`: Temporary setup issues (device offline)
-  - `ConfigEntryAuthFailed`: Authentication problems
-  - `ConfigEntryError`: Permanent setup issues
-- **Try/Catch Best Practices**:
-  - Only wrap code that can throw exceptions
-  - Keep try blocks minimal - process data after the try/catch
-  - **Avoid bare exceptions** except in specific cases:
-    - ❌ Generally not allowed: `except:` or `except Exception:`
-    - ✅ Allowed in config flows to ensure robustness
-    - ✅ Allowed in functions/methods that run in background tasks
-  - Bad pattern:
-    ```python
-    try:
-        data = await device.get_data()  # Can throw
-        # ❌ Don't process data inside try block
-        processed = data.get("value", 0) * 100
-        self._attr_native_value = processed
-    except DeviceError:
-        _LOGGER.error("Failed to get data")
-    ```
-  - Good pattern:
-    ```python
-    try:
-        data = await device.get_data()  # Can throw
-    except DeviceError:
-        _LOGGER.error("Failed to get data")
-        return
-    
-    # ✅ Process data outside try block
-    processed = data.get("value", 0) * 100
-    self._attr_native_value = processed
-    ```
-- **Bare Exception Usage**:
-  ```python
-  # ❌ Not allowed in regular code
-  try:
-      data = await device.get_data()
-  except Exception:  # Too broad
-      _LOGGER.error("Failed")
-  
-  # ✅ Allowed in config flow for robustness
-  async def async_step_user(self, user_input=None):
-      try:
-          await self._test_connection(user_input)
-      except Exception:  # Allowed here
-          errors["base"] = "unknown"
-  
-  # ✅ Allowed in background tasks
-  async def _background_refresh():
-      try:
-          await coordinator.async_refresh()
-      except Exception:  # Allowed in task
-          _LOGGER.exception("Unexpected error in background task")
-  ```
-- **Setup Failure Patterns**:
-  ```python
-  try:
-      await device.async_setup()
-  except (asyncio.TimeoutError, TimeoutException) as ex:
-      raise ConfigEntryNotReady(f"Timeout connecting to {device.host}") from ex
-  except AuthFailed as ex:
-      raise ConfigEntryAuthFailed(f"Credentials expired for {device.name}") from ex
-  ```
-
-### Logging
-- **Format Guidelines**:
-  - No periods at end of messages
-  - No integration names/domains (added automatically)
-  - No sensitive data (keys, tokens, passwords)
-- Use debug level for non-user-facing messages
-- **Use Lazy Logging**:
-  ```python
-  _LOGGER.debug("This is a log message with %s", variable)
-  ```
-
-### Unavailability Logging
-- **Log Once**: When device/service becomes unavailable (info level)
-- **Log Recovery**: When device/service comes back online
-- **Implementation Pattern**:
-  ```python
-  _unavailable_logged: bool = False
-  
-  if not self._unavailable_logged:
-      _LOGGER.info("The sensor is unavailable: %s", ex)
-      self._unavailable_logged = True
-  # On recovery:
-  if self._unavailable_logged:
-      _LOGGER.info("The sensor is back online")
-      self._unavailable_logged = False
-  ```
-
-## Entity Development
-
-### Unique IDs
-- **Required**: Every entity must have a unique ID for registry tracking
-- Must be unique per platform (not per integration)
-- Don't include integration domain or platform in ID
-- **Implementation**:
-  ```python
-  class MySensor(SensorEntity):
-      def __init__(self, device_id: str) -> None:
-          self._attr_unique_id = f"{device_id}_temperature"
-  ```
-
-**Acceptable ID Sources**:
-- Device serial numbers
-- MAC addresses (formatted using `format_mac` from device registry)
-- Physical identifiers (printed/EEPROM)
-- Config entry ID as last resort: `f"{entry.entry_id}-battery"`
-
-**Never Use**:
-- IP addresses, hostnames, URLs
-- Device names
-- Email addresses, usernames
-
-### Entity Descriptions
-- **Lambda/Anonymous Functions**: Often used in EntityDescription for value transformation
-- **Multiline Lambdas**: When lambdas exceed line length, wrap in parentheses for readability
-- **Bad pattern**:
-  ```python
-  SensorEntityDescription(
-      key="temperature",
-      name="Temperature",
-      value_fn=lambda data: round(data["temp_value"] * 1.8 + 32, 1) if data.get("temp_value") is not None else None,  # ❌ Too long
-  )
-  ```
-- **Good pattern**:
-  ```python
-  SensorEntityDescription(
-      key="temperature", 
-      name="Temperature",
-      value_fn=lambda data: (  # ✅ Parenthesis on same line as lambda
-          round(data["temp_value"] * 1.8 + 32, 1)
-          if data.get("temp_value") is not None
-          else None
-      ),
-  )
-  ```
-
-### Entity Naming
-- **Use has_entity_name**: Set `_attr_has_entity_name = True`
-- **For specific fields**:
-  ```python
-  class MySensor(SensorEntity):
-      _attr_has_entity_name = True
-      def __init__(self, device: Device, field: str) -> None:
-          self._attr_device_info = DeviceInfo(
-              identifiers={(DOMAIN, device.id)},
-              name=device.name,
-          )
-          self._attr_name = field  # e.g., "temperature", "humidity"
-  ```
-- **For device itself**: Set `_attr_name = None`
-
-### Event Lifecycle Management
-- **Subscribe in `async_added_to_hass`**:
-  ```python
-  async def async_added_to_hass(self) -> None:
-      """Subscribe to events."""
-      self.async_on_remove(
-          self.client.events.subscribe("my_event", self._handle_event)
-      )
-  ```
-- **Unsubscribe in `async_will_remove_from_hass`** if not using `async_on_remove`
-- Never subscribe in `__init__` or other methods
-
-### State Handling
-- Unknown values: Use `None` (not "unknown" or "unavailable")
-- Availability: Implement `available()` property instead of using "unavailable" state
-
-### Entity Availability
-- **Mark Unavailable**: When data cannot be fetched from device/service
-- **Coordinator Pattern**:
-  ```python
-  @property
-  def available(self) -> bool:
-      """Return if entity is available."""
-      return super().available and self.identifier in self.coordinator.data
-  ```
-- **Direct Update Pattern**:
-  ```python
-  async def async_update(self) -> None:
-      """Update entity."""
-      try:
-          data = await self.client.get_data()
-      except MyException:
-          self._attr_available = False
-      else:
-          self._attr_available = True
-          self._attr_native_value = data.value
-  ```
-
-### Extra State Attributes
-- All attribute keys must always be present
-- Unknown values: Use `None`
-- Provide descriptive attributes
-
-## Device Management
-
-### Device Registry
-- **Create Devices**: Group related entities under devices
-- **Device Info**: Provide comprehensive metadata:
-  ```python
-  _attr_device_info = DeviceInfo(
-      connections={(CONNECTION_NETWORK_MAC, device.mac)},
-      identifiers={(DOMAIN, device.id)},
-      name=device.name,
-      manufacturer="My Company",
-      model="My Sensor",
-      sw_version=device.version,
-  )
-  ```
-- For services: Add `entry_type=DeviceEntryType.SERVICE`
-
-### Dynamic Device Addition
-- **Auto-detect New Devices**: After initial setup
-- **Implementation Pattern**:
-  ```python
-  def _check_device() -> None:
-      current_devices = set(coordinator.data)
-      new_devices = current_devices - known_devices
-      if new_devices:
-          known_devices.update(new_devices)
-          async_add_entities([MySensor(coordinator, device_id) for device_id in new_devices])
-  
-  entry.async_on_unload(coordinator.async_add_listener(_check_device))
-  ```
-
-### Stale Device Removal
-- **Auto-remove**: When devices disappear from hub/account
-- **Device Registry Update**:
-  ```python
-  device_registry.async_update_device(
-      device_id=device.id,
-      remove_config_entry_id=self.config_entry.entry_id,
-  )
-  ```
-- **Manual Deletion**: Implement `async_remove_config_entry_device` when needed
-
-## Diagnostics and Repairs
-
-### Integration Diagnostics
-- **Required**: Implement diagnostic data collection
-- **Implementation**:
-  ```python
-  TO_REDACT = [CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE]
-  
-  async def async_get_config_entry_diagnostics(
-      hass: HomeAssistant, entry: MyConfigEntry
-  ) -> dict[str, Any]:
-      """Return diagnostics for a config entry."""
-      return {
-          "entry_data": async_redact_data(entry.data, TO_REDACT),
-          "data": entry.runtime_data.data,
-      }
-  ```
-- **Security**: Never expose passwords, tokens, or sensitive coordinates
-
-### Repair Issues
-- **Actionable Issues Required**: All repair issues must be actionable for end users
-- **Issue Content Requirements**:
-  - Clearly explain what is happening
-  - Provide specific steps users need to take to resolve the issue
-  - Use friendly, helpful language
-  - Include relevant context (device names, error details, etc.)
-- **Implementation**:
-  ```python
-  ir.async_create_issue(
-      hass,
-      DOMAIN,
-      "outdated_version",
-      is_fixable=False,
-      issue_domain=DOMAIN,
-      severity=ir.IssueSeverity.ERROR,
-      translation_key="outdated_version",
-  )
-  ```
-- **Translation Strings Requirements**: Must contain user-actionable text in `strings.json`:
-  ```json
-  {
-    "issues": {
-      "outdated_version": {
-        "title": "Device firmware is outdated",
-        "description": "Your device firmware version {current_version} is below the minimum required version {min_version}. To fix this issue: 1) Open the manufacturer's mobile app, 2) Navigate to device settings, 3) Select 'Update Firmware', 4) Wait for the update to complete, then 5) Restart Home Assistant."
-      }
-    }
-  }
-  ```
-- **String Content Must Include**:
-  - What the problem is
-  - Why it matters
-  - Exact steps to resolve (numbered list when multiple steps)
-  - What to expect after following the steps
-- **Avoid Vague Instructions**: Don't just say "update firmware" - provide specific steps
-- **Severity Guidelines**:
-  - `CRITICAL`: Reserved for extreme scenarios only
-  - `ERROR`: Requires immediate user attention  
-  - `WARNING`: Indicates future potential breakage
-- **Additional Attributes**:
-  ```python
-  ir.async_create_issue(
-      hass, DOMAIN, "issue_id",
-      breaks_in_ha_version="2024.1.0",
-      is_fixable=True,
-      is_persistent=True,
-      severity=ir.IssueSeverity.ERROR,
-      translation_key="issue_description",
-  )
-  ```
-- Only create issues for problems users can potentially resolve
-
-### Entity Categories
-- **Required**: Assign appropriate category to entities
-- **Implementation**: Set `_attr_entity_category`
-  ```python
-  class MySensor(SensorEntity):
-      _attr_entity_category = EntityCategory.DIAGNOSTIC
-  ```
-- Categories include: `DIAGNOSTIC` for system/technical information
-
-### Device Classes
-- **Use When Available**: Set appropriate device class for entity type
-  ```python
-  class MyTemperatureSensor(SensorEntity):
-      _attr_device_class = SensorDeviceClass.TEMPERATURE
-  ```
-- Provides context for: unit conversion, voice control, UI representation
-
-### Disabled by Default
-- **Disable Noisy/Less Popular Entities**: Reduce resource usage
-  ```python
-  class MySignalStrengthSensor(SensorEntity):
-      _attr_entity_registry_enabled_default = False
-  ```
-- Target: frequently changing states, technical diagnostics
-
-### Entity Translations
-- **Required with has_entity_name**: Support international users
-- **Implementation**:
-  ```python
-  class MySensor(SensorEntity):
-      _attr_has_entity_name = True
-      _attr_translation_key = "phase_voltage"
-  ```
-- Create `strings.json` with translations:
-  ```json
-  {
-    "entity": {
-      "sensor": {
-        "phase_voltage": {
-          "name": "Phase voltage"
-        }
-      }
-    }
-  }
-  ```
-
-### Exception Translations (Gold)
-- **Translatable Errors**: Use translation keys for user-facing exceptions
-- **Implementation**:
-  ```python
-  raise ServiceValidationError(
-      translation_domain=DOMAIN,
-      translation_key="end_date_before_start_date",
-  )
-  ```
-- Add to `strings.json`:
-  ```json
-  {
-    "exceptions": {
-      "end_date_before_start_date": {
-        "message": "The end date cannot be before the start date."
-      }
-    }
-  }
-  ```
-
-### Icon Translations (Gold)
-- **Dynamic Icons**: Support state and range-based icon selection
-- **State-based Icons**:
-  ```json
-  {
-    "entity": {
-      "sensor": {
-        "tree_pollen": {
-          "default": "mdi:tree",
-          "state": {
-            "high": "mdi:tree-outline"
-          }
-        }
-      }
-    }
-  }
-  ```
-- **Range-based Icons** (for numeric values):
-  ```json
-  {
-    "entity": {
-      "sensor": {
-        "battery_level": {
-          "default": "mdi:battery-unknown",
-          "range": {
-            "0": "mdi:battery-outline",
-            "90": "mdi:battery-90",
-            "100": "mdi:battery"
-          }
-        }
-      }
-    }
-  }
-  ```
-
-## Testing Requirements
-
-- **Location**: `tests/components/{domain}/`
-- **Coverage Requirement**: Above 95% test coverage for all modules
-- **Best Practices**:
-  - Use pytest fixtures from `tests.common`
-  - Mock all external dependencies
-  - Use snapshots for complex data structures
-  - Follow existing test patterns
-
-### Config Flow Testing
-- **100% Coverage Required**: All config flow paths must be tested
-- **Test Scenarios**:
-  - All flow initiation methods (user, discovery, import)
-  - Successful configuration paths
-  - Error recovery scenarios
-  - Prevention of duplicate entries
-  - Flow completion after errors
+**Bronze rules are always mandatory.** Higher tiers apply only if targeting that level.
 
 ## Development Commands
 
-### Code Quality & Linting
-- **Run all linters on all files**: `pre-commit run --all-files`
-- **Run linters on staged files only**: `pre-commit run`
-- **PyLint on everything** (slow): `pylint homeassistant`
-- **PyLint on specific folder**: `pylint homeassistant/components/my_integration`
-- **MyPy type checking (whole project)**: `mypy homeassistant/`
-- **MyPy on specific integration**: `mypy homeassistant/components/my_integration`
-
 ### Testing
-- **Integration-specific tests** (recommended):
-  ```bash
-  pytest ./tests/components/<integration_domain> \
-    --cov=homeassistant.components.<integration_domain> \
-    --cov-report term-missing \
-    --durations-min=1 \
-    --durations=0 \
-    --numprocesses=auto
-  ```
-- **Quick test of changed files**: `pytest --timeout=10 --picked`
-- **Update test snapshots**: Add `--snapshot-update` to pytest command
-  - ⚠️ Omit test results after using `--snapshot-update`
-  - Always run tests again without the flag to verify snapshots
-- **Full test suite** (AVOID - very slow): `pytest ./tests`
+```bash
+# Integration tests with coverage
+pytest ./tests/components/<domain> \
+  --cov=homeassistant.components.<domain> \
+  --cov-report term-missing \
+  --numprocesses=auto
 
-### Dependencies & Requirements
-- **Update generated files after dependency changes**: `python -m script.gen_requirements_all`
-- **Install all Python requirements**: 
-  ```bash
-  uv pip install -r requirements_all.txt -r requirements.txt -r requirements_test.txt
-  ```
-- **Install test requirements only**: 
-  ```bash
-  uv pip install -r requirements_test_all.txt -r requirements.txt
-  ```
+# Quick test of changed files
+pytest --timeout=10 --picked
 
-### Translations
-- **Update translations after strings.json changes**: 
-  ```bash
-  python -m script.translations develop --all
-  ```
-
-### Project Validation
-- **Run hassfest** (checks project structure and updates generated files): 
-  ```bash
-  python -m script.hassfest
-  ```
-
-### File Locations
-- **Integration code**: `./homeassistant/components/<integration_domain>/`
-- **Integration tests**: `./tests/components/<integration_domain>/`
-
-## Integration Templates
-
-### Standard Integration Structure
-```
-homeassistant/components/my_integration/
-├── __init__.py          # Entry point with async_setup_entry
-├── manifest.json        # Integration metadata and dependencies
-├── const.py            # Domain and constants
-├── config_flow.py      # UI configuration flow
-├── coordinator.py      # Data update coordinator (if needed)
-├── entity.py          # Base entity class (if shared patterns)
-├── sensor.py          # Sensor platform
-├── strings.json        # User-facing text and translations
-├── services.yaml       # Service definitions (if applicable)
-└── quality_scale.yaml  # Quality scale rule status
+# Update snapshots (then run again without flag to verify)
+pytest ./tests/components/<domain> --snapshot-update
 ```
 
-### Quality Scale Progression
-- **Bronze → Silver**: Add entity unavailability, parallel updates, auth flows
-- **Silver → Gold**: Add device management, diagnostics, translations  
-- **Gold → Platinum**: Add strict typing, async dependencies, websession injection
+### Validation
+```bash
+# Run all linters
+pre-commit run --all-files
 
-### Minimal Integration Checklist
-- [ ] `manifest.json` with required fields (domain, name, codeowners, etc.)
-- [ ] `__init__.py` with `async_setup_entry` and `async_unload_entry`
-- [ ] `config_flow.py` with UI configuration support
-- [ ] `const.py` with `DOMAIN` constant
-- [ ] `strings.json` with at least config flow text
-- [ ] Platform files (`sensor.py`, etc.) as needed
-- [ ] `quality_scale.yaml` with rule status tracking
+# Validate project structure
+python -m script.hassfest
 
-## Common Anti-Patterns & Best Practices
+# Update translations after strings.json changes
+python -m script.translations develop --all
 
-### ❌ **Avoid These Patterns**
+# Update requirements after dependency changes
+python -m script.gen_requirements_all
+```
+
+## Key Patterns
+
+### Runtime Data
 ```python
-# Blocking operations in event loop
-data = requests.get(url)  # ❌ Blocks event loop
-time.sleep(5)  # ❌ Blocks event loop
+type MyIntegrationConfigEntry = ConfigEntry[MyClient]
 
-# Reusing BleakClient instances
-self.client = BleakClient(address)
-await self.client.connect()
-# Later...
-await self.client.connect()  # ❌ Don't reuse
-
-# Hardcoded strings in code
-self._attr_name = "Temperature Sensor"  # ❌ Not translatable
-
-# Missing error handling
-data = await self.api.get_data()  # ❌ No exception handling
-
-# Storing sensitive data in diagnostics
-return {"api_key": entry.data[CONF_API_KEY]}  # ❌ Exposes secrets
-
-# Accessing hass.data directly in tests
-coordinator = hass.data[DOMAIN][entry.entry_id]  # ❌ Don't access hass.data
-
-# User-configurable polling intervals
-# In config flow
-vol.Optional("scan_interval", default=60): cv.positive_int  # ❌ Not allowed
-# In coordinator
-update_interval = timedelta(minutes=entry.data.get("scan_interval", 1))  # ❌ Not allowed
-
-# User-configurable config entry names (non-helper integrations)
-vol.Optional("name", default="My Device"): cv.string  # ❌ Not allowed in regular integrations
-
-# Too much code in try block
-try:
-    response = await client.get_data()  # Can throw
-    # ❌ Data processing should be outside try block
-    temperature = response["temperature"] / 10
-    humidity = response["humidity"] 
-    self._attr_native_value = temperature
-except ClientError:
-    _LOGGER.error("Failed to fetch data")
-
-# Bare exceptions in regular code
-try:
-    value = await sensor.read_value()
-except Exception:  # ❌ Too broad - catch specific exceptions
-    _LOGGER.error("Failed to read sensor")
+async def async_setup_entry(hass: HomeAssistant, entry: MyIntegrationConfigEntry) -> bool:
+    client = MyClient(entry.data[CONF_HOST])
+    entry.runtime_data = client
 ```
 
-### ✅ **Use These Patterns Instead**
+### Coordinator
 ```python
-# Async operations with executor
-data = await hass.async_add_executor_job(requests.get, url)
-await asyncio.sleep(5)  # ✅ Non-blocking
-
-# Fresh BleakClient instances
-client = BleakClient(address)  # ✅ New instance each time
-await client.connect()
-
-# Translatable entity names
-_attr_translation_key = "temperature_sensor"  # ✅ Translatable
-
-# Proper error handling
-try:
-    data = await self.api.get_data()
-except ApiException as err:
-    raise UpdateFailed(f"API error: {err}") from err
-
-# Redacted diagnostics data
-return async_redact_data(data, {"api_key", "password"})  # ✅ Safe
-
-# Test through proper integration setup and fixtures
-@pytest.fixture
-async def init_integration(hass, mock_config_entry, mock_api):
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)  # ✅ Proper setup
-
-# Integration-determined polling intervals (not user-configurable)
-SCAN_INTERVAL = timedelta(minutes=5)  # ✅ Common pattern: constant in const.py
-
 class MyCoordinator(DataUpdateCoordinator[MyData]):
     def __init__(self, hass: HomeAssistant, client: MyClient, config_entry: ConfigEntry) -> None:
-        # ✅ Integration determines interval based on device capabilities, connection type, etc.
-        interval = timedelta(minutes=1) if client.is_local else SCAN_INTERVAL
         super().__init__(
-            hass, 
-            logger=LOGGER, 
-            name=DOMAIN, 
-            update_interval=interval,
-            config_entry=config_entry,  # ✅ Pass config_entry - it's accepted and recommended
+            hass, logger=LOGGER, name=DOMAIN,
+            update_interval=timedelta(minutes=5),
+            config_entry=config_entry,  # Always pass this
         )
 ```
 
-### Entity Performance Optimization
+### Entity Base
 ```python
-# Use __slots__ for memory efficiency
-class MySensor(SensorEntity):
-    __slots__ = ("_attr_native_value", "_attr_available")
-    
-    @property 
-    def should_poll(self) -> bool:
-        """Disable polling when using coordinator."""
-        return False  # ✅ Let coordinator handle updates
+class MyEntity(CoordinatorEntity[MyCoordinator]):
+    _attr_has_entity_name = True
 ```
 
-## Testing Patterns
+### Unique IDs
+- Use: serial numbers, MAC addresses, physical IDs
+- Never use: IP addresses, hostnames, device names
 
-### Testing Best Practices
-- **Never access `hass.data` directly** - Use fixtures and proper integration setup instead
-- **Use snapshot testing** - For verifying entity states and attributes
-- **Test through integration setup** - Don't test entities in isolation
-- **Mock external APIs** - Use fixtures with realistic JSON data
-- **Verify registries** - Ensure entities are properly registered with devices
+## Critical Rules
 
-### Config Flow Testing Template
-```python
-async def test_user_flow_success(hass, mock_api):
-    """Test successful user flow."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "user"
+- **Polling intervals**: NOT user-configurable (integration determines)
+- **Config entry names**: NOT set in config flows (auto-generated)
+- **Blocking calls**: Use `hass.async_add_executor_job()` for blocking I/O
+- **Error handling**: Keep try blocks minimal, process data outside
+- **Bare exceptions**: Only allowed in config flows and background tasks
+- **Sensitive data**: Never expose in diagnostics (use `async_redact_data`)
+- **Tests**: Never access `hass.data` directly, use fixtures
 
-    # Test form submission
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=TEST_USER_INPUT
-    )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "My Device"
-    assert result["data"] == TEST_USER_INPUT
+## Code Review Guidelines
 
-async def test_flow_connection_error(hass, mock_api_error):
-    """Test connection error handling."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=TEST_USER_INPUT
-    )
-    assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {"base": "cannot_connect"}
-```
+**Do NOT comment on:**
+- Missing imports (static analysis catches these)
+- Code formatting (Ruff handles this)
 
-### Entity Testing Patterns
-```python
-@pytest.fixture 
-def platforms() -> list[Platform]: 
-    """Overridden fixture to specify platforms to test.""" 
-    return [Platform.SENSOR]  # Or another specific platform as needed.
+**Git practices:**
+- Do NOT amend/squash/rebase commits after review starts
 
-@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
-async def test_entities(
-    hass: HomeAssistant,
-    snapshot: SnapshotAssertion,
-    entity_registry: er.EntityRegistry,
-    device_registry: dr.DeviceRegistry,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test the sensor entities."""
-    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+## Available Skills
 
-    # Ensure entities are correctly assigned to device
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "device_unique_id")}
-    )
-    assert device_entry
-    entity_entries = er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
-    for entity_entry in entity_entries:
-        assert entity_entry.device_id == device_entry.id
-```
+Invoke with `/skill-name`:
 
-### Mock Patterns
-```python
-# Modern integration fixture setup
-@pytest.fixture
-def mock_config_entry() -> MockConfigEntry:
-    """Return the default mocked config entry."""
-    return MockConfigEntry(
-        title="My Integration",
-        domain=DOMAIN,
-        data={CONF_HOST: "127.0.0.1", CONF_API_KEY: "test_key"},
-        unique_id="device_unique_id",
-    )
+| Skill | Purpose |
+|-------|---------|
+| `/improve-integration` | Workflow for improving integration quality scale |
+| `/test-integration` | Testing patterns and commands |
+| `/add-entity` | Adding new entity types |
+| `/add-config-flow` | Config flow implementation |
 
-@pytest.fixture
-def mock_device_api() -> Generator[MagicMock]:
-    """Return a mocked device API."""
-    with patch("homeassistant.components.my_integration.MyDeviceAPI", autospec=True) as api_mock:
-        api = api_mock.return_value
-        api.get_data.return_value = MyDeviceData.from_json(
-            load_fixture("device_data.json", DOMAIN)
-        )
-        yield api
+## Available Agents
 
-@pytest.fixture 
-def platforms() -> list[Platform]: 
-    """Fixture to specify platforms to test.""" 
-    return PLATFORMS
+| Agent | Purpose |
+|-------|---------|
+| `/quality-scale-rule-verifier` | Verify specific quality scale rules |
 
-@pytest.fixture
-async def init_integration(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_device_api: MagicMock,
-    platforms: list[Platform],
-) -> MockConfigEntry:
-    """Set up the integration for testing."""
-    mock_config_entry.add_to_hass(hass)
-    
-    with patch("homeassistant.components.my_integration.PLATFORMS", platforms):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+## Reference Documentation
 
-    return mock_config_entry
-```
+Detailed patterns available in `.claude/docs/`:
 
-## Debugging & Troubleshooting
+| Document | Content |
+|----------|---------|
+| `async-patterns.md` | Async programming, executors, coordinators |
+| `entity-patterns.md` | Entity development, availability, lifecycle |
+| `config-flow-patterns.md` | Config flow implementation |
+| `discovery-patterns.md` | Zeroconf, SSDP, Bluetooth, DHCP |
+| `testing-patterns.md` | Fixtures, mocks, snapshots |
+| `services-patterns.md` | Service registration and actions |
+| `device-management.md` | Device registry patterns |
+| `diagnostics-repairs.md` | Diagnostics and repair issues |
+| `translations.md` | Entity, exception, icon translations |
+| `anti-patterns.md` | Common mistakes and solutions |
 
-### Common Issues & Solutions
-- **Integration won't load**: Check `manifest.json` syntax and required fields
-- **Entities not appearing**: Verify `unique_id` and `has_entity_name` implementation  
-- **Config flow errors**: Check `strings.json` entries and error handling
-- **Discovery not working**: Verify manifest discovery configuration and callbacks
-- **Tests failing**: Check mock setup and async context
-
-### Debug Logging Setup
-```python
-# Enable debug logging in tests
-caplog.set_level(logging.DEBUG, logger="my_integration")
-
-# In integration code - use proper logging
-_LOGGER = logging.getLogger(__name__)
-_LOGGER.debug("Processing data: %s", data)  # Use lazy logging
-```
-
-### Validation Commands
-```bash
-# Check specific integration
-python -m script.hassfest --integration-path homeassistant/components/my_integration
-
-# Validate quality scale
-# Check quality_scale.yaml against current rules
-
-# Run integration tests with coverage
-pytest ./tests/components/my_integration \
-  --cov=homeassistant.components.my_integration \
-  --cov-report term-missing
-```
+See `.claude/docs/README.md` for full index.


### PR DESCRIPTION
## Summary
- Reorganizes the monolithic CLAUDE.md into a modular structure with separate skill files and documentation
- Creates `.claude/skills/` directory with reusable workflow skills (improve-integration, test-integration, add-entity, add-config-flow)
- Creates `.claude/docs/` directory with detailed pattern documentation (async, entities, config flows, testing, etc.)
- Keeps CLAUDE.md concise with essential rules and references to detailed docs
- Adds advanced entity patterns documentation for complex scenarios

## Benefits
- Easier to maintain and update individual topics
- Skills can be invoked directly with `/skill-name`
- Documentation is organized by topic for quick reference
- Reduces context window usage by loading only relevant docs
- Better separation of concerns between quick reference and detailed patterns

## Test plan
- [x] Verified CLAUDE.md structure is valid
- [x] Tested sensor.py recreation using only core files to validate documentation effectiveness
- [ ] Test skill invocation with Claude Code

🤖 Generated with [Claude Code](https://claude.ai/code)