### PR TITLE
Add support for packaging version >= 26 on the version bump script

### DIFF
--- a/script/version_bump.py
+++ b/script/version_bump.py
@@ -13,6 +13,8 @@ from packaging.version import Version
 from homeassistant import const
 from homeassistant.util import dt as dt_util
 
+_PACKAGING_VERSION_BELOW_26 = Version(packaging.__version__) < Version("26.0dev0")
+
 
 def _bump_release(release, bump_type):
     """Bump a release tuple consisting of 3 numbers."""
@@ -29,7 +31,7 @@ def _bump_release(release, bump_type):
 
 def _get_dev_change(dev: int) -> int | tuple[str, int]:
     """Return the dev change based on packaging version."""
-    if Version(packaging.__version__) < Version("26.0dev0"):
+    if _PACKAGING_VERSION_BELOW_26:
         return ("dev", dev)
     return dev
 
@@ -116,7 +118,7 @@ def bump_version(
     else:
         raise ValueError(f"Unsupported type: {bump_type}")
 
-    if Version(packaging.__version__) < Version("26.0dev0"):
+    if _PACKAGING_VERSION_BELOW_26:
         temp = Version("0")
         temp._version = version._version._replace(**to_change)  # noqa: SLF001
         return Version(str(temp))

--- a/script/version_bump.py
+++ b/script/version_bump.py
@@ -2,10 +2,12 @@
 """Helper script to bump the current version."""
 
 import argparse
+from copy import replace
 from pathlib import Path
 import re
 import subprocess
 
+import packaging
 from packaging.version import Version
 
 from homeassistant import const
@@ -23,6 +25,13 @@ def _bump_release(release, bump_type):
         patch = 0
 
     return major, minor, patch
+
+
+def _get_dev_change(dev: int) -> int | tuple[str, int]:
+    """Return the dev change based on packaging version."""
+    if Version(packaging.__version__) < Version("26.0dev0"):
+        return ("dev", dev)
+    return dev
 
 
 def bump_version(
@@ -58,9 +67,10 @@ def bump_version(
         # Convert 0.67.3.b5 to 0.67.4.dev0
         # Convert 0.67.3.dev0 to 0.67.3.dev1
         if version.is_devrelease:
-            to_change["dev"] = ("dev", version.dev + 1)
+            to_change["dev"] = _get_dev_change(version.dev + 1)
         else:
-            to_change["pre"] = ("dev", 0)
+            to_change["dev"] = _get_dev_change(0)
+            to_change["pre"] = None
             to_change["release"] = _bump_release(version.release, "minor")
 
     elif bump_type == "beta":
@@ -99,14 +109,19 @@ def bump_version(
                 raise ValueError("Nightly version must be a dev version")
             new_dev = new_version.dev
 
-        to_change["dev"] = ("dev", new_dev)
+        if not isinstance(new_dev, int):
+            new_dev = int(new_dev)
+        to_change["dev"] = _get_dev_change(new_dev)
 
     else:
         raise ValueError(f"Unsupported type: {bump_type}")
 
-    temp = Version("0")
-    temp._version = version._version._replace(**to_change)  # noqa: SLF001
-    return Version(str(temp))
+    if Version(packaging.__version__) < Version("26.0dev0"):
+        temp = Version("0")
+        temp._version = version._version._replace(**to_change)  # noqa: SLF001
+        return Version(str(temp))
+
+    return replace(version, **to_change)
 
 
 def write_version(version):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for packaging version >= 26 on the version bump script
Fixes nightlies (https://github.com/home-assistant/core/actions/runs/20942739594/job/60179665358)
Successful test build: https://github.com/home-assistant/core/actions/runs/20964325894
I added it to the milestone, so we are sure stable version will not have the same issue

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
