### PR TITLE
fix(asuswrt): correct typo in field name

### DIFF
--- a/homeassistant/components/asuswrt/bridge.py
+++ b/homeassistant/components/asuswrt/bridge.py
@@ -67,7 +67,7 @@ class WrtDevice(NamedTuple):
 
     ip: str | None
     name: str | None
-    conneted_to: str | None
+    connected_to: str | None
 
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
This pull request fixes a typo in the asuswrt integration.

The `WrtDevice` NamedTuple had a misspelled field name `conneted_to` which has been corrected to `connected_to`.

Changes:
- Fixed typo in field name from `conneted_to` to `connected_to` in `homeassistant/components/asuswrt/bridge.py`
