### PR TITLE
Remove useless @pytest.mark.asyncio decorators from tests

### DIFF
--- a/tests/components/esphome/test_analytics.py
+++ b/tests/components/esphome/test_analytics.py
@@ -1,7 +1,5 @@
 """Tests for analytics platform."""
 
-import pytest
-
 from homeassistant.components.analytics import async_devices_payload
 from homeassistant.components.esphome import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -11,7 +9,6 @@ from homeassistant.setup import async_setup_component
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.asyncio
 async def test_analytics(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:

--- a/tests/components/fluss/__init__.py
+++ b/tests/components/fluss/__init__.py
@@ -52,7 +52,6 @@ async def test_async_setup_entry_errors(
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-@pytest.mark.asyncio
 async def test_async_setup_entry_success(
     hass: HomeAssistant,
     mock_config_entry: MagicMock,
@@ -67,7 +66,6 @@ async def test_async_setup_entry_success(
         )
 
 
-@pytest.mark.asyncio
 async def test_async_unload_entry(
     hass: HomeAssistant,
     mock_config_entry: MagicMock,
@@ -87,7 +85,6 @@ async def test_async_unload_entry(
         assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-@pytest.mark.asyncio
 async def test_platforms_forwarded(
     hass: HomeAssistant,
     mock_config_entry: MagicMock,

--- a/tests/components/imeon_inverter/test_sensor.py
+++ b/tests/components/imeon_inverter/test_sensor.py
@@ -38,7 +38,6 @@ async def test_sensors(
         ValueError,
     ],
 )
-@pytest.mark.asyncio
 async def test_sensor_unavailable_on_update_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/onvif/test_init.py
+++ b/tests/components/onvif/test_init.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -12,7 +10,6 @@ from . import MAC, setup_mock_device
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.asyncio
 async def test_migrate_camera_entities_unique_ids(hass: HomeAssistant) -> None:
     """Test that camera entities unique ids get migrated properly."""
     config_entry = MockConfigEntry(domain="onvif", unique_id=MAC)

--- a/tests/components/ridwell/test_calendar.py
+++ b/tests/components/ridwell/test_calendar.py
@@ -21,7 +21,6 @@ START_DATE = date(2025, 10, 4)
 END_DATE = date(2025, 10, 5)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     (
         "pickup_name",

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -260,7 +260,6 @@ async def test_remove_privacy_zone(
     assert not doorbell.privacy_zones
 
 
-@pytest.mark.asyncio
 async def get_user_keyring_info(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/wled/test_analytics.py
+++ b/tests/components/wled/test_analytics.py
@@ -1,7 +1,5 @@
 """Tests for analytics platform."""
 
-import pytest
-
 from homeassistant.components.analytics import async_devices_payload
 from homeassistant.components.wled import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -11,7 +9,6 @@ from homeassistant.setup import async_setup_component
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.asyncio
 async def test_analytics(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove useless `@pytest.mark.asyncio` decorators from tests

The marker is not needed because we use the `pytest-asyncio` plugin with [`asyncio_mode = "auto"`](https://pytest-asyncio.readthedocs.io/en/stable/reference/configuration.html#asyncio-mode)

https://github.com/home-assistant/core/blob/92a2f90f2cbd79f9e4ad766fc84e93f008f1f8cd/pyproject.toml#L453

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
