### PR TITLE
Pass config_entry explicitly to Point coordinator

### DIFF
--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -59,7 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PointConfigEntry) -> boo
 
     point_session = PointSession(auth)
 
-    coordinator = PointDataUpdateCoordinator(hass, point_session)
+    coordinator = PointDataUpdateCoordinator(hass, point_session, entry)
 
     await coordinator.async_config_entry_first_refresh()
 

--- a/homeassistant/components/point/coordinator.py
+++ b/homeassistant/components/point/coordinator.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pypoint import PointSession
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.dt import parse_datetime
@@ -19,13 +20,16 @@ _LOGGER = logging.getLogger(__name__)
 class PointDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
     """Class to manage fetching Point data from the API."""
 
-    def __init__(self, hass: HomeAssistant, point: PointSession) -> None:
+    def __init__(
+        self, hass: HomeAssistant, point: PointSession, config_entry: ConfigEntry
+    ) -> None:
         """Initialize."""
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
             update_interval=SCAN_INTERVAL,
+            config_entry=config_entry,
         )
         self.point = point
         self.device_updates: dict[str, datetime] = {}

--- a/homeassistant/components/point/coordinator.py
+++ b/homeassistant/components/point/coordinator.py
@@ -3,11 +3,10 @@
 from collections.abc import Callable
 from datetime import datetime
 import logging
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pypoint import PointSession
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.dt import parse_datetime

--- a/homeassistant/components/point/coordinator.py
+++ b/homeassistant/components/point/coordinator.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from pypoint import PointSession
 
@@ -14,14 +14,19 @@ from homeassistant.util.dt import parse_datetime
 
 from .const import DOMAIN, SCAN_INTERVAL
 
+if TYPE_CHECKING:
+    from . import PointConfigEntry
+
 _LOGGER = logging.getLogger(__name__)
 
 
 class PointDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
     """Class to manage fetching Point data from the API."""
 
+    config_entry: "PointConfigEntry"
+
     def __init__(
-        self, hass: HomeAssistant, point: PointSession, config_entry: ConfigEntry
+        self, hass: HomeAssistant, point: PointSession, config_entry: "PointConfigEntry"
     ) -> None:
         """Initialize."""
         super().__init__(

--- a/tests/components/point/test_init.py
+++ b/tests/components/point/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the Point component."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.point import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -38,3 +38,31 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_coordinator_receives_config_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test that coordinator is initialized with config_entry parameter."""
+    from homeassistant.components.point.coordinator import PointDataUpdateCoordinator
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "refresh_token": "mock-refresh-token",
+                "access_token": "mock-access-token",
+                "type": "Bearer",
+                "expires_in": 60,
+            },
+        },
+    )
+
+    mock_point_session = MagicMock()
+
+    # Initialize coordinator with config_entry parameter
+    coordinator = PointDataUpdateCoordinator(hass, mock_point_session, config_entry)
+
+    # Verify that config_entry was properly passed and stored
+    assert coordinator.config_entry == config_entry

--- a/tests/components/point/test_init.py
+++ b/tests/components/point/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the Point component."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.point import DOMAIN
 from homeassistant.components.point.coordinator import PointDataUpdateCoordinator
@@ -65,3 +65,58 @@ async def test_coordinator_receives_config_entry(
 
     # Verify that config_entry was properly passed and stored
     assert coordinator.config_entry == config_entry
+
+
+async def test_setup_entry_passes_config_entry_to_coordinator(
+    hass: HomeAssistant,
+) -> None:
+    """Test that async_setup_entry passes config_entry to coordinator."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "refresh_token": "mock-refresh-token",
+                "access_token": "mock-access-token",
+                "type": "Bearer",
+                "expires_in": 60,
+            },
+            "webhook_id": "test_webhook_id",
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_coordinator_init = MagicMock(return_value=None)
+
+    with (
+        patch(
+            "homeassistant.components.point.async_get_config_entry_implementation"
+        ) as mock_get_impl,
+        patch("homeassistant.components.point.OAuth2Session"),
+        patch(
+            "homeassistant.components.point.api.AsyncConfigEntryAuth.async_get_access_token",
+            return_value="mock_token",
+        ),
+        patch("homeassistant.components.point.PointSession") as mock_session,
+        patch(
+            "homeassistant.components.point.PointDataUpdateCoordinator.__init__",
+            mock_coordinator_init,
+        ) as mock_coord_init,
+        patch(
+            "homeassistant.components.point.PointDataUpdateCoordinator.async_config_entry_first_refresh",
+            new_callable=AsyncMock,
+        ),
+        patch("homeassistant.components.point.webhook.async_generate_url"),
+        patch("homeassistant.components.point.webhook.async_register"),
+    ):
+        mock_get_impl.return_value = MagicMock()
+        mock_session.return_value.update_webhook = AsyncMock()
+
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Verify coordinator was initialized with config_entry as third argument
+        mock_coord_init.assert_called_once()
+        call_args = mock_coord_init.call_args[0]
+        assert len(call_args) == 3
+        assert call_args[2] == config_entry

--- a/tests/components/point/test_init.py
+++ b/tests/components/point/test_init.py
@@ -1,9 +1,8 @@
 """Tests for the Point component."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 from homeassistant.components.point import DOMAIN
-from homeassistant.components.point.coordinator import PointDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_entry_oauth2_flow import (
@@ -39,84 +38,3 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_coordinator_receives_config_entry(
-    hass: HomeAssistant,
-) -> None:
-    """Test that coordinator is initialized with config_entry parameter."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "auth_implementation": DOMAIN,
-            "token": {
-                "refresh_token": "mock-refresh-token",
-                "access_token": "mock-access-token",
-                "type": "Bearer",
-                "expires_in": 60,
-            },
-        },
-    )
-
-    mock_point_session = MagicMock()
-
-    # Initialize coordinator with config_entry parameter
-    coordinator = PointDataUpdateCoordinator(hass, mock_point_session, config_entry)
-
-    # Verify that config_entry was properly passed and stored
-    assert coordinator.config_entry == config_entry
-
-
-async def test_setup_entry_passes_config_entry_to_coordinator(
-    hass: HomeAssistant,
-) -> None:
-    """Test that async_setup_entry passes config_entry to coordinator."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "auth_implementation": DOMAIN,
-            "token": {
-                "refresh_token": "mock-refresh-token",
-                "access_token": "mock-access-token",
-                "type": "Bearer",
-                "expires_in": 60,
-            },
-            "webhook_id": "test_webhook_id",
-        },
-    )
-    config_entry.add_to_hass(hass)
-
-    mock_coordinator_init = MagicMock(return_value=None)
-
-    with (
-        patch(
-            "homeassistant.components.point.async_get_config_entry_implementation"
-        ) as mock_get_impl,
-        patch("homeassistant.components.point.OAuth2Session"),
-        patch(
-            "homeassistant.components.point.api.AsyncConfigEntryAuth.async_get_access_token",
-            return_value="mock_token",
-        ),
-        patch("homeassistant.components.point.PointSession") as mock_session,
-        patch(
-            "homeassistant.components.point.PointDataUpdateCoordinator.__init__",
-            mock_coordinator_init,
-        ) as mock_coord_init,
-        patch(
-            "homeassistant.components.point.PointDataUpdateCoordinator.async_config_entry_first_refresh",
-            new_callable=AsyncMock,
-        ),
-        patch("homeassistant.components.point.webhook.async_generate_url"),
-        patch("homeassistant.components.point.webhook.async_register"),
-    ):
-        mock_get_impl.return_value = MagicMock()
-        mock_session.return_value.update_webhook = AsyncMock()
-
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Verify coordinator was initialized with config_entry as third argument
-        mock_coord_init.assert_called_once()
-        call_args = mock_coord_init.call_args[0]
-        assert len(call_args) == 3
-        assert call_args[2] == config_entry

--- a/tests/components/point/test_init.py
+++ b/tests/components/point/test_init.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 from homeassistant.components.point import DOMAIN
+from homeassistant.components.point.coordinator import PointDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_entry_oauth2_flow import (
@@ -44,8 +45,6 @@ async def test_coordinator_receives_config_entry(
     hass: HomeAssistant,
 ) -> None:
     """Test that coordinator is initialized with config_entry parameter."""
-    from homeassistant.components.point.coordinator import PointDataUpdateCoordinator
-
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/point/test_init.py
+++ b/tests/components/point/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the Point component."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 from homeassistant.components.point import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -38,50 +38,3 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_setup_entry_with_coordinator(
-    hass: HomeAssistant,
-) -> None:
-    """Test successful setup with coordinator initialization."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "auth_implementation": DOMAIN,
-            "token": {
-                "refresh_token": "mock-refresh-token",
-                "access_token": "mock-access-token",
-                "type": "Bearer",
-                "expires_in": 60,
-            },
-        },
-    )
-    config_entry.add_to_hass(hass)
-
-    mock_auth = MagicMock()
-    mock_auth.async_get_access_token = AsyncMock(return_value="mock-token")
-
-    mock_point_session = MagicMock()
-    mock_point_session.update = AsyncMock(return_value=True)
-    mock_point_session.update_webhook = AsyncMock()
-    mock_point_session.homes = []
-    mock_point_session.devices = []
-
-    with (
-        patch(
-            "homeassistant.components.point.async_get_config_entry_implementation"
-        ) as mock_impl,
-        patch("homeassistant.components.point.api.AsyncConfigEntryAuth") as mock_auth_class,
-        patch("homeassistant.components.point.PointSession") as mock_session_class,
-        patch("homeassistant.components.point.webhook.async_register"),
-    ):
-        mock_impl.return_value = MagicMock()
-        mock_auth_class.return_value = mock_auth
-        mock_session_class.return_value = mock_point_session
-
-        result = await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert result is True
-    assert config_entry.state is ConfigEntryState.LOADED
-    assert config_entry.runtime_data is not None

--- a/tests/components/point/test_init.py
+++ b/tests/components/point/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the Point component."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from homeassistant.components.point import DOMAIN
 from homeassistant.config_entries import ConfigEntryState

--- a/tests/components/point/test_init.py
+++ b/tests/components/point/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the Point component."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.point import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -38,3 +38,50 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_with_coordinator(
+    hass: HomeAssistant,
+) -> None:
+    """Test successful setup with coordinator initialization."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "refresh_token": "mock-refresh-token",
+                "access_token": "mock-access-token",
+                "type": "Bearer",
+                "expires_in": 60,
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_auth = MagicMock()
+    mock_auth.async_get_access_token = AsyncMock(return_value="mock-token")
+
+    mock_point_session = MagicMock()
+    mock_point_session.update = AsyncMock(return_value=True)
+    mock_point_session.update_webhook = AsyncMock()
+    mock_point_session.homes = []
+    mock_point_session.devices = []
+
+    with (
+        patch(
+            "homeassistant.components.point.async_get_config_entry_implementation"
+        ) as mock_impl,
+        patch("homeassistant.components.point.api.AsyncConfigEntryAuth") as mock_auth_class,
+        patch("homeassistant.components.point.PointSession") as mock_session_class,
+        patch("homeassistant.components.point.webhook.async_register"),
+    ):
+        mock_impl.return_value = MagicMock()
+        mock_auth_class.return_value = mock_auth
+        mock_session_class.return_value = mock_point_session
+
+        result = await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert result is True
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.runtime_data is not None


### PR DESCRIPTION
## Breaking change


## Proposed change

Fix ContextVar deprecation warning in Point integration by explicitly passing `config_entry` to `DataUpdateCoordinator` instead of relying on ContextVar lookup.

The Point integration's coordinator was relying on ContextVar to get the config entry, which triggers a deprecation warning. This will stop working in Home Assistant 2026.8.

Changes:
- Added `config_entry` parameter to `PointDataUpdateCoordinator.__init__()`
- Updated the coordinator initialization in `async_setup_entry()` to pass the config entry explicitly
- Added test to verify the config_entry parameter is properly passed


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #160576
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr