### PR TITLE
fix(hardware): fix translation placeholder mismatch for firmware install

### DIFF
--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -11,7 +11,7 @@
         "zha_still_using_stick": "This {model} is in use by the Zigbee Home Automation integration. Please migrate your Zigbee network to another adapter or delete the integration and try again."
       },
       "progress": {
-        "install_firmware": "Installing {firmware_name} firmware.\n\nDo not make any changes to your hardware or software until this finishes.",
+        "install_firmware": "Installing {firmware_name} firmware on {model}.\n\nDo not make any changes to your hardware or software until this finishes.",
         "install_otbr_addon": "Installing add-on",
         "start_otbr_addon": "Starting add-on"
       },


### PR DESCRIPTION
This pull request fixes a translation placeholder mismatch in the homeassistant_hardware component.

The English translation for the firmware installation progress message was missing the `{model}` placeholder that was present in the French and Italian translations. This caused a translation inconsistency where the model name would not be displayed in English.

Changes:
- Added `{model}` placeholder to the English `install_firmware` progress message in `homeassistant/components/homeassistant_hardware/strings.json`
