### PR TITLE
Add alarm_control_panel conditions

### DIFF
--- a/homeassistant/components/alarm_control_panel/condition.py
+++ b/homeassistant/components/alarm_control_panel/condition.py
@@ -13,7 +13,7 @@ from .const import DOMAIN, AlarmControlPanelEntityFeature, AlarmControlPanelStat
 
 
 def supports_feature(hass: HomeAssistant, entity_id: str, features: int) -> bool:
-    """Get the device class of an entity or UNDEFINED if not found."""
+    """Test if an entity supports the specified features."""
     try:
         return bool(get_supported_features(hass, entity_id) & features)
     except HomeAssistantError:
@@ -38,7 +38,7 @@ class EntityStateConditionRequiredFeatures(EntityStateConditionBase):
 def make_entity_state_condition_required_features(
     domain: str, to_state: str, required_features: int
 ) -> type[EntityStateConditionRequiredFeatures]:
-    """Create an entity state trigger class."""
+    """Create an entity state condition class with required feature filtering."""
 
     class CustomCondition(EntityStateConditionRequiredFeatures):
         """Trigger for entity state changes."""

--- a/homeassistant/components/alarm_control_panel/condition.py
+++ b/homeassistant/components/alarm_control_panel/condition.py
@@ -20,13 +20,13 @@ def supports_feature(hass: HomeAssistant, entity_id: str, features: int) -> bool
         return False
 
 
-class EntityStateConditionRequiredFeatures(EntityStateConditionBase):
+class EntityStateRequiredFeaturesCondition(EntityStateConditionBase):
     """State condition."""
 
     _required_features: int
 
     def entity_filter(self, entities: set[str]) -> set[str]:
-        """Filter entities of this domain."""
+        """Filter entities of this domain with the required features."""
         entities = super().entity_filter(entities)
         return {
             entity_id
@@ -35,13 +35,13 @@ class EntityStateConditionRequiredFeatures(EntityStateConditionBase):
         }
 
 
-def make_entity_state_condition_required_features(
+def make_entity_state_required_features_condition(
     domain: str, to_state: str, required_features: int
-) -> type[EntityStateConditionRequiredFeatures]:
+) -> type[EntityStateRequiredFeaturesCondition]:
     """Create an entity state condition class with required feature filtering."""
 
-    class CustomCondition(EntityStateConditionRequiredFeatures):
-        """Trigger for entity state changes."""
+    class CustomCondition(EntityStateRequiredFeaturesCondition):
+        """Condition for entity state changes."""
 
         _domain = domain
         _states = {to_state}
@@ -61,22 +61,22 @@ CONDITIONS: dict[str, type[Condition]] = {
             AlarmControlPanelState.ARMED_VACATION,
         },
     ),
-    "is_armed_away": make_entity_state_condition_required_features(
+    "is_armed_away": make_entity_state_required_features_condition(
         DOMAIN,
         AlarmControlPanelState.ARMED_AWAY,
         AlarmControlPanelEntityFeature.ARM_AWAY,
     ),
-    "is_armed_home": make_entity_state_condition_required_features(
+    "is_armed_home": make_entity_state_required_features_condition(
         DOMAIN,
         AlarmControlPanelState.ARMED_HOME,
         AlarmControlPanelEntityFeature.ARM_HOME,
     ),
-    "is_armed_night": make_entity_state_condition_required_features(
+    "is_armed_night": make_entity_state_required_features_condition(
         DOMAIN,
         AlarmControlPanelState.ARMED_NIGHT,
         AlarmControlPanelEntityFeature.ARM_NIGHT,
     ),
-    "is_armed_vacation": make_entity_state_condition_required_features(
+    "is_armed_vacation": make_entity_state_required_features_condition(
         DOMAIN,
         AlarmControlPanelState.ARMED_VACATION,
         AlarmControlPanelEntityFeature.ARM_VACATION,

--- a/homeassistant/components/alarm_control_panel/condition.py
+++ b/homeassistant/components/alarm_control_panel/condition.py
@@ -1,0 +1,93 @@
+"""Provides conditions for alarm control panels."""
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.condition import (
+    Condition,
+    EntityStateConditionBase,
+    make_entity_state_condition,
+)
+from homeassistant.helpers.entity import get_supported_features
+
+from .const import DOMAIN, AlarmControlPanelEntityFeature, AlarmControlPanelState
+
+
+def supports_feature(hass: HomeAssistant, entity_id: str, features: int) -> bool:
+    """Get the device class of an entity or UNDEFINED if not found."""
+    try:
+        return bool(get_supported_features(hass, entity_id) & features)
+    except HomeAssistantError:
+        return False
+
+
+class EntityStateConditionRequiredFeatures(EntityStateConditionBase):
+    """State condition."""
+
+    _required_features: int
+
+    def entity_filter(self, entities: set[str]) -> set[str]:
+        """Filter entities of this domain."""
+        entities = super().entity_filter(entities)
+        return {
+            entity_id
+            for entity_id in entities
+            if supports_feature(self._hass, entity_id, self._required_features)
+        }
+
+
+def make_entity_state_condition_required_features(
+    domain: str, to_state: str, required_features: int
+) -> type[EntityStateConditionRequiredFeatures]:
+    """Create an entity state trigger class."""
+
+    class CustomCondition(EntityStateConditionRequiredFeatures):
+        """Trigger for entity state changes."""
+
+        _domain = domain
+        _states = {to_state}
+        _required_features = required_features
+
+    return CustomCondition
+
+
+CONDITIONS: dict[str, type[Condition]] = {
+    "is_armed": make_entity_state_condition(
+        DOMAIN,
+        {
+            AlarmControlPanelState.ARMED_AWAY,
+            AlarmControlPanelState.ARMED_CUSTOM_BYPASS,
+            AlarmControlPanelState.ARMED_HOME,
+            AlarmControlPanelState.ARMED_NIGHT,
+            AlarmControlPanelState.ARMED_VACATION,
+        },
+    ),
+    "is_armed_away": make_entity_state_condition_required_features(
+        DOMAIN,
+        AlarmControlPanelState.ARMED_AWAY,
+        AlarmControlPanelEntityFeature.ARM_AWAY,
+    ),
+    "is_armed_home": make_entity_state_condition_required_features(
+        DOMAIN,
+        AlarmControlPanelState.ARMED_HOME,
+        AlarmControlPanelEntityFeature.ARM_HOME,
+    ),
+    "is_armed_night": make_entity_state_condition_required_features(
+        DOMAIN,
+        AlarmControlPanelState.ARMED_NIGHT,
+        AlarmControlPanelEntityFeature.ARM_NIGHT,
+    ),
+    "is_armed_vacation": make_entity_state_condition_required_features(
+        DOMAIN,
+        AlarmControlPanelState.ARMED_VACATION,
+        AlarmControlPanelEntityFeature.ARM_VACATION,
+    ),
+    "is_disarmed": make_entity_state_condition(DOMAIN, AlarmControlPanelState.DISARMED),
+    "is_triggered": make_entity_state_condition(
+        DOMAIN, AlarmControlPanelState.TRIGGERED
+    ),
+}
+
+
+async def async_get_conditions(hass: HomeAssistant) -> dict[str, type[Condition]]:
+    """Return the alarm control panel conditions."""
+    return CONDITIONS

--- a/homeassistant/components/alarm_control_panel/conditions.yaml
+++ b/homeassistant/components/alarm_control_panel/conditions.yaml
@@ -1,0 +1,52 @@
+.condition_common: &condition_common
+  target:
+    entity:
+      domain: alarm_control_panel
+  fields: &condition_common_fields
+    behavior:
+      required: true
+      default: any
+      selector:
+        select:
+          translation_key: condition_behavior
+          options:
+            - all
+            - any
+
+is_armed: *condition_common
+
+is_armed_away:
+  fields: *condition_common_fields
+  target:
+    entity:
+      domain: alarm_control_panel
+      supported_features:
+        - alarm_control_panel.AlarmControlPanelEntityFeature.ARM_AWAY
+
+is_armed_home:
+  fields: *condition_common_fields
+  target:
+    entity:
+      domain: alarm_control_panel
+      supported_features:
+        - alarm_control_panel.AlarmControlPanelEntityFeature.ARM_HOME
+
+is_armed_night:
+  fields: *condition_common_fields
+  target:
+    entity:
+      domain: alarm_control_panel
+      supported_features:
+        - alarm_control_panel.AlarmControlPanelEntityFeature.ARM_NIGHT
+
+is_armed_vacation:
+  fields: *condition_common_fields
+  target:
+    entity:
+      domain: alarm_control_panel
+      supported_features:
+        - alarm_control_panel.AlarmControlPanelEntityFeature.ARM_VACATION
+
+is_disarmed: *condition_common
+
+is_triggered: *condition_common

--- a/homeassistant/components/alarm_control_panel/icons.json
+++ b/homeassistant/components/alarm_control_panel/icons.json
@@ -1,4 +1,27 @@
 {
+  "conditions": {
+    "is_armed": {
+      "condition": "mdi:shield"
+    },
+    "is_armed_away": {
+      "condition": "mdi:shield-lock"
+    },
+    "is_armed_home": {
+      "condition": "mdi:shield-home"
+    },
+    "is_armed_night": {
+      "condition": "mdi:shield-moon"
+    },
+    "is_armed_vacation": {
+      "condition": "mdi:shield-airplane"
+    },
+    "is_disarmed": {
+      "condition": "mdi:shield-off"
+    },
+    "is_triggered": {
+      "condition": "mdi:bell-ring"
+    }
+  },
   "entity_component": {
     "_": {
       "default": "mdi:shield",

--- a/homeassistant/components/alarm_control_panel/strings.json
+++ b/homeassistant/components/alarm_control_panel/strings.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "condition_behavior_description": "How the state should match on the targeted fans.",
+    "condition_behavior_description": "How the state should match on the targeted alarms.",
     "condition_behavior_name": "Behavior",
     "trigger_behavior_description": "The behavior of the targeted alarms to trigger on.",
     "trigger_behavior_name": "Behavior"

--- a/homeassistant/components/alarm_control_panel/strings.json
+++ b/homeassistant/components/alarm_control_panel/strings.json
@@ -1,7 +1,81 @@
 {
   "common": {
+    "condition_behavior_description": "How the state should match on the targeted fans.",
+    "condition_behavior_name": "Behavior",
     "trigger_behavior_description": "The behavior of the targeted alarms to trigger on.",
     "trigger_behavior_name": "Behavior"
+  },
+  "conditions": {
+    "is_armed": {
+      "description": "Tests if one or more alarms are armed.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::alarm_control_panel::common::condition_behavior_description%]",
+          "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
+        }
+      },
+      "name": "If an alarm is armed"
+    },
+    "is_armed_away": {
+      "description": "Tests if one or more alarms are armed in away mode.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::alarm_control_panel::common::condition_behavior_description%]",
+          "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
+        }
+      },
+      "name": "If an alarm is armed away"
+    },
+    "is_armed_home": {
+      "description": "Tests if one or more alarms are armed in home mode.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::alarm_control_panel::common::condition_behavior_description%]",
+          "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
+        }
+      },
+      "name": "If an alarm is armed home"
+    },
+    "is_armed_night": {
+      "description": "Tests if one or more alarms are armed in night mode.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::alarm_control_panel::common::condition_behavior_description%]",
+          "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
+        }
+      },
+      "name": "If an alarm is armed night"
+    },
+    "is_armed_vacation": {
+      "description": "Tests if one or more alarms are armed in vacation mode.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::alarm_control_panel::common::condition_behavior_description%]",
+          "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
+        }
+      },
+      "name": "If an alarm is armed vacation"
+    },
+    "is_disarmed": {
+      "description": "Tests if one or more alarms are disarmed.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::alarm_control_panel::common::condition_behavior_description%]",
+          "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
+        }
+      },
+      "name": "If an alarm is disarmed"
+    },
+    "is_triggered": {
+      "description": "Tests if one or more alarms are triggered.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::alarm_control_panel::common::condition_behavior_description%]",
+          "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
+        }
+      },
+      "name": "If an alarm is triggered"
+    }
   },
   "device_automation": {
     "action_type": {
@@ -76,6 +150,12 @@
     }
   },
   "selector": {
+    "condition_behavior": {
+      "options": {
+        "all": "All",
+        "any": "Any"
+      }
+    },
     "trigger_behavior": {
       "options": {
         "any": "Any",

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -123,6 +123,7 @@ SERVICE_TRIGGER = "trigger"
 NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG = "new_triggers_conditions"
 
 _EXPERIMENTAL_CONDITION_PLATFORMS = {
+    "alarm_control_panel",
     "fan",
     "light",
 }

--- a/tests/components/__init__.py
+++ b/tests/components/__init__.py
@@ -254,12 +254,20 @@ def parametrize_condition_states(
                         state_with_attributes(other_state, False, True)
                         for other_state in other_states
                     ),
-                    (
-                        state_with_attributes(target_state, True, True)
-                        for target_state in target_states
-                    ),
-                )
+                ),
             ),
+        ),
+        # Test each target state individually to isolate condition_true expectations
+        *(
+            (
+                condition,
+                condition_options,
+                [
+                    state_with_attributes(other_states[0], False, True),
+                    state_with_attributes(target_state, True, True),
+                ],
+            )
+            for target_state in target_states
         ),
     ]
 

--- a/tests/components/alarm_control_panel/test_condition.py
+++ b/tests/components/alarm_control_panel/test_condition.py
@@ -1,0 +1,275 @@
+"""Test alarm_control_panel conditions."""
+
+from typing import Any
+
+import pytest
+
+from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
+)
+from homeassistant.const import ATTR_SUPPORTED_FEATURES
+from homeassistant.core import HomeAssistant
+
+from tests.components import (
+    ConditionStateDescription,
+    assert_condition_gated_by_labs_flag,
+    create_target_condition,
+    other_states,
+    parametrize_condition_states,
+    parametrize_target_entities,
+    set_or_remove_state,
+    target_entities,
+)
+
+
+@pytest.fixture(autouse=True, name="stub_blueprint_populate")
+def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
+    """Stub copying the blueprints to the config folder."""
+
+
+@pytest.fixture
+async def target_alarm_control_panels(hass: HomeAssistant) -> list[str]:
+    """Create multiple alarm_control_panel entities associated with different targets."""
+    return (await target_entities(hass, "alarm_control_panel"))["included"]
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "alarm_control_panel.is_armed",
+        "alarm_control_panel.is_armed_away",
+        "alarm_control_panel.is_armed_home",
+        "alarm_control_panel.is_armed_night",
+        "alarm_control_panel.is_armed_vacation",
+        "alarm_control_panel.is_disarmed",
+        "alarm_control_panel.is_triggered",
+    ],
+)
+async def test_alarm_control_panel_conditions_gated_by_labs_flag(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, condition: str
+) -> None:
+    """Test the alarm_control_panel conditions are gated by the labs flag."""
+    await assert_condition_gated_by_labs_flag(hass, caplog, condition)
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("condition_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("alarm_control_panel"),
+)
+@pytest.mark.parametrize(
+    ("condition", "condition_options", "states"),
+    [
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_armed",
+            target_states=[
+                AlarmControlPanelState.ARMED_AWAY,
+                AlarmControlPanelState.ARMED_CUSTOM_BYPASS,
+                AlarmControlPanelState.ARMED_HOME,
+                AlarmControlPanelState.ARMED_NIGHT,
+                AlarmControlPanelState.ARMED_VACATION,
+            ],
+            other_states=[
+                AlarmControlPanelState.ARMING,
+                AlarmControlPanelState.DISARMED,
+                AlarmControlPanelState.DISARMING,
+                AlarmControlPanelState.PENDING,
+                AlarmControlPanelState.TRIGGERED,
+            ],
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_armed_away",
+            target_states=[AlarmControlPanelState.ARMED_AWAY],
+            other_states=other_states(AlarmControlPanelState.ARMED_AWAY),
+            additional_attributes={
+                ATTR_SUPPORTED_FEATURES: AlarmControlPanelEntityFeature.ARM_AWAY
+            },
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_armed_home",
+            target_states=[AlarmControlPanelState.ARMED_HOME],
+            other_states=other_states(AlarmControlPanelState.ARMED_HOME),
+            additional_attributes={
+                ATTR_SUPPORTED_FEATURES: AlarmControlPanelEntityFeature.ARM_HOME
+            },
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_armed_night",
+            target_states=[AlarmControlPanelState.ARMED_NIGHT],
+            other_states=other_states(AlarmControlPanelState.ARMED_NIGHT),
+            additional_attributes={
+                ATTR_SUPPORTED_FEATURES: AlarmControlPanelEntityFeature.ARM_NIGHT
+            },
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_armed_vacation",
+            target_states=[AlarmControlPanelState.ARMED_VACATION],
+            other_states=other_states(AlarmControlPanelState.ARMED_VACATION),
+            additional_attributes={
+                ATTR_SUPPORTED_FEATURES: AlarmControlPanelEntityFeature.ARM_VACATION
+            },
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_disarmed",
+            target_states=[AlarmControlPanelState.DISARMED],
+            other_states=other_states(AlarmControlPanelState.DISARMED),
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_triggered",
+            target_states=[AlarmControlPanelState.TRIGGERED],
+            other_states=other_states(AlarmControlPanelState.TRIGGERED),
+        ),
+    ],
+)
+async def test_alarm_control_panel_state_condition_behavior_any(
+    hass: HomeAssistant,
+    target_alarm_control_panels: list[str],
+    condition_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    condition: str,
+    condition_options: dict[str, Any],
+    states: list[ConditionStateDescription],
+) -> None:
+    """Test the alarm_control_panel state condition with the 'any' behavior."""
+    other_entity_ids = set(target_alarm_control_panels) - {entity_id}
+
+    # Set all alarm_control_panels, including the tested alarm_control_panel, to the initial state
+    for eid in target_alarm_control_panels:
+        set_or_remove_state(hass, eid, states[0]["included"])
+        await hass.async_block_till_done()
+
+    condition = await create_target_condition(
+        hass,
+        condition=condition,
+        target=condition_target_config,
+        behavior="any",
+    )
+
+    for state in states:
+        included_state = state["included"]
+        set_or_remove_state(hass, entity_id, included_state)
+        await hass.async_block_till_done()
+        assert condition(hass) == state["condition_true"]
+
+        # Check if changing other alarm_control_panels also passes the condition
+        for other_entity_id in other_entity_ids:
+            set_or_remove_state(hass, other_entity_id, included_state)
+            await hass.async_block_till_done()
+        assert condition(hass) == state["condition_true"]
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("condition_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("alarm_control_panel"),
+)
+@pytest.mark.parametrize(
+    ("condition", "condition_options", "states"),
+    [
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_armed",
+            target_states=[
+                AlarmControlPanelState.ARMED_AWAY,
+                AlarmControlPanelState.ARMED_CUSTOM_BYPASS,
+                AlarmControlPanelState.ARMED_HOME,
+                AlarmControlPanelState.ARMED_NIGHT,
+                AlarmControlPanelState.ARMED_VACATION,
+            ],
+            other_states=[
+                AlarmControlPanelState.ARMING,
+                AlarmControlPanelState.DISARMED,
+                AlarmControlPanelState.DISARMING,
+                AlarmControlPanelState.PENDING,
+                AlarmControlPanelState.TRIGGERED,
+            ],
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_armed_away",
+            target_states=[AlarmControlPanelState.ARMED_AWAY],
+            other_states=other_states(AlarmControlPanelState.ARMED_AWAY),
+            additional_attributes={
+                ATTR_SUPPORTED_FEATURES: AlarmControlPanelEntityFeature.ARM_AWAY
+            },
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_armed_home",
+            target_states=[AlarmControlPanelState.ARMED_HOME],
+            other_states=other_states(AlarmControlPanelState.ARMED_HOME),
+            additional_attributes={
+                ATTR_SUPPORTED_FEATURES: AlarmControlPanelEntityFeature.ARM_HOME
+            },
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_armed_night",
+            target_states=[AlarmControlPanelState.ARMED_NIGHT],
+            other_states=other_states(AlarmControlPanelState.ARMED_NIGHT),
+            additional_attributes={
+                ATTR_SUPPORTED_FEATURES: AlarmControlPanelEntityFeature.ARM_NIGHT
+            },
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_armed_vacation",
+            target_states=[AlarmControlPanelState.ARMED_VACATION],
+            other_states=other_states(AlarmControlPanelState.ARMED_VACATION),
+            additional_attributes={
+                ATTR_SUPPORTED_FEATURES: AlarmControlPanelEntityFeature.ARM_VACATION
+            },
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_disarmed",
+            target_states=[AlarmControlPanelState.DISARMED],
+            other_states=other_states(AlarmControlPanelState.DISARMED),
+        ),
+        *parametrize_condition_states(
+            condition="alarm_control_panel.is_triggered",
+            target_states=[AlarmControlPanelState.TRIGGERED],
+            other_states=other_states(AlarmControlPanelState.TRIGGERED),
+        ),
+    ],
+)
+async def test_alarm_control_panel_state_condition_behavior_all(
+    hass: HomeAssistant,
+    target_alarm_control_panels: list[str],
+    condition_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    condition: str,
+    condition_options: dict[str, Any],
+    states: list[ConditionStateDescription],
+) -> None:
+    """Test the alarm_control_panel state condition with the 'all' behavior."""
+    other_entity_ids = set(target_alarm_control_panels) - {entity_id}
+
+    # Set all alarm_control_panels, including the tested alarm_control_panel, to the initial state
+    for eid in target_alarm_control_panels:
+        set_or_remove_state(hass, eid, states[0]["included"])
+        await hass.async_block_till_done()
+
+    condition = await create_target_condition(
+        hass,
+        condition=condition,
+        target=condition_target_config,
+        behavior="all",
+    )
+
+    for state in states:
+        included_state = state["included"]
+
+        set_or_remove_state(hass, entity_id, included_state)
+        await hass.async_block_till_done()
+        # The condition passes if all entities are either in a target state or invalid
+        assert condition(hass) == (
+            (not state["state_valid"])
+            or (state["condition_true"] and entities_in_target == 1)
+        )
+
+        for other_entity_id in other_entity_ids:
+            set_or_remove_state(hass, other_entity_id, included_state)
+            await hass.async_block_till_done()
+
+        # The condition passes if all entities are either in a target state or invalid
+        assert condition(hass) == (
+            (not state["state_valid"]) or state["condition_true"]
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add alarm_control_panel conditions:
    - `alarm_control_panel.is_armed`
    - `alarm_control_panel.is_armed_away`
    - `alarm_control_panel.is_armed_home`
    - `alarm_control_panel.is_armed_night`
    - `alarm_control_panel.is_armed_vacation`
    - `alarm_control_panel.is_disarmed`
    - `alarm_control_panel.is_triggered`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes #158550
  - fixes #158551
  - fixes #158552
  - fixes #158553
  - fixes #158554
  - fixes #158555
  - fixes #158556
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
