### PR TITLE
Adjust entity condition strings

### DIFF
--- a/homeassistant/components/alarm_control_panel/strings.json
+++ b/homeassistant/components/alarm_control_panel/strings.json
@@ -14,7 +14,7 @@
           "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
         }
       },
-      "name": "If an alarm is armed"
+      "name": "Alarm is armed"
     },
     "is_armed_away": {
       "description": "Tests if one or more alarms are armed in away mode.",
@@ -24,7 +24,7 @@
           "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
         }
       },
-      "name": "If an alarm is armed away"
+      "name": "Alarm is armed away"
     },
     "is_armed_home": {
       "description": "Tests if one or more alarms are armed in home mode.",
@@ -34,7 +34,7 @@
           "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
         }
       },
-      "name": "If an alarm is armed home"
+      "name": "Alarm is armed home"
     },
     "is_armed_night": {
       "description": "Tests if one or more alarms are armed in night mode.",
@@ -44,7 +44,7 @@
           "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
         }
       },
-      "name": "If an alarm is armed night"
+      "name": "Alarm is armed night"
     },
     "is_armed_vacation": {
       "description": "Tests if one or more alarms are armed in vacation mode.",
@@ -54,7 +54,7 @@
           "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
         }
       },
-      "name": "If an alarm is armed vacation"
+      "name": "Alarm is armed vacation"
     },
     "is_disarmed": {
       "description": "Tests if one or more alarms are disarmed.",
@@ -64,7 +64,7 @@
           "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
         }
       },
-      "name": "If an alarm is disarmed"
+      "name": "Alarm is disarmed"
     },
     "is_triggered": {
       "description": "Tests if one or more alarms are triggered.",
@@ -74,7 +74,7 @@
           "name": "[%key:component::alarm_control_panel::common::condition_behavior_name%]"
         }
       },
-      "name": "If an alarm is triggered"
+      "name": "Alarm is triggered"
     }
   },
   "device_automation": {

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -14,7 +14,7 @@
           "name": "[%key:component::assist_satellite::common::condition_behavior_name%]"
         }
       },
-      "name": "If a satellite is idle"
+      "name": "Satellite is idle"
     },
     "is_listening": {
       "description": "Tests if one or more Assist satellites are listening.",
@@ -24,7 +24,7 @@
           "name": "[%key:component::assist_satellite::common::condition_behavior_name%]"
         }
       },
-      "name": "If a satellite is listening"
+      "name": "Satellite is listening"
     },
     "is_processing": {
       "description": "Tests if one or more Assist satellites are processing.",
@@ -34,7 +34,7 @@
           "name": "[%key:component::assist_satellite::common::condition_behavior_name%]"
         }
       },
-      "name": "If a satellite is processing"
+      "name": "Satellite is processing"
     },
     "is_responding": {
       "description": "Tests if one or more Assist satellites are responding.",
@@ -44,7 +44,7 @@
           "name": "[%key:component::assist_satellite::common::condition_behavior_name%]"
         }
       },
-      "name": "If a satellite is responding"
+      "name": "Satellite is responding"
     }
   },
   "entity_component": {

--- a/homeassistant/components/fan/strings.json
+++ b/homeassistant/components/fan/strings.json
@@ -14,7 +14,7 @@
           "name": "[%key:component::fan::common::condition_behavior_name%]"
         }
       },
-      "name": "If a fan is off"
+      "name": "Fan is off"
     },
     "is_on": {
       "description": "Tests if one or more fans are on.",
@@ -24,7 +24,7 @@
           "name": "[%key:component::fan::common::condition_behavior_name%]"
         }
       },
-      "name": "If a fan is on"
+      "name": "Fan is on"
     }
   },
   "device_automation": {

--- a/homeassistant/components/light/strings.json
+++ b/homeassistant/components/light/strings.json
@@ -49,7 +49,7 @@
           "name": "[%key:component::light::common::condition_behavior_name%]"
         }
       },
-      "name": "If a light is off"
+      "name": "Light is off"
     },
     "is_on": {
       "description": "Tests if one or more lights are on.",
@@ -59,7 +59,7 @@
           "name": "[%key:component::light::common::condition_behavior_name%]"
         }
       },
-      "name": "If a light is on"
+      "name": "Light is on"
     }
   },
   "device_automation": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust entity condition strings from for example "If an alarm is armed" to just "Alarm is armed"

This addresses this review comment https://github.com/home-assistant/core/pull/160975#discussion_r2693653618

I think simplifying to "If alarm is" as suggested in the review comment is poor grammar. This PR simplifies a bit more though, to just "Alarm is armed".

UI with the change:
<img width="1035" height="804" alt="image" src="https://github.com/user-attachments/assets/3158bccd-c995-4be3-8fe2-c497476c90d5" />

UI without the change:
<img width="1032" height="811" alt="image" src="https://github.com/user-attachments/assets/97f9ab49-adf2-429f-a2d6-a9843db0fd08" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
