### PR TITLE
feat(sensor): add ppb unit support for ozone device class

### DIFF
--- a/homeassistant/components/sensor/const.py
+++ b/homeassistant/components/sensor/const.py
@@ -300,7 +300,7 @@ class SensorDeviceClass(StrEnum):
     OZONE = "ozone"
     """Amount of O3.
 
-    Unit of measurement: `μg/m³`
+    Unit of measurement: `μg/m³`, `ppb`
     """
 
     PH = "ph"
@@ -631,7 +631,10 @@ DEVICE_CLASS_UNITS: dict[SensorDeviceClass, set[type[StrEnum] | str | None]] = {
     SensorDeviceClass.NITROGEN_DIOXIDE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
     SensorDeviceClass.NITROGEN_MONOXIDE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
     SensorDeviceClass.NITROUS_OXIDE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    SensorDeviceClass.OZONE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
+    SensorDeviceClass.OZONE: {
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        CONCENTRATION_PARTS_PER_BILLION,
+    },
     SensorDeviceClass.PH: {None},
     SensorDeviceClass.PM1: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
     SensorDeviceClass.PM10: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -103,6 +103,7 @@ _AMBIENT_IDEAL_GAS_MOLAR_VOLUME = (  # m3⋅mol⁻¹
 )
 # Molar masses in g⋅mol⁻¹
 _CARBON_MONOXIDE_MOLAR_MASS = 28.01
+_OZONE_MOLAR_MASS = 48.00
 
 
 class BaseUnitConverter:
@@ -203,6 +204,29 @@ class CarbonMonoxideConcentrationConverter(BaseUnitConverter):
     }
     VALID_UNITS = {
         CONCENTRATION_PARTS_PER_MILLION,
+        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    }
+
+
+class OzoneConcentrationConverter(BaseUnitConverter):
+    """Convert ozone ratio to mass per volume.
+
+    Using ambient temperature of 20°C and pressure of 1 ATM.
+    """
+
+    UNIT_CLASS = "ozone"
+    _UNIT_CONVERSION: dict[str | None, float] = {
+        CONCENTRATION_PARTS_PER_BILLION: 1e9,
+        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: (
+            _OZONE_MOLAR_MASS / _AMBIENT_IDEAL_GAS_MOLAR_VOLUME * 1e3
+        ),
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER: (
+            _OZONE_MOLAR_MASS / _AMBIENT_IDEAL_GAS_MOLAR_VOLUME * 1e6
+        ),
+    }
+    VALID_UNITS = {
+        CONCENTRATION_PARTS_PER_BILLION,
         CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
         CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     }

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -56,6 +56,7 @@ from homeassistant.util.unit_conversion import (
     InformationConverter,
     MassConverter,
     MassVolumeConcentrationConverter,
+    OzoneConcentrationConverter,
     PowerConverter,
     PressureConverter,
     ReactiveEnergyConverter,
@@ -81,6 +82,7 @@ _ALL_CONVERTERS: dict[type[BaseUnitConverter], list[str | None]] = {
         BloodGlucoseConcentrationConverter,
         MassVolumeConcentrationConverter,
         CarbonMonoxideConcentrationConverter,
+        OzoneConcentrationConverter,
         ConductivityConverter,
         DataRateConverter,
         DistanceConverter,
@@ -122,6 +124,11 @@ _GET_UNIT_RATIO: dict[type[BaseUnitConverter], tuple[str | None, str | None, flo
         CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
         CONCENTRATION_PARTS_PER_MILLION,
         1.16441,
+    ),
+    OzoneConcentrationConverter: (
+        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+        CONCENTRATION_PARTS_PER_BILLION,
+        1.99542,
     ),
     ConductivityConverter: (
         UnitOfConductivity.MICROSIEMENS_PER_CM,
@@ -332,6 +339,47 @@ _CONVERTED_VALUE: dict[
             120000,
             CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             120,
+            CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+        ),
+    ],
+    OzoneConcentrationConverter: [
+        # PPB to other units (ozone molar mass: 48.00 g/mol)
+        (
+            1,
+            CONCENTRATION_PARTS_PER_BILLION,
+            1.99542,
+            CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+        ),
+        (
+            1,
+            CONCENTRATION_PARTS_PER_BILLION,
+            1995.42,
+            CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        ),
+        # MILLIGRAMS_PER_CUBIC_METER to other units
+        (
+            100,
+            CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+            50.11531,
+            CONCENTRATION_PARTS_PER_BILLION,
+        ),
+        (
+            100,
+            CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+            100000,
+            CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        ),
+        # MICROGRAMS_PER_CUBIC_METER to other units
+        (
+            100000,
+            CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            50.11531,
+            CONCENTRATION_PARTS_PER_BILLION,
+        ),
+        (
+            100000,
+            CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            100,
             CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
         ),
     ],


### PR DESCRIPTION
This pull request adds ppb (parts per billion) as a supported unit of measurement for the ozone sensor device class.

The ppb unit is commonly used for measuring low concentrations of ozone in air quality monitoring, particularly by environmental agencies like EPA Victoria.

Changes:
- Updated ozone device class documentation to include ppb as a supported unit
- Added CONCENTRATION_PARTS_PER_BILLION to the valid units for ozone device class
