### PR TITLE
MQTT: icon_template for sensor, binary_sensor, number and switch

### DIFF
--- a/homeassistant/components/mqtt/switch.py
+++ b/homeassistant/components/mqtt/switch.py
@@ -137,7 +137,8 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
     @callback
     def _state_message_received(self, msg: ReceiveMessage) -> None:
         """Handle new MQTT state messages."""
-        payload = self._value_template(msg.payload)
+        if (payload := self._value_template(msg.payload)) in self._is_on_map:
+            self._attr_is_on = self._is_on_map[payload]
 
         # Update icon from icon_template, if configured
         if CONF_ICON_TEMPLATE in self._config and self._icon_template:
@@ -155,9 +156,6 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
                     self._attr_icon = icon
                 else:
                     self._attr_icon = None
-
-        if payload in self._is_on_map:
-            self._attr_is_on = self._is_on_map[payload]
 
     @callback
     def _prepare_subscribe_topics(self) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MQTT entities currently do not support icon_template. Thus it is not possible to add custom icons based on the value of the current state. This PR adds this functionality to the generic entities in MQTT. I did not add it to covers, locks, lights or other devices as they already have interpreted states that represent the icon based on the state. 

Entities that now support icon_template: 
* Switch
* Number
* Sensor
* Binary Sensor

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

For testing locally, you can add the following settings to your configuration.yaml

```yaml
mqtt:
  sensor:
    - name: "Test Sensor"
      state_topic: "home/sensor/state"
      unit_of_measurement: "°C"
      icon_template: >
        {% if (value | float) > 25 %}
          mdi:thermometer-high
        {% elif (value | float) < 18 %}
          mdi:thermometer-low
        {% else %}
          mdi:thermometer
        {% endif %}
  switch:
    - name: "Test Switch"
      state_topic: "home/switch/state"
      command_topic: "home/switch/command"
      icon_template: >
        {% if value == 'ON' %}
          mdi:power-plug
        {% else %}
          mdi:power-plug-off
        {% endif %}

  binary_sensor:
    - name: "Test Binary Sensor"
      state_topic: "home/binary_sensor/state"
      icon_template: >
        {% if value == 'ON' %}
          mdi:alert
        {% else %}
          mdi:check-circle
        {% endif %}
  number:
    - name: "Test Number"
      state_topic: "home/number/state"
      command_topic: "home/number/command"
      min: 0
      max: 100
      step: 1
      icon_template: >
        {% if (value | int) > 50 %}
          mdi:numeric-9-box
        {% else %}
          mdi:numeric-0-box
        {% endif %}
```


There have been a few feature requests regarding support for icon_template in mqtt. I created one myself and while creating it I thought I could try to implement it. 

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/orgs/home-assistant/discussions/2383
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: not needed

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

TBD: not yet, which branch should the PR be made to? current or next? 

If the code communicates with devices, web services, or third-party tools:

It does not communicate with other devices besides mqtt. 

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
