### PR TITLE
Improve polling error messages for Telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -24,13 +24,13 @@ async def async_setup_platform(
     return pollbot
 
 
-async def process_error(update: object, context: CallbackContext) -> None:
+async def process_error(bot: Bot, update: object, context: CallbackContext) -> None:
     """Telegram bot error handler."""
     if context.error:
-        error_callback(context.error, update)
+        error_callback(bot, context.error, update)
 
 
-def error_callback(error: Exception, update: object | None = None) -> None:
+def error_callback(bot: Bot, error: Exception, update: object | None = None) -> None:
     """Log the error."""
     try:
         raise error
@@ -39,9 +39,17 @@ def error_callback(error: Exception, update: object | None = None) -> None:
         pass
     except TelegramError:
         if update is not None:
-            _LOGGER.error('Update "%s" caused error: "%s"', update, error)
+            _LOGGER.error(
+                '[%s %s] Update "%s" caused error: "%s"',
+                bot.username,
+                bot.id,
+                update,
+                error,
+            )
         else:
-            _LOGGER.error("%s: %s", error.__class__.__name__, error)
+            _LOGGER.error(
+                "[%s %s] %s: %s", bot.username, bot.id, error.__class__.__name__, error
+            )
 
 
 class PollBot(BaseTelegramBot):
@@ -58,7 +66,9 @@ class PollBot(BaseTelegramBot):
         self.bot = bot
         self.application = ApplicationBuilder().bot(self.bot).build()
         self.application.add_handler(TypeHandler(Update, self.handle_update))
-        self.application.add_error_handler(process_error)
+        self.application.add_error_handler(
+            lambda update, context: process_error(self.bot, update, context)
+        )
 
     async def shutdown(self) -> None:
         """Shutdown the app."""
@@ -66,16 +76,18 @@ class PollBot(BaseTelegramBot):
 
     async def start_polling(self) -> None:
         """Start the polling task."""
-        _LOGGER.debug("Starting polling")
         await self.application.initialize()
         if self.application.updater:
-            await self.application.updater.start_polling(error_callback=error_callback)
+            await self.application.updater.start_polling(
+                error_callback=lambda error: error_callback(self.bot, error, None)
+            )
         await self.application.start()
+        _LOGGER.info("[%s %s] Started polling", self.bot.username, self.bot.id)
 
     async def stop_polling(self) -> None:
         """Stop the polling task."""
-        _LOGGER.debug("Stopping polling")
         if self.application.updater:
             await self.application.updater.stop()
         await self.application.stop()
         await self.application.shutdown()
+        _LOGGER.info("[%s %s] Stopped polling", self.bot.username, self.bot.id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updated error messages for the Telegram polling bot to identify which bot is throwing the error.
This is useful in troubleshooting a setup with multiple bots configured.

The start/stop polling messages are also updated from debug level to info.
These messages are only logged when the config entry is loaded/unloaded so they shouldn't clutter the log file.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
