### PR TITLE
Proof of concept for implementing triggers in a different domain

### DIFF
--- a/homeassistant/components/binary_sensor/icons.json
+++ b/homeassistant/components/binary_sensor/icons.json
@@ -176,7 +176,7 @@
     }
   },
   "triggers": {
-    "door.opened": {
+    "_door.opened": {
       "trigger": "mdi:door-open"
     },
     "occupancy_cleared": {

--- a/homeassistant/components/binary_sensor/icons.json
+++ b/homeassistant/components/binary_sensor/icons.json
@@ -176,6 +176,9 @@
     }
   },
   "triggers": {
+    "door.opened": {
+      "trigger": "mdi:door-open"
+    },
     "occupancy_cleared": {
       "trigger": "mdi:home-outline"
     },

--- a/homeassistant/components/binary_sensor/strings.json
+++ b/homeassistant/components/binary_sensor/strings.json
@@ -332,7 +332,7 @@
   },
   "title": "Binary sensor",
   "triggers": {
-    "door.opened": {
+    "_door.opened": {
       "description": "Triggers after one or more occupancy doors open.",
       "fields": {
         "behavior": {

--- a/homeassistant/components/binary_sensor/strings.json
+++ b/homeassistant/components/binary_sensor/strings.json
@@ -332,6 +332,16 @@
   },
   "title": "Binary sensor",
   "triggers": {
+    "door.opened": {
+      "description": "Triggers after one or more occupancy doors open.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::binary_sensor::common::trigger_behavior_description_occupancy%]",
+          "name": "[%key:component::binary_sensor::common::trigger_behavior_name%]"
+        }
+      },
+      "name": "Door opened"
+    },
     "occupancy_cleared": {
       "description": "Triggers after one or more occupancy sensors stop detecting occupancy.",
       "fields": {

--- a/homeassistant/components/binary_sensor/trigger.py
+++ b/homeassistant/components/binary_sensor/trigger.py
@@ -53,6 +53,7 @@ def make_binary_sensor_trigger(
 
 
 TRIGGERS: dict[str, type[Trigger]] = {
+    "_door.opened": make_binary_sensor_trigger(BinarySensorDeviceClass.DOOR, STATE_ON),
     "occupancy_detected": make_binary_sensor_trigger(
         BinarySensorDeviceClass.OCCUPANCY, STATE_ON
     ),

--- a/homeassistant/components/binary_sensor/triggers.yaml
+++ b/homeassistant/components/binary_sensor/triggers.yaml
@@ -23,3 +23,10 @@ occupancy_detected:
     entity:
       domain: binary_sensor
       device_class: occupancy
+
+_door.opened:
+  fields: *trigger_common_fields
+  target:
+    entity:
+      domain: binary_sensor
+      device_class: door

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -655,10 +655,15 @@ def slug(value: Any) -> str:
     raise vol.Invalid(f"invalid slug {value} (try {slg})")
 
 
+def slugs(value: Any) -> list[str]:
+    """Validate slugs separated by period."""
+    return [slug(item) for item in value.split(".")]
+
+
 def underscore_slug(value: Any) -> str:
     """Validate value is a valid slug, possibly starting with an underscore."""
     if value.startswith("_"):
-        return f"_{slug(value[1:])}"
+        return f"_{'.'.join(slugs(value[1:]))}"
     return slug(value)
 
 

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -121,7 +121,7 @@ def starts_with_dot(key: str) -> str:
 _TRIGGERS_DESCRIPTION_SCHEMA = vol.Schema(
     {
         vol.Remove(vol.All(str, starts_with_dot)): object,
-        cv.underscore_slug: vol.Any(None, _TRIGGER_DESCRIPTION_SCHEMA),
+        str: vol.Any(None, _TRIGGER_DESCRIPTION_SCHEMA),
     }
 )
 
@@ -1432,6 +1432,10 @@ async def async_get_all_descriptions(
         description = {"fields": yaml_description.get("fields", {})}
         if (target := yaml_description.get("target")) is not None:
             description["target"] = target
+
+        prefix, sep, _ = missing_trigger.partition(".")
+        if sep and domain != prefix:
+            description["translation_domain"] = domain
 
         new_descriptions_cache[missing_trigger] = description
     hass.data[TRIGGER_DESCRIPTION_CACHE] = new_descriptions_cache

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -121,7 +121,7 @@ def starts_with_dot(key: str) -> str:
 _TRIGGERS_DESCRIPTION_SCHEMA = vol.Schema(
     {
         vol.Remove(vol.All(str, starts_with_dot)): object,
-        str: vol.Any(None, _TRIGGER_DESCRIPTION_SCHEMA),
+        cv.underscore_slug: vol.Any(None, _TRIGGER_DESCRIPTION_SCHEMA),
     }
 )
 

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -1073,9 +1073,10 @@ async def _async_get_trigger_platform(
 ) -> tuple[str, TriggerProtocol]:
     from homeassistant.components import automation  # noqa: PLC0415
 
-    platform_and_sub_type = trigger_key.split(".")
-    platform = platform_and_sub_type[0]
-    platform = _PLATFORM_ALIASES.get(platform, platform)
+    if not (platform := hass.data[TRIGGERS].get(trigger_key)):
+        platform = _PLATFORM_ALIASES.get(trigger_key)
+    if not platform:
+        raise vol.Invalid(f"Invalid trigger '{trigger_key}' specified")
 
     if automation.is_disabled_experimental_trigger(hass, platform):
         raise vol.Invalid(

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -66,6 +66,16 @@ async def test_bad_trigger_platform(hass: HomeAssistant) -> None:
 
 async def test_trigger_subtype(hass: HomeAssistant) -> None:
     """Test trigger subtypes."""
+
+    async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+        return {
+            "subtype": Mock(),
+        }
+
+    mock_integration(hass, MockModule("test"))
+    mock_platform(hass, "test.trigger", Mock(async_get_triggers=async_get_triggers))
+    await async_setup_component(hass, "test", {})
+
     with patch(
         "homeassistant.helpers.trigger.async_get_integration",
         return_value=MagicMock(async_get_platform=AsyncMock()),
@@ -530,6 +540,7 @@ async def test_platform_multiple_triggers(
 
     mock_integration(hass, MockModule("test"))
     mock_platform(hass, "test.trigger", Mock(async_get_triggers=async_get_triggers))
+    await async_setup_component(hass, "test", {})
 
     config_1 = [{"platform": "test"}]
     config_2 = [{"platform": "test.trig_2", "options": {"x": 1}}]
@@ -576,7 +587,9 @@ async def test_platform_multiple_triggers(
     }
     action_helper.action_calls.clear()
 
-    with pytest.raises(KeyError):
+    with pytest.raises(
+        vol.Invalid, match="Invalid trigger 'test.unknown_trig' specified"
+    ):
         await async_initialize_triggers(
             hass, config_3, action_method, "test", "", log_cb
         )
@@ -617,6 +630,7 @@ async def test_platform_migrate_trigger(hass: HomeAssistant) -> None:
 
     mock_integration(hass, MockModule("test"))
     mock_platform(hass, "test.trigger", Mock(async_get_triggers=async_get_triggers))
+    await async_setup_component(hass, "test", {})
 
     config_1 = [{"platform": "test", "option_1": "value_1", "option_2": 2}]
     config_2 = [{"platform": "test", "option_1": "value_1"}]
@@ -646,6 +660,7 @@ async def test_platform_backwards_compatibility_for_new_style_configs(
 
     mock_integration(hass, MockModule("test"))
     mock_platform(hass, "test.trigger", MockTriggerPlatform())
+    await async_setup_component(hass, "test", {})
 
     config_old_style = [{"platform": "test", "option_1": "value_1", "option_2": 2}]
     result = await async_validate_trigger_config(hass, config_old_style)
@@ -1255,6 +1270,7 @@ async def test_numerical_state_attribute_changed_trigger_config_validation(
 
     mock_integration(hass, MockModule("test"))
     mock_platform(hass, "test.trigger", Mock(async_get_triggers=async_get_triggers))
+    await async_setup_component(hass, "test", {})
 
     with expected_result:
         await async_validate_trigger_config(
@@ -1283,6 +1299,7 @@ async def test_numerical_state_attribute_changed_error_handling(
 
     mock_integration(hass, MockModule("test"))
     mock_platform(hass, "test.trigger", Mock(async_get_triggers=async_get_triggers))
+    await async_setup_component(hass, "test", {})
 
     hass.states.async_set("test.test_entity", "on", {"test_attribute": 20})
 
@@ -1565,6 +1582,7 @@ async def test_numerical_state_attribute_crossed_threshold_trigger_config_valida
 
     mock_integration(hass, MockModule("test"))
     mock_platform(hass, "test.trigger", Mock(async_get_triggers=async_get_triggers))
+    await async_setup_component(hass, "test", {})
 
     with expected_result:
         await async_validate_trigger_config(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Proof of concept for implementing triggers in a different domain

Note:
- In this PR, the `binary_sensor` integration provides the trigger `door.opened`. This is just meant as an example, a `door.opened` trigger (if not implemented by a `door` integraiton) whould probably be in a `homassistant` or `multi_domain_triggers` integration.

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
