### PR TITLE
Complete entity name and icon translations in FRITZ!Box Tools

### DIFF
--- a/homeassistant/components/fritz/button.py
+++ b/homeassistant/components/fritz/button.py
@@ -164,13 +164,12 @@ def _async_wol_buttons_list(
 class FritzBoxWOLButton(FritzDeviceBase, ButtonEntity):
     """Defines a FRITZ!Box Tools Wake On LAN button."""
 
-    _attr_icon = "mdi:lan-pending"
     _attr_entity_registry_enabled_default = False
+    _attr_translation_key = "wake_on_lan"
 
     def __init__(self, avm_wrapper: AvmWrapper, device: FritzDevice) -> None:
         """Initialize Fritz!Box WOL button."""
         super().__init__(avm_wrapper, device)
-        self._name = f"{self.hostname} Wake on LAN"
         self._attr_unique_id = f"{self._mac}_wake_on_lan"
         self._is_available = True
 

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DEFAULT_DEVICE_NAME
 from .coordinator import FRITZ_DATA_KEY, AvmWrapper, FritzConfigEntry, FritzData
 from .entity import FritzDeviceBase
 from .helpers import device_filter_out_from_trackers
@@ -71,6 +72,7 @@ class FritzBoxTracker(FritzDeviceBase, ScannerEntity):
     def __init__(self, avm_wrapper: AvmWrapper, device: FritzDevice) -> None:
         """Initialize a FRITZ!Box device."""
         super().__init__(avm_wrapper, device)
+        self._attr_name: str = device.hostname or DEFAULT_DEVICE_NAME
         self._last_activity: datetime.datetime | None = device.last_activity
 
     @property

--- a/homeassistant/components/fritz/entity.py
+++ b/homeassistant/components/fritz/entity.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DEFAULT_DEVICE_NAME, DOMAIN
+from .const import DOMAIN
 from .coordinator import AvmWrapper
 from .models import FritzDevice
 
@@ -21,20 +21,16 @@ from .models import FritzDevice
 class FritzDeviceBase(CoordinatorEntity[AvmWrapper]):
     """Entity base class for a device connected to a FRITZ!Box device."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, avm_wrapper: AvmWrapper, device: FritzDevice) -> None:
         """Initialize a FRITZ!Box device."""
         super().__init__(avm_wrapper)
         self._avm_wrapper = avm_wrapper
         self._mac: str = device.mac_address
-        self._name: str = device.hostname or DEFAULT_DEVICE_NAME
         self._attr_device_info = DeviceInfo(
             connections={(dr.CONNECTION_NETWORK_MAC, device.mac_address)}
         )
-
-    @property
-    def name(self) -> str:
-        """Return device name."""
-        return self._name
 
     @property
     def ip_address(self) -> str | None:

--- a/homeassistant/components/fritz/icons.json
+++ b/homeassistant/components/fritz/icons.json
@@ -3,6 +3,9 @@
     "button": {
       "cleanup": {
         "default": "mdi:broom"
+      },
+      "wake_on_lan": {
+        "default": "mdi:lan-pending"
       }
     },
     "sensor": {
@@ -47,6 +50,11 @@
       },
       "max_kb_s_sent": {
         "default": "mdi:upload"
+      }
+    },
+    "switch": {
+      "internet_access": {
+        "default": "mdi:router-wireless-settings"
       }
     }
   },

--- a/homeassistant/components/fritz/manifest.json
+++ b/homeassistant/components/fritz/manifest.json
@@ -8,6 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["fritzconnection"],
+  "quality_scale": "bronze",
   "requirements": ["fritzconnection[qr]==1.15.0", "xmltodict==1.0.2"],
   "ssdp": [
     {

--- a/homeassistant/components/fritz/quality_scale.yaml
+++ b/homeassistant/components/fritz/quality_scale.yaml
@@ -13,9 +13,7 @@ rules:
   docs-removal-instructions: done
   entity-event-setup: done
   entity-unique-id: done
-  has-entity-name:
-    status: todo
-    comment: partially done
+  has-entity-name: done
   runtime-data: done
   test-before-configure: done
   test-before-setup: done

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -108,6 +108,9 @@
       },
       "reconnect": {
         "name": "Reconnect"
+      },
+      "wake_on_lan": {
+        "name": "Wake on LAN"
       }
     },
     "sensor": {
@@ -161,6 +164,11 @@
       },
       "max_kb_s_sent": {
         "name": "Max connection upload throughput"
+      }
+    },
+    "switch": {
+      "internet_access": {
+        "name": "Internet Access"
       }
     }
   },

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -168,7 +168,7 @@
     },
     "switch": {
       "internet_access": {
-        "name": "Internet Access"
+        "name": "Internet access"
       }
     }
   },

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -499,13 +499,12 @@ class FritzBoxDeflectionSwitch(FritzBoxBaseCoordinatorSwitch):
 class FritzBoxProfileSwitch(FritzDeviceBase, SwitchEntity):
     """Defines a FRITZ!Box Tools DeviceProfile switch."""
 
-    _attr_icon = "mdi:router-wireless-settings"
+    _attr_translation_key = "internet_access"
 
     def __init__(self, avm_wrapper: AvmWrapper, device: FritzDevice) -> None:
         """Init Fritz profile."""
         super().__init__(avm_wrapper, device)
         self._attr_is_on: bool = False
-        self._name = f"{device.hostname} Internet Access"
         self._attr_unique_id = f"{self._mac}_internet_access"
         self._attr_entity_category = EntityCategory.CONFIG
 

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1390,7 +1390,6 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "freebox",
     "freedns",
     "freedompro",
-    "fritz",
     "fritzbox",
     "fritzbox_callmonitor",
     "frontier_silicon",

--- a/tests/components/fritz/snapshots/test_button.ambr
+++ b/tests/components/fritz/snapshots/test_button.ambr
@@ -208,7 +208,7 @@
     'domain': 'button',
     'entity_category': None,
     'entity_id': 'button.printer_wake_on_lan',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -218,13 +218,13 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:lan-pending',
-    'original_name': 'printer Wake on LAN',
+    'original_icon': None,
+    'original_name': 'Wake on LAN',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'wake_on_lan',
     'unique_id': 'AA:BB:CC:00:11:22_wake_on_lan',
     'unit_of_measurement': None,
   })
@@ -233,7 +233,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'printer Wake on LAN',
-      'icon': 'mdi:lan-pending',
     }),
     'context': <ANY>,
     'entity_id': 'button.printer_wake_on_lan',

--- a/tests/components/fritz/snapshots/test_switch.ambr
+++ b/tests/components/fritz/snapshots/test_switch.ambr
@@ -122,7 +122,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Internet Access',
+    'original_name': 'Internet access',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -135,7 +135,7 @@
 # name: test_switch_setup[fc_data0][switch.printer_internet_access-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'printer Internet Access',
+      'friendly_name': 'printer Internet access',
     }),
     'context': <ANY>,
     'entity_id': 'switch.printer_internet_access',
@@ -268,7 +268,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Internet Access',
+    'original_name': 'Internet access',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -281,7 +281,7 @@
 # name: test_switch_setup[fc_data1][switch.printer_internet_access-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'printer Internet Access',
+      'friendly_name': 'printer Internet access',
     }),
     'context': <ANY>,
     'entity_id': 'switch.printer_internet_access',
@@ -414,7 +414,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Internet Access',
+    'original_name': 'Internet access',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -427,7 +427,7 @@
 # name: test_switch_setup[fc_data2][switch.printer_internet_access-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'printer Internet Access',
+      'friendly_name': 'printer Internet access',
     }),
     'context': <ANY>,
     'entity_id': 'switch.printer_internet_access',
@@ -566,7 +566,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Internet Access',
+    'original_name': 'Internet access',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -579,7 +579,7 @@
 # name: test_switch_setup[fc_data3][switch.printer_internet_access-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'printer Internet Access',
+      'friendly_name': 'printer Internet access',
     }),
     'context': <ANY>,
     'entity_id': 'switch.printer_internet_access',

--- a/tests/components/fritz/snapshots/test_switch.ambr
+++ b/tests/components/fritz/snapshots/test_switch.ambr
@@ -111,7 +111,7 @@
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
     'entity_id': 'switch.printer_internet_access',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -121,13 +121,13 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:router-wireless-settings',
-    'original_name': 'printer Internet Access',
+    'original_icon': None,
+    'original_name': 'Internet Access',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'internet_access',
     'unique_id': 'AA:BB:CC:00:11:22_internet_access',
     'unit_of_measurement': None,
   })
@@ -136,7 +136,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'printer Internet Access',
-      'icon': 'mdi:router-wireless-settings',
     }),
     'context': <ANY>,
     'entity_id': 'switch.printer_internet_access',
@@ -258,7 +257,7 @@
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
     'entity_id': 'switch.printer_internet_access',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -268,13 +267,13 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:router-wireless-settings',
-    'original_name': 'printer Internet Access',
+    'original_icon': None,
+    'original_name': 'Internet Access',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'internet_access',
     'unique_id': 'AA:BB:CC:00:11:22_internet_access',
     'unit_of_measurement': None,
   })
@@ -283,7 +282,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'printer Internet Access',
-      'icon': 'mdi:router-wireless-settings',
     }),
     'context': <ANY>,
     'entity_id': 'switch.printer_internet_access',
@@ -405,7 +403,7 @@
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
     'entity_id': 'switch.printer_internet_access',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -415,13 +413,13 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:router-wireless-settings',
-    'original_name': 'printer Internet Access',
+    'original_icon': None,
+    'original_name': 'Internet Access',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'internet_access',
     'unique_id': 'AA:BB:CC:00:11:22_internet_access',
     'unit_of_measurement': None,
   })
@@ -430,7 +428,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'printer Internet Access',
-      'icon': 'mdi:router-wireless-settings',
     }),
     'context': <ANY>,
     'entity_id': 'switch.printer_internet_access',
@@ -558,7 +555,7 @@
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
     'entity_id': 'switch.printer_internet_access',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -568,13 +565,13 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:router-wireless-settings',
-    'original_name': 'printer Internet Access',
+    'original_icon': None,
+    'original_name': 'Internet Access',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'internet_access',
     'unique_id': 'AA:BB:CC:00:11:22_internet_access',
     'unit_of_measurement': None,
   })
@@ -583,7 +580,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'printer Internet Access',
-      'icon': 'mdi:router-wireless-settings',
     }),
     'context': <ANY>,
     'entity_id': 'switch.printer_internet_access',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the last piece to achieve the [`has-entity-name`](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/has-entity-name/) IQS rule and those reach the quality scale bronze

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
