### PR TITLE
Google Cast: detect state and attributes when device is doing active non-media casting

### DIFF
--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -822,10 +822,7 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
             # Some apps don't report media status, show the player as playing
             return MediaPlayerState.PLAYING
 
-        if (
-            self.app_id is not None
-            and self.app_id != pychromecast.config.APP_BACKDROP
-        ):
+        if self.app_id is not None and self.app_id != pychromecast.config.APP_BACKDROP:
             # We have an active app
             return MediaPlayerState.IDLE
 

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -807,6 +807,7 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
         # The lovelace app loops media to prevent timing out, don't show that
         if self.app_id == CAST_APP_ID_HOMEASSISTANT_LOVELACE:
             return MediaPlayerState.PLAYING
+
         if (media_status := self._media_status()[0]) is not None:
             if media_status.player_state == MEDIA_PLAYER_STATE_PLAYING:
                 return MediaPlayerState.PLAYING
@@ -817,18 +818,21 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
             if media_status.player_is_idle:
                 return MediaPlayerState.IDLE
 
-        if self._chromecast is not None and self._chromecast.is_idle:
-            # If library consider us idle, that is our off state
-            # it takes HDMI status into account for cast devices.
-            return MediaPlayerState.OFF
-
         if self.app_id in APP_IDS_UNRELIABLE_MEDIA_INFO:
             # Some apps don't report media status, show the player as playing
             return MediaPlayerState.PLAYING
 
-        if self.app_id is not None:
+        if (
+            self.app_id is not None
+            and self.app_id != pychromecast.config.APP_BACKDROP
+        ):
             # We have an active app
             return MediaPlayerState.IDLE
+
+        if self._chromecast is not None and self._chromecast.is_idle:
+            # If library consider us idle, that is our off state
+            # it takes HDMI status into account for cast devices.
+            return MediaPlayerState.OFF
 
         return None
 

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -2386,42 +2386,34 @@ async def test_ha_cast(hass: HomeAssistant, ha_controller_mock) -> None:
     unregister_cb()
     chromecast.unregister_handler.assert_not_called()
 
-async def test_entity_media_states_active_app_reported_idle(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
-) -> None:
-    """Test entity state when app is active but device reports idle (fixes #160814)."""
-    entity_id = "media_player.speaker"
-    info = get_fake_chromecast_info()
-    chromecast, _ = await async_setup_media_player_cast(hass, info)
-    cast_status_cb, conn_status_cb, _ = get_status_callbacks(chromecast)
+@property
+    def state(self) -> MediaPlayerState | None:
+        """Return the state of the player."""
+        # The lovelace app loops media to prevent timing out, don't show that
+        if self.app_id == CAST_APP_ID_HOMEASSISTANT_LOVELACE:
+            return MediaPlayerState.PLAYING
 
-    # Connect the device
-    connection_status = MagicMock()
-    connection_status.status = "CONNECTED"
-    conn_status_cb(connection_status)
-    await hass.async_block_till_done()
+        if (media_status := self._media_status()[0]) is not None:
+            if media_status.player_state == MEDIA_PLAYER_STATE_PLAYING:
+                return MediaPlayerState.PLAYING
+            if media_status.player_state == MEDIA_PLAYER_STATE_BUFFERING:
+                return MediaPlayerState.BUFFERING
+            if media_status.player_is_paused:
+                return MediaPlayerState.PAUSED
+            if media_status.player_is_idle:
+                return MediaPlayerState.IDLE
 
-    # Scenario: Custom App is running (e.g. DashCast), but device reports is_idle=True
-    chromecast.app_id = "84912283"  # Example Custom App ID
-    chromecast.is_idle = True       # Device thinks it's idle/standby
+        if self.app_id in APP_IDS_UNRELIABLE_MEDIA_INFO:
+            # Some apps don't report media status, show the player as playing
+            return MediaPlayerState.PLAYING
 
-    # Trigger a status update
-    cast_status = MagicMock()
-    cast_status_cb(cast_status)
-    await hass.async_block_till_done()
+        if self.app_id is not None and self.app_id != pychromecast.config.APP_BACKDROP:
+            # We have an active app
+            return MediaPlayerState.IDLE
 
-    state = hass.states.get(entity_id)
-    assert state is not None
-    # BEFORE FIX: This would be "off"
-    # AFTER FIX: This should be "idle"
-    assert state.state == "idle"
+        if self._chromecast is not None and self._chromecast.is_idle:
+            # If library consider us idle, that is our off state
+            # it takes HDMI status into account for cast devices.
+            return MediaPlayerState.OFF
 
-    # Scenario: Backdrop (Screensaver) is running. Should still be OFF.
-    chromecast.app_id = pychromecast.config.APP_BACKDROP
-    chromecast.is_idle = True
-
-    cast_status_cb(cast_status)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state.state == "off"
+        return None

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -2413,8 +2413,6 @@ async def test_entity_media_states_active_app_reported_idle(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    # BEFORE FIX: This would be "off"
-    # AFTER FIX: This should be "idle"
     assert state.state == "idle"
 
     # Scenario: Backdrop (Screensaver) is running. Should still be OFF.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes an issue where Cast devices running custom receiver applications (such as DashCast) are incorrectly reported as `off` in Home Assistant.

Currently, the integration checks `self._chromecast.is_idle` before checking if a specific `app_id` is active. Many custom apps do not implement the media namespace or report status in a way `pychromecast` expects, resulting in the library reporting the device as idle/standby even when the app is visible on screen.

This change reorders the checks in the `state` property. It now checks for a valid `app_id` **before** checking the idle status.
- If a valid `app_id` is present (and it is **not** the default `APP_BACKDROP`), the state is reported as `IDLE` (or `PLAYING` for known unreliable apps).
- This ensures the entity remains available in Home Assistant, allowing users to see the `app_id` attribute or stop the application.
- The default screensaver (Backdrop) continues to correctly report as `OFF`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #160814, #156199
- This PR is related to issue: #160814, #156199
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr