### PR TITLE
Allow OpenAI integration to use custom endpoints (Azure OpenAI e.g.)

### DIFF
--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -36,7 +36,6 @@ from homeassistant.helpers import (
     entity_registry as er,
     selector,
 )
-from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -59,6 +58,7 @@ from .const import (
     RECOMMENDED_TOP_P,
 )
 from .entity import async_prepare_files_for_prompt
+from .helpers import create_client
 
 SERVICE_GENERATE_IMAGE = "generate_image"
 SERVICE_GENERATE_CONTENT = "generate_content"
@@ -240,10 +240,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: OpenAIConfigEntry) -> bool:
     """Set up OpenAI Conversation from a config entry."""
-    client = openai.AsyncOpenAI(
-        api_key=entry.data[CONF_API_KEY],
-        http_client=get_async_client(hass),
-    )
+    client = create_client(hass, entry.data)
 
     # Cache current platform data which gets added to each request (caching done by library)
     _ = await hass.async_add_executor_job(client.platform_headers)

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -8,6 +8,9 @@ from homeassistant.helpers import llm
 DOMAIN = "openai_conversation"
 LOGGER: logging.Logger = logging.getLogger(__package__)
 
+CONF_API_BASE = "api_base"
+CONF_DEFAULT_QUERY = "default_query"
+
 DEFAULT_CONVERSATION_NAME = "OpenAI Conversation"
 DEFAULT_AI_TASK_NAME = "OpenAI AI Task"
 DEFAULT_NAME = "OpenAI Conversation"

--- a/homeassistant/components/openai_conversation/helpers.py
+++ b/homeassistant/components/openai_conversation/helpers.py
@@ -1,0 +1,56 @@
+"""Helper functions for the OpenAI Conversation integration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import openai
+
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.httpx_client import get_async_client
+
+from .const import CONF_API_BASE, CONF_DEFAULT_QUERY
+
+
+def parse_default_query(query_string: str) -> dict[str, str]:
+    """Parse a query string like 'api-version=preview&foo=bar' into a dict."""
+    if not query_string:
+        return {}
+    result: dict[str, str] = {}
+    for pair in query_string.split("&"):
+        if "=" in pair:
+            key, value = pair.split("=", 1)
+            result[key.strip()] = value.strip()
+    return result
+
+
+def create_client(hass: HomeAssistant, data: Mapping[str, Any]) -> openai.AsyncClient:
+    """Create an OpenAI client from config entry data."""
+    client_kwargs: dict[str, Any] = {
+        "api_key": data[CONF_API_KEY],
+        "http_client": get_async_client(hass),
+    }
+
+    if api_base := data.get(CONF_API_BASE):
+        client_kwargs["base_url"] = normalize_openai_endpoint(api_base)
+
+    if default_query := data.get(CONF_DEFAULT_QUERY):
+        client_kwargs["default_query"] = parse_default_query(default_query)
+
+    return openai.AsyncOpenAI(**client_kwargs)
+
+
+def normalize_openai_endpoint(uri: str) -> str:
+    """Normalize OpenAI endpoint URI by ensuring it ends with /openai/v1/."""
+
+    normalized = uri.rstrip("/")
+
+    if not normalized.endswith("/openai/v1"):
+        normalized += "/openai/v1"
+
+    if not normalized.endswith("/"):
+        normalized += "/"
+
+    return normalized

--- a/homeassistant/components/openai_conversation/strings.json
+++ b/homeassistant/components/openai_conversation/strings.json
@@ -31,11 +31,11 @@
           "default_query": "Default query parameters"
         },
         "data_description": {
-          "api_base": "Leave empty for standard OpenAI, or set your own API endpoint (e.g. your own Azure OpenAI endpoint).",
+          "api_base": "Optional. Leave empty to use the standard OpenAI endpoint. To use a custom or OpenAI-compatible endpoint (for example Azure OpenAI or a proxy), enter the full base URL.",
           "api_key": "Your OpenAI API key.",
-          "default_query": "Optional query parameters (e.g. for Azure OpenAI you must add `api-version=preview`). Separate multiple parameters with `&`."
+          "default_query": "Optional query string that is appended to every request, in the form `key=value&other_key=other_value` (without a leading `?`). For Azure OpenAI you typically must include `api-version`, for example `api-version=preview`. Separate multiple parameters with `&`."
         },
-        "description": "Set up OpenAI Conversation integration by providing your OpenAI API key. Instructions to obtain an API key can be found [here]({instructions_url})."
+        "description": "Set up the OpenAI Conversation integration by providing your OpenAI API key and, optionally, a custom API endpoint and default query parameters. Instructions to obtain an API key can be found [here]({instructions_url})."
       }
     }
   },

--- a/homeassistant/components/openai_conversation/strings.json
+++ b/homeassistant/components/openai_conversation/strings.json
@@ -12,19 +12,27 @@
     "step": {
       "reauth_confirm": {
         "data": {
-          "api_key": "[%key:common::config_flow::data::api_key%]"
+          "api_base": "[%key:component::openai_conversation::config::step::user::data::api_base%]",
+          "api_key": "[%key:common::config_flow::data::api_key%]",
+          "default_query": "[%key:component::openai_conversation::config::step::user::data::default_query%]"
         },
         "data_description": {
-          "api_key": "[%key:component::openai_conversation::config::step::user::data_description::api_key%]"
+          "api_base": "[%key:component::openai_conversation::config::step::user::data_description::api_base%]",
+          "api_key": "[%key:component::openai_conversation::config::step::user::data_description::api_key%]",
+          "default_query": "[%key:component::openai_conversation::config::step::user::data_description::default_query%]"
         },
         "description": "Reauthentication required. Please enter your updated API key."
       },
       "user": {
         "data": {
-          "api_key": "[%key:common::config_flow::data::api_key%]"
+          "api_base": "Custom API endpoint",
+          "api_key": "[%key:common::config_flow::data::api_key%]",
+          "default_query": "Default query parameters"
         },
         "data_description": {
-          "api_key": "Your OpenAI API key."
+          "api_base": "Leave empty for standard OpenAI, or set your own API endpoint (e.g. your own Azure OpenAI endpoint).",
+          "api_key": "Your OpenAI API key.",
+          "default_query": "Optional query parameters (e.g. for Azure OpenAI you must add `api-version=preview`). Separate multiple parameters with `&`."
         },
         "description": "Set up OpenAI Conversation integration by providing your OpenAI API key. Instructions to obtain an API key can be found [here]({instructions_url})."
       }

--- a/homeassistant/components/openai_conversation/strings.json
+++ b/homeassistant/components/openai_conversation/strings.json
@@ -7,6 +7,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_url": "Invalid URL format. Please enter a valid URL.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {

--- a/tests/components/openai_conversation/test_config_flow.py
+++ b/tests/components/openai_conversation/test_config_flow.py
@@ -141,6 +141,20 @@ async def test_form_with_azure_openai(hass: HomeAssistant) -> None:
         CONF_DEFAULT_QUERY: "api-version=2024-06-01",
     }
     assert result2["options"] == {}
+    assert result2["subentries"] == [
+        {
+            "subentry_type": "conversation",
+            "data": RECOMMENDED_CONVERSATION_OPTIONS,
+            "title": DEFAULT_CONVERSATION_NAME,
+            "unique_id": None,
+        },
+        {
+            "subentry_type": "ai_task_data",
+            "data": RECOMMENDED_AI_TASK_OPTIONS,
+            "title": DEFAULT_AI_TASK_NAME,
+            "unique_id": None,
+        },
+    ]
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -179,6 +193,21 @@ async def test_form_with_custom_endpoint_only(hass: HomeAssistant) -> None:
         CONF_API_KEY: "custom-key",
         CONF_API_BASE: "https://custom-api.example.com/v1",
     }
+    assert result2["options"] == {}
+    assert result2["subentries"] == [
+        {
+            "subentry_type": "conversation",
+            "data": RECOMMENDED_CONVERSATION_OPTIONS,
+            "title": DEFAULT_CONVERSATION_NAME,
+            "unique_id": None,
+        },
+        {
+            "subentry_type": "ai_task_data",
+            "data": RECOMMENDED_AI_TASK_OPTIONS,
+            "title": DEFAULT_AI_TASK_NAME,
+            "unique_id": None,
+        },
+    ]
 
 
 async def test_form_invalid_url(hass: HomeAssistant) -> None:

--- a/tests/components/openai_conversation/test_config_flow.py
+++ b/tests/components/openai_conversation/test_config_flow.py
@@ -12,8 +12,10 @@ from homeassistant.components.openai_conversation.config_flow import (
     RECOMMENDED_CONVERSATION_OPTIONS,
 )
 from homeassistant.components.openai_conversation.const import (
+    CONF_API_BASE,
     CONF_CHAT_MODEL,
     CONF_CODE_INTERPRETER,
+    CONF_DEFAULT_QUERY,
     CONF_IMAGE_MODEL,
     CONF_MAX_TOKENS,
     CONF_PROMPT,
@@ -97,6 +99,86 @@ async def test_form(hass: HomeAssistant) -> None:
         },
     ]
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_with_azure_openai(hass: HomeAssistant) -> None:
+    """Test config flow with Azure OpenAI endpoint settings."""
+    hass.config.components.add("openai_conversation")
+    MockConfigEntry(
+        domain=DOMAIN,
+        state=config_entries.ConfigEntryState.LOADED,
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.openai_conversation.config_flow.openai.resources.models.AsyncModels.list",
+        ),
+        patch(
+            "homeassistant.components.openai_conversation.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_KEY: "azure-key",
+                CONF_API_BASE: "https://my-resource.openai.azure.com/openai/deployments/gpt-4",
+                CONF_DEFAULT_QUERY: "api-version=2024-06-01",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"] == {
+        CONF_API_KEY: "azure-key",
+        CONF_API_BASE: "https://my-resource.openai.azure.com/openai/deployments/gpt-4",
+        CONF_DEFAULT_QUERY: "api-version=2024-06-01",
+    }
+    assert result2["options"] == {}
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_with_custom_endpoint_only(hass: HomeAssistant) -> None:
+    """Test config flow with only custom API endpoint (no query params)."""
+    hass.config.components.add("openai_conversation")
+    MockConfigEntry(
+        domain=DOMAIN,
+        state=config_entries.ConfigEntryState.LOADED,
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with (
+        patch(
+            "homeassistant.components.openai_conversation.config_flow.openai.resources.models.AsyncModels.list",
+        ),
+        patch(
+            "homeassistant.components.openai_conversation.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_KEY: "custom-key",
+                CONF_API_BASE: "https://custom-api.example.com/v1",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"] == {
+        CONF_API_KEY: "custom-key",
+        CONF_API_BASE: "https://custom-api.example.com/v1",
+    }
 
 
 async def test_duplicate_entry(hass: HomeAssistant) -> None:

--- a/tests/components/openai_conversation/test_helpers.py
+++ b/tests/components/openai_conversation/test_helpers.py
@@ -1,0 +1,219 @@
+"""Tests for the OpenAI Conversation helpers."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.openai_conversation.const import (
+    CONF_API_BASE,
+    CONF_DEFAULT_QUERY,
+)
+from homeassistant.components.openai_conversation.helpers import (
+    create_client,
+    normalize_openai_endpoint,
+    parse_default_query,
+)
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+
+
+class TestParseDefaultQuery:
+    """Tests for parse_default_query function."""
+
+    def test_empty_string(self) -> None:
+        """Test parsing empty string returns empty dict."""
+        assert parse_default_query("") == {}
+
+    def test_single_parameter(self) -> None:
+        """Test parsing single parameter."""
+        assert parse_default_query("api-version=2024-06-01") == {
+            "api-version": "2024-06-01"
+        }
+
+    def test_multiple_parameters(self) -> None:
+        """Test parsing multiple parameters."""
+        assert parse_default_query("api-version=preview&foo=bar") == {
+            "api-version": "preview",
+            "foo": "bar",
+        }
+
+    def test_parameters_with_whitespace(self) -> None:
+        """Test parsing parameters with whitespace gets trimmed."""
+        assert parse_default_query(" api-version = preview & foo = bar ") == {
+            "api-version": "preview",
+            "foo": "bar",
+        }
+
+    def test_parameter_without_value(self) -> None:
+        """Test parsing parameter without equals sign is ignored."""
+        assert parse_default_query("api-version=preview&invalid&foo=bar") == {
+            "api-version": "preview",
+            "foo": "bar",
+        }
+
+    def test_parameter_with_equals_in_value(self) -> None:
+        """Test parsing parameter with equals sign in value."""
+        assert parse_default_query("filter=name=test") == {"filter": "name=test"}
+
+
+class TestNormalizeOpenAIEndpoint:
+    """Tests for normalize_openai_endpoint function."""
+
+    def test_basic_azure_endpoint(self) -> None:
+        """Test normalizing basic Azure endpoint."""
+        result = normalize_openai_endpoint(
+            "https://my-resource.openai.azure.com/openai/deployments/gpt-4"
+        )
+        assert result == (
+            "https://my-resource.openai.azure.com/openai/deployments/gpt-4/openai/v1/"
+        )
+
+    def test_endpoint_with_trailing_slash(self) -> None:
+        """Test normalizing endpoint with trailing slash."""
+        result = normalize_openai_endpoint(
+            "https://my-resource.openai.azure.com/openai/deployments/gpt-4/"
+        )
+        assert result == (
+            "https://my-resource.openai.azure.com/openai/deployments/gpt-4/openai/v1/"
+        )
+
+    def test_endpoint_already_normalized(self) -> None:
+        """Test endpoint that already ends with /openai/v1."""
+        result = normalize_openai_endpoint(
+            "https://my-resource.openai.azure.com/openai/v1"
+        )
+        assert result == "https://my-resource.openai.azure.com/openai/v1/"
+
+    def test_endpoint_already_normalized_with_trailing_slash(self) -> None:
+        """Test endpoint that already ends with /openai/v1/."""
+        result = normalize_openai_endpoint(
+            "https://my-resource.openai.azure.com/openai/v1/"
+        )
+        assert result == "https://my-resource.openai.azure.com/openai/v1/"
+
+
+class TestCreateClient:
+    """Tests for create_client function."""
+
+    async def test_create_client_basic(self, hass: HomeAssistant) -> None:
+        """Test creating client with only API key."""
+        with patch(
+            "homeassistant.components.openai_conversation.helpers.get_async_client"
+        ) as mock_get_client:
+            mock_http_client = MagicMock()
+            mock_get_client.return_value = mock_http_client
+
+            with patch(
+                "homeassistant.components.openai_conversation.helpers.openai.AsyncOpenAI"
+            ) as mock_openai:
+                create_client(hass, {CONF_API_KEY: "test-key"})
+
+                mock_openai.assert_called_once_with(
+                    api_key="test-key",
+                    http_client=mock_http_client,
+                )
+
+    async def test_create_client_with_custom_endpoint(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Test creating client with custom API endpoint."""
+        with patch(
+            "homeassistant.components.openai_conversation.helpers.get_async_client"
+        ) as mock_get_client:
+            mock_http_client = MagicMock()
+            mock_get_client.return_value = mock_http_client
+
+            with patch(
+                "homeassistant.components.openai_conversation.helpers.openai.AsyncOpenAI"
+            ) as mock_openai:
+                create_client(
+                    hass,
+                    {
+                        CONF_API_KEY: "test-key",
+                        CONF_API_BASE: "https://my-resource.openai.azure.com",
+                    },
+                )
+
+                mock_openai.assert_called_once_with(
+                    api_key="test-key",
+                    http_client=mock_http_client,
+                    base_url="https://my-resource.openai.azure.com/openai/v1/",
+                )
+
+    async def test_create_client_with_default_query(self, hass: HomeAssistant) -> None:
+        """Test creating client with default query parameters."""
+        with patch(
+            "homeassistant.components.openai_conversation.helpers.get_async_client"
+        ) as mock_get_client:
+            mock_http_client = MagicMock()
+            mock_get_client.return_value = mock_http_client
+
+            with patch(
+                "homeassistant.components.openai_conversation.helpers.openai.AsyncOpenAI"
+            ) as mock_openai:
+                create_client(
+                    hass,
+                    {
+                        CONF_API_KEY: "test-key",
+                        CONF_DEFAULT_QUERY: "api-version=2024-06-01",
+                    },
+                )
+
+                mock_openai.assert_called_once_with(
+                    api_key="test-key",
+                    http_client=mock_http_client,
+                    default_query={"api-version": "2024-06-01"},
+                )
+
+    async def test_create_client_with_all_options(self, hass: HomeAssistant) -> None:
+        """Test creating client with all custom options (Azure OpenAI scenario)."""
+        with patch(
+            "homeassistant.components.openai_conversation.helpers.get_async_client"
+        ) as mock_get_client:
+            mock_http_client = MagicMock()
+            mock_get_client.return_value = mock_http_client
+
+            with patch(
+                "homeassistant.components.openai_conversation.helpers.openai.AsyncOpenAI"
+            ) as mock_openai:
+                create_client(
+                    hass,
+                    {
+                        CONF_API_KEY: "azure-api-key",
+                        CONF_API_BASE: "https://my-resource.openai.azure.com/openai/deployments/gpt-4",
+                        CONF_DEFAULT_QUERY: "api-version=2024-06-01&custom=value",
+                    },
+                )
+
+                mock_openai.assert_called_once_with(
+                    api_key="azure-api-key",
+                    http_client=mock_http_client,
+                    base_url="https://my-resource.openai.azure.com/openai/deployments/gpt-4/openai/v1/",
+                    default_query={"api-version": "2024-06-01", "custom": "value"},
+                )
+
+    async def test_create_client_empty_optional_values(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Test creating client with empty optional values are ignored."""
+        with patch(
+            "homeassistant.components.openai_conversation.helpers.get_async_client"
+        ) as mock_get_client:
+            mock_http_client = MagicMock()
+            mock_get_client.return_value = mock_http_client
+
+            with patch(
+                "homeassistant.components.openai_conversation.helpers.openai.AsyncOpenAI"
+            ) as mock_openai:
+                create_client(
+                    hass,
+                    {
+                        CONF_API_KEY: "test-key",
+                        CONF_API_BASE: "",
+                        CONF_DEFAULT_QUERY: "",
+                    },
+                )
+
+                # Empty strings should not result in base_url or default_query being set
+                mock_openai.assert_called_once_with(
+                    api_key="test-key",
+                    http_client=mock_http_client,
+                )

--- a/tests/components/openai_conversation/test_helpers.py
+++ b/tests/components/openai_conversation/test_helpers.py
@@ -8,7 +8,6 @@ from homeassistant.components.openai_conversation.const import (
 )
 from homeassistant.components.openai_conversation.helpers import (
     create_client,
-    normalize_openai_endpoint,
     parse_default_query,
 )
 from homeassistant.const import CONF_API_KEY
@@ -36,58 +35,26 @@ class TestParseDefaultQuery:
         }
 
     def test_parameters_with_whitespace(self) -> None:
-        """Test parsing parameters with whitespace gets trimmed."""
-        assert parse_default_query(" api-version = preview & foo = bar ") == {
+        """Test parsing parameters - whitespace is preserved by standard URL parsing."""
+        # Standard URL parsing preserves whitespace in keys/values
+        # Users should not include whitespace in query strings
+        assert parse_default_query("api-version=preview&foo=bar") == {
             "api-version": "preview",
             "foo": "bar",
         }
 
     def test_parameter_without_value(self) -> None:
-        """Test parsing parameter without equals sign is ignored."""
+        """Test parsing parameter without value gets empty string."""
+        # Standard URL parsing treats 'invalid' as 'invalid=' (empty value)
         assert parse_default_query("api-version=preview&invalid&foo=bar") == {
             "api-version": "preview",
+            "invalid": "",
             "foo": "bar",
         }
 
     def test_parameter_with_equals_in_value(self) -> None:
         """Test parsing parameter with equals sign in value."""
         assert parse_default_query("filter=name=test") == {"filter": "name=test"}
-
-
-class TestNormalizeOpenAIEndpoint:
-    """Tests for normalize_openai_endpoint function."""
-
-    def test_basic_azure_endpoint(self) -> None:
-        """Test normalizing basic Azure endpoint."""
-        result = normalize_openai_endpoint(
-            "https://my-resource.openai.azure.com/openai/deployments/gpt-4"
-        )
-        assert result == (
-            "https://my-resource.openai.azure.com/openai/deployments/gpt-4/openai/v1/"
-        )
-
-    def test_endpoint_with_trailing_slash(self) -> None:
-        """Test normalizing endpoint with trailing slash."""
-        result = normalize_openai_endpoint(
-            "https://my-resource.openai.azure.com/openai/deployments/gpt-4/"
-        )
-        assert result == (
-            "https://my-resource.openai.azure.com/openai/deployments/gpt-4/openai/v1/"
-        )
-
-    def test_endpoint_already_normalized(self) -> None:
-        """Test endpoint that already ends with /openai/v1."""
-        result = normalize_openai_endpoint(
-            "https://my-resource.openai.azure.com/openai/v1"
-        )
-        assert result == "https://my-resource.openai.azure.com/openai/v1/"
-
-    def test_endpoint_already_normalized_with_trailing_slash(self) -> None:
-        """Test endpoint that already ends with /openai/v1/."""
-        result = normalize_openai_endpoint(
-            "https://my-resource.openai.azure.com/openai/v1/"
-        )
-        assert result == "https://my-resource.openai.azure.com/openai/v1/"
 
 
 class TestCreateClient:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This PR adds support for Azure OpenAI endpoints and other OpenAI-compatible APIs to the _openai_conversation_ integration.

###Description

Currently, the OpenAI Conversation integration only works with the standard OpenAI API. Many users and organizations use Azure OpenAI Service, which requires:

A custom base URL (the Azure resource endpoint)
API version query parameters (e.g., [api-version=preview])
This PR adds two new optional configuration fields to the integration setup:

Custom API endpoint (api_base): Allows users to specify their own API endpoint URL (e.g., Azure OpenAI endpoint)
Default query parameters (default_query): Allows users to specify query parameters that are sent with every request (e.g., [api-version=preview]

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

E.g. to use your own Azure OpenAI model follow this instruction


### Configuring Azure Models

1. Deploy an [Azure AI Foundry](https://portal.azure.com/#create/Microsoft.CognitiveServicesAIFoundry) instance to a **region supported by the [Responses API](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/responses?tabs=python-secure#region-availability)**.  
   *(If you already have a Foundry instance, you can skip this step.)*
2. To enable conversations, deploy a chat completion model (such as `gpt-4o-mini` or `gpt-4.1-mini`).  
   *If your model is not the default `gpt-4o-mini`, you’ll need to configure it manually in model settings.*
   *The deployed model name MUST match the model name in the settings*
3. If you want to generate images using the `generate_image` service, you must also deploy the `dall-e-3` model.



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
