### PR TITLE
Teslemetry: Add OAuth error handling guards

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -108,7 +108,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
 
     try:
         implementation = await async_get_config_entry_implementation(hass, entry)
-    except ValueError as err:
+    except ImplementationUnavailableError as err:
         LOGGER.error(
             "OAuth implementation not available, try reauthenticating: %s", err
         )

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -2,10 +2,10 @@
 
 import asyncio
 from collections.abc import Callable
+from functools import partial
 from typing import Final
 
-from aiohttp import ClientResponseError
-from aiohttp.client_exceptions import ClientError
+from aiohttp import ClientError, ClientResponseError
 from tesla_fleet_api.const import Scope
 from tesla_fleet_api.exceptions import (
     Forbidden,
@@ -75,28 +75,54 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+async def _get_access_token(oauth_session: OAuth2Session) -> str:
+    """Get a valid access token, refreshing if necessary."""
+    LOGGER.debug(
+        "Token valid: %s, expires_at: %s",
+        oauth_session.valid_token,
+        oauth_session.token.get("expires_at"),
+    )
+    try:
+        await oauth_session.async_ensure_token_valid()
+    except ClientResponseError as err:
+        LOGGER.error("Token refresh HTTP error: %s", err)
+        if err.status == 401:
+            raise ConfigEntryAuthFailed from err
+        raise ConfigEntryNotReady from err
+    except (KeyError, TypeError) as err:
+        LOGGER.error("Token data malformed, try reauthenticating: %s", err)
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="token_data_malformed",
+        ) from err
+    except ClientError as err:
+        LOGGER.error("Token refresh connection error: %s", err)
+        raise ConfigEntryNotReady from err
+    return oauth_session.token[CONF_ACCESS_TOKEN]
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
     """Set up Teslemetry config."""
 
     session = async_get_clientsession(hass)
 
-    implementation = await async_get_config_entry_implementation(hass, entry)
+    try:
+        implementation = await async_get_config_entry_implementation(hass, entry)
+    except ValueError as err:
+        LOGGER.error(
+            "OAuth implementation not available, try reauthenticating: %s", err
+        )
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="oauth_implementation_not_available",
+        ) from err
     oauth_session = OAuth2Session(hass, entry, implementation)
 
-    async def _get_access_token() -> str:
-        try:
-            await oauth_session.async_ensure_token_valid()
-        except ClientResponseError as e:
-            if e.status == 401:
-                raise ConfigEntryAuthFailed from e
-            raise ConfigEntryNotReady from e
-        token: str = oauth_session.token[CONF_ACCESS_TOKEN]
-        return token
-
     # Create API connection
+    access_token = partial(_get_access_token, oauth_session)
     teslemetry = Teslemetry(
         session=session,
-        access_token=_get_access_token,
+        access_token=access_token,
     )
     try:
         calls = await asyncio.gather(
@@ -154,7 +180,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             if not stream:
                 stream = TeslemetryStream(
                     session,
-                    _get_access_token,
+                    access_token,
                     server=f"{region.lower()}.teslemetry.com",
                     parse_timestamp=True,
                     manual=True,

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -27,6 +27,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
+    ImplementationUnavailableError,
     OAuth2Session,
     async_get_config_entry_implementation,
 )

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -106,9 +106,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
     try:
         implementation = await async_get_config_entry_implementation(hass, entry)
     except ImplementationUnavailableError as err:
-        LOGGER.error(
-            "OAuth implementation not available, try reauthenticating: %s", err
-        )
         raise ConfigEntryAuthFailed(
             translation_domain=DOMAIN,
             translation_key="oauth_implementation_not_available",

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -85,18 +85,15 @@ async def _get_access_token(oauth_session: OAuth2Session) -> str:
     try:
         await oauth_session.async_ensure_token_valid()
     except ClientResponseError as err:
-        LOGGER.error("Token refresh HTTP error: %s", err)
         if err.status == 401:
             raise ConfigEntryAuthFailed from err
         raise ConfigEntryNotReady from err
     except (KeyError, TypeError) as err:
-        LOGGER.error("Token data malformed, try reauthenticating: %s", err)
         raise ConfigEntryAuthFailed(
             translation_domain=DOMAIN,
             translation_key="token_data_malformed",
         ) from err
     except ClientError as err:
-        LOGGER.error("Token refresh connection error: %s", err)
         raise ConfigEntryNotReady from err
     return oauth_session.token[CONF_ACCESS_TOKEN]
 

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -997,7 +997,6 @@
       "total_grid_energy_exported": {
         "name": "Grid exported"
       },
-
       "total_home_usage": {
         "name": "Home usage"
       },
@@ -1127,6 +1126,9 @@
     "no_vehicle_data_for_device": {
       "message": "No vehicle data for device ID: {device_id}"
     },
+    "oauth_implementation_not_available": {
+      "message": "OAuth implementation not available, try reauthenticating"
+    },
     "set_scheduled_charging_time": {
       "message": "Scheduled charging time is required when enabling"
     },
@@ -1135,6 +1137,9 @@
     },
     "set_scheduled_departure_preconditioning": {
       "message": "Preconditioning departure time is required when enabling"
+    },
+    "token_data_malformed": {
+      "message": "Token data malformed, try reauthenticating"
     },
     "wake_up_failed": {
       "message": "Failed to wake up vehicle: {message}"


### PR DESCRIPTION
## Proposed change

Add proper error handling guards for OAuth-related failures in the Teslemetry integration:

- Handle `ValueError` when the OAuth implementation is not available (e.g., after restore from backup), raising `ConfigEntryAuthFailed` to trigger reauthentication
- Handle `KeyError`/`TypeError` for malformed token data, triggering reauthentication instead of failing silently
- Handle `ClientError` for network issues during token refresh, raising `ConfigEntryNotReady` for retry
- Add improved logging for token refresh debugging
- Move the access token function to module level using `functools.partial` for cleaner code

This improves the user experience by properly triggering reauthentication flows when OAuth tokens become invalid or unavailable, rather than failing with unclear errors.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr