### PR TITLE
Add parent device for Satel Integra

### DIFF
--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -17,7 +17,11 @@ from homeassistant.const import (
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    issue_registry as ir,
+)
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_registry import RegistryEntry, async_migrate_entries
 from homeassistant.helpers.typing import ConfigType
@@ -200,6 +204,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: SatelConfigEntry) -> boo
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
     entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close))
+
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id)},
+        name="Satel Integra",
+        manufacturer="Satel",
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -209,7 +209,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: SatelConfigEntry) -> boo
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id)},
-        name="Satel Integra",
         manufacturer="Satel",
     )
 

--- a/homeassistant/components/satel_integra/entity.py
+++ b/homeassistant/components/satel_integra/entity.py
@@ -54,5 +54,7 @@ class SatelIntegraEntity(Entity):
         self._attr_unique_id = f"{config_entry_id}_{entity_type}_{device_number}"
 
         self._attr_device_info = DeviceInfo(
-            name=subentry.data[CONF_NAME], identifiers={(DOMAIN, self._attr_unique_id)}
+            name=subentry.data[CONF_NAME],
+            identifiers={(DOMAIN, self._attr_unique_id)},
+            via_device=(DOMAIN, config_entry_id),
         )

--- a/tests/components/satel_integra/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/satel_integra/snapshots/test_alarm_control_panel.ambr
@@ -79,6 +79,6 @@
     'primary_config_entry': <ANY>,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---

--- a/tests/components/satel_integra/snapshots/test_binary_sensor.ambr
+++ b/tests/components/satel_integra/snapshots/test_binary_sensor.ambr
@@ -125,7 +125,7 @@
     'primary_config_entry': <ANY>,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_binary_sensors[device-zone]
@@ -156,6 +156,6 @@
     'primary_config_entry': <ANY>,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---

--- a/tests/components/satel_integra/snapshots/test_init.ambr
+++ b/tests/components/satel_integra/snapshots/test_init.ambr
@@ -50,6 +50,37 @@
     'unique_id': 'switchable_output_1',
   })
 # ---
+# name: test_parent_device_exists[parent-device]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'satel_integra',
+        '1234567890',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Satel',
+    'model': None,
+    'model_id': None,
+    'name': 'Satel Integra',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_unique_id_migration_from_single_config[alarm_control_panel-satel_alarm_panel_1-1234567890_alarm_panel_1]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/satel_integra/snapshots/test_init.ambr
+++ b/tests/components/satel_integra/snapshots/test_init.ambr
@@ -73,7 +73,7 @@
     'manufacturer': 'Satel',
     'model': None,
     'model_id': None,
-    'name': 'Satel Integra',
+    'name': '192.168.0.2',
     'name_by_user': None,
     'primary_config_entry': <ANY>,
     'serial_number': None,

--- a/tests/components/satel_integra/snapshots/test_switch.ambr
+++ b/tests/components/satel_integra/snapshots/test_switch.ambr
@@ -27,7 +27,7 @@
     'primary_config_entry': <ANY>,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_switches[switch.switchable_output-entry]

--- a/tests/components/satel_integra/test_init.py
+++ b/tests/components/satel_integra/test_init.py
@@ -12,6 +12,7 @@ from homeassistant.components.satel_integra.const import DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 
 from . import (
@@ -120,3 +121,20 @@ async def test_unique_id_migration_from_single_config(
     assert entity.unique_id == new_id
 
     assert entity == snapshot
+
+
+async def test_parent_device_exists(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_satel: AsyncMock,
+    device_registry: DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a parent device is created for the alarm panel."""
+
+    await setup_integration(hass, mock_config_entry)
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, MOCK_ENTRY_ID)}
+    )
+    assert device_entry == snapshot(name="parent-device")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the overarching device for Satel Integra, this device represents the complete alarm system. The current library does not yet support grabbing hardware info and name, those items will be populated later.
The child devices (individual sensors) link back to the parent device. 
This parent device will also hold system state sensors (battery issues, system tamper etc).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
