### PR TITLE
Remove overwriting of haffmpeg in smartthings test

### DIFF
--- a/tests/components/smartthings/__init__.py
+++ b/tests/components/smartthings/__init__.py
@@ -1,7 +1,5 @@
 """Tests for the SmartThings integration."""
 
-import sys
-import types
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -92,38 +90,3 @@ async def trigger_health_update(
         if call[0][0] == device_id:
             call[0][1](event)
     await hass.async_block_till_done()
-
-
-def ensure_haffmpeg_stubs() -> None:
-    """Ensure haffmpeg stubs are available for SmartThings tests."""
-    if "haffmpeg" in sys.modules:
-        return
-
-    haffmpeg_module = types.ModuleType("haffmpeg")
-    haffmpeg_core_module = types.ModuleType("haffmpeg.core")
-    haffmpeg_tools_module = types.ModuleType("haffmpeg.tools")
-
-    class _StubHAFFmpeg: ...
-
-    class _StubFFVersion:
-        def __init__(self, bin_path: str | None = None) -> None:
-            self.bin_path = bin_path
-
-        async def get_version(self) -> str:
-            return "4.0.0"
-
-    class _StubImageFrame: ...
-
-    haffmpeg_core_module.HAFFmpeg = _StubHAFFmpeg
-    haffmpeg_tools_module.IMAGE_JPEG = b""
-    haffmpeg_tools_module.FFVersion = _StubFFVersion
-    haffmpeg_tools_module.ImageFrame = _StubImageFrame
-    haffmpeg_module.core = haffmpeg_core_module
-    haffmpeg_module.tools = haffmpeg_tools_module
-
-    sys.modules["haffmpeg"] = haffmpeg_module
-    sys.modules["haffmpeg.core"] = haffmpeg_core_module
-    sys.modules["haffmpeg.tools"] = haffmpeg_tools_module
-
-
-ensure_haffmpeg_stubs()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the function `ensure_haffmpeg_stubs` which overwrites `haffmpeg` in `smartthings` test

Rationale:
We should not overwrite modules, because it breaks other tests. Instead, if needed, we should patch module functionality during the test by using test fixtures.
In this case, tests pass even after removing `ensure_haffmpeg_stubs` so it seems it can be removed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
