### PR TITLE
Bump pynina to 1.0.2

### DIFF
--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -141,7 +141,7 @@ class NinaConfigFlow(ConfigFlow, domain=DOMAIN):
 
             try:
                 self._all_region_codes_sorted = swap_key_value(
-                    await nina.getAllRegionalCodes()
+                    await nina.get_all_regional_codes()
                 )
             except ApiError:
                 return self.async_abort(reason="no_fetch")
@@ -221,7 +221,7 @@ class OptionsFlowHandler(OptionsFlowWithReload):
 
             try:
                 self._all_region_codes_sorted = swap_key_value(
-                    await nina.getAllRegionalCodes()
+                    await nina.get_all_regional_codes()
                 )
             except ApiError:
                 return self.async_abort(reason="no_fetch")

--- a/homeassistant/components/nina/coordinator.py
+++ b/homeassistant/components/nina/coordinator.py
@@ -66,7 +66,7 @@ class NINADataUpdateCoordinator(
 
         regions: dict[str, str] = config_entry.data[CONF_REGIONS]
         for region in regions:
-            self._nina.addRegion(region)
+            self._nina.add_region(region)
 
         super().__init__(
             hass,
@@ -151,7 +151,7 @@ class NINADataUpdateCoordinator(
                     raw_warn.sent or "",
                     raw_warn.start or "",
                     raw_warn.expires or "",
-                    raw_warn.isValid(),
+                    raw_warn.is_valid,
                 )
                 warnings_for_regions.append(warning_data)
 

--- a/homeassistant/components/nina/manifest.json
+++ b/homeassistant/components/nina/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "loggers": ["pynina"],
   "quality_scale": "bronze",
-  "requirements": ["pynina==0.3.6"],
+  "requirements": ["pynina==1.0.1"],
   "single_config_entry": true
 }

--- a/homeassistant/components/nina/manifest.json
+++ b/homeassistant/components/nina/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "loggers": ["pynina"],
   "quality_scale": "bronze",
-  "requirements": ["pynina==1.0.1"],
+  "requirements": ["pynina==1.0.2"],
   "single_config_entry": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2234,7 +2234,7 @@ pynetgear==0.10.10
 pynetio==0.1.9.1
 
 # homeassistant.components.nina
-pynina==1.0.1
+pynina==1.0.2
 
 # homeassistant.components.nintendo_parental_controls
 pynintendoauth==1.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2234,7 +2234,7 @@ pynetgear==0.10.10
 pynetio==0.1.9.1
 
 # homeassistant.components.nina
-pynina==0.3.6
+pynina==1.0.1
 
 # homeassistant.components.nintendo_parental_controls
 pynintendoauth==1.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1887,7 +1887,7 @@ pynecil==4.2.1
 pynetgear==0.10.10
 
 # homeassistant.components.nina
-pynina==1.0.1
+pynina==1.0.2
 
 # homeassistant.components.nintendo_parental_controls
 pynintendoauth==1.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1887,7 +1887,7 @@ pynecil==4.2.1
 pynetgear==0.10.10
 
 # homeassistant.components.nina
-pynina==0.3.6
+pynina==1.0.1
 
 # homeassistant.components.nintendo_parental_controls
 pynintendoauth==1.0.2

--- a/tests/components/nina/__init__.py
+++ b/tests/components/nina/__init__.py
@@ -17,7 +17,7 @@ from tests.common import (
 async def setup_platform(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Set up the NINA platform."""
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         wraps=mocked_request_function,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/nina/snapshots/test_diagnostics.ambr
+++ b/tests/components/nina/snapshots/test_diagnostics.ambr
@@ -25,7 +25,7 @@
           'id': 'biw.BIWAPP-69634',
           'is_valid': False,
           'recommended_actions': '',
-          'sender': '',
+          'sender': None,
           'sent': '1999-08-07T10:59:00+02:00',
           'severity': 'Minor',
           'start': '',

--- a/tests/components/nina/test_config_flow.py
+++ b/tests/components/nina/test_config_flow.py
@@ -49,7 +49,7 @@ def assert_dummy_entry_created(result: dict[str, Any]) -> None:
 async def test_step_user_connection_error(hass: HomeAssistant) -> None:
     """Test starting a flow by user but no connection."""
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         side_effect=ApiError("Could not connect to Api"),
     ):
         result: dict[str, Any] = await hass.config_entries.flow.async_init(
@@ -63,7 +63,7 @@ async def test_step_user_connection_error(hass: HomeAssistant) -> None:
 async def test_step_user_unexpected_exception(hass: HomeAssistant) -> None:
     """Test starting a flow by user but with an unexpected exception."""
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         side_effect=Exception("DUMMY"),
     ):
         result: dict[str, Any] = await hass.config_entries.flow.async_init(
@@ -77,7 +77,7 @@ async def test_step_user_unexpected_exception(hass: HomeAssistant) -> None:
 async def test_step_user(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     """Test starting a flow by user with valid values."""
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         wraps=mocked_request_function,
     ):
         result: dict[str, Any] = await hass.config_entries.flow.async_init(
@@ -95,7 +95,7 @@ async def test_step_user(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
 async def test_step_user_no_selection(hass: HomeAssistant) -> None:
     """Test starting a flow by user with no selection."""
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         wraps=mocked_request_function,
     ):
         result: dict[str, Any] = await hass.config_entries.flow.async_init(
@@ -121,7 +121,7 @@ async def test_step_user_already_configured(
 ) -> None:
     """Test starting a flow by user, but it was already configured."""
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         wraps=mocked_request_function,
     ):
         result = await hass.config_entries.flow.async_init(
@@ -141,7 +141,7 @@ async def test_options_flow_init(
 
     with (
         patch(
-            "pynina.baseApi.BaseAPI._makeRequest",
+            "pynina.api_client.APIClient.make_request",
             wraps=mocked_request_function,
         ),
     ):
@@ -195,7 +195,7 @@ async def test_options_flow_with_no_selection(
 
     with (
         patch(
-            "pynina.baseApi.BaseAPI._makeRequest",
+            "pynina.api_client.APIClient.make_request",
             wraps=mocked_request_function,
         ),
     ):
@@ -263,7 +263,7 @@ async def test_options_flow_connection_error(
     await setup_platform(hass, mock_config_entry)
 
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         side_effect=ApiError("Could not connect to Api"),
     ):
         result = await hass.config_entries.options.async_init(
@@ -283,7 +283,7 @@ async def test_options_flow_unexpected_exception(
 
     with (
         patch(
-            "pynina.baseApi.BaseAPI._makeRequest",
+            "pynina.api_client.APIClient.make_request",
             side_effect=Exception("DUMMY"),
         ),
     ):
@@ -312,7 +312,7 @@ async def test_options_flow_entity_removal(
 
     with (
         patch(
-            "pynina.baseApi.BaseAPI._makeRequest",
+            "pynina.api_client.APIClient.make_request",
             wraps=mocked_request_function,
         ),
     ):

--- a/tests/components/nina/test_diagnostics.py
+++ b/tests/components/nina/test_diagnostics.py
@@ -32,7 +32,7 @@ async def test_diagnostics(
     """Test diagnostics."""
 
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         wraps=mocked_request_function,
     ):
         config_entry: MockConfigEntry = MockConfigEntry(

--- a/tests/components/nina/test_init.py
+++ b/tests/components/nina/test_init.py
@@ -28,7 +28,7 @@ async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
     """Set up the NINA integration in Home Assistant."""
 
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         wraps=mocked_request_function,
     ):
         entry: MockConfigEntry = MockConfigEntry(
@@ -54,7 +54,7 @@ async def test_config_migration_from1_1(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         wraps=mocked_request_function,
     ):
         old_conf_entry.add_to_hass(hass)
@@ -82,7 +82,7 @@ async def test_config_migration_from1_2(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         wraps=mocked_request_function,
     ):
         old_conf_entry.add_to_hass(hass)
@@ -104,7 +104,7 @@ async def test_config_migration_downgrade(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         wraps=mocked_request_function,
     ):
         conf_entry.add_to_hass(hass)
@@ -126,7 +126,7 @@ async def test_config_entry_not_ready(hass: HomeAssistant) -> None:
 async def test_sensors_connection_error(hass: HomeAssistant) -> None:
     """Test the creation and values of the NINA sensors with no connected."""
     with patch(
-        "pynina.baseApi.BaseAPI._makeRequest",
+        "pynina.api_client.APIClient.make_request",
         side_effect=ApiError("Could not connect to Api"),
     ):
         conf_entry: MockConfigEntry = MockConfigEntry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pynina to 1.0.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Diff: https://gitlab.com/DeerMaximum/pynina/-/compare/v0.3.6...v1.0.2
- Releases: https://gitlab.com/DeerMaximum/pynina/-/releases

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
