### PR TITLE
Add reconfigure flow in Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -18,7 +18,11 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    SOURCE_RECONFIGURE,
+    ConfigFlowResult,
+)
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -73,6 +77,11 @@ class OAuth2FlowHandler(
             return self.async_update_reload_and_abort(
                 self._get_reauth_entry(), data=data
             )
+        if self.source == SOURCE_RECONFIGURE:
+            self._abort_if_unique_id_mismatch(reason="reconfigure_account_mismatch")
+            return self.async_update_reload_and_abort(
+                self._get_reconfigure_entry(), data=data
+            )
         self._abort_if_unique_id_configured()
 
         return self.async_create_entry(
@@ -121,3 +130,9 @@ class OAuth2FlowHandler(
             )
 
         return await super().async_step_user()
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration."""
+        return await self.async_step_user()

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -33,7 +33,9 @@
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
       "reauth_account_mismatch": "The reauthentication account does not match the original account",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_account_mismatch": "The reconfiguration account does not match the original account",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/tests/components/teslemetry/conftest.py
+++ b/tests/components/teslemetry/conftest.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from copy import deepcopy
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from teslemetry_stream.stream import recursive_match
+
+from homeassistant.components.teslemetry.const import TOKEN_URL
 
 from .const import (
     COMMAND_OK,
@@ -21,6 +24,8 @@ from .const import (
     WAKE_UP_ONLINE,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
+
 
 @pytest.fixture
 def mock_setup_entry():
@@ -29,6 +34,25 @@ def mock_setup_entry():
         "homeassistant.components.teslemetry.async_setup_entry", return_value=True
     ) as mock_async_setup_entry:
         yield mock_async_setup_entry
+
+
+@pytest.fixture
+def mock_token_response() -> dict[str, Any]:
+    """Return a mock OAuth token response."""
+    return {
+        "refresh_token": "mock-refresh-token",
+        "access_token": "mock-access-token",
+        "type": "Bearer",
+        "expires_in": 60,
+    }
+
+
+@pytest.fixture
+def mock_token_post(
+    aioclient_mock: AiohttpClientMocker, mock_token_response: dict[str, Any]
+) -> None:
+    """Mock the OAuth token endpoint."""
+    aioclient_mock.post(TOKEN_URL, json=mock_token_response)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Proposed change

Add a reconfigure flow to the Teslemetry integration that allows users to re-authenticate their account without removing and re-adding the integration. This is useful when OAuth credentials need to be refreshed or when users want to update their authentication.

Changes:
- Add `async_step_reconfigure` method to handle reconfiguration flow
- Handle `SOURCE_RECONFIGURE` in `async_oauth_create_entry` to update existing config entry
- Add translation strings for reconfigure abort reasons (`reconfigure_account_mismatch`, `reconfigure_successful`)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr