### PR TITLE
Local custom integration brand icons

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1607,18 +1607,23 @@ def mock_integration(
     module: MockModule,
     built_in: bool = True,
     top_level_files: set[str] | None = None,
+    path: pathlib.Path | str | None = None,
 ) -> loader.Integration:
     """Mock an integration."""
-    path = (
+    pkg_path = (
         f"{loader.PACKAGE_BUILTIN}.{module.DOMAIN}"
         if built_in
         else f"{loader.PACKAGE_CUSTOM_COMPONENTS}.{module.DOMAIN}"
     )
+    if path is None:
+        file_path = pathlib.Path(pkg_path.replace(".", "/"))
+    else:
+        file_path = pathlib.Path(path)
 
     integration = loader.Integration(
         hass,
-        path,
-        pathlib.Path(path.replace(".", "/")),
+        pkg_path,
+        file_path,
         module.mock_manifest(),
         top_level_files,
     )

--- a/tests/components/frontend/test_brands.py
+++ b/tests/components/frontend/test_brands.py
@@ -1,0 +1,103 @@
+"""Test the brand icon serving."""
+
+from http import HTTPStatus
+from pathlib import Path
+
+from aiohttp.test_utils import TestClient
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.loader import async_get_integration
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockModule, mock_integration
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
+
+
+@pytest.fixture
+async def frontend(hass: HomeAssistant) -> None:
+    """Frontend setup."""
+    assert await async_setup_component(hass, "frontend", {})
+
+
+@pytest.fixture
+async def mock_http_client(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator, frontend: None
+) -> TestClient:
+    """Start the Home Assistant HTTP component."""
+    return await aiohttp_client(hass.http.app)
+
+
+async def test_brands_local_icon(
+    hass: HomeAssistant, mock_http_client: TestClient, tmp_path: Path
+) -> None:
+    """Test serving a local brand icon."""
+    domain = "test_integration"
+    filename = "icon.png"
+
+    integration_path = tmp_path / domain
+    integration_path.mkdir()
+    icon_file = integration_path / filename
+    icon_file.write_bytes(b"pseudo-png-content")
+
+    mock_integration(hass, MockModule(domain), path=str(integration_path))
+
+    # We need to make sure async_get_integration returns our mock integration with the correct path
+    integration = await async_get_integration(hass, domain)
+    assert str(integration.file_path) == str(integration_path)
+
+    resp = await mock_http_client.get(f"/brands/{domain}/{filename}")
+    assert resp.status == HTTPStatus.OK
+    assert await resp.read() == b"pseudo-png-content"
+
+
+async def test_brands_proxy_external(
+    hass: HomeAssistant,
+    mock_http_client: TestClient,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test proxying to external brands service when local icon is missing."""
+    domain = "test_integration"
+
+    aioclient_mock.get(
+        f"https://brands.home-assistant.io/_/{domain}/icon.png",
+        content=b"proxied-content",
+        status=200,
+    )
+
+    resp = await mock_http_client.get(f"/brands/{domain}/icon.png")
+    assert resp.status == HTTPStatus.OK
+    assert await resp.read() == b"proxied-content"
+
+
+async def test_brands_invalid_filename(
+    hass: HomeAssistant, mock_http_client: TestClient
+) -> None:
+    """Test security checks for invalid filenames."""
+    domain = "test_integration"
+
+    mock_integration(hass, MockModule(domain))
+
+    resp = await mock_http_client.get(f"/brands/{domain}/manifest.json")
+    assert resp.status == HTTPStatus.FORBIDDEN
+
+
+async def test_brands_dark_fallback(
+    hass: HomeAssistant, mock_http_client: TestClient, tmp_path: Path
+) -> None:
+    """Test falling back to non-dark icon if dark icon is missing."""
+    domain = "test_integration"
+    dark_filename = "dark_icon.png"
+    fallback_filename = "icon.png"
+
+    integration_path = tmp_path / domain
+    integration_path.mkdir()
+    icon_file = integration_path / fallback_filename
+    icon_file.write_bytes(b"fallback-content")
+
+    mock_integration(hass, MockModule(domain), path=str(integration_path))
+
+    resp = await mock_http_client.get(f"/brands/{domain}/{dark_filename}")
+    assert resp.status == HTTPStatus.OK
+    assert await resp.read() == b"fallback-content"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a new view at `/brands/{domain}/{filename}` to serve custom integration brand icons. It allows each integration to use their own icons and logos without pushing them to `brands.home-assistant.io`.

It first attempts to serve the icon from the local integration's directory. If the icon is not found locally, it proxies the request to `brands.home-assistant.io` as a fallback.

Based on discussion: https://github.com/home-assistant/brands/pull/8742

Follow up frontend change, already prepared: https://github.com/aydarik/hass-frontend/pull/1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/1321
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/aydarik/hass-frontend/pull/1 (on fork for now)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
