### PR TITLE
Add HDFury diagnostics

### DIFF
--- a/homeassistant/components/hdfury/diagnostics.py
+++ b/homeassistant/components/hdfury/diagnostics.py
@@ -1,0 +1,21 @@
+"""Diagnostics for HDFury Integration."""
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .coordinator import HDFuryCoordinator
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: HDFuryCoordinator = entry.runtime_data
+
+    return {
+        "board": coordinator.data.board,
+        "info": coordinator.data.info,
+        "config": coordinator.data.config,
+    }

--- a/homeassistant/components/hdfury/quality_scale.yaml
+++ b/homeassistant/components/hdfury/quality_scale.yaml
@@ -43,7 +43,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info: todo
   discovery: todo
   docs-data-update: todo

--- a/tests/components/hdfury/snapshots/test_diagnostics.ambr
+++ b/tests/components/hdfury/snapshots/test_diagnostics.ambr
@@ -1,0 +1,30 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'board': dict({
+      'hostname': 'VRROOM-02',
+      'ipaddress': '192.168.1.123',
+      'pcbv': '3',
+      'serial': '000123456789',
+      'version': 'FW: 0.61',
+    }),
+    'config': dict({
+      'autosw': '1',
+      'htpcmode0': '0',
+      'htpcmode1': '0',
+      'htpcmode2': '0',
+      'htpcmode3': '0',
+      'iractive': '1',
+      'macaddr': 'c7:1c:df:9d:f6:40',
+      'mutetx0': '1',
+      'mutetx1': '1',
+      'oled': '1',
+      'relay': '0',
+    }),
+    'info': dict({
+      'opmode': '0',
+      'portseltx0': '0',
+      'portseltx1': '4',
+    }),
+  })
+# ---

--- a/tests/components/hdfury/test_diagnostics.py
+++ b/tests/components/hdfury/test_diagnostics.py
@@ -1,0 +1,31 @@
+"""Tests for the HDFury diagnostics."""
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.hdfury import PLATFORMS
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test HDFury diagnostics."""
+
+    await setup_integration(hass, mock_config_entry, PLATFORMS)
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert diagnostics == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the diagnostics to the HDFury integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
