### PR TITLE
Expose power and energy sensors for vera metered switches

### DIFF
--- a/homeassistant/components/vera/sensor.py
+++ b/homeassistant/components/vera/sensor.py
@@ -11,12 +11,14 @@ from homeassistant.components.sensor import (
     ENTITY_ID_FORMAT,
     SensorDeviceClass,
     SensorEntity,
+    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
     Platform,
+    UnitOfEnergy,
     UnitOfPower,
     UnitOfTemperature,
 )
@@ -36,13 +38,19 @@ async def async_setup_entry(
 ) -> None:
     """Set up the sensor config entry."""
     controller_data = get_controller_data(hass, entry)
-    async_add_entities(
-        [
-            VeraSensor(device, controller_data)
-            for device in controller_data.devices[Platform.SENSOR]
-        ],
-        True,
-    )
+
+    entities: list[SensorEntity] = [
+        VeraSensor(device, controller_data)
+        for device in controller_data.devices[Platform.SENSOR]
+    ]
+
+    for device in controller_data.devices[Platform.SWITCH]:
+        if device.power is not None:
+            entities.append(VeraPowerSensor(device, controller_data))
+        if device.energy is not None:
+            entities.append(VeraEnergySensor(device, controller_data))
+
+    async_add_entities(entities, True)
 
 
 class VeraSensor(VeraEntity[veraApi.VeraSensor], SensorEntity):
@@ -109,3 +117,49 @@ class VeraSensor(VeraEntity[veraApi.VeraSensor], SensorEntity):
             self._attr_native_value = "Tripped" if tripped else "Not Tripped"
         else:
             self._attr_native_value = "Unknown"
+
+
+class VeraPowerSensor(VeraEntity[veraApi.VeraSwitch], SensorEntity):
+    """Power sensor derived from a Vera switch with metering."""
+
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+
+    def __init__(
+        self, vera_device: veraApi.VeraSwitch, controller_data: ControllerData
+    ) -> None:
+        """Initialize the power sensor."""
+        VeraEntity.__init__(self, vera_device, controller_data)
+        self._attr_name = f"{self.vera_device.name} Power"
+        self._name = f"{self.vera_device.name} Power"
+        self._unique_id = f"{self._unique_id}_power"
+        self.entity_id = f"sensor.{self.vera_id}_power"
+
+    def update(self) -> None:
+        """Update the sensor state."""
+        super().update()
+        self._attr_native_value = self.vera_device.power
+
+
+class VeraEnergySensor(VeraEntity[veraApi.VeraSwitch], SensorEntity):
+    """Energy sensor derived from a Vera switch with metering."""
+
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+
+    def __init__(
+        self, vera_device: veraApi.VeraSwitch, controller_data: ControllerData
+    ) -> None:
+        """Initialize the energy sensor."""
+        VeraEntity.__init__(self, vera_device, controller_data)
+        self._attr_name = f"{self.vera_device.name} Energy"
+        self._name = f"{self.vera_device.name} Energy"
+        self._unique_id = f"{self._unique_id}_energy"
+        self.entity_id = f"sensor.{self.vera_id}_energy"
+
+    def update(self) -> None:
+        """Update the sensor state."""
+        super().update()
+        self._attr_native_value = self.vera_device.energy

--- a/homeassistant/components/vera/sensor.py
+++ b/homeassistant/components/vera/sensor.py
@@ -132,9 +132,7 @@ class VeraPowerSensor(VeraEntity[veraApi.VeraSwitch], SensorEntity):
         """Initialize the power sensor."""
         VeraEntity.__init__(self, vera_device, controller_data)
         self._attr_name = f"{self.vera_device.name} Power"
-        self._name = f"{self.vera_device.name} Power"
         self._unique_id = f"{self._unique_id}_power"
-        self.entity_id = f"sensor.{self.vera_id}_power"
 
     def update(self) -> None:
         """Update the sensor state."""
@@ -155,9 +153,7 @@ class VeraEnergySensor(VeraEntity[veraApi.VeraSwitch], SensorEntity):
         """Initialize the energy sensor."""
         VeraEntity.__init__(self, vera_device, controller_data)
         self._attr_name = f"{self.vera_device.name} Energy"
-        self._name = f"{self.vera_device.name} Energy"
         self._unique_id = f"{self._unique_id}_energy"
-        self.entity_id = f"sensor.{self.vera_id}_energy"
 
     def update(self) -> None:
         """Update the sensor state."""

--- a/homeassistant/components/vera/sensor.py
+++ b/homeassistant/components/vera/sensor.py
@@ -126,7 +126,6 @@ class VeraPowerSensor(VeraEntity[veraApi.VeraSwitch], SensorEntity):
     _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = UnitOfPower.WATT
-    _attr_translation_key = "power"
 
     def __init__(
         self, vera_device: veraApi.VeraSwitch, controller_data: ControllerData
@@ -148,7 +147,6 @@ class VeraEnergySensor(VeraEntity[veraApi.VeraSwitch], SensorEntity):
     _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-    _attr_translation_key = "energy"
 
     def __init__(
         self, vera_device: veraApi.VeraSwitch, controller_data: ControllerData

--- a/homeassistant/components/vera/sensor.py
+++ b/homeassistant/components/vera/sensor.py
@@ -123,15 +123,16 @@ class VeraPowerSensor(VeraEntity[veraApi.VeraSwitch], SensorEntity):
     """Power sensor derived from a Vera switch with metering."""
 
     _attr_device_class = SensorDeviceClass.POWER
+    _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_translation_key = "power"
 
     def __init__(
         self, vera_device: veraApi.VeraSwitch, controller_data: ControllerData
     ) -> None:
         """Initialize the power sensor."""
         VeraEntity.__init__(self, vera_device, controller_data)
-        self._attr_name = f"{self.vera_device.name} Power"
         self._unique_id = f"{self._unique_id}_power"
 
     def update(self) -> None:
@@ -144,15 +145,16 @@ class VeraEnergySensor(VeraEntity[veraApi.VeraSwitch], SensorEntity):
     """Energy sensor derived from a Vera switch with metering."""
 
     _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_translation_key = "energy"
 
     def __init__(
         self, vera_device: veraApi.VeraSwitch, controller_data: ControllerData
     ) -> None:
         """Initialize the energy sensor."""
         VeraEntity.__init__(self, vera_device, controller_data)
-        self._attr_name = f"{self.vera_device.name} Energy"
         self._unique_id = f"{self._unique_id}_energy"
 
     def update(self) -> None:

--- a/homeassistant/components/vera/strings.json
+++ b/homeassistant/components/vera/strings.json
@@ -17,6 +17,16 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "energy": {
+        "name": "Energy"
+      },
+      "power": {
+        "name": "Power"
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/homeassistant/components/vera/strings.json
+++ b/homeassistant/components/vera/strings.json
@@ -17,16 +17,6 @@
       }
     }
   },
-  "entity": {
-    "sensor": {
-      "energy": {
-        "name": "Energy"
-      },
-      "power": {
-        "name": "Power"
-      }
-    }
-  },
   "options": {
     "step": {
       "init": {

--- a/tests/components/vera/test_sensor.py
+++ b/tests/components/vera/test_sensor.py
@@ -283,5 +283,12 @@ async def test_switch_without_metering_does_not_create_power_energy_sensors(
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.plain_switch_1_power") is None
-    assert hass.states.get("sensor.plain_switch_1_energy") is None
+    ent_reg = er.async_get(hass)
+
+    power_entity_id = ent_reg.async_get_entity_id("sensor", "vera", "vera_1111_1_power")
+    energy_entity_id = ent_reg.async_get_entity_id(
+        "sensor", "vera", "vera_1111_1_energy"
+    )
+
+    assert power_entity_id is None
+    assert energy_entity_id is None

--- a/tests/components/vera/test_sensor.py
+++ b/tests/components/vera/test_sensor.py
@@ -201,3 +201,79 @@ async def test_scene_controller_sensor(
     update_callback(vera_device)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == "id0"
+
+
+async def test_switch_power_and_energy_sensors_created(
+    hass: HomeAssistant, vera_component_factory: ComponentFactory
+) -> None:
+    """Test that switches with metering expose power and energy sensors."""
+    vera_switch: pv.VeraSwitch = MagicMock(spec=pv.VeraSwitch)
+    vera_switch.device_id = 1
+    vera_switch.vera_device_id = vera_switch.device_id
+    vera_switch.comm_failure = False
+    vera_switch.name = "metered_switch"
+    vera_switch.category = 0
+    vera_switch.power = 12
+    vera_switch.energy = 3
+
+    vera_sensor: pv.VeraSensor = MagicMock(spec=pv.VeraSensor)
+    vera_sensor.device_id = 2
+    vera_sensor.vera_device_id = vera_sensor.device_id
+    vera_sensor.comm_failure = False
+    vera_sensor.name = "dummy_sensor"
+    vera_sensor.category = pv.CATEGORY_TEMPERATURE_SENSOR
+    vera_sensor.temperature = "20"
+
+    await vera_component_factory.configure_component(
+        hass=hass,
+        controller_config=new_simple_controller_config(
+            devices=(vera_switch, vera_sensor)
+        ),
+    )
+    await hass.async_block_till_done()
+
+    power_entity_id = "sensor.metered_switch_1_power"
+    energy_entity_id = "sensor.metered_switch_1_energy"
+
+    power_state = hass.states.get(power_entity_id)
+    assert power_state is not None
+    assert power_state.state == "12"
+    assert power_state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "W"
+
+    energy_state = hass.states.get(energy_entity_id)
+    assert energy_state is not None
+    assert energy_state.state == "3"
+    assert energy_state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "kWh"
+
+
+async def test_switch_without_metering_does_not_create_power_energy_sensors(
+    hass: HomeAssistant, vera_component_factory: ComponentFactory
+) -> None:
+    """Test that non-metered switches do not create power/energy sensors."""
+    vera_switch: pv.VeraSwitch = MagicMock(spec=pv.VeraSwitch)
+    vera_switch.device_id = 1
+    vera_switch.vera_device_id = vera_switch.device_id
+    vera_switch.comm_failure = False
+    vera_switch.name = "plain_switch"
+    vera_switch.category = 0
+    vera_switch.power = None
+    vera_switch.energy = None
+
+    vera_sensor: pv.VeraSensor = MagicMock(spec=pv.VeraSensor)
+    vera_sensor.device_id = 2
+    vera_sensor.vera_device_id = vera_sensor.device_id
+    vera_sensor.comm_failure = False
+    vera_sensor.name = "dummy_sensor"
+    vera_sensor.category = pv.CATEGORY_TEMPERATURE_SENSOR
+    vera_sensor.temperature = "20"
+
+    await vera_component_factory.configure_component(
+        hass=hass,
+        controller_config=new_simple_controller_config(
+            devices=(vera_switch, vera_sensor)
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.plain_switch_1_power") is None
+    assert hass.states.get("sensor.plain_switch_1_energy") is None

--- a/tests/components/vera/test_sensor.py
+++ b/tests/components/vera/test_sensor.py
@@ -205,7 +205,9 @@ async def test_scene_controller_sensor(
 
 
 async def test_switch_power_and_energy_sensors_created(
-    hass: HomeAssistant, vera_component_factory: ComponentFactory
+    hass: HomeAssistant,
+    vera_component_factory: ComponentFactory,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test that switches with metering expose power and energy sensors."""
     vera_switch: pv.VeraSwitch = MagicMock(spec=pv.VeraSwitch)
@@ -233,10 +235,10 @@ async def test_switch_power_and_energy_sensors_created(
     )
     await hass.async_block_till_done()
 
-    ent_reg = er.async_get(hass)
-
-    power_entity_id = ent_reg.async_get_entity_id("sensor", "vera", "vera_1111_1_power")
-    energy_entity_id = ent_reg.async_get_entity_id(
+    power_entity_id = entity_registry.async_get_entity_id(
+        "sensor", "vera", "vera_1111_1_power"
+    )
+    energy_entity_id = entity_registry.async_get_entity_id(
         "sensor", "vera", "vera_1111_1_energy"
     )
 
@@ -255,7 +257,9 @@ async def test_switch_power_and_energy_sensors_created(
 
 
 async def test_switch_without_metering_does_not_create_power_energy_sensors(
-    hass: HomeAssistant, vera_component_factory: ComponentFactory
+    hass: HomeAssistant,
+    vera_component_factory: ComponentFactory,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test that non-metered switches do not create power/energy sensors."""
     vera_switch: pv.VeraSwitch = MagicMock(spec=pv.VeraSwitch)
@@ -283,10 +287,10 @@ async def test_switch_without_metering_does_not_create_power_energy_sensors(
     )
     await hass.async_block_till_done()
 
-    ent_reg = er.async_get(hass)
-
-    power_entity_id = ent_reg.async_get_entity_id("sensor", "vera", "vera_1111_1_power")
-    energy_entity_id = ent_reg.async_get_entity_id(
+    power_entity_id = entity_registry.async_get_entity_id(
+        "sensor", "vera", "vera_1111_1_power"
+    )
+    energy_entity_id = entity_registry.async_get_entity_id(
         "sensor", "vera", "vera_1111_1_energy"
     )
 

--- a/tests/components/vera/test_sensor.py
+++ b/tests/components/vera/test_sensor.py
@@ -11,6 +11,7 @@ import pyvera as pv
 from homeassistant.components.sensor import async_rounded_state
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, LIGHT_LUX, PERCENTAGE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .common import ComponentFactory, new_simple_controller_config
 
@@ -232,8 +233,15 @@ async def test_switch_power_and_energy_sensors_created(
     )
     await hass.async_block_till_done()
 
-    power_entity_id = "sensor.metered_switch_1_power"
-    energy_entity_id = "sensor.metered_switch_1_energy"
+    ent_reg = er.async_get(hass)
+
+    power_entity_id = ent_reg.async_get_entity_id("sensor", "vera", "vera_1111_1_power")
+    energy_entity_id = ent_reg.async_get_entity_id(
+        "sensor", "vera", "vera_1111_1_energy"
+    )
+
+    assert power_entity_id is not None
+    assert energy_entity_id is not None
 
     power_state = hass.states.get(power_entity_id)
     assert power_state is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Vera integration does not currently expose power/energy metering sensors, while other integrations gained similar sensors in #68821.

This PR adds Power (W) and Energy (kWh) sensor entities for Vera switches that expose metering values.
Similar functionality was discussed in #84120, but was not merged due to missing test coverage.

For each metered Vera switch, two additional sensor entities are created:

* Power (SensorDeviceClass.POWER, state_class=measurement, unit W)
* Energy (SensorDeviceClass.ENERGY, state_class=total_increasing, unit kWh)

Sensors are only created when the Vera device actually reports metering values, to avoid false positives on non-metered devices.

Verified against real Vera hardware to confirm correct detection of metered vs non-metered devices.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53325
- This PR is related to issue: #68821
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
