### PR TITLE
Add HDFury button platform

### DIFF
--- a/homeassistant/components/hdfury/__init__.py
+++ b/homeassistant/components/hdfury/__init__.py
@@ -6,6 +6,7 @@ from homeassistant.core import HomeAssistant
 from .coordinator import HDFuryConfigEntry, HDFuryCoordinator
 
 PLATFORMS = [
+    Platform.BUTTON,
     Platform.SELECT,
 ]
 

--- a/homeassistant/components/hdfury/button.py
+++ b/homeassistant/components/hdfury/button.py
@@ -52,11 +52,9 @@ async def async_setup_entry(
 
     coordinator = entry.runtime_data
 
-    entities: list[HDFuryEntity] = [
+    async_add_entities(
         HDFuryButton(coordinator, description) for description in BUTTONS
-    ]
-
-    async_add_entities(entities)
+    )
 
 
 class HDFuryButton(HDFuryEntity, ButtonEntity):

--- a/homeassistant/components/hdfury/button.py
+++ b/homeassistant/components/hdfury/button.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 
 from hdfury import HDFuryAPI, HDFuryError
 
-from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -26,7 +30,7 @@ class HDFuryButtonEntityDescription(ButtonEntityDescription):
 BUTTONS: tuple[HDFuryButtonEntityDescription, ...] = (
     HDFuryButtonEntityDescription(
         key="reboot",
-        translation_key="reboot",
+        device_class=ButtonDeviceClass.RESTART,
         entity_category=EntityCategory.CONFIG,
         press_fn=lambda client: client.issue_reboot(),
     ),

--- a/homeassistant/components/hdfury/button.py
+++ b/homeassistant/components/hdfury/button.py
@@ -1,0 +1,72 @@
+"""Button platform for HDFury Integration."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from hdfury import HDFuryAPI, HDFuryError
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .entity import HDFuryEntity
+
+
+@dataclass(kw_only=True, frozen=True)
+class HDFuryButtonEntityDescription(ButtonEntityDescription):
+    """Description for HDFury button entities."""
+
+    press_fn: Callable[[HDFuryAPI], Awaitable[None]]
+
+
+BUTTONS: tuple[HDFuryButtonEntityDescription, ...] = (
+    HDFuryButtonEntityDescription(
+        key="reboot",
+        translation_key="reboot",
+        entity_category=EntityCategory.CONFIG,
+        press_fn=lambda client: client.issue_reboot(),
+    ),
+    HDFuryButtonEntityDescription(
+        key="issue_hotplug",
+        translation_key="issue_hotplug",
+        entity_category=EntityCategory.CONFIG,
+        press_fn=lambda client: client.issue_hotplug(),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up buttons using the platform schema."""
+
+    coordinator = entry.runtime_data
+
+    entities: list[HDFuryEntity] = [
+        HDFuryButton(coordinator, description) for description in BUTTONS
+    ]
+
+    async_add_entities(entities)
+
+
+class HDFuryButton(HDFuryEntity, ButtonEntity):
+    """HDFury Button Class."""
+
+    entity_description: HDFuryButtonEntityDescription
+
+    async def async_press(self) -> None:
+        """Handle Button Press."""
+
+        try:
+            await self.entity_description.press_fn(self.coordinator.client)
+        except HDFuryError as error:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from error

--- a/homeassistant/components/hdfury/button.py
+++ b/homeassistant/components/hdfury/button.py
@@ -6,13 +6,13 @@ from dataclasses import dataclass
 from hdfury import HDFuryAPI, HDFuryError
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
+from .coordinator import HDFuryConfigEntry
 from .entity import HDFuryEntity
 
 
@@ -41,7 +41,7 @@ BUTTONS: tuple[HDFuryButtonEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: HDFuryConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up buttons using the platform schema."""

--- a/homeassistant/components/hdfury/icons.json
+++ b/homeassistant/components/hdfury/icons.json
@@ -3,9 +3,6 @@
     "button": {
       "issue_hotplug": {
         "default": "mdi:connection"
-      },
-      "reboot": {
-        "default": "mdi:restart"
       }
     },
     "select": {

--- a/homeassistant/components/hdfury/icons.json
+++ b/homeassistant/components/hdfury/icons.json
@@ -1,5 +1,13 @@
 {
   "entity": {
+    "button": {
+      "issue_hotplug": {
+        "default": "mdi:connection"
+      },
+      "reboot": {
+        "default": "mdi:restart"
+      }
+    },
     "select": {
       "opmode": {
         "default": "mdi:cogs"

--- a/homeassistant/components/hdfury/strings.json
+++ b/homeassistant/components/hdfury/strings.json
@@ -19,6 +19,14 @@
     }
   },
   "entity": {
+    "button": {
+      "issue_hotplug": {
+        "name": "Issue Hotplug"
+      },
+      "reboot": {
+        "name": "Reboot"
+      }
+    },
     "select": {
       "opmode": {
         "name": "Operation mode",

--- a/homeassistant/components/hdfury/strings.json
+++ b/homeassistant/components/hdfury/strings.json
@@ -21,10 +21,7 @@
   "entity": {
     "button": {
       "issue_hotplug": {
-        "name": "Issue Hotplug"
-      },
-      "reboot": {
-        "name": "Reboot"
+        "name": "Issue hotplug"
       }
     },
     "select": {

--- a/tests/components/hdfury/__init__.py
+++ b/tests/components/hdfury/__init__.py
@@ -1,13 +1,19 @@
 """Tests for the HDFury integration."""
 
+from unittest.mock import patch
+
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+async def setup_integration(
+    hass: HomeAssistant, config_entry: MockConfigEntry, platforms: list[Platform]
+) -> None:
     """Fixture for setting up the integration."""
     config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    with patch("homeassistant.components.hdfury.PLATFORMS", platforms):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/components/hdfury/snapshots/test_button.ambr
+++ b/tests/components/hdfury/snapshots/test_button.ambr
@@ -1,0 +1,97 @@
+# serializer version: 1
+# name: test_button_entities[button.hdfury_vrroom_02_issue_hotplug-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.hdfury_vrroom_02_issue_hotplug',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Issue Hotplug',
+    'platform': 'hdfury',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'issue_hotplug',
+    'unique_id': '000123456789_issue_hotplug',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities[button.hdfury_vrroom_02_issue_hotplug-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'HDFury VRROOM-02 Issue Hotplug',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.hdfury_vrroom_02_issue_hotplug',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities[button.hdfury_vrroom_02_reboot-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.hdfury_vrroom_02_reboot',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Reboot',
+    'platform': 'hdfury',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'reboot',
+    'unique_id': '000123456789_reboot',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities[button.hdfury_vrroom_02_reboot-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'HDFury VRROOM-02 Reboot',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.hdfury_vrroom_02_reboot',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/hdfury/snapshots/test_button.ambr
+++ b/tests/components/hdfury/snapshots/test_button.ambr
@@ -24,7 +24,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Issue Hotplug',
+    'original_name': 'Issue hotplug',
     'platform': 'hdfury',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -37,7 +37,7 @@
 # name: test_button_entities[button.hdfury_vrroom_02_issue_hotplug-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'HDFury VRROOM-02 Issue Hotplug',
+      'friendly_name': 'HDFury VRROOM-02 Issue hotplug',
     }),
     'context': <ANY>,
     'entity_id': 'button.hdfury_vrroom_02_issue_hotplug',
@@ -47,7 +47,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_button_entities[button.hdfury_vrroom_02_reboot-entry]
+# name: test_button_entities[button.hdfury_vrroom_02_restart-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -60,7 +60,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.hdfury_vrroom_02_reboot',
+    'entity_id': 'button.hdfury_vrroom_02_restart',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -70,25 +70,26 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
     'original_icon': None,
-    'original_name': 'Reboot',
+    'original_name': 'Restart',
     'platform': 'hdfury',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'reboot',
+    'translation_key': None,
     'unique_id': '000123456789_reboot',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_button_entities[button.hdfury_vrroom_02_reboot-state]
+# name: test_button_entities[button.hdfury_vrroom_02_restart-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'HDFury VRROOM-02 Reboot',
+      'device_class': 'restart',
+      'friendly_name': 'HDFury VRROOM-02 Restart',
     }),
     'context': <ANY>,
-    'entity_id': 'button.hdfury_vrroom_02_reboot',
+    'entity_id': 'button.hdfury_vrroom_02_restart',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/hdfury/test_button.py
+++ b/tests/components/hdfury/test_button.py
@@ -1,4 +1,4 @@
-"""Tests for the HDFury select platform."""
+"""Tests for the HDFury button platform."""
 
 from syrupy.assertion import SnapshotAssertion
 
@@ -11,13 +11,13 @@ from . import setup_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 
-async def test_select_entities(
+async def test_button_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test HDFury select entities."""
+    """Test HDFury button entities."""
 
-    await setup_integration(hass, mock_config_entry, [Platform.SELECT])
+    await setup_integration(hass, mock_config_entry, [Platform.BUTTON])
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)

--- a/tests/components/hdfury/test_button.py
+++ b/tests/components/hdfury/test_button.py
@@ -31,7 +31,7 @@ async def test_button_entities(
 @pytest.mark.parametrize(
     ("entity_id", "method"),
     [
-        ("button.hdfury_vrroom_02_reboot", "issue_reboot"),
+        ("button.hdfury_vrroom_02_restart", "issue_reboot"),
         ("button.hdfury_vrroom_02_issue_hotplug", "issue_hotplug"),
     ],
 )
@@ -71,6 +71,6 @@ async def test_button_press_error(
         await hass.services.async_call(
             "button",
             "press",
-            {"entity_id": "button.hdfury_vrroom_02_reboot"},
+            {"entity_id": "button.hdfury_vrroom_02_restart"},
             blocking=True,
         )

--- a/tests/components/hdfury/test_button.py
+++ b/tests/components/hdfury/test_button.py
@@ -1,9 +1,14 @@
 """Tests for the HDFury button platform."""
 
+from unittest.mock import AsyncMock
+
+from hdfury import HDFuryError
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.entity_registry as er
 
 from . import setup_integration
@@ -21,3 +26,51 @@ async def test_button_entities(
 
     await setup_integration(hass, mock_config_entry, [Platform.BUTTON])
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "method"),
+    [
+        ("button.hdfury_vrroom_02_reboot", "issue_reboot"),
+        ("button.hdfury_vrroom_02_issue_hotplug", "issue_hotplug"),
+    ],
+)
+async def test_button_presses(
+    hass: HomeAssistant,
+    mock_hdfury_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    method: str,
+) -> None:
+    """Test pressing the device buttons."""
+
+    await setup_integration(hass, mock_config_entry, [Platform.BUTTON])
+
+    await hass.services.async_call(
+        "button",
+        "press",
+        {"entity_id": entity_id},
+        blocking=True,
+    )
+
+    getattr(mock_hdfury_client, method).assert_awaited_once()
+
+
+async def test_button_press_error(
+    hass: HomeAssistant,
+    mock_hdfury_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test button press raises HomeAssistantError on API failure."""
+
+    mock_hdfury_client.issue_reboot.side_effect = HDFuryError()
+
+    await setup_integration(hass, mock_config_entry, [Platform.BUTTON])
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": "button.hdfury_vrroom_02_reboot"},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the button platform to the HDFury integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42959
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
