### PR TITLE
Change device class to energy_storage for some enphase_envoy battery entities

### DIFF
--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -764,7 +764,7 @@ ENCHARGE_AGGREGATE_SENSORS = (
         translation_key="available_energy",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.ENERGY,
+        device_class=SensorDeviceClass.ENERGY_STORAGE,
         value_fn=attrgetter("available_energy"),
     ),
     EnvoyEnchargeAggregateSensorEntityDescription(
@@ -772,14 +772,14 @@ ENCHARGE_AGGREGATE_SENSORS = (
         translation_key="reserve_energy",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.ENERGY,
+        device_class=SensorDeviceClass.ENERGY_STORAGE,
         value_fn=attrgetter("backup_reserve"),
     ),
     EnvoyEnchargeAggregateSensorEntityDescription(
         key="max_capacity",
         translation_key="max_capacity",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
+        device_class=SensorDeviceClass.ENERGY_STORAGE,
         value_fn=attrgetter("max_available_capacity"),
     ),
 )

--- a/tests/components/enphase_envoy/snapshots/test_diagnostics.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_diagnostics.ambr
@@ -9432,7 +9432,7 @@
                   'suggested_display_precision': 0,
                 }),
               }),
-              'original_device_class': 'energy',
+              'original_device_class': 'energy_storage',
               'original_icon': None,
               'original_name': 'Available battery energy',
               'platform': 'enphase_envoy',
@@ -9445,7 +9445,7 @@
             }),
             'state': dict({
               'attributes': dict({
-                'device_class': 'energy',
+                'device_class': 'energy_storage',
                 'friendly_name': 'Envoy <<envoyserial>> Available battery energy',
                 'state_class': 'measurement',
                 'unit_of_measurement': 'Wh',
@@ -9482,7 +9482,7 @@
                   'suggested_display_precision': 0,
                 }),
               }),
-              'original_device_class': 'energy',
+              'original_device_class': 'energy_storage',
               'original_icon': None,
               'original_name': 'Reserve battery energy',
               'platform': 'enphase_envoy',
@@ -9495,7 +9495,7 @@
             }),
             'state': dict({
               'attributes': dict({
-                'device_class': 'energy',
+                'device_class': 'energy_storage',
                 'friendly_name': 'Envoy <<envoyserial>> Reserve battery energy',
                 'state_class': 'measurement',
                 'unit_of_measurement': 'Wh',
@@ -9530,7 +9530,7 @@
                   'suggested_display_precision': 0,
                 }),
               }),
-              'original_device_class': 'energy',
+              'original_device_class': 'energy_storage',
               'original_icon': None,
               'original_name': 'Battery capacity',
               'platform': 'enphase_envoy',
@@ -9543,7 +9543,7 @@
             }),
             'state': dict({
               'attributes': dict({
-                'device_class': 'energy',
+                'device_class': 'energy_storage',
                 'friendly_name': 'Envoy <<envoyserial>> Battery capacity',
                 'unit_of_measurement': 'Wh',
               }),

--- a/tests/components/enphase_envoy/snapshots/test_sensor.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_sensor.ambr
@@ -3802,7 +3802,7 @@
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
     'original_icon': None,
     'original_name': 'Available battery energy',
     'platform': 'enphase_envoy',
@@ -3817,7 +3817,7 @@
 # name: test_sensor[envoy_acb_batt][sensor.envoy_1234_available_battery_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy',
+      'device_class': 'energy_storage',
       'friendly_name': 'Envoy 1234 Available battery energy',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
@@ -3968,7 +3968,7 @@
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
     'original_icon': None,
     'original_name': 'Battery capacity',
     'platform': 'enphase_envoy',
@@ -3983,7 +3983,7 @@
 # name: test_sensor[envoy_acb_batt][sensor.envoy_1234_battery_capacity-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy',
+      'device_class': 'energy_storage',
       'friendly_name': 'Envoy 1234 Battery capacity',
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
@@ -7480,7 +7480,7 @@
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
     'original_icon': None,
     'original_name': 'Reserve battery energy',
     'platform': 'enphase_envoy',
@@ -7495,7 +7495,7 @@
 # name: test_sensor[envoy_acb_batt][sensor.envoy_1234_reserve_battery_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy',
+      'device_class': 'energy_storage',
       'friendly_name': 'Envoy 1234 Reserve battery energy',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
@@ -9055,7 +9055,7 @@
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
     'original_icon': None,
     'original_name': 'Available battery energy',
     'platform': 'enphase_envoy',
@@ -9070,7 +9070,7 @@
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_available_battery_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy',
+      'device_class': 'energy_storage',
       'friendly_name': 'Envoy 1234 Available battery energy',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
@@ -9221,7 +9221,7 @@
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
     'original_icon': None,
     'original_name': 'Battery capacity',
     'platform': 'enphase_envoy',
@@ -9236,7 +9236,7 @@
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_battery_capacity-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy',
+      'device_class': 'energy_storage',
       'friendly_name': 'Envoy 1234 Battery capacity',
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
@@ -12733,7 +12733,7 @@
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
     'original_icon': None,
     'original_name': 'Reserve battery energy',
     'platform': 'enphase_envoy',
@@ -12748,7 +12748,7 @@
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_reserve_battery_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy',
+      'device_class': 'energy_storage',
       'friendly_name': 'Envoy 1234 Reserve battery energy',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
@@ -14711,7 +14711,7 @@
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
     'original_icon': None,
     'original_name': 'Available battery energy',
     'platform': 'enphase_envoy',
@@ -14726,7 +14726,7 @@
 # name: test_sensor[envoy_metered_batt_relay][sensor.envoy_1234_available_battery_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy',
+      'device_class': 'energy_storage',
       'friendly_name': 'Envoy 1234 Available battery energy',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
@@ -15054,7 +15054,7 @@
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
     'original_icon': None,
     'original_name': 'Battery capacity',
     'platform': 'enphase_envoy',
@@ -15069,7 +15069,7 @@
 # name: test_sensor[envoy_metered_batt_relay][sensor.envoy_1234_battery_capacity-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy',
+      'device_class': 'energy_storage',
       'friendly_name': 'Envoy 1234 Battery capacity',
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
@@ -21725,7 +21725,7 @@
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
     'original_icon': None,
     'original_name': 'Reserve battery energy',
     'platform': 'enphase_envoy',
@@ -21740,7 +21740,7 @@
 # name: test_sensor[envoy_metered_batt_relay][sensor.envoy_1234_reserve_battery_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy',
+      'device_class': 'energy_storage',
       'friendly_name': 'Envoy 1234 Reserve battery energy',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,

--- a/tests/components/enphase_envoy/test_sensor.py
+++ b/tests/components/enphase_envoy/test_sensor.py
@@ -1264,3 +1264,35 @@ async def test_fw_update(
 
     assert "firmware changed from: " in caplog.text
     assert "to: 0.0.0, reloading enphase envoy integration" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy",
+        "envoy_1p_metered",
+        "envoy_eu_batt",
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+        "envoy_tot_cons_metered",
+        "envoy_acb_batt",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_no_state_class_warnings(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_envoy: AsyncMock,
+    entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test enphase_envoy sensor creation does not result in deviceclass/state_class warnings."""
+    logging.getLogger("homeassistant.components.enphase_envoy").setLevel(logging.DEBUG)
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    # Simple test to verify no sensor device class / state class mismatch warning is reported
+    #
+    # assert "which is impossible considering" not in caplog.text
+    assert "create a bug report at" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

3 Battery sensors that represent battery energy content is some way, have device_class Energy and state_class Measurement. These are not compatible and a warning is issued in the log.

This PR:
- changes the device class for these 3 sensors to SensorDeviceClass.ENERGY_STORAGE.
- adds a simple test to detect such a warning in the log file.
- updates 2 test snapshot files for the changed device class.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #157935
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
