### PR TITLE
Use configuration constants in NINA tests

### DIFF
--- a/tests/components/nina/test_binary_sensor.py
+++ b/tests/components/nina/test_binary_sensor.py
@@ -7,7 +7,15 @@ from unittest.mock import AsyncMock
 
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.nina.const import ATTR_HEADLINE, DOMAIN
+from homeassistant.components.nina.const import (
+    ATTR_HEADLINE,
+    CONF_AREA_FILTER,
+    CONF_FILTERS,
+    CONF_HEADLINE_FILTER,
+    CONF_MESSAGE_SLOTS,
+    CONF_REGIONS,
+    DOMAIN,
+)
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -17,20 +25,20 @@ from . import setup_platform
 from tests.common import MockConfigEntry, snapshot_platform
 
 ENTRY_DATA_NO_CORONA: dict[str, Any] = {
-    "slots": 5,
-    "regions": {"083350000000": "Aach, Stadt"},
-    "filters": {
-        "headline_filter": "/(?!)/",
-        "area_filter": ".*",
+    CONF_MESSAGE_SLOTS: 5,
+    CONF_REGIONS: {"083350000000": "Aach, Stadt"},
+    CONF_FILTERS: {
+        CONF_HEADLINE_FILTER: "/(?!)/",
+        CONF_AREA_FILTER: ".*",
     },
 }
 
 ENTRY_DATA_SPECIFIC_AREA: dict[str, Any] = {
-    "slots": 5,
-    "regions": {"083350000000": "Aach, Stadt"},
-    "filters": {
-        "headline_filter": "/(?!)/",
-        "area_filter": ".*nagold.*",
+    CONF_MESSAGE_SLOTS: 5,
+    CONF_REGIONS: {"083350000000": "Aach, Stadt"},
+    CONF_FILTERS: {
+        CONF_HEADLINE_FILTER: "/(?!)/",
+        CONF_AREA_FILTER: ".*nagold.*",
     },
 }
 

--- a/tests/components/nina/test_init.py
+++ b/tests/components/nina/test_init.py
@@ -5,7 +5,15 @@ from unittest.mock import AsyncMock
 
 from pynina import ApiError
 
-from homeassistant.components.nina.const import DOMAIN
+from homeassistant.components.nina.const import (
+    CONF_AREA_FILTER,
+    CONF_FILTER_CORONA,
+    CONF_FILTERS,
+    CONF_HEADLINE_FILTER,
+    CONF_MESSAGE_SLOTS,
+    CONF_REGIONS,
+    DOMAIN,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -14,11 +22,11 @@ from . import setup_platform
 from tests.common import MockConfigEntry
 
 ENTRY_DATA: dict[str, Any] = {
-    "slots": 5,
-    "regions": {"083350000000": "Aach, Stadt"},
-    "filters": {
-        "headline_filter": ".*corona.*",
-        "area_filter": ".*",
+    CONF_MESSAGE_SLOTS: 5,
+    CONF_REGIONS: {"083350000000": "Aach, Stadt"},
+    CONF_FILTERS: {
+        CONF_HEADLINE_FILTER: ".*corona.*",
+        CONF_AREA_FILTER: ".*",
     },
 }
 
@@ -30,9 +38,9 @@ async def test_config_migration_from1_1(
 ) -> None:
     """Test the migration to a new configuration layout."""
     old_entry_data: dict[str, Any] = {
-        "slots": 5,
-        "corona_filter": True,
-        "regions": {"083350000000": "Aach, Stadt"},
+        CONF_MESSAGE_SLOTS: 5,
+        CONF_FILTER_CORONA: True,
+        CONF_REGIONS: {"083350000000": "Aach, Stadt"},
     }
 
     old_conf_entry: MockConfigEntry = MockConfigEntry(
@@ -56,10 +64,10 @@ async def test_config_migration_from1_2(
 ) -> None:
     """Test the migration to a new configuration layout with sections."""
     old_entry_data: dict[str, Any] = {
-        "slots": 5,
-        "headline_filter": ".*corona.*",
-        "area_filter": ".*",
-        "regions": {"083350000000": "Aach, Stadt"},
+        CONF_MESSAGE_SLOTS: 5,
+        CONF_HEADLINE_FILTER: ".*corona.*",
+        CONF_AREA_FILTER: ".*",
+        CONF_REGIONS: {"083350000000": "Aach, Stadt"},
     }
 
     old_conf_entry: MockConfigEntry = MockConfigEntry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use common configuration constants in the tests for NINA instead of writing the values manual.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
