### PR TITLE
Bump python-bsblan to version 4.1.0

### DIFF
--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -112,10 +112,16 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
         return self.coordinator.data.state.target_temperature.value
 
     @property
+    def _hvac_mode_value(self) -> int | str | None:
+        """Return the raw hvac_mode value from the coordinator."""
+        if (hvac_mode := self.coordinator.data.state.hvac_mode) is None:
+            return None
+        return hvac_mode.value
+
+    @property
     def hvac_mode(self) -> HVACMode | None:
         """Return hvac operation ie. heat, cool mode."""
-        hvac_mode_value = self.coordinator.data.state.hvac_mode.value
-        if hvac_mode_value is None:
+        if (hvac_mode_value := self._hvac_mode_value) is None:
             return None
         # BSB-Lan returns integer values: 0=off, 1=auto, 2=eco, 3=heat
         if isinstance(hvac_mode_value, int):
@@ -125,9 +131,8 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
-        hvac_mode_value = self.coordinator.data.state.hvac_mode.value
         # BSB-Lan mode 2 is eco/reduced mode
-        if hvac_mode_value == 2:
+        if self._hvac_mode_value == 2:
             return PRESET_ECO
         return PRESET_NONE
 

--- a/homeassistant/components/bsblan/entity.py
+++ b/homeassistant/components/bsblan/entity.py
@@ -29,7 +29,11 @@ class BSBLanEntityBase[_T: BSBLanCoordinator](CoordinatorEntity[_T]):
             connections={(CONNECTION_NETWORK_MAC, format_mac(mac))},
             name=data.device.name,
             manufacturer="BSBLAN Inc.",
-            model=data.info.device_identification.value,
+            model=(
+                data.info.device_identification.value
+                if data.info.device_identification
+                else None
+            ),
             sw_version=data.device.version,
             configuration_url=f"http://{host}",
         )

--- a/homeassistant/components/bsblan/manifest.json
+++ b/homeassistant/components/bsblan/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["bsblan"],
-  "requirements": ["python-bsblan==3.1.6"],
+  "requirements": ["python-bsblan==4.0.0"],
   "zeroconf": [
     {
       "name": "bsb-lan*",

--- a/homeassistant/components/bsblan/manifest.json
+++ b/homeassistant/components/bsblan/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["bsblan"],
-  "requirements": ["python-bsblan==4.0.0"],
+  "requirements": ["python-bsblan==4.1.0"],
   "zeroconf": [
     {
       "name": "bsb-lan*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2481,7 +2481,7 @@ python-awair==0.2.5
 python-blockchain-api==0.0.2
 
 # homeassistant.components.bsblan
-python-bsblan==3.1.6
+python-bsblan==4.0.0
 
 # homeassistant.components.citybikes
 python-citybikes==0.3.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2481,7 +2481,7 @@ python-awair==0.2.5
 python-blockchain-api==0.0.2
 
 # homeassistant.components.bsblan
-python-bsblan==4.0.0
+python-bsblan==4.1.0
 
 # homeassistant.components.citybikes
 python-citybikes==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2098,7 +2098,7 @@ python-MotionMount==2.3.0
 python-awair==0.2.5
 
 # homeassistant.components.bsblan
-python-bsblan==3.1.6
+python-bsblan==4.0.0
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2098,7 +2098,7 @@ python-MotionMount==2.3.0
 python-awair==0.2.5
 
 # homeassistant.components.bsblan
-python-bsblan==4.0.0
+python-bsblan==4.1.0
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -159,6 +159,30 @@ async def test_climate_hvac_mode_none_value(
     assert state.state == "unknown"
 
 
+async def test_climate_hvac_mode_object_none(
+    hass: HomeAssistant,
+    mock_bsblan: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test climate entity when hvac_mode object itself is None."""
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
+
+    # Set hvac_mode to None (the object itself, not just the value)
+    mock_bsblan.state.return_value.hvac_mode = None
+
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # State should be unknown when hvac_mode object is None
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "unknown"
+    # preset_mode should be "none" when hvac_mode object is None
+    assert state.attributes["preset_mode"] == PRESET_NONE
+
+
 async def test_climate_hvac_mode_string_fallback(
     hass: HomeAssistant,
     mock_bsblan: AsyncMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/liudger/python-bsblan/compare/v3.1.6...v4.1.0
https://github.com/liudger/python-bsblan/releases/tag/v4.0.0

This pull request updates the BSBLan integration for Home Assistant to improve robustness when handling missing device data and to support the latest version of the `python-bsblan` library. The changes ensure that the integration can gracefully handle cases where certain attributes (like `hvac_mode` or device identification) may be absent, and adds test coverage for these scenarios.

**Dependency update:**
- Upgraded the `python-bsblan` library to version 4.1.0 in `manifest.json`, `requirements_all.txt`, and `requirements_test_all.txt` to support new features and fixes. [[1]](diffhunk://#diff-fbd49835c369530338a67413a9b235d801f9a0affb21aa1a4645440499c5fef6L10-R10) [[2]](diffhunk://#diff-ae66cd41e5a8644fe0cdd7b9a2f0fee97b5deabe5f3793da15b73fa6353d2128L2484-R2484) [[3]](diffhunk://#diff-f946654c97927cbf41d54a07e10b9f92e95e9a43c0a7e2455d30acc696f08019L2101-R2101)

**Robustness improvements for missing attributes:**
- In `climate.py`, added the `_hvac_mode_value` property to safely handle cases where the `hvac_mode` object itself may be `None`, preventing attribute errors in both the `hvac_mode` and `preset_mode` properties. [[1]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729R114-R124) [[2]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L128-R135)
- In `entity.py`, updated the initialization of the `model` attribute to handle cases where `device_identification` may be missing, setting it to `None` if absent.

**Testing enhancements:**
- Added a new test in `test_climate.py` to verify that the climate entity behaves correctly when the `hvac_mode` object is `None`, ensuring the state is set to "unknown" and the preset mode is "none".

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
