### PR TITLE
Fix TOU mode validation to accept hyphenated format

### DIFF
--- a/homeassistant/components/growatt_server/services.py
+++ b/homeassistant/components/growatt_server/services.py
@@ -97,16 +97,19 @@ async def async_register_services(hass: HomeAssistant) -> None:
             )
 
         # Validate and convert batt_mode string to integer
+        # Normalize hyphenated format to underscore format for compatibility
+        batt_mode_normalized = batt_mode_str.replace("-", "_")
+
         valid_modes = {
             "load_first": BATT_MODE_LOAD_FIRST,
             "battery_first": BATT_MODE_BATTERY_FIRST,
             "grid_first": BATT_MODE_GRID_FIRST,
         }
-        if batt_mode_str not in valid_modes:
+        if batt_mode_normalized not in valid_modes:
             raise ServiceValidationError(
                 f"batt_mode must be one of {list(valid_modes.keys())}, got '{batt_mode_str}'"
             )
-        batt_mode: int = valid_modes[batt_mode_str]
+        batt_mode: int = valid_modes[batt_mode_normalized]
 
         # Convert time strings to datetime.time objects
         # UI time selector sends HH:MM:SS, but we only need HH:MM (strip seconds)


### PR DESCRIPTION
## Breaking change

N/A - This is a bugfix only.

## Proposed change

Fixes a validation error in the `update_time_segment` service where battery mode values sent from the Home Assistant UI in hyphenated format (battery-first, grid-first, load-first) were being rejected.

The root cause is that when using `translation_key` in the service selector configuration, the UI may send hyphenated format values, but the service validation only accepted underscore format (battery_first, grid_first, load_first).

This PR adds normalization to convert hyphens to underscores before validation, allowing both formats to work correctly while maintaining backward compatibility.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr