### PR TITLE
Add minutes and energy sensors to Nuheat

### DIFF
--- a/homeassistant/components/nuheat/__init__.py
+++ b/homeassistant/components/nuheat/__init__.py
@@ -1,8 +1,12 @@
 """Support for NuHeat thermostats."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
 from datetime import timedelta
 from http import HTTPStatus
 import logging
+from typing import Any
 
 import nuheat
 import requests
@@ -11,11 +15,31 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_SERIAL_NUMBER, DOMAIN, PLATFORMS
+from .const import (
+    CONF_FLOOR_AREA,
+    CONF_SERIAL_NUMBER,
+    CONF_WATT_DENSITY,
+    DEFAULT_WATT_DENSITY,
+    DOMAIN,
+    PLATFORMS,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class NuHeatEnergyData:
+    """Energy data from NuHeat API."""
+
+    energy_kwh: float | None
+    heating_minutes: int
+
+
+type NuHeatConfigEntry = ConfigEntry[
+    tuple[Any, DataUpdateCoordinator, DataUpdateCoordinator[NuHeatEnergyData]]
+]
 
 
 def _get_thermostat(api, serial_number):
@@ -24,9 +48,8 @@ def _get_thermostat(api, serial_number):
     return api.get_thermostat(serial_number)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: NuHeatConfigEntry) -> bool:
     """Set up NuHeat from a config entry."""
-
     conf = entry.data
 
     username = conf[CONF_USERNAME]
@@ -66,15 +89,65 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_interval=timedelta(minutes=5),
     )
 
+    # Energy coordinator
+    async def _async_update_energy_data() -> NuHeatEnergyData:
+        """Fetch energy data from NuHeat API."""
+        try:
+            energy = await hass.async_add_executor_job(thermostat.get_energy_usage)
+        except requests.exceptions.RequestException as err:
+            raise UpdateFailed(f"Error fetching energy data: {err}") from err
+
+        total_minutes = energy.heating_minutes
+        api_kwh = energy.energy_kwh
+
+        # Calculate energy from floor area and watt density if configured
+        floor_area = entry.options.get(CONF_FLOOR_AREA)
+        if floor_area:
+            watt_density = entry.options.get(CONF_WATT_DENSITY, DEFAULT_WATT_DENSITY)
+            # Power (watts) = floor_area (sqft) * watt_density (watts/sqft)
+            # Energy (kWh) = power (watts) * time (minutes) / 60 / 1000
+            power_watts = floor_area * watt_density
+            calculated_kwh = (power_watts * total_minutes) / 60 / 1000
+            energy_kwh: float | None = calculated_kwh
+        elif api_kwh is not None:
+            energy_kwh = api_kwh
+        else:
+            energy_kwh = None
+
+        return NuHeatEnergyData(
+            energy_kwh=energy_kwh,
+            heating_minutes=total_minutes,
+        )
+
+    energy_coordinator: DataUpdateCoordinator[NuHeatEnergyData] = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        config_entry=entry,
+        name=f"nuheat energy {serial_number}",
+        update_method=_async_update_energy_data,
+        update_interval=timedelta(minutes=30),
+    )
+
+    # Initial refresh
+    await coordinator.async_config_entry_first_refresh()
+    await energy_coordinator.async_config_entry_first_refresh()
+
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = (thermostat, coordinator)
+    hass.data[DOMAIN][entry.entry_id] = (thermostat, coordinator, energy_coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(update_listener))
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def update_listener(hass: HomeAssistant, entry: NuHeatConfigEntry) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: NuHeatConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:

--- a/homeassistant/components/nuheat/climate.py
+++ b/homeassistant/components/nuheat/climate.py
@@ -1,5 +1,7 @@
 """Support for NuHeat thermostats."""
 
+from __future__ import annotations
+
 import logging
 from typing import Any
 
@@ -58,7 +60,9 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the NuHeat thermostat(s)."""
-    thermostat, coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    thermostat, coordinator, _energy_coordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
 
     temperature_unit = hass.config.units.temperature_unit
     entity = NuHeatThermostat(coordinator, thermostat, temperature_unit)

--- a/homeassistant/components/nuheat/const.py
+++ b/homeassistant/components/nuheat/const.py
@@ -4,9 +4,14 @@ from homeassistant.const import Platform
 
 DOMAIN = "nuheat"
 
-PLATFORMS = [Platform.CLIMATE]
+PLATFORMS = [Platform.CLIMATE, Platform.SENSOR]
 
 CONF_SERIAL_NUMBER = "serial_number"
+
+# Options for energy calculation
+CONF_FLOOR_AREA = "floor_area"
+CONF_WATT_DENSITY = "watt_density"
+DEFAULT_WATT_DENSITY = 12  # watts per square foot
 
 MANUFACTURER = "NuHeat"
 

--- a/homeassistant/components/nuheat/sensor.py
+++ b/homeassistant/components/nuheat/sensor.py
@@ -1,0 +1,130 @@
+"""Sensor platform for NuHeat integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfEnergy, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from . import NuHeatEnergyData
+from .const import DOMAIN, MANUFACTURER
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class NuHeatSensorEntityDescription(SensorEntityDescription):
+    """Describes NuHeat sensor entity."""
+
+    value_fn: Callable[[NuHeatEnergyData], StateType]
+
+
+SENSOR_DESCRIPTIONS: tuple[NuHeatSensorEntityDescription, ...] = (
+    NuHeatSensorEntityDescription(
+        key="energy",
+        translation_key="energy",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        value_fn=lambda data: data.energy_kwh,
+    ),
+    NuHeatSensorEntityDescription(
+        key="heating_time",
+        translation_key="heating_time",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        value_fn=lambda data: data.heating_minutes,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up NuHeat sensor entities."""
+    thermostat, _coordinator, energy_coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[NuHeatSensor] = []
+
+    for description in SENSOR_DESCRIPTIONS:
+        # Only add energy sensor if we have valid kWh data
+        if description.key == "energy" and energy_coordinator.data.energy_kwh is None:
+            continue
+
+        entities.append(
+            NuHeatSensor(
+                energy_coordinator,
+                thermostat,
+                description,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class NuHeatSensor(
+    CoordinatorEntity[DataUpdateCoordinator[NuHeatEnergyData]], SensorEntity
+):
+    """NuHeat sensor entity."""
+
+    _attr_has_entity_name = True
+    entity_description: NuHeatSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[NuHeatEnergyData],
+        thermostat: Any,
+        description: NuHeatSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._thermostat = thermostat
+        self.entity_description = description
+        self._attr_unique_id = f"{thermostat.serial_number}_{description.key}"
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the sensor value."""
+        return self.entity_description.value_fn(self.coordinator.data)
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        if not self.coordinator.last_update_success:
+            return False
+        if self.entity_description.key == "energy":
+            return self.coordinator.data.energy_kwh is not None
+        return True
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device_info of the device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._thermostat.serial_number)},
+            serial_number=self._thermostat.serial_number,
+            name=self._thermostat.room,
+            model="nVent Signature",
+            manufacturer=MANUFACTURER,
+            suggested_area=self._thermostat.room,
+        )

--- a/homeassistant/components/nuheat/strings.json
+++ b/homeassistant/components/nuheat/strings.json
@@ -17,7 +17,32 @@
           "username": "[%key:common::config_flow::data::username%]"
         },
         "description": "You will need to obtain your thermostat\u2019s numeric serial number or ID by logging into {nuheat_url} and selecting your thermostat(s).",
-        "title": "Connect to the NuHeat"
+        "title": "Connect to Nuheat"
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "The Nuheat API only reports energy usage if you have configured watt density in the Nuheat app. If you haven't done that, you can enter your floor specifications here to calculate energy from heating time instead.",
+        "data": {
+          "floor_area": "Heated floor area (square feet)",
+          "watt_density": "Watt density (watts per square foot)"
+        },
+        "data_description": {
+          "floor_area": "The total area covered by your heated floor mat. Check your installation documentation or measure the heated area.",
+          "watt_density": "Power output per square foot. Most Nuheat mats are 12 watts/sqft. Check your mat's specifications if unsure."
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "energy": {
+        "name": "Energy"
+      },
+      "heating_time": {
+        "name": "Heating time"
       }
     }
   }

--- a/tests/components/nuheat/mocks.py
+++ b/tests/components/nuheat/mocks.py
@@ -14,6 +14,14 @@ MOCK_CONFIG_ENTRY = {
 }
 
 
+def _create_mock_energy_usage(heating_minutes=210, energy_kwh=2.6):
+    """Create a mock EnergyUsage object."""
+    energy = Mock()
+    energy.heating_minutes = heating_minutes
+    energy.energy_kwh = energy_kwh
+    return energy
+
+
 def _get_mock_thermostat_run():
     serial_number = "12345"
     thermostat = Mock(
@@ -35,6 +43,7 @@ def _get_mock_thermostat_run():
     )
 
     thermostat.get_data = Mock()
+    thermostat.get_energy_usage = Mock(return_value=_create_mock_energy_usage())
     thermostat.resume_schedule = Mock()
     thermostat.schedule_mode = Mock()
     return thermostat
@@ -61,6 +70,7 @@ def _get_mock_thermostat_schedule_hold_unavailable():
     )
 
     thermostat.get_data = Mock()
+    thermostat.get_energy_usage = Mock(return_value=_create_mock_energy_usage())
     thermostat.resume_schedule = Mock()
     thermostat.schedule_mode = Mock()
     return thermostat
@@ -87,6 +97,7 @@ def _get_mock_thermostat_schedule_hold_available():
     )
 
     thermostat.get_data = Mock()
+    thermostat.get_energy_usage = Mock(return_value=_create_mock_energy_usage())
     thermostat.resume_schedule = Mock()
     thermostat.schedule_mode = Mock()
     return thermostat
@@ -115,6 +126,7 @@ def _get_mock_thermostat_schedule_temporary_hold():
     )
 
     thermostat.get_data = Mock()
+    thermostat.get_energy_usage = Mock(return_value=_create_mock_energy_usage())
     thermostat.resume_schedule = Mock()
     thermostat.schedule_mode = Mock()
     return thermostat

--- a/tests/components/nuheat/test_init.py
+++ b/tests/components/nuheat/test_init.py
@@ -1,11 +1,20 @@
 """NuHeat component tests."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from homeassistant.components.nuheat.const import DOMAIN
+from homeassistant.components.nuheat.const import (
+    CONF_FLOOR_AREA,
+    CONF_WATT_DENSITY,
+    DOMAIN,
+)
 from homeassistant.core import HomeAssistant
 
-from .mocks import MOCK_CONFIG_ENTRY, _get_mock_nuheat
+from .mocks import (
+    MOCK_CONFIG_ENTRY,
+    _create_mock_energy_usage,
+    _get_mock_nuheat,
+    _get_mock_thermostat_run,
+)
 
 from tests.common import MockConfigEntry
 
@@ -17,7 +26,8 @@ INVALID_CONFIG = {"nuheat": {"username": "warm", "password": "feet"}}
 
 async def test_init_success(hass: HomeAssistant) -> None:
     """Test that we can setup with valid config."""
-    mock_nuheat = _get_mock_nuheat()
+    mock_thermostat = _get_mock_thermostat_run()
+    mock_nuheat = _get_mock_nuheat(get_thermostat=mock_thermostat)
 
     with patch(
         "homeassistant.components.nuheat.nuheat.NuHeat",
@@ -27,3 +37,81 @@ async def test_init_success(hass: HomeAssistant) -> None:
         config_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
+
+    # Check that both climate and sensor entities are created
+    state = hass.states.get("climate.master_bathroom")
+    assert state is not None
+
+    # Check heating time sensor (underscore naming convention)
+    heating_time_state = hass.states.get("sensor.master_bathroom_heating_time")
+    assert heating_time_state is not None
+    assert int(heating_time_state.state) == 210  # 120 + 90
+
+    # Check energy sensor
+    energy_state = hass.states.get("sensor.master_bathroom_energy")
+    assert energy_state is not None
+    assert float(energy_state.state) == 2.6  # 1.5 + 1.1
+
+
+async def test_init_energy_api_no_kwh_data(hass: HomeAssistant) -> None:
+    """Test that energy sensor is not created when API returns no kWh data."""
+    mock_thermostat = _get_mock_thermostat_run()
+    # Override the mock to return no kWh data (user hasn't configured watt density)
+    mock_thermostat.get_energy_usage = Mock(
+        return_value=_create_mock_energy_usage(heating_minutes=120, energy_kwh=None)
+    )
+    mock_nuheat = _get_mock_nuheat(get_thermostat=mock_thermostat)
+
+    with patch(
+        "homeassistant.components.nuheat.nuheat.NuHeat",
+        return_value=mock_nuheat,
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Heating time sensor should still be created
+    heating_time_state = hass.states.get("sensor.master_bathroom_heating_time")
+    assert heating_time_state is not None
+    assert int(heating_time_state.state) == 120
+
+    # Energy sensor should not be created (no kWh data)
+    energy_state = hass.states.get("sensor.master_bathroom_energy")
+    assert energy_state is None
+
+
+async def test_init_energy_calculated_from_options(hass: HomeAssistant) -> None:
+    """Test that energy is calculated from floor area when configured."""
+    mock_thermostat = _get_mock_thermostat_run()
+    # Override the mock to return 60 minutes and no kWh data
+    mock_thermostat.get_energy_usage = Mock(
+        return_value=_create_mock_energy_usage(heating_minutes=60, energy_kwh=None)
+    )
+    mock_nuheat = _get_mock_nuheat(get_thermostat=mock_thermostat)
+
+    with patch(
+        "homeassistant.components.nuheat.nuheat.NuHeat",
+        return_value=mock_nuheat,
+    ):
+        # Configure options for energy calculation
+        # 100 sqft * 12 watts/sqft = 1200 watts
+        # 1200 watts * 60 minutes / 60 / 1000 = 1.2 kWh
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=MOCK_CONFIG_ENTRY,
+            options={CONF_FLOOR_AREA: 100.0, CONF_WATT_DENSITY: 12.0},
+        )
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Energy sensor should be created with calculated value
+    energy_state = hass.states.get("sensor.master_bathroom_energy")
+    assert energy_state is not None
+    assert float(energy_state.state) == 1.2  # Calculated from floor area
+
+    # Heating time should also be present
+    heating_time_state = hass.states.get("sensor.master_bathroom_heating_time")
+    assert heating_time_state is not None
+    assert int(heating_time_state.state) == 60


### PR DESCRIPTION
## Proposed change

The Nuheat API has the number of minutes the floor was on, which can be used to calculate an estimated energy usage. If the settings have been set on the Nuheat server, it will use that to calculate the energy usage, but if not, they can be provided in Home Assistant settings.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: home-assistant/home-assistant.io#43006

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
