### PR TITLE
Improve type hints in ness_alarm

### DIFF
--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -1,8 +1,8 @@
 """Support for Ness D8X/D16X devices."""
 
-from collections import namedtuple
 import datetime
 import logging
+from typing import NamedTuple
 
 from nessclient import ArmingMode, ArmingState, Client
 import voluptuous as vol
@@ -25,11 +25,12 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.hass_dict import HassKey
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "ness_alarm"
-DATA_NESS = "ness_alarm"
+DATA_NESS: HassKey[Client] = HassKey(DOMAIN)
 
 CONF_DEVICE_PORT = "port"
 CONF_INFER_ARMING_STATE = "infer_arming_state"
@@ -44,7 +45,13 @@ DEFAULT_INFER_ARMING_STATE = False
 SIGNAL_ZONE_CHANGED = "ness_alarm.zone_changed"
 SIGNAL_ARMING_STATE_CHANGED = "ness_alarm.arming_state_changed"
 
-ZoneChangedData = namedtuple("ZoneChangedData", ["zone_id", "state"])  # noqa: PYI024
+
+class ZoneChangedData(NamedTuple):
+    """Data for a zone state change."""
+
+    zone_id: int
+    state: bool
+
 
 DEFAULT_ZONE_TYPE = BinarySensorDeviceClass.MOTION
 ZONE_SCHEMA = vol.Schema(

--- a/homeassistant/components/ness_alarm/binary_sensor.py
+++ b/homeassistant/components/ness_alarm/binary_sensor.py
@@ -33,18 +33,14 @@ async def async_setup_platform(
 
     configured_zones = discovery_info[CONF_ZONES]
 
-    devices = []
-
-    for zone_config in configured_zones:
-        zone_type = zone_config[CONF_ZONE_TYPE]
-        zone_name = zone_config[CONF_ZONE_NAME]
-        zone_id = zone_config[CONF_ZONE_ID]
-        device = NessZoneBinarySensor(
-            zone_id=zone_id, name=zone_name, zone_type=zone_type
+    async_add_entities(
+        NessZoneBinarySensor(
+            zone_id=zone_config[CONF_ZONE_ID],
+            name=zone_config[CONF_ZONE_NAME],
+            zone_type=zone_config[CONF_ZONE_TYPE],
         )
-        devices.append(device)
-
-    async_add_entities(devices)
+        for zone_config in configured_zones
+    )
 
 
 class NessZoneBinarySensor(BinarySensorEntity):
@@ -52,12 +48,14 @@ class NessZoneBinarySensor(BinarySensorEntity):
 
     _attr_should_poll = False
 
-    def __init__(self, zone_id, name, zone_type):
+    def __init__(
+        self, zone_id: int, name: str, zone_type: BinarySensorDeviceClass
+    ) -> None:
         """Initialize the binary_sensor."""
         self._zone_id = zone_id
-        self._name = name
-        self._type = zone_type
-        self._state = 0
+        self._attr_name = name
+        self._attr_device_class = zone_type
+        self._attr_is_on = False
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -67,24 +65,9 @@ class NessZoneBinarySensor(BinarySensorEntity):
             )
         )
 
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return self._name
-
-    @property
-    def is_on(self):
-        """Return true if sensor is on."""
-        return self._state == 1
-
-    @property
-    def device_class(self) -> BinarySensorDeviceClass:
-        """Return the class of this sensor, from DEVICE_CLASSES."""
-        return self._type
-
     @callback
-    def _handle_zone_change(self, data: ZoneChangedData):
+    def _handle_zone_change(self, data: ZoneChangedData) -> None:
         """Handle zone state update."""
         if self._zone_id == data.zone_id:
-            self._state = data.state
+            self._attr_is_on = data.state == 1
             self.async_write_ha_state()

--- a/homeassistant/components/ness_alarm/binary_sensor.py
+++ b/homeassistant/components/ness_alarm/binary_sensor.py
@@ -69,5 +69,5 @@ class NessZoneBinarySensor(BinarySensorEntity):
     def _handle_zone_change(self, data: ZoneChangedData) -> None:
         """Handle zone state update."""
         if self._zone_id == data.zone_id:
-            self._attr_is_on = data.state == 1
+            self._attr_is_on = data.state
             self.async_write_ha_state()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted in, and follow-up to #160934

- Migrate from namedtuple to NamedTuple
- use HassKey
- use shorthand attributes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
