### PR TITLE
Add annual statistics aggregation

### DIFF
--- a/homeassistant/components/recorder/services.py
+++ b/homeassistant/components/recorder/services.py
@@ -77,7 +77,9 @@ SERVICE_GET_STATISTICS_SCHEMA = vol.Schema(
         vol.Required("start_time"): cv.datetime,
         vol.Optional("end_time"): cv.datetime,
         vol.Required("statistic_ids"): vol.All(cv.ensure_list, [cv.string]),
-        vol.Required("period"): vol.In(["5minute", "hour", "day", "week", "month"]),
+        vol.Required("period"): vol.In(
+            ["5minute", "hour", "day", "week", "month", "year"]
+        ),
         vol.Required("types"): vol.All(
             cv.ensure_list,
             [vol.In(["change", "last_reset", "max", "mean", "min", "state", "sum"])],

--- a/homeassistant/components/recorder/services.yaml
+++ b/homeassistant/components/recorder/services.yaml
@@ -83,6 +83,7 @@ get_statistics:
             - "day"
             - "week"
             - "month"
+            - "year"
 
     types:
       required: true

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1327,6 +1327,54 @@ def _reduce_statistics_per_month(
     )
 
 
+def reduce_year_ts_factory() -> tuple[
+    Callable[[float, float], bool],
+    Callable[[float], tuple[float, float]],
+]:
+    """Return functions to match same year and year start end."""
+    _lower_bound: float = 0
+    _upper_bound: float = 0
+
+    # We have to recreate _local_from_timestamp in the closure in case the timezone changes
+    _local_from_timestamp = partial(
+        datetime.fromtimestamp, tz=dt_util.get_default_time_zone()
+    )
+
+    def _same_year_ts(time1: float, time2: float) -> bool:
+        """Return True if time1 and time2 are in the same year."""
+        nonlocal _lower_bound, _upper_bound
+        if not _lower_bound <= time1 < _upper_bound:
+            _lower_bound, _upper_bound = _year_start_end_ts_cached(time1)
+        return _lower_bound <= time2 < _upper_bound
+
+    def _year_start_end_ts(time: float) -> tuple[float, float]:
+        """Return the start and end of the period (day) time is within."""
+        start_local = _local_from_timestamp(time).replace(
+            month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+        return (
+            start_local.timestamp(),
+            (start_local.replace(year=start_local.year + 1)).timestamp(),
+        )
+
+    # We create _year_start_end_ts_cached in the closure in case the timezone changes
+    _year_start_end_ts_cached = lru_cache(maxsize=6)(_year_start_end_ts)
+
+    return _same_year_ts, _year_start_end_ts_cached
+
+
+def _reduce_statistics_per_year(
+    stats: dict[str, list[StatisticsRow]],
+    types: set[Literal["last_reset", "max", "mean", "min", "state", "sum"]],
+    metadata: dict[str, tuple[int, StatisticMetaData]],
+) -> dict[str, list[StatisticsRow]]:
+    """Reduce hourly statistics to yearly statistics."""
+    _same_year_ts, _year_start_end_ts = reduce_year_ts_factory()
+    return _reduce_statistics(
+        stats, _same_year_ts, _year_start_end_ts, timedelta(days=366), types, metadata
+    )
+
+
 def _generate_statistics_during_period_stmt(
     start_time: datetime,
     end_time: datetime | None,
@@ -1957,7 +2005,7 @@ def _statistics_during_period_with_session(
     start_time: datetime,
     end_time: datetime | None,
     statistic_ids: set[str] | None,
-    period: Literal["5minute", "day", "hour", "week", "month"],
+    period: Literal["5minute", "day", "hour", "week", "month", "year"],
     units: dict[str, str] | None,
     _types: set[Literal["change", "last_reset", "max", "mean", "min", "state", "sum"]],
 ) -> dict[str, list[StatisticsRow]]:
@@ -2018,6 +2066,22 @@ def _statistics_during_period_with_session(
         if end_time is not None:
             end_time = _find_month_end_time(dt_util.as_local(end_time))
 
+    elif period == "year":
+        start_time = dt_util.as_local(start_time).replace(
+            month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+        if end_time is not None:
+            end_local = dt_util.as_local(end_time)
+            end_time = end_local.replace(
+                year=end_local.year + 1,
+                month=1,
+                day=1,
+                hour=0,
+                minute=0,
+                second=0,
+                microsecond=0,
+            )
+
     table: type[Statistics | StatisticsShortTerm] = (
         Statistics if period != "5minute" else StatisticsShortTerm
     )
@@ -2051,6 +2115,9 @@ def _statistics_during_period_with_session(
     if period == "month":
         result = _reduce_statistics_per_month(result, types, metadata)
 
+    if period == "year":
+        result = _reduce_statistics_per_year(result, types, metadata)
+
     if "change" in _types:
         _augment_result_with_change(
             hass, session, start_time, units, _types, table, metadata, result
@@ -2071,7 +2138,7 @@ def statistics_during_period(
     start_time: datetime,
     end_time: datetime | None,
     statistic_ids: set[str] | None,
-    period: Literal["5minute", "day", "hour", "week", "month"],
+    period: Literal["5minute", "day", "hour", "week", "month", "year"],
     units: dict[str, str] | None,
     types: set[Literal["change", "last_reset", "max", "mean", "min", "state", "sum"]],
 ) -> dict[str, list[StatisticsRow]]:

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1348,7 +1348,7 @@ def reduce_year_ts_factory() -> tuple[
         return _lower_bound <= time2 < _upper_bound
 
     def _year_start_end_ts(time: float) -> tuple[float, float]:
-        """Return the start and end of the period (day) time is within."""
+        """Return the start and end of the period (year) time is within."""
         start_local = _local_from_timestamp(time).replace(
             month=1, day=1, hour=0, minute=0, second=0, microsecond=0
         )

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -184,7 +184,7 @@ def _ws_get_statistics_during_period(
     start_time: dt,
     end_time: dt | None,
     statistic_ids: set[str] | None,
-    period: Literal["5minute", "day", "hour", "week", "month"],
+    period: Literal["5minute", "day", "hour", "week", "month", "year"],
     units: dict[str, str],
     types: set[Literal["change", "last_reset", "max", "mean", "min", "state", "sum"]],
 ) -> bytes:
@@ -253,7 +253,9 @@ async def ws_handle_get_statistics_during_period(
         vol.Required("start_time"): str,
         vol.Optional("end_time"): str,
         vol.Required("statistic_ids"): vol.All([str], vol.Length(min=1)),
-        vol.Required("period"): vol.Any("5minute", "hour", "day", "week", "month"),
+        vol.Required("period"): vol.Any(
+            "5minute", "hour", "day", "week", "month", "year"
+        ),
         vol.Optional("units"): UNIT_SCHEMA,
         vol.Optional("types"): vol.All(
             [vol.Any("change", "last_reset", "max", "mean", "min", "state", "sum")],

--- a/tests/components/recorder/common.py
+++ b/tests/components/recorder/common.py
@@ -200,7 +200,7 @@ def statistics_during_period(
     start_time: datetime,
     end_time: datetime | None = None,
     statistic_ids: set[str] | None = None,
-    period: Literal["5minute", "day", "hour", "week", "month"] = "hour",
+    period: Literal["5minute", "day", "hour", "week", "month", "year"] = "hour",
     units: dict[str, str] | None = None,
     types: set[Literal["last_reset", "max", "mean", "min", "state", "sum"]]
     | None = None,

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -2469,6 +2469,244 @@ async def test_monthly_statistics_sum(
     assert stats == {}
 
 
+@pytest.mark.usefixtures("multiple_start_time_chunk_sizes")
+@pytest.mark.parametrize("timezone", ["America/Regina", "Europe/Vienna", "UTC"])
+@pytest.mark.freeze_time("2020-01-01 00:00:00+00:00")
+async def test_yearly_statistics_sum(
+    hass: HomeAssistant,
+    setup_recorder: None,
+    caplog: pytest.LogCaptureFixture,
+    timezone,
+) -> None:
+    """Test monthly statistics."""
+    await hass.config.async_set_time_zone(timezone)
+    await async_wait_recording_done(hass)
+    assert "Compiling statistics for" not in caplog.text
+    assert "Statistics already compiled" not in caplog.text
+
+    zero = dt_util.utcnow()
+    period1 = dt_util.as_utc(dt_util.parse_datetime("2020-01-01 00:00:00"))
+    period2 = dt_util.as_utc(dt_util.parse_datetime("2020-12-31 23:00:00"))
+    period3 = dt_util.as_utc(dt_util.parse_datetime("2021-01-01 00:00:00"))
+    period4 = dt_util.as_utc(dt_util.parse_datetime("2021-12-31 23:00:00"))
+    period5 = dt_util.as_utc(dt_util.parse_datetime("2022-01-01 00:00:00"))
+    period6 = dt_util.as_utc(dt_util.parse_datetime("2022-12-31 23:00:00"))
+
+    external_statistics = (
+        {
+            "start": period1,
+            "last_reset": None,
+            "state": 0,
+            "sum": 2,
+        },
+        {
+            "start": period2,
+            "last_reset": None,
+            "state": 1,
+            "sum": 3,
+        },
+        {
+            "start": period3,
+            "last_reset": None,
+            "state": 2,
+            "sum": 4,
+        },
+        {
+            "start": period4,
+            "last_reset": None,
+            "state": 3,
+            "sum": 5,
+        },
+        {
+            "start": period5,
+            "last_reset": None,
+            "state": 4,
+            "sum": 6,
+        },
+        {
+            "start": period6,
+            "last_reset": None,
+            "state": 5,
+            "sum": 7,
+        },
+    )
+    external_metadata = {
+        "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
+        "name": "Total imported energy",
+        "source": "test",
+        "statistic_id": "test:total_energy_import",
+        "unit_class": "energy",
+        "unit_of_measurement": "kWh",
+    }
+
+    async_add_external_statistics(hass, external_metadata, external_statistics)
+    await async_wait_recording_done(hass)
+    stats = statistics_during_period(
+        hass, zero, period="year", statistic_ids={"test:total_energy_import"}
+    )
+    yr2020_start = dt_util.as_utc(dt_util.parse_datetime("2020-01-01 00:00:00"))
+    yr2020_end = dt_util.as_utc(dt_util.parse_datetime("2021-01-01 00:00:00"))
+    yr2021_start = dt_util.as_utc(dt_util.parse_datetime("2021-01-01 00:00:00"))
+    yr2021_end = dt_util.as_utc(dt_util.parse_datetime("2022-01-01 00:00:00"))
+    yr2022_start = dt_util.as_utc(dt_util.parse_datetime("2022-01-01 00:00:00"))
+    yr2022_end = dt_util.as_utc(dt_util.parse_datetime("2023-01-01 00:00:00"))
+    expected_stats = {
+        "test:total_energy_import": [
+            {
+                "start": yr2020_start.timestamp(),
+                "end": yr2020_end.timestamp(),
+                "last_reset": None,
+                "state": pytest.approx(1.0),
+                "sum": pytest.approx(3.0),
+            },
+            {
+                "start": yr2021_start.timestamp(),
+                "end": yr2021_end.timestamp(),
+                "last_reset": None,
+                "state": pytest.approx(3.0),
+                "sum": pytest.approx(5.0),
+            },
+            {
+                "start": yr2022_start.timestamp(),
+                "end": yr2022_end.timestamp(),
+                "last_reset": None,
+                "state": 5.0,
+                "sum": 7.0,
+            },
+        ]
+    }
+    assert stats == expected_stats
+
+    # Get change
+    stats = statistics_during_period(
+        hass,
+        start_time=period1,
+        statistic_ids={"test:total_energy_import"},
+        period="year",
+        types={"change"},
+    )
+    assert stats == {
+        "test:total_energy_import": [
+            {
+                "start": yr2020_start.timestamp(),
+                "end": yr2020_end.timestamp(),
+                "change": 3.0,
+            },
+            {
+                "start": yr2021_start.timestamp(),
+                "end": yr2021_end.timestamp(),
+                "change": 2.0,
+            },
+            {
+                "start": yr2022_start.timestamp(),
+                "end": yr2022_end.timestamp(),
+                "change": 2.0,
+            },
+        ]
+    }
+    # Get data with start during the first period
+    stats = statistics_during_period(
+        hass,
+        start_time=period1 + timedelta(days=1),
+        statistic_ids={"test:total_energy_import"},
+        period="year",
+    )
+    assert stats == expected_stats
+
+    # Get data with end during the third period
+    stats = statistics_during_period(
+        hass,
+        start_time=zero,
+        end_time=period6 - timedelta(days=1),
+        statistic_ids={"test:total_energy_import"},
+        period="year",
+    )
+    assert stats == expected_stats
+
+    # Try to get data for entities which do not exist
+    stats = statistics_during_period(
+        hass,
+        start_time=zero,
+        statistic_ids={"not", "the", "same", "test:total_energy_import"},
+        period="year",
+    )
+    assert stats == expected_stats
+
+    # Get only sum
+    stats = statistics_during_period(
+        hass,
+        start_time=zero,
+        statistic_ids={"not", "the", "same", "test:total_energy_import"},
+        period="year",
+        types={"sum"},
+    )
+    assert stats == {
+        "test:total_energy_import": [
+            {
+                "start": yr2020_start.timestamp(),
+                "end": yr2020_end.timestamp(),
+                "sum": pytest.approx(3.0),
+            },
+            {
+                "start": yr2021_start.timestamp(),
+                "end": yr2021_end.timestamp(),
+                "sum": pytest.approx(5.0),
+            },
+            {
+                "start": yr2022_start.timestamp(),
+                "end": yr2022_end.timestamp(),
+                "sum": pytest.approx(7.0),
+            },
+        ]
+    }
+
+    # Get only sum + convert units
+    stats = statistics_during_period(
+        hass,
+        start_time=zero,
+        statistic_ids={"not", "the", "same", "test:total_energy_import"},
+        period="year",
+        types={"sum"},
+        units={"energy": "Wh"},
+    )
+    assert stats == {
+        "test:total_energy_import": [
+            {
+                "start": yr2020_start.timestamp(),
+                "end": yr2020_end.timestamp(),
+                "sum": pytest.approx(3000.0),
+            },
+            {
+                "start": yr2021_start.timestamp(),
+                "end": yr2021_end.timestamp(),
+                "sum": pytest.approx(5000.0),
+            },
+            {
+                "start": yr2022_start.timestamp(),
+                "end": yr2022_end.timestamp(),
+                "sum": pytest.approx(7000.0),
+            },
+        ]
+    }
+
+    # Use 5minute to ensure table switch works
+    stats = statistics_during_period(
+        hass,
+        start_time=zero,
+        statistic_ids=["test:total_energy_import", "with_other"],
+        period="5minute",
+    )
+    assert stats == {}
+
+    # Ensure future date has not data
+    future = dt_util.as_utc(dt_util.parse_datetime("2221-11-01 00:00:00"))
+    stats = statistics_during_period(
+        hass, start_time=future, end_time=future, period="year"
+    )
+    assert stats == {}
+
+
 def test_cache_key_for_generate_statistics_during_period_stmt() -> None:
     """Test cache key for _generate_statistics_during_period_stmt."""
     stmt = _generate_statistics_during_period_stmt(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Getting some user requests to allow for fetching statistics aggregation at an annual period. LTS has been around for a few years now and users may have some good length of history stored, and may be interested to see how things change in their home year over year, in a way that monthly aggregations won't be able to easily visualize. 

I was a little concerned about the perf of fetching so much data, but I checked out how long it would take to summarize for something with 10 years of data and it wasn't too bad, just a second on my test instance.

Doesn't change any frontend cards yet, but this function is accessible via `recorder.get_statistics`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
https://github.com/orgs/home-assistant/discussions/1032
https://github.com/orgs/home-assistant/discussions/1523

- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
