### PR TITLE
openevse: Add device_info and unique_id to sensors

### DIFF
--- a/homeassistant/components/openevse/sensor.py
+++ b/homeassistant/components/openevse/sensor.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
@@ -159,7 +159,7 @@ async def async_setup_entry(
     async_add_entities(
         (
             OpenEVSESensor(
-                config_entry,
+                config_entry.unique_id,
                 config_entry.runtime_data,
                 description,
             )
@@ -176,7 +176,7 @@ class OpenEVSESensor(SensorEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        unique_id: str | None,
         charger: OpenEVSE,
         description: SensorEntityDescription,
     ) -> None:
@@ -184,13 +184,14 @@ class OpenEVSESensor(SensorEntity):
         self.entity_description = description
         self.charger = charger
 
-        if config_entry.unique_id:
-            self._attr_unique_id = f"{config_entry.unique_id}_{description.key}"
+        if unique_id:
+            self._attr_unique_id = f"{unique_id}_{description.key}"
 
             self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, config_entry.unique_id)},
-                name="OpenEVSE",
+                identifiers={(DOMAIN, unique_id)},
                 manufacturer="OpenEVSE",
+                # unique_id is the mac address
+                connections={(CONNECTION_NETWORK_MAC, unique_id)},
             )
 
     async def async_update(self) -> None:

--- a/homeassistant/components/openevse/strings.json
+++ b/homeassistant/components/openevse/strings.json
@@ -39,7 +39,7 @@
         "name": "Usage this session"
       },
       "usage_total": {
-        "name": "Total usage"
+        "name": "Total energy usage"
       }
     }
   },

--- a/homeassistant/components/openevse/strings.json
+++ b/homeassistant/components/openevse/strings.json
@@ -18,6 +18,31 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "ambient_temp": {
+        "name": "Ambient temperature"
+      },
+      "charge_time": {
+        "name": "Charge time elapsed"
+      },
+      "ir_temp": {
+        "name": "IR temperature"
+      },
+      "rtc_temp": {
+        "name": "RTC temperature"
+      },
+      "status": {
+        "name": "Charging status"
+      },
+      "usage_session": {
+        "name": "Usage this session"
+      },
+      "usage_total": {
+        "name": "Total usage"
+      }
+    }
+  },
   "issues": {
     "yaml_deprecated": {
       "description": "Configuring OpenEVSE using YAML is being removed. Your existing YAML configuration has been imported into the UI automatically. Remove the `openevse` configuration from your configuration.yaml file and restart Home Assistant to fix this issue.",

--- a/tests/components/openevse/conftest.py
+++ b/tests/components/openevse/conftest.py
@@ -69,6 +69,7 @@ def serial_number(has_serial_number: bool) -> str | None:
 def mock_config_entry(serial_number: str) -> MockConfigEntry:
     """Create a mock config entry."""
     return MockConfigEntry(
+        title="openevse_mock_config",
         domain=DOMAIN,
         data={CONF_HOST: "192.168.1.100"},
         entry_id="FAKE",

--- a/tests/components/openevse/snapshots/test_sensor.ambr
+++ b/tests/components/openevse/snapshots/test_sensor.ambr
@@ -1,0 +1,385 @@
+# serializer version: 1
+# name: test_entities[sensor.openevse_ambient_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openevse_ambient_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Ambient temperature',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ambient_temp',
+    'unique_id': 'deadbeeffeed_ambient_temp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_entities[sensor.openevse_ambient_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'OpenEVSE Ambient temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openevse_ambient_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.5',
+  })
+# ---
+# name: test_entities[sensor.openevse_charge_time_elapsed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openevse_charge_time_elapsed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Charge time elapsed',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charge_time',
+    'unique_id': 'deadbeeffeed_charge_time',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_entities[sensor.openevse_charge_time_elapsed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'OpenEVSE Charge time elapsed',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openevse_charge_time_elapsed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '60.0',
+  })
+# ---
+# name: test_entities[sensor.openevse_charging_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openevse_charging_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Charging status',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'status',
+    'unique_id': 'deadbeeffeed_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.openevse_charging_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'OpenEVSE Charging status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openevse_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Charging',
+  })
+# ---
+# name: test_entities[sensor.openevse_ir_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openevse_ir_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'IR temperature',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ir_temp',
+    'unique_id': 'deadbeeffeed_ir_temp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_entities[sensor.openevse_ir_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'OpenEVSE IR temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openevse_ir_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30.2',
+  })
+# ---
+# name: test_entities[sensor.openevse_rtc_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openevse_rtc_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'RTC temperature',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'rtc_temp',
+    'unique_id': 'deadbeeffeed_rtc_temp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_entities[sensor.openevse_rtc_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'OpenEVSE RTC temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openevse_rtc_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '28.7',
+  })
+# ---
+# name: test_entities[sensor.openevse_total_usage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openevse_total_usage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Total usage',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'usage_total',
+    'unique_id': 'deadbeeffeed_usage_total',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_entities[sensor.openevse_total_usage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'OpenEVSE Total usage',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openevse_total_usage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '500.0',
+  })
+# ---
+# name: test_entities[sensor.openevse_usage_this_session-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openevse_usage_this_session',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Usage this session',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'usage_session',
+    'unique_id': 'deadbeeffeed_usage_session',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_entities[sensor.openevse_usage_this_session-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'OpenEVSE Usage this session',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openevse_usage_this_session',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '15.0',
+  })
+# ---

--- a/tests/components/openevse/snapshots/test_sensor.ambr
+++ b/tests/components/openevse/snapshots/test_sensor.ambr
@@ -327,62 +327,6 @@
     'state': '500.0',
   })
 # ---
-# name: test_entities[sensor.openevse_mock_config_total_usage-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.openevse_mock_config_total_usage',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 2,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
-    'original_icon': None,
-    'original_name': 'Total usage',
-    'platform': 'openevse',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'usage_total',
-    'unique_id': 'deadbeeffeed_usage_total',
-    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-  })
-# ---
-# name: test_entities[sensor.openevse_mock_config_total_usage-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'openevse_mock_config Total usage',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.openevse_mock_config_total_usage',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '500.0',
-  })
-# ---
 # name: test_entities[sensor.openevse_mock_config_usage_this_session-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/openevse/snapshots/test_sensor.ambr
+++ b/tests/components/openevse/snapshots/test_sensor.ambr
@@ -271,6 +271,62 @@
     'state': '28.7',
   })
 # ---
+# name: test_entities[sensor.openevse_mock_config_total_energy_usage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openevse_mock_config_total_energy_usage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Total energy usage',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'usage_total',
+    'unique_id': 'deadbeeffeed_usage_total',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_entities[sensor.openevse_mock_config_total_energy_usage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'openevse_mock_config Total energy usage',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openevse_mock_config_total_energy_usage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '500.0',
+  })
+# ---
 # name: test_entities[sensor.openevse_mock_config_total_usage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/openevse/snapshots/test_sensor.ambr
+++ b/tests/components/openevse/snapshots/test_sensor.ambr
@@ -35,7 +35,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'ambient_temp',
-    'unique_id': 'deadbeeffeed_ambient_temp',
+    'unique_id': 'deadbeeffeed-ambient_temp',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -91,7 +91,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'charge_time',
-    'unique_id': 'deadbeeffeed_charge_time',
+    'unique_id': 'deadbeeffeed-charge_time',
     'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
   })
 # ---
@@ -142,7 +142,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'status',
-    'unique_id': 'deadbeeffeed_status',
+    'unique_id': 'deadbeeffeed-status',
     'unit_of_measurement': None,
   })
 # ---
@@ -195,7 +195,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'ir_temp',
-    'unique_id': 'deadbeeffeed_ir_temp',
+    'unique_id': 'deadbeeffeed-ir_temp',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -251,7 +251,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'rtc_temp',
-    'unique_id': 'deadbeeffeed_rtc_temp',
+    'unique_id': 'deadbeeffeed-rtc_temp',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -307,7 +307,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'usage_total',
-    'unique_id': 'deadbeeffeed_usage_total',
+    'unique_id': 'deadbeeffeed-usage_total',
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
@@ -363,7 +363,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'usage_session',
-    'unique_id': 'deadbeeffeed_usage_session',
+    'unique_id': 'deadbeeffeed-usage_session',
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---

--- a/tests/components/openevse/snapshots/test_sensor.ambr
+++ b/tests/components/openevse/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_entities[sensor.openevse_ambient_temperature-entry]
+# name: test_entities[sensor.mock_title_ambient_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -14,7 +14,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.openevse_ambient_temperature',
+    'entity_id': 'sensor.mock_title_ambient_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -39,23 +39,23 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_entities[sensor.openevse_ambient_temperature-state]
+# name: test_entities[sensor.mock_title_ambient_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'OpenEVSE Ambient temperature',
+      'friendly_name': 'Mock Title Ambient temperature',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.openevse_ambient_temperature',
+    'entity_id': 'sensor.mock_title_ambient_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25.5',
   })
 # ---
-# name: test_entities[sensor.openevse_charge_time_elapsed-entry]
+# name: test_entities[sensor.mock_title_charge_time_elapsed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -70,7 +70,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.openevse_charge_time_elapsed',
+    'entity_id': 'sensor.mock_title_charge_time_elapsed',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -95,23 +95,23 @@
     'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
   })
 # ---
-# name: test_entities[sensor.openevse_charge_time_elapsed-state]
+# name: test_entities[sensor.mock_title_charge_time_elapsed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
-      'friendly_name': 'OpenEVSE Charge time elapsed',
+      'friendly_name': 'Mock Title Charge time elapsed',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.openevse_charge_time_elapsed',
+    'entity_id': 'sensor.mock_title_charge_time_elapsed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '60.0',
   })
 # ---
-# name: test_entities[sensor.openevse_charging_status-entry]
+# name: test_entities[sensor.mock_title_charging_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -124,7 +124,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.openevse_charging_status',
+    'entity_id': 'sensor.mock_title_charging_status',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -146,20 +146,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[sensor.openevse_charging_status-state]
+# name: test_entities[sensor.mock_title_charging_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'OpenEVSE Charging status',
+      'friendly_name': 'Mock Title Charging status',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.openevse_charging_status',
+    'entity_id': 'sensor.mock_title_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'Charging',
   })
 # ---
-# name: test_entities[sensor.openevse_ir_temperature-entry]
+# name: test_entities[sensor.mock_title_ir_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -174,7 +174,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.openevse_ir_temperature',
+    'entity_id': 'sensor.mock_title_ir_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -199,23 +199,23 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_entities[sensor.openevse_ir_temperature-state]
+# name: test_entities[sensor.mock_title_ir_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'OpenEVSE IR temperature',
+      'friendly_name': 'Mock Title IR temperature',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.openevse_ir_temperature',
+    'entity_id': 'sensor.mock_title_ir_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '30.2',
   })
 # ---
-# name: test_entities[sensor.openevse_rtc_temperature-entry]
+# name: test_entities[sensor.mock_title_rtc_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -230,7 +230,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.openevse_rtc_temperature',
+    'entity_id': 'sensor.mock_title_rtc_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -255,23 +255,23 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_entities[sensor.openevse_rtc_temperature-state]
+# name: test_entities[sensor.mock_title_rtc_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'OpenEVSE RTC temperature',
+      'friendly_name': 'Mock Title RTC temperature',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.openevse_rtc_temperature',
+    'entity_id': 'sensor.mock_title_rtc_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '28.7',
   })
 # ---
-# name: test_entities[sensor.openevse_total_usage-entry]
+# name: test_entities[sensor.mock_title_total_usage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -286,7 +286,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.openevse_total_usage',
+    'entity_id': 'sensor.mock_title_total_usage',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -311,23 +311,23 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_entities[sensor.openevse_total_usage-state]
+# name: test_entities[sensor.mock_title_total_usage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'OpenEVSE Total usage',
+      'friendly_name': 'Mock Title Total usage',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.openevse_total_usage',
+    'entity_id': 'sensor.mock_title_total_usage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '500.0',
   })
 # ---
-# name: test_entities[sensor.openevse_usage_this_session-entry]
+# name: test_entities[sensor.mock_title_usage_this_session-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -342,7 +342,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.openevse_usage_this_session',
+    'entity_id': 'sensor.mock_title_usage_this_session',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -367,16 +367,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_entities[sensor.openevse_usage_this_session-state]
+# name: test_entities[sensor.mock_title_usage_this_session-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'OpenEVSE Usage this session',
+      'friendly_name': 'Mock Title Usage this session',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.openevse_usage_this_session',
+    'entity_id': 'sensor.mock_title_usage_this_session',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/openevse/snapshots/test_sensor.ambr
+++ b/tests/components/openevse/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_entities[sensor.mock_title_ambient_temperature-entry]
+# name: test_entities[sensor.openevse_mock_config_ambient_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -14,7 +14,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.mock_title_ambient_temperature',
+    'entity_id': 'sensor.openevse_mock_config_ambient_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -39,23 +39,23 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_entities[sensor.mock_title_ambient_temperature-state]
+# name: test_entities[sensor.openevse_mock_config_ambient_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Mock Title Ambient temperature',
+      'friendly_name': 'openevse_mock_config Ambient temperature',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.mock_title_ambient_temperature',
+    'entity_id': 'sensor.openevse_mock_config_ambient_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25.5',
   })
 # ---
-# name: test_entities[sensor.mock_title_charge_time_elapsed-entry]
+# name: test_entities[sensor.openevse_mock_config_charge_time_elapsed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -70,7 +70,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.mock_title_charge_time_elapsed',
+    'entity_id': 'sensor.openevse_mock_config_charge_time_elapsed',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -95,23 +95,23 @@
     'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
   })
 # ---
-# name: test_entities[sensor.mock_title_charge_time_elapsed-state]
+# name: test_entities[sensor.openevse_mock_config_charge_time_elapsed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
-      'friendly_name': 'Mock Title Charge time elapsed',
+      'friendly_name': 'openevse_mock_config Charge time elapsed',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.mock_title_charge_time_elapsed',
+    'entity_id': 'sensor.openevse_mock_config_charge_time_elapsed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '60.0',
   })
 # ---
-# name: test_entities[sensor.mock_title_charging_status-entry]
+# name: test_entities[sensor.openevse_mock_config_charging_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -124,7 +124,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.mock_title_charging_status',
+    'entity_id': 'sensor.openevse_mock_config_charging_status',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -146,20 +146,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[sensor.mock_title_charging_status-state]
+# name: test_entities[sensor.openevse_mock_config_charging_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Title Charging status',
+      'friendly_name': 'openevse_mock_config Charging status',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.mock_title_charging_status',
+    'entity_id': 'sensor.openevse_mock_config_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'Charging',
   })
 # ---
-# name: test_entities[sensor.mock_title_ir_temperature-entry]
+# name: test_entities[sensor.openevse_mock_config_ir_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -174,7 +174,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.mock_title_ir_temperature',
+    'entity_id': 'sensor.openevse_mock_config_ir_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -199,23 +199,23 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_entities[sensor.mock_title_ir_temperature-state]
+# name: test_entities[sensor.openevse_mock_config_ir_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Mock Title IR temperature',
+      'friendly_name': 'openevse_mock_config IR temperature',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.mock_title_ir_temperature',
+    'entity_id': 'sensor.openevse_mock_config_ir_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '30.2',
   })
 # ---
-# name: test_entities[sensor.mock_title_rtc_temperature-entry]
+# name: test_entities[sensor.openevse_mock_config_rtc_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -230,7 +230,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.mock_title_rtc_temperature',
+    'entity_id': 'sensor.openevse_mock_config_rtc_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -255,23 +255,23 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_entities[sensor.mock_title_rtc_temperature-state]
+# name: test_entities[sensor.openevse_mock_config_rtc_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Mock Title RTC temperature',
+      'friendly_name': 'openevse_mock_config RTC temperature',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.mock_title_rtc_temperature',
+    'entity_id': 'sensor.openevse_mock_config_rtc_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '28.7',
   })
 # ---
-# name: test_entities[sensor.mock_title_total_usage-entry]
+# name: test_entities[sensor.openevse_mock_config_total_usage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -286,7 +286,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.mock_title_total_usage',
+    'entity_id': 'sensor.openevse_mock_config_total_usage',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -311,23 +311,23 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_entities[sensor.mock_title_total_usage-state]
+# name: test_entities[sensor.openevse_mock_config_total_usage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Mock Title Total usage',
+      'friendly_name': 'openevse_mock_config Total usage',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.mock_title_total_usage',
+    'entity_id': 'sensor.openevse_mock_config_total_usage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '500.0',
   })
 # ---
-# name: test_entities[sensor.mock_title_usage_this_session-entry]
+# name: test_entities[sensor.openevse_mock_config_usage_this_session-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -342,7 +342,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.mock_title_usage_this_session',
+    'entity_id': 'sensor.openevse_mock_config_usage_this_session',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -367,16 +367,16 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_entities[sensor.mock_title_usage_this_session-state]
+# name: test_entities[sensor.openevse_mock_config_usage_this_session-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Mock Title Usage this session',
+      'friendly_name': 'openevse_mock_config Usage this session',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.mock_title_usage_this_session',
+    'entity_id': 'sensor.openevse_mock_config_usage_this_session',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/openevse/test_sensor.py
+++ b/tests/components/openevse/test_sensor.py
@@ -2,63 +2,52 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 
-async def test_sensor_setup(
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: MagicMock,
+) -> None:
+    """Test the sensor entities."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_disabled_by_default_entities(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_charger: MagicMock,
 ) -> None:
-    """Test setting up the sensor platform."""
+    """Test the disabled by default sensor entities."""
     mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Entity IDs are generated from translation keys
-    state = hass.states.get("sensor.openevse_charging_status")
-    assert state is not None
-    assert state.state == "Charging"
-    entry = entity_registry.async_get("sensor.openevse_charging_status")
-    assert entry
-    assert entry.unique_id == "deadbeeffeed_status"
-
-    state = hass.states.get("sensor.openevse_charge_time_elapsed")
-    assert state is not None
-    assert state.state == "60.0"
-    entry = entity_registry.async_get("sensor.openevse_charge_time_elapsed")
-    assert entry
-    assert entry.unique_id == "deadbeeffeed_charge_time"
-
-    state = hass.states.get("sensor.openevse_ambient_temperature")
-    assert state is not None
-    assert state.state == "25.5"
-    entry = entity_registry.async_get("sensor.openevse_ambient_temperature")
-    assert entry
-    assert entry.unique_id == "deadbeeffeed_ambient_temp"
-
-    state = hass.states.get("sensor.openevse_usage_this_session")
-    assert state is not None
-    assert state.state == "15.0"
-    entry = entity_registry.async_get("sensor.openevse_usage_this_session")
-    assert entry
-    assert entry.unique_id == "deadbeeffeed_usage_session"
-
-    state = hass.states.get("sensor.openevse_total_usage")
-    assert state is not None
-    assert state.state == "500.0"
-    entry = entity_registry.async_get("sensor.openevse_total_usage")
-    assert entry
-    assert entry.unique_id == "deadbeeffeed_usage_total"
-
-    # Disabled by default entities
     state = hass.states.get("sensor.openevse_ir_temperature")
     assert state is None
 
+    entry = entity_registry.async_get("sensor.openevse_ir_temperature")
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
     state = hass.states.get("sensor.openevse_rtc_temperature")
     assert state is None
+
+    entry = entity_registry.async_get("sensor.openevse_rtc_temperature")
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION

--- a/tests/components/openevse/test_sensor.py
+++ b/tests/components/openevse/test_sensor.py
@@ -36,18 +36,18 @@ async def test_disabled_by_default_entities(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    state = hass.states.get("sensor.mock_title_ir_temperature")
+    state = hass.states.get("sensor.openevse_mock_config_ir_temperature")
     assert state is None
 
-    entry = entity_registry.async_get("sensor.mock_title_ir_temperature")
+    entry = entity_registry.async_get("sensor.openevse_mock_config_ir_temperature")
     assert entry
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
-    state = hass.states.get("sensor.mock_title_rtc_temperature")
+    state = hass.states.get("sensor.openevse_mock_config_temperature")
     assert state is None
 
-    entry = entity_registry.async_get("sensor.mock_title_rtc_temperature")
+    entry = entity_registry.async_get("sensor.openevse_mock_config_rtc_temperature")
     assert entry
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION

--- a/tests/components/openevse/test_sensor.py
+++ b/tests/components/openevse/test_sensor.py
@@ -3,12 +3,14 @@
 from unittest.mock import MagicMock
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
 
 async def test_sensor_setup(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_charger: MagicMock,
 ) -> None:
@@ -18,30 +20,45 @@ async def test_sensor_setup(
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.charging_status")
+    # Entity IDs are generated from translation keys
+    state = hass.states.get("sensor.openevse_charging_status")
     assert state is not None
     assert state.state == "Charging"
+    entry = entity_registry.async_get("sensor.openevse_charging_status")
+    assert entry
+    assert entry.unique_id == "deadbeeffeed_status"
 
-    state = hass.states.get("sensor.charge_time_elapsed")
+    state = hass.states.get("sensor.openevse_charge_time_elapsed")
     assert state is not None
     assert state.state == "60.0"
+    entry = entity_registry.async_get("sensor.openevse_charge_time_elapsed")
+    assert entry
+    assert entry.unique_id == "deadbeeffeed_charge_time"
 
-    state = hass.states.get("sensor.ambient_temperature")
+    state = hass.states.get("sensor.openevse_ambient_temperature")
     assert state is not None
     assert state.state == "25.5"
+    entry = entity_registry.async_get("sensor.openevse_ambient_temperature")
+    assert entry
+    assert entry.unique_id == "deadbeeffeed_ambient_temp"
 
-    state = hass.states.get("sensor.usage_this_session")
+    state = hass.states.get("sensor.openevse_usage_this_session")
     assert state is not None
     assert state.state == "15.0"
+    entry = entity_registry.async_get("sensor.openevse_usage_this_session")
+    assert entry
+    assert entry.unique_id == "deadbeeffeed_usage_session"
 
-    state = hass.states.get("sensor.total_usage")
+    state = hass.states.get("sensor.openevse_total_usage")
     assert state is not None
     assert state.state == "500.0"
+    entry = entity_registry.async_get("sensor.openevse_total_usage")
+    assert entry
+    assert entry.unique_id == "deadbeeffeed_usage_total"
 
-    state = hass.states.get("sensor.ir_temperature")
-    assert state is not None
-    assert state.state == "30.2"
+    # Disabled by default entities
+    state = hass.states.get("sensor.openevse_ir_temperature")
+    assert state is None
 
-    state = hass.states.get("sensor.rtc_temperature")
-    assert state is not None
-    assert state.state == "28.7"
+    state = hass.states.get("sensor.openevse_rtc_temperature")
+    assert state is None

--- a/tests/components/openevse/test_sensor.py
+++ b/tests/components/openevse/test_sensor.py
@@ -36,18 +36,18 @@ async def test_disabled_by_default_entities(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    state = hass.states.get("sensor.openevse_ir_temperature")
+    state = hass.states.get("sensor.mock_title_ir_temperature")
     assert state is None
 
-    entry = entity_registry.async_get("sensor.openevse_ir_temperature")
+    entry = entity_registry.async_get("sensor.mock_title_ir_temperature")
     assert entry
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
-    state = hass.states.get("sensor.openevse_rtc_temperature")
+    state = hass.states.get("sensor.mock_title_rtc_temperature")
     assert state is None
 
-    entry = entity_registry.async_get("sensor.openevse_rtc_temperature")
+    entry = entity_registry.async_get("sensor.mock_title_rtc_temperature")
     assert entry
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This correctly sets up device info and gives entities a valid unique_id


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
