### PR TITLE
Fix Climate signal in Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -291,9 +291,7 @@ class TeslemetryStreamingClimateEntity(
             )
         )
         self.async_on_remove(
-            self.vehicle.stream_vehicle.listen_HvacACEnabled(
-                self._async_handle_hvac_ac_enabled
-            )
+            self.vehicle.stream_vehicle.listen_HvacPower(self._async_handle_hvac_power)
         )
         self.async_on_remove(
             self.vehicle.stream_vehicle.listen_ClimateKeeperMode(
@@ -335,9 +333,13 @@ class TeslemetryStreamingClimateEntity(
         self._attr_current_temperature = data
         self.async_write_ha_state()
 
-    def _async_handle_hvac_ac_enabled(self, data: bool | None):
+    def _async_handle_hvac_power(self, data: str | None):
         self._attr_hvac_mode = (
-            None if data is None else HVACMode.HEAT_COOL if data else HVACMode.OFF
+            None
+            if data is None
+            else HVACMode.HEAT_COOL
+            if data == "On"
+            else HVACMode.OFF
         )
         self.async_write_ha_state()
 

--- a/tests/components/teslemetry/test_climate.py
+++ b/tests/components/teslemetry/test_climate.py
@@ -321,7 +321,7 @@ async def test_select_streaming(
             "vin": VEHICLE_DATA_ALT["response"]["vin"],
             "data": {
                 Signal.INSIDE_TEMP: 26,
-                Signal.HVAC_AC_ENABLED: True,
+                Signal.HVAC_POWER: "HvacPowerStateOn",
                 Signal.CLIMATE_KEEPER_MODE: "ClimateKeeperModeOn",
                 Signal.RIGHT_HAND_DRIVE: True,
                 Signal.HVAC_LEFT_TEMPERATURE_REQUEST: 22,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Teslemetry has been using the wrong signal for realtime climate, the old value HvacACPower closely matched, but wasn't always exactly the same as HvacPower, and users started noticing incorrect behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
