### PR TITLE
Overkiz cover - add a service to set cover tilt and position in one command

### DIFF
--- a/homeassistant/components/overkiz/cover/__init__.py
+++ b/homeassistant/components/overkiz/cover/__init__.py
@@ -1,10 +1,14 @@
 """Support for Overkiz covers - shutters etc."""
 
 from pyoverkiz.enums import OverkizCommand, UIClass
+import voluptuous as vol
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    async_get_current_platform,
+)
 
 from .. import OverkizDataConfigEntry
 from .awning import Awning
@@ -39,3 +43,17 @@ async def async_setup_entry(
     ]
 
     async_add_entities(entities)
+
+    platform = async_get_current_platform()
+    platform.async_register_entity_service(
+        "set_cover_position_and_tilt_position",
+        {
+            vol.Required("position"): vol.All(
+                vol.Coerce(int), vol.Range(min=0, max=100)
+            ),
+            vol.Required("tilt_position"): vol.All(
+                vol.Coerce(int), vol.Range(min=0, max=100)
+            ),
+        },
+        "async_set_cover_position_and_tilt_position",
+    )

--- a/homeassistant/components/overkiz/cover/generic_cover.py
+++ b/homeassistant/components/overkiz/cover/generic_cover.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from homeassistant.components.cover import (
+    ATTR_POSITION,
     ATTR_TILT_POSITION,
     CoverEntity,
     CoverEntityFeature,
@@ -43,6 +44,10 @@ COMMANDS_CLOSE_TILT: list[OverkizCommand] = [
 
 COMMANDS_SET_TILT_POSITION: list[OverkizCommand] = [OverkizCommand.SET_ORIENTATION]
 
+COMMANDS_SET_CLOSURE_AND_TILT_POSITION: list[OverkizCommand] = [
+    OverkizCommand.SET_CLOSURE_AND_ORIENTATION
+]
+
 
 class OverkizGenericCover(OverkizEntity, CoverEntity):
     """Representation of an Overkiz Cover."""
@@ -66,6 +71,17 @@ class OverkizGenericCover(OverkizEntity, CoverEntity):
         if command := self.executor.select_command(*COMMANDS_SET_TILT_POSITION):
             await self.executor.async_execute_command(
                 command,
+                100 - kwargs[ATTR_TILT_POSITION],
+            )
+
+    async def async_set_cover_position_and_tilt_position(self, **kwargs: Any) -> None:
+        """Move the cover and tilt to a specific position."""
+        if command := self.executor.select_command(
+            *COMMANDS_SET_CLOSURE_AND_TILT_POSITION
+        ):
+            await self.executor.async_execute_command(
+                command,
+                100 - kwargs[ATTR_POSITION],
                 100 - kwargs[ATTR_TILT_POSITION],
             )
 

--- a/homeassistant/components/overkiz/icons.json
+++ b/homeassistant/components/overkiz/icons.json
@@ -42,5 +42,10 @@
         }
       }
     }
+  },
+  "services": {
+    "set_cover_position_and_tilt_position": {
+      "service": "mdi:window-shutter"
+    }
   }
 }

--- a/homeassistant/components/overkiz/services.yaml
+++ b/homeassistant/components/overkiz/services.yaml
@@ -1,0 +1,23 @@
+set_cover_position_and_tilt_position:
+  fields:
+    position:
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+    tilt_position:
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+  target:
+    entity:
+      integration: overkiz
+      domain: cover
+      supported_features:
+        - cover.CoverEntityFeature.SET_POSITION
+        - cover.CoverEntityFeature.SET_TILT_POSITION

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -179,5 +179,21 @@
         }
       }
     }
+  },
+  "services": {
+    "set_cover_position_and_tilt_position": {
+      "description": "Moves the cover and tilt to a specific position.",
+      "fields": {
+        "position": {
+          "description": "The target position of the cover.",
+          "name": "Position"
+        },
+        "tilt_position": {
+          "description": "The target tilt position of the cover.",
+          "name": "Tilt position"
+        }
+      },
+      "name": "Set cover position and tilt position"
+    }
   }
 }

--- a/tests/components/overkiz/fixtures/setup_cover_with_tilt.json
+++ b/tests/components/overkiz/fixtures/setup_cover_with_tilt.json
@@ -1,0 +1,110 @@
+{
+  "creationTime": 1665238624000,
+  "lastUpdateTime": 1665238624000,
+  "id": "SETUP-****-****-6867",
+  "location": {
+    "creationTime": 1665238624000,
+    "lastUpdateTime": 1667054735000,
+    "city": "** **",
+    "country": "**",
+    "postalCode": "** **",
+    "addressLine1": "** **",
+    "addressLine2": "*",
+    "timezone": "Europe/Amsterdam",
+    "longitude": "**",
+    "latitude": "**",
+    "twilightMode": 2,
+    "twilightAngle": "SOLAR",
+    "twilightCity": "amsterdam",
+    "summerSolsticeDuskMinutes": 1290,
+    "winterSolsticeDuskMinutes": 990,
+    "twilightOffsetEnabled": false,
+    "dawnOffset": 0,
+    "duskOffset": 0,
+    "countryCode": "NL"
+  },
+  "gateways": [
+    {
+      "gatewayId": "****-****-6867",
+      "type": 98,
+      "subType": 1,
+      "placeOID": "41d63e43-bfa8-4e24-8c16-4faae0448cab",
+      "autoUpdateEnabled": true,
+      "alive": true,
+      "timeReliable": true,
+      "connectivity": {
+        "status": "OK",
+        "protocolVersion": "2023.4.4"
+      },
+      "upToDate": true,
+      "updateStatus": "UP_TO_DATE",
+      "syncInProgress": false,
+      "mode": "ACTIVE",
+      "functions": "INTERNET_AUTHORIZATION,SCENARIO_DOWNLOAD,SCENARIO_AUTO_LAUNCHING,SCENARIO_TELECO_LAUNCHING,INTERNET_UPLOAD,INTERNET_UPDATE,TRIGGERS_SENSORS"
+    }
+  ],
+  "devices": [
+    {
+      "creationTime": 1667840384000,
+      "lastUpdateTime": 1667840384000,
+      "label": "Venetian Blind",
+      "deviceURL": "io://****-****-6867/12345678",
+      "shortcut": false,
+      "controllableName": "io:ExteriorVenetianBlindIOComponent",
+      "definition": {
+        "commands": [
+          {
+            "commandName": "close",
+            "nparams": 0
+          },
+          {
+            "commandName": "open",
+            "nparams": 0
+          },
+          {
+            "commandName": "stop",
+            "nparams": 0
+          },
+          {
+            "commandName": "setClosure",
+            "nparams": 1
+          },
+          {
+            "commandName": "setOrientation",
+            "nparams": 1
+          },
+          {
+            "commandName": "setClosureAndOrientation",
+            "nparams": 2
+          }
+        ],
+        "states": [
+          {
+            "type": 1,
+            "name": "core:ClosureState",
+            "value": "0"
+          },
+          {
+            "type": 1,
+            "name": "core:SlateOrientationState",
+            "value": "0"
+          }
+        ],
+        "dataProperties": [],
+        "widgetName": "ExteriorVenetianBlind",
+        "uiProfiles": ["ExteriorVenetianBlind"],
+        "uiClass": "ExteriorVenetianBlind",
+        "qualifiedName": "io:ExteriorVenetianBlindIOComponent",
+        "type": "ACTUATOR"
+      },
+      "attributes": [],
+      "available": true,
+      "enabled": true,
+      "placeOID": "9e3d6899-50bb-4869-9c5e-46c2b57f7c9e",
+      "type": 1,
+      "widget": "ExteriorVenetianBlind",
+      "oid": "1a10d6f6-9bc3-40f3-a33c-e383fd41d3e8",
+      "uiClass": "ExteriorVenetianBlind"
+    }
+  ]
+}

--- a/tests/components/overkiz/test_cover.py
+++ b/tests/components/overkiz/test_cover.py
@@ -1,0 +1,70 @@
+"""Tests for Overkiz cover entities."""
+
+from unittest.mock import patch
+
+from pyoverkiz.enums import OverkizCommand
+import pytest
+
+from homeassistant.components.overkiz.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from . import load_setup_fixture
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize("mock_setup_fixture", ["overkiz/setup_cover_with_tilt.json"])
+async def test_set_cover_position_and_tilt_position(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_setup_fixture: str
+) -> None:
+    """Test set_cover_position_and_tilt_position service."""
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
+        patch(
+            "pyoverkiz.client.OverkizClient.get_setup",
+            return_value=load_setup_fixture(mock_setup_fixture),
+        ),
+        patch(
+            "pyoverkiz.client.OverkizClient.get_scenarios",
+            return_value=[],
+        ),
+        patch(
+            "pyoverkiz.client.OverkizClient.register_event_listener",
+            return_value="1234",
+        ),
+        patch(
+            "pyoverkiz.client.OverkizClient.fetch_events",
+            return_value=[],
+        ),
+        patch("pyoverkiz.client.OverkizClient.execute_command") as mock_execute_command,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        entity_id = "cover.venetian_blind"
+
+        # Position 50, Tilt 20
+        # Expected sent: Closure 50 (100-50), Orientation 80 (100-20)
+        await hass.services.async_call(
+            DOMAIN,
+            "set_cover_position_and_tilt_position",
+            {
+                ATTR_ENTITY_ID: entity_id,
+                "position": 50,
+                "tilt_position": 20,
+            },
+            blocking=True,
+        )
+
+        assert mock_execute_command.call_count == 1
+        call_args = mock_execute_command.call_args
+
+        # Check positional arguments
+        assert call_args.args[0] == "io://****-****-6867/12345678"
+        command = call_args.args[1]
+        assert command.name == OverkizCommand.SET_CLOSURE_AND_ORIENTATION
+        assert command.parameters == [50, 80]
+        assert call_args.args[2] == "Home Assistant"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the covers provided by the overkiz integration support tilt and position settings only separately. This, however, does not work well—for example, in automations where the goal is to set both attributes—because the latter command requires a timeout to allow the first one to finish; otherwise, it halts the execution of the first command.

The new service attempts to fix that behaviour by using the existing `pyoverkiz.enums.OverkizCommand.SET_CLOSURE_AND_ORIENTATION` command from the `pyoverkiz` library, which allows cover position and tilt position to be sent as a single payload.

<img width="1183" height="713" alt="image" src="https://github.com/user-attachments/assets/1ec6ba31-ec6b-4e40-a223-b8d7d023868d" />

This PR is scoped to changes within the `overkiz` integration. However, it could be reworked to add support for actions that set tilt and position simultaneously in the core `cover` integration, allowing the `overkiz` integration to make better use of supported features. At this point, I decided to make this PR smaller by only making it work within the `overkiz`, but I will be glad for any feedback on any potential improvements.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
