### PR TITLE
Use load_json_object_fixture in tests for NINA

### DIFF
--- a/homeassistant/components/nina/quality_scale.yaml
+++ b/homeassistant/components/nina/quality_scale.yaml
@@ -47,7 +47,6 @@ rules:
   test-coverage:
     status: todo
     comment: |
-      Use load_json_object_fixture in tests
       Patch the library instead of the HTTP requests
       Create a shared fixture for the mock config entry
       Use init_integration in tests

--- a/tests/components/nina/__init__.py
+++ b/tests/components/nina/__init__.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_fixture, load_json_object_fixture
 
 
 async def setup_platform(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
@@ -24,20 +24,20 @@ async def setup_platform(hass: HomeAssistant, config_entry: MockConfigEntry) -> 
 
 def mocked_request_function(url: str) -> dict[str, Any]:
     """Mock of the request function."""
-    dummy_response: dict[str, Any] = json.loads(
+    dummy_response: list[dict[str, Any]] = json.loads(
         load_fixture("sample_warnings.json", "nina")
     )
 
-    dummy_response_details: dict[str, Any] = json.loads(
-        load_fixture("sample_warning_details.json", "nina")
+    dummy_response_details: dict[str, Any] = load_json_object_fixture(
+        "sample_warning_details.json", "nina"
     )
 
-    dummy_response_regions: dict[str, Any] = json.loads(
-        load_fixture("sample_regions.json", "nina")
+    dummy_response_regions: dict[str, Any] = load_json_object_fixture(
+        "sample_regions.json", "nina"
     )
 
-    dummy_response_labels: dict[str, Any] = json.loads(
-        load_fixture("sample_labels.json", "nina")
+    dummy_response_labels: dict[str, Any] = load_json_object_fixture(
+        "sample_labels.json", "nina"
     )
 
     if "https://warnung.bund.de/api31/dashboard/" in url:  # codespell:ignore bund

--- a/tests/components/nina/__init__.py
+++ b/tests/components/nina/__init__.py
@@ -3,6 +3,7 @@
 from typing import Any
 from unittest.mock import patch
 
+from homeassistant.components.nina.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -28,19 +29,19 @@ async def setup_platform(hass: HomeAssistant, config_entry: MockConfigEntry) -> 
 def mocked_request_function(url: str) -> dict[str, Any]:
     """Mock of the request function."""
     dummy_response: list[dict[str, Any]] = load_json_array_fixture(
-        "sample_warnings.json", "nina"
+        "sample_warnings.json", DOMAIN
     )
 
     dummy_response_details: dict[str, Any] = load_json_object_fixture(
-        "sample_warning_details.json", "nina"
+        "sample_warning_details.json", DOMAIN
     )
 
     dummy_response_regions: dict[str, Any] = load_json_object_fixture(
-        "sample_regions.json", "nina"
+        "sample_regions.json", DOMAIN
     )
 
     dummy_response_labels: dict[str, Any] = load_json_object_fixture(
-        "sample_labels.json", "nina"
+        "sample_labels.json", DOMAIN
     )
 
     if "https://warnung.bund.de/api31/dashboard/" in url:  # codespell:ignore bund

--- a/tests/components/nina/__init__.py
+++ b/tests/components/nina/__init__.py
@@ -1,13 +1,16 @@
 """Tests for the Nina integration."""
 
-import json
 from typing import Any
 from unittest.mock import patch
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture, load_json_object_fixture
+from tests.common import (
+    MockConfigEntry,
+    load_json_array_fixture,
+    load_json_object_fixture,
+)
 
 
 async def setup_platform(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
@@ -24,8 +27,8 @@ async def setup_platform(hass: HomeAssistant, config_entry: MockConfigEntry) -> 
 
 def mocked_request_function(url: str) -> dict[str, Any]:
     """Mock of the request function."""
-    dummy_response: list[dict[str, Any]] = json.loads(
-        load_fixture("sample_warnings.json", "nina")
+    dummy_response: list[dict[str, Any]] = load_json_array_fixture(
+        "sample_warnings.json", "nina"
     )
 
     dummy_response_details: dict[str, Any] = load_json_object_fixture(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace the usage of `json.loads(load_fixture())` by using `load_json_object_fixture` and `load_json_array_fixture` where possible. 



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
