### PR TITLE
Add MQTT (devices) integration to Victron Remote Monitoring

### DIFF
--- a/homeassistant/components/victron_remote_monitoring/__init__.py
+++ b/homeassistant/components/victron_remote_monitoring/__init__.py
@@ -6,11 +6,20 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .coordinator import (
+    LOGGER,
     VictronRemoteMonitoringConfigEntry,
     VictronRemoteMonitoringDataUpdateCoordinator,
 )
 
-_PLATFORMS: list[Platform] = [Platform.SENSOR]
+_PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.TIME,
+]
 
 
 async def async_setup_entry(
@@ -22,7 +31,16 @@ async def async_setup_entry(
 
     entry.runtime_data = coordinator
 
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+
+    try:
+        await coordinator.start_mqtt()
+    except Exception as ex:
+        LOGGER.error("Failed to start MQTT client: %s", ex)
+        await async_unload_entry(hass, entry)
+        raise
 
     return True
 
@@ -31,4 +49,17 @@ async def async_unload_entry(
     hass: HomeAssistant, entry: VictronRemoteMonitoringConfigEntry
 ) -> bool:
     """Unload a config entry."""
+    coordinator: VictronRemoteMonitoringDataUpdateCoordinator = entry.runtime_data
+    if coordinator.mqtt_client is not None:
+        await coordinator.stop_mqtt()
+
+    coordinator.mqtt_hub.unregister_all_new_metric_callbacks()
+
     return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: VictronRemoteMonitoringConfigEntry
+) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/victron_remote_monitoring/__init__.py
+++ b/homeassistant/components/victron_remote_monitoring/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from victron_vrm.exceptions import VictronVRMError
+
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
@@ -37,7 +39,7 @@ async def async_setup_entry(
 
     try:
         await coordinator.start_mqtt()
-    except Exception as ex:
+    except (TimeoutError, OSError, RuntimeError, VictronVRMError) as ex:
         LOGGER.error("Failed to start MQTT client: %s", ex)
         await async_unload_entry(hass, entry)
         raise

--- a/homeassistant/components/victron_remote_monitoring/binary_sensor.py
+++ b/homeassistant/components/victron_remote_monitoring/binary_sensor.py
@@ -1,0 +1,63 @@
+"""MQTT-backed binary sensors for Victron Remote Monitoring."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from victron_mqtt import Device as VictronDevice, Metric as VictronMetric, MetricKind
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import SWITCH_ON
+from .coordinator import VictronRemoteMonitoringConfigEntry
+from .entity import VRMMqttBaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VictronRemoteMonitoringConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up MQTT binary sensors from a config entry."""
+    coordinator = entry.runtime_data
+    mqtt_hub = coordinator.mqtt_hub
+
+    def on_new_metric(
+        device: VictronDevice,
+        metric: VictronMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        async_add_entities([VRMMqttBinarySensor(device, metric, device_info, site_id)])
+
+    mqtt_hub.register_new_metric_callback(MetricKind.BINARY_SENSOR, on_new_metric)
+
+
+class VRMMqttBinarySensor(VRMMqttBaseEntity, BinarySensorEntity):
+    """Binary sensor backed by Victron MQTT metrics."""
+
+    def __init__(
+        self,
+        device: VictronDevice,
+        metric: VictronMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        """Initialize the binary sensor."""
+        self._attr_is_on = self._is_on(metric.value)
+        super().__init__(device, metric, device_info, site_id)
+
+    @staticmethod
+    def _is_on(value: Any) -> bool:
+        return str(value) == SWITCH_ON
+
+    @callback
+    def _on_update_task(self, value: Any) -> None:
+        new_state = self._is_on(value)
+        if self._attr_is_on == new_state:
+            return
+        self._attr_is_on = new_state
+        self.async_write_ha_state()

--- a/homeassistant/components/victron_remote_monitoring/button.py
+++ b/homeassistant/components/victron_remote_monitoring/button.py
@@ -1,0 +1,66 @@
+"""MQTT-backed buttons for Victron Remote Monitoring."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from victron_mqtt import (
+    Device as VictronDevice,
+    Metric as VictronMetric,
+    MetricKind,
+    WritableMetric as VictronWritableMetric,
+)
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import SWITCH_ON
+from .coordinator import VictronRemoteMonitoringConfigEntry
+from .entity import VRMMqttBaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VictronRemoteMonitoringConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up MQTT button entities from a config entry."""
+    coordinator = entry.runtime_data
+    mqtt_hub = coordinator.mqtt_hub
+
+    def on_new_metric(
+        device: VictronDevice,
+        metric: VictronMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        assert isinstance(metric, VictronWritableMetric)
+        async_add_entities([VRMMqttButton(device, metric, device_info, site_id)])
+
+    mqtt_hub.register_new_metric_callback(MetricKind.BUTTON, on_new_metric)
+
+
+class VRMMqttButton(VRMMqttBaseEntity, ButtonEntity):
+    """Button entity backed by Victron MQTT metrics."""
+
+    def __init__(
+        self,
+        device: VictronDevice,
+        metric: VictronWritableMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        """Initialize the button entity."""
+        super().__init__(device, metric, device_info, site_id)
+
+    @callback
+    def _on_update_task(self, value: Any) -> None:
+        """Handle updates from the metric."""
+        return
+
+    def press(self) -> None:
+        """Press the button."""
+        assert isinstance(self._metric, VictronWritableMetric)
+        self._metric.set(SWITCH_ON)

--- a/homeassistant/components/victron_remote_monitoring/button.py
+++ b/homeassistant/components/victron_remote_monitoring/button.py
@@ -58,7 +58,6 @@ class VRMMqttButton(VRMMqttBaseEntity, ButtonEntity):
     @callback
     def _on_update_task(self, value: Any) -> None:
         """Handle updates from the metric."""
-        return
 
     def press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/victron_remote_monitoring/const.py
+++ b/homeassistant/components/victron_remote_monitoring/const.py
@@ -7,3 +7,10 @@ LOGGER = logging.getLogger(__package__)
 
 CONF_SITE_ID = "site_id"
 CONF_API_TOKEN = "api_token"
+
+CONF_MQTT_UPDATE_FREQUENCY_SECONDS = "mqtt_update_frequency"
+
+DEFAULT_MQTT_UPDATE_FREQUENCY_SECONDS = 5
+
+SWITCH_ON = "On"
+SWITCH_OFF = "Off"

--- a/homeassistant/components/victron_remote_monitoring/coordinator.py
+++ b/homeassistant/components/victron_remote_monitoring/coordinator.py
@@ -124,7 +124,7 @@ class VictronRemoteMonitoringDataUpdateCoordinator(
             self.mqtt_hub.attach(mqtt_client)
             await mqtt_client.connect()
             LOGGER.debug("MQTT client connected")
-        except Exception as ex:
+        except (TimeoutError, OSError, RuntimeError, VictronVRMError) as ex:
             self.mqtt_hub.detach()
             self.mqtt_client = None
             LOGGER.error("Failed to connect MQTT client: %s", ex)
@@ -138,7 +138,7 @@ class VictronRemoteMonitoringDataUpdateCoordinator(
         try:
             await self.mqtt_client.disconnect()
             LOGGER.debug("MQTT client disconnected")
-        except Exception as ex:
+        except (TimeoutError, OSError, RuntimeError, VictronVRMError) as ex:
             LOGGER.error("Failed to disconnect MQTT client: %s", ex)
             raise
         finally:

--- a/homeassistant/components/victron_remote_monitoring/coordinator.py
+++ b/homeassistant/components/victron_remote_monitoring/coordinator.py
@@ -14,7 +14,15 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_API_TOKEN, CONF_SITE_ID, DOMAIN, LOGGER
+from .const import (
+    CONF_API_TOKEN,
+    CONF_MQTT_UPDATE_FREQUENCY_SECONDS,
+    CONF_SITE_ID,
+    DEFAULT_MQTT_UPDATE_FREQUENCY_SECONDS,
+    DOMAIN,
+    LOGGER,
+)
+from .mqtt_hub import VRMMqttHub
 
 type VictronRemoteMonitoringConfigEntry = ConfigEntry[
     VictronRemoteMonitoringDataUpdateCoordinator
@@ -78,6 +86,8 @@ class VictronRemoteMonitoringDataUpdateCoordinator(
             client_session=async_get_clientsession(hass),
         )
         self.site_id = config_entry.data[CONF_SITE_ID]
+        self.mqtt_client = None
+        self.mqtt_hub = VRMMqttHub(self.site_id)
         super().__init__(
             hass,
             LOGGER,
@@ -96,3 +106,41 @@ class VictronRemoteMonitoringDataUpdateCoordinator(
             ) from err
         except VictronVRMError as err:
             raise UpdateFailed(f"Cannot connect to VRM API: {err}") from err
+
+    async def start_mqtt(self) -> None:
+        """Start the MQTT client."""
+        if self.mqtt_client is not None:
+            LOGGER.debug("MQTT client already started")
+            return  # Already started
+        update_frequency = self.config_entry.options.get(
+            CONF_MQTT_UPDATE_FREQUENCY_SECONDS,
+            DEFAULT_MQTT_UPDATE_FREQUENCY_SECONDS,
+        )
+        mqtt_client = await self.client.get_mqtt_client_for_installation(
+            self.site_id, update_frequency=update_frequency
+        )
+        self.mqtt_client = mqtt_client
+        try:
+            self.mqtt_hub.attach(mqtt_client)
+            await mqtt_client.connect()
+            LOGGER.debug("MQTT client connected")
+        except Exception as ex:
+            self.mqtt_hub.detach()
+            self.mqtt_client = None
+            LOGGER.error("Failed to connect MQTT client: %s", ex)
+            raise
+
+    async def stop_mqtt(self) -> None:
+        """Stop the MQTT client."""
+        if self.mqtt_client is None:
+            LOGGER.debug("MQTT client not started")
+            return  # Not started
+        try:
+            await self.mqtt_client.disconnect()
+            LOGGER.debug("MQTT client disconnected")
+        except Exception as ex:
+            LOGGER.error("Failed to disconnect MQTT client: %s", ex)
+            raise
+        finally:
+            self.mqtt_hub.detach()
+            self.mqtt_client = None

--- a/homeassistant/components/victron_remote_monitoring/entity.py
+++ b/homeassistant/components/victron_remote_monitoring/entity.py
@@ -1,0 +1,120 @@
+"""Shared MQTT entity helpers for Victron Remote Monitoring."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any
+
+from victron_mqtt import (
+    Device as VictronDevice,
+    Metric as VictronMetric,
+    MetricNature,
+    MetricType,
+)
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfTime
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+
+
+class VRMMqttBaseEntity(Entity):
+    """Base class for MQTT-backed entities."""
+
+    def __init__(
+        self,
+        device: VictronDevice,
+        metric: VictronMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        """Initialize the MQTT entity."""
+        self._device = device
+        self._metric = metric
+        self._attr_unique_id = f"{site_id}_{metric.unique_id}"
+        self._attr_device_info = device_info
+        self._attr_has_entity_name = True
+        self._attr_name = self._build_name(metric)
+        self._attr_suggested_display_precision = metric.precision
+        self._attr_native_unit_of_measurement = self._map_unit(metric)
+        self._attr_device_class = self._map_device_class(metric)
+        self._attr_state_class = self._map_state_class(metric)
+        self._attr_should_poll = False
+
+    @staticmethod
+    def _build_name(metric: VictronMetric) -> str:
+        name = getattr(metric, "name", None)
+        return name or metric.short_id
+
+    @staticmethod
+    def _map_device_class(
+        metric: VictronMetric,
+    ) -> SensorDeviceClass | None:
+        match metric.metric_type:
+            case MetricType.POWER:
+                return SensorDeviceClass.POWER
+            case MetricType.APPARENT_POWER:
+                return SensorDeviceClass.APPARENT_POWER
+            case MetricType.ENERGY:
+                return SensorDeviceClass.ENERGY
+            case MetricType.VOLTAGE:
+                return SensorDeviceClass.VOLTAGE
+            case MetricType.CURRENT:
+                return SensorDeviceClass.CURRENT
+            case MetricType.FREQUENCY:
+                return SensorDeviceClass.FREQUENCY
+            case MetricType.ELECTRIC_STORAGE_PERCENTAGE:
+                return SensorDeviceClass.BATTERY
+            case MetricType.TEMPERATURE:
+                return SensorDeviceClass.TEMPERATURE
+            case MetricType.SPEED:
+                return SensorDeviceClass.SPEED
+            case MetricType.LIQUID_VOLUME:
+                return SensorDeviceClass.VOLUME_STORAGE
+            case MetricType.DURATION:
+                return SensorDeviceClass.DURATION
+            case MetricType.TIME:
+                return None
+            case _:
+                return None
+
+    @staticmethod
+    def _map_state_class(
+        metric: VictronMetric,
+    ) -> SensorStateClass | str | None:
+        if metric.metric_nature == MetricNature.CUMULATIVE:
+            return SensorStateClass.TOTAL
+        if metric.metric_nature == MetricNature.INSTANTANEOUS:
+            return SensorStateClass.MEASUREMENT
+        return None
+
+    @staticmethod
+    def _map_unit(metric: VictronMetric) -> str | None:
+        if metric.unit_of_measurement == "s":
+            return UnitOfTime.SECONDS
+        if metric.unit_of_measurement == "min":
+            return UnitOfTime.MINUTES
+        if metric.unit_of_measurement == "h":
+            return UnitOfTime.HOURS
+        return metric.unit_of_measurement
+
+    @abstractmethod
+    def _on_update_task(self, value: Any) -> None:
+        """Handle metric update in subclasses."""
+
+    @callback
+    def _on_update(self, metric: VictronMetric, value: Any) -> None:
+        if self.hass is None:
+            return
+        self._on_update_task(value)
+
+    async def async_added_to_hass(self) -> None:
+        """Register update callback."""
+        await super().async_added_to_hass()
+        self._metric.on_update = self._on_update
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove update callback."""
+        self._metric.on_update = None
+        await super().async_will_remove_from_hass()

--- a/homeassistant/components/victron_remote_monitoring/manifest.json
+++ b/homeassistant/components/victron_remote_monitoring/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
-  "requirements": ["victron-vrm==0.1.8"]
+  "requirements": ["victron-vrm==0.1.11"]
 }

--- a/homeassistant/components/victron_remote_monitoring/mqtt_hub.py
+++ b/homeassistant/components/victron_remote_monitoring/mqtt_hub.py
@@ -1,0 +1,82 @@
+"""MQTT hub adapter for Victron Remote Monitoring."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import logging
+
+from victron_mqtt import (
+    Device as VictronDevice,
+    Hub as VictronMQTTHub,
+    Metric as VictronMetric,
+    MetricKind,
+)
+
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+NewMetricCallback = Callable[[VictronDevice, VictronMetric, DeviceInfo, int], None]
+
+
+class VRMMqttHub:
+    """Adapter to handle MQTT metrics and Home Assistant callbacks."""
+
+    def __init__(self, site_id: int) -> None:
+        """Initialize the adapter."""
+        self._site_id = site_id
+        self._hub: VictronMQTTHub | None = None
+        self._callbacks: dict[MetricKind, NewMetricCallback] = {}
+
+    def attach(self, hub: VictronMQTTHub) -> None:
+        """Attach the underlying Victron MQTT hub."""
+        self._hub = hub
+        self._hub.on_new_metric = self._on_new_metric
+
+    def detach(self) -> None:
+        """Detach the underlying Victron MQTT hub."""
+        if self._hub is not None:
+            self._hub.on_new_metric = None
+        self._hub = None
+
+    def register_new_metric_callback(
+        self, kind: MetricKind, callback: NewMetricCallback
+    ) -> None:
+        """Register a callback for a metric kind."""
+        if kind in self._callbacks:
+            _LOGGER.debug("Metric callback already registered: %s", kind)
+            return
+        self._callbacks[kind] = callback
+
+    def unregister_all_new_metric_callbacks(self) -> None:
+        """Remove all metric callbacks."""
+        self._callbacks.clear()
+
+    def _on_new_metric(
+        self,
+        hub: VictronMQTTHub,
+        device: VictronDevice,
+        metric: VictronMetric,
+    ) -> None:
+        """Handle new metric discovery from the MQTT hub."""
+        _LOGGER.debug("New MQTT metric discovered: %s", metric)
+        device_info = self._map_device_info(device)
+        callback = self._callbacks.get(metric.metric_kind)
+        if callback is not None:
+            callback(device, metric, device_info, self._site_id)
+
+    def _map_device_info(self, device: VictronDevice) -> DeviceInfo:
+        """Create Home Assistant device info for a Victron device."""
+        name = device.name
+        if device.device_id != "0":
+            name = f"{name} (ID: {device.device_id})"
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self._site_id}_{device.unique_id}")},
+            manufacturer=device.manufacturer or "Victron Energy",
+            model=device.model,
+            name=name,
+            serial_number=device.serial_number,
+        )

--- a/homeassistant/components/victron_remote_monitoring/number.py
+++ b/homeassistant/components/victron_remote_monitoring/number.py
@@ -1,0 +1,74 @@
+"""MQTT-backed numbers for Victron Remote Monitoring."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from victron_mqtt import (
+    Device as VictronDevice,
+    Metric as VictronMetric,
+    MetricKind,
+    WritableMetric as VictronWritableMetric,
+)
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import VictronRemoteMonitoringConfigEntry
+from .entity import VRMMqttBaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VictronRemoteMonitoringConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up MQTT number entities from a config entry."""
+    coordinator = entry.runtime_data
+    mqtt_hub = coordinator.mqtt_hub
+
+    def on_new_metric(
+        device: VictronDevice,
+        metric: VictronMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        assert isinstance(metric, VictronWritableMetric)
+        async_add_entities([VRMMqttNumber(device, metric, device_info, site_id)])
+
+    mqtt_hub.register_new_metric_callback(MetricKind.NUMBER, on_new_metric)
+
+
+class VRMMqttNumber(VRMMqttBaseEntity, NumberEntity):
+    """Number entity backed by Victron MQTT metrics."""
+
+    def __init__(
+        self,
+        device: VictronDevice,
+        metric: VictronWritableMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        """Initialize the number entity."""
+        self._attr_native_value = metric.value
+        if isinstance(metric.min_value, int | float):
+            self._attr_native_min_value = metric.min_value
+        if isinstance(metric.max_value, int | float):
+            self._attr_native_max_value = metric.max_value
+        if isinstance(metric.step, int | float):
+            self._attr_native_step = metric.step
+        super().__init__(device, metric, device_info, site_id)
+
+    @callback
+    def _on_update_task(self, value: Any) -> None:
+        if self._attr_native_value == value:
+            return
+        self._attr_native_value = value
+        self.async_write_ha_state()
+
+    def set_native_value(self, value: float) -> None:
+        """Set a new value."""
+        assert isinstance(self._metric, VictronWritableMetric)
+        self._metric.set(value)

--- a/homeassistant/components/victron_remote_monitoring/quality_scale.yaml
+++ b/homeassistant/components/victron_remote_monitoring/quality_scale.yaml
@@ -28,14 +28,14 @@ rules:
     status: exempt
     comment: "This integration does not use actions."
   config-entry-unloading: done
-  docs-configuration-parameters: todo
+  docs-configuration-parameters: done
   docs-installation-parameters: done
   entity-unavailable: todo
-  integration-owner: todo
+  integration-owner: done
   log-when-unavailable: todo
   parallel-updates: todo
   reauthentication-flow: done
-  test-coverage: todo
+  test-coverage: done
 
   # Gold
   devices: done

--- a/homeassistant/components/victron_remote_monitoring/select.py
+++ b/homeassistant/components/victron_remote_monitoring/select.py
@@ -1,0 +1,78 @@
+"""MQTT-backed selects for Victron Remote Monitoring."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from victron_mqtt import (
+    Device as VictronDevice,
+    Metric as VictronMetric,
+    MetricKind,
+    WritableMetric as VictronWritableMetric,
+)
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import VictronRemoteMonitoringConfigEntry
+from .entity import VRMMqttBaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VictronRemoteMonitoringConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up MQTT select entities from a config entry."""
+    coordinator = entry.runtime_data
+    mqtt_hub = coordinator.mqtt_hub
+
+    def on_new_metric(
+        device: VictronDevice,
+        metric: VictronMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        assert isinstance(metric, VictronWritableMetric)
+        async_add_entities([VRMMqttSelect(device, metric, device_info, site_id)])
+
+    mqtt_hub.register_new_metric_callback(MetricKind.SELECT, on_new_metric)
+
+
+class VRMMqttSelect(VRMMqttBaseEntity, SelectEntity):
+    """Select entity backed by Victron MQTT metrics."""
+
+    def __init__(
+        self,
+        device: VictronDevice,
+        metric: VictronWritableMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        """Initialize the select entity."""
+        assert metric.enum_values is not None
+        self._attr_options = metric.enum_values
+        self._attr_current_option = self._map_value_to_option(metric.value)
+        super().__init__(device, metric, device_info, site_id)
+
+    @callback
+    def _on_update_task(self, value: Any) -> None:
+        new_value = self._map_value_to_option(value)
+        if self._attr_current_option == new_value:
+            return
+        self._attr_current_option = new_value
+        self.async_write_ha_state()
+
+    def select_option(self, option: str) -> None:
+        """Select a new option."""
+        assert isinstance(self._metric, VictronWritableMetric)
+        assert self._metric.enum_values is not None
+        if option not in self._metric.enum_values:
+            return
+        self._metric.set(option)
+
+    @staticmethod
+    def _map_value_to_option(value: Any) -> str:
+        return str(value)

--- a/homeassistant/components/victron_remote_monitoring/strings.json
+++ b/homeassistant/components/victron_remote_monitoring/strings.json
@@ -98,5 +98,18 @@
         "name": "Highest peak time - Yesterday"
       }
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "mqtt_update_frequency": "MQTT update frequency (seconds)"
+        },
+        "data_description": {
+          "mqtt_update_frequency": "Minimum seconds between metric updates. Set to 0 to update on every MQTT message."
+        },
+        "description": "Configure MQTT update throttling."
+      }
+    }
   }
 }

--- a/homeassistant/components/victron_remote_monitoring/switch.py
+++ b/homeassistant/components/victron_remote_monitoring/switch.py
@@ -1,0 +1,75 @@
+"""MQTT-backed switches for Victron Remote Monitoring."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from victron_mqtt import (
+    Device as VictronDevice,
+    Metric as VictronMetric,
+    MetricKind,
+    WritableMetric as VictronWritableMetric,
+)
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import SWITCH_OFF, SWITCH_ON
+from .coordinator import VictronRemoteMonitoringConfigEntry
+from .entity import VRMMqttBaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VictronRemoteMonitoringConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up MQTT switches from a config entry."""
+    coordinator = entry.runtime_data
+    mqtt_hub = coordinator.mqtt_hub
+
+    def on_new_metric(
+        device: VictronDevice,
+        metric: VictronMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        assert isinstance(metric, VictronWritableMetric)
+        async_add_entities([VRMMqttSwitch(device, metric, device_info, site_id)])
+
+    mqtt_hub.register_new_metric_callback(MetricKind.SWITCH, on_new_metric)
+
+
+class VRMMqttSwitch(VRMMqttBaseEntity, SwitchEntity):
+    """Switch backed by Victron MQTT metrics."""
+
+    def __init__(
+        self,
+        device: VictronDevice,
+        metric: VictronWritableMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        """Initialize the switch."""
+        self._attr_is_on = str(metric.value) == SWITCH_ON
+        super().__init__(device, metric, device_info, site_id)
+
+    @callback
+    def _on_update_task(self, value: Any) -> None:
+        new_state = str(value) == SWITCH_ON
+        if self._attr_is_on == new_state:
+            return
+        self._attr_is_on = new_state
+        self.async_write_ha_state()
+
+    def turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        assert isinstance(self._metric, VictronWritableMetric)
+        self._metric.set(SWITCH_ON)
+
+    def turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        assert isinstance(self._metric, VictronWritableMetric)
+        self._metric.set(SWITCH_OFF)

--- a/homeassistant/components/victron_remote_monitoring/time.py
+++ b/homeassistant/components/victron_remote_monitoring/time.py
@@ -1,0 +1,81 @@
+"""MQTT-backed time entities for Victron Remote Monitoring."""
+
+from __future__ import annotations
+
+from datetime import time
+from typing import Any
+
+from victron_mqtt import (
+    Device as VictronDevice,
+    Metric as VictronMetric,
+    MetricKind,
+    WritableMetric as VictronWritableMetric,
+)
+
+from homeassistant.components.time import TimeEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import VictronRemoteMonitoringConfigEntry
+from .entity import VRMMqttBaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VictronRemoteMonitoringConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up MQTT time entities from a config entry."""
+    coordinator = entry.runtime_data
+    mqtt_hub = coordinator.mqtt_hub
+
+    def on_new_metric(
+        device: VictronDevice,
+        metric: VictronMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        assert isinstance(metric, VictronWritableMetric)
+        async_add_entities([VRMMqttTime(device, metric, device_info, site_id)])
+
+    mqtt_hub.register_new_metric_callback(MetricKind.TIME, on_new_metric)
+
+
+class VRMMqttTime(VRMMqttBaseEntity, TimeEntity):
+    """Time entity backed by Victron MQTT metrics."""
+
+    @staticmethod
+    def _to_time(value: int | None) -> time | None:
+        if value is None:
+            return None
+        total_minutes = int(value)
+        return time(hour=total_minutes // 60, minute=total_minutes % 60)
+
+    @staticmethod
+    def _to_minutes(value: time) -> int:
+        return value.hour * 60 + value.minute
+
+    def __init__(
+        self,
+        device: VictronDevice,
+        metric: VictronWritableMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        """Initialize the time entity."""
+        self._attr_native_value = self._to_time(metric.value)
+        super().__init__(device, metric, device_info, site_id)
+
+    @callback
+    def _on_update_task(self, value: Any) -> None:
+        new_time = self._to_time(value)
+        if self._attr_native_value == new_time:
+            return
+        self._attr_native_value = new_time
+        self.async_write_ha_state()
+
+    def set_value(self, value: time) -> None:
+        """Set a new time value."""
+        assert isinstance(self._metric, VictronWritableMetric)
+        self._metric.set(self._to_minutes(value))

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3133,7 +3133,7 @@ venstarcolortouch==0.21
 victron-ble-ha-parser==0.4.9
 
 # homeassistant.components.victron_remote_monitoring
-victron-vrm==0.1.8
+victron-vrm==0.1.11
 
 # homeassistant.components.vilfo
 vilfo-api-client==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2624,7 +2624,7 @@ venstarcolortouch==0.21
 victron-ble-ha-parser==0.4.9
 
 # homeassistant.components.victron_remote_monitoring
-victron-vrm==0.1.8
+victron-vrm==0.1.11
 
 # homeassistant.components.vilfo
 vilfo-api-client==0.5.0

--- a/tests/components/victron_remote_monitoring/snapshots/test_mqtt_entities.ambr
+++ b/tests/components/victron_remote_monitoring/snapshots/test_mqtt_entities.ambr
@@ -1,0 +1,106 @@
+# serializer version: 1
+# name: test_mqtt_entities_snapshot
+  list([
+    dict({
+      'domain': 'binary_sensor',
+      'entity_id': 'binary_sensor.cerbo_gx_id_1_system_relay',
+      'original_name': 'System relay',
+      'platform': 'victron_remote_monitoring',
+      'unique_id': '123456_system_0_relay',
+    }),
+    dict({
+      'domain': 'button',
+      'entity_id': 'button.cerbo_gx_id_1_system_reboot',
+      'original_name': 'System reboot',
+      'platform': 'victron_remote_monitoring',
+      'unique_id': '123456_system_0_reboot',
+    }),
+    dict({
+      'domain': 'number',
+      'entity_id': 'number.cerbo_gx_id_1_charge_limit',
+      'original_name': 'Charge limit',
+      'platform': 'victron_remote_monitoring',
+      'unique_id': '123456_charger_0_limit',
+    }),
+    dict({
+      'domain': 'select',
+      'entity_id': 'select.cerbo_gx_id_1_system_mode',
+      'original_name': 'System mode',
+      'platform': 'victron_remote_monitoring',
+      'unique_id': '123456_system_0_mode',
+    }),
+    dict({
+      'domain': 'sensor',
+      'entity_id': 'sensor.cerbo_gx_id_1_system_voltage',
+      'original_name': 'System voltage',
+      'platform': 'victron_remote_monitoring',
+      'unique_id': '123456_system_0_voltage',
+    }),
+    dict({
+      'domain': 'switch',
+      'entity_id': 'switch.cerbo_gx_id_1_system_switch',
+      'original_name': 'System switch',
+      'platform': 'victron_remote_monitoring',
+      'unique_id': '123456_system_0_switch',
+    }),
+    dict({
+      'domain': 'time',
+      'entity_id': 'time.cerbo_gx_id_1_quiet_hours_start',
+      'original_name': 'Quiet hours start',
+      'platform': 'victron_remote_monitoring',
+      'unique_id': '123456_system_0_quiet_hours_start',
+    }),
+  ])
+# ---
+# name: test_mqtt_entities_snapshot.1
+  dict({
+    'binary_sensor.cerbo_gx_id_1_system_relay': dict({
+      'attributes': dict({
+        'friendly_name': 'Cerbo GX (ID: 1) System relay',
+      }),
+      'state': 'on',
+    }),
+    'button.cerbo_gx_id_1_system_reboot': dict({
+      'attributes': dict({
+        'friendly_name': 'Cerbo GX (ID: 1) System reboot',
+      }),
+      'state': 'unknown',
+    }),
+    'number.cerbo_gx_id_1_charge_limit': dict({
+      'attributes': dict({
+        'friendly_name': 'Cerbo GX (ID: 1) Charge limit',
+        'unit_of_measurement': 'A',
+      }),
+      'state': '10.5',
+    }),
+    'select.cerbo_gx_id_1_system_mode': dict({
+      'attributes': dict({
+        'friendly_name': 'Cerbo GX (ID: 1) System mode',
+        'options': list([
+          'On',
+          'Off',
+        ]),
+      }),
+      'state': 'On',
+    }),
+    'sensor.cerbo_gx_id_1_system_voltage': dict({
+      'attributes': dict({
+        'friendly_name': 'Cerbo GX (ID: 1) System voltage',
+        'unit_of_measurement': 'V',
+      }),
+      'state': '12.3',
+    }),
+    'switch.cerbo_gx_id_1_system_switch': dict({
+      'attributes': dict({
+        'friendly_name': 'Cerbo GX (ID: 1) System switch',
+      }),
+      'state': 'on',
+    }),
+    'time.cerbo_gx_id_1_quiet_hours_start': dict({
+      'attributes': dict({
+        'friendly_name': 'Cerbo GX (ID: 1) Quiet hours start',
+      }),
+      'state': '08:00:00',
+    }),
+  })
+# ---

--- a/tests/components/victron_remote_monitoring/test_init.py
+++ b/tests/components/victron_remote_monitoring/test_init.py
@@ -75,3 +75,24 @@ async def test_setup_entry_mqtt_failure_unloads(
         await hass.async_block_till_done()
 
     assert mock_unload.called
+
+
+async def test_options_update_triggers_reload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify options update reloads the entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch.object(
+        hass.config_entries, "async_reload", new=AsyncMock()
+    ) as mock_reload:
+        hass.config_entries.async_update_entry(
+            mock_config_entry, options={"mqtt_update_frequency": 10}
+        )
+        await hass.async_block_till_done()
+
+        assert mock_reload.called

--- a/tests/components/victron_remote_monitoring/test_init.py
+++ b/tests/components/victron_remote_monitoring/test_init.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from victron_vrm.exceptions import AuthenticationError, VictronVRMError
 
@@ -49,3 +51,27 @@ async def test_setup_auth_or_connection_error_starts_retry_or_reauth(
     assert mock_config_entry.state is expected_state
     flows_list = list(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
     assert bool(flows_list) is expects_reauth
+
+
+async def test_setup_entry_mqtt_failure_unloads(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Ensure MQTT startup errors trigger unload handling."""
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.victron_remote_monitoring."
+            "VictronRemoteMonitoringDataUpdateCoordinator.start_mqtt",
+            side_effect=RuntimeError("Something went wrong starting MQTT"),
+        ),
+        patch(
+            "homeassistant.components.victron_remote_monitoring.async_unload_entry",
+            new=AsyncMock(return_value=True),
+        ) as mock_unload,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_unload.called

--- a/tests/components/victron_remote_monitoring/test_mqtt_coordinator.py
+++ b/tests/components/victron_remote_monitoring/test_mqtt_coordinator.py
@@ -1,0 +1,108 @@
+"""Tests for MQTT coordinator lifecycle."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant.components.victron_remote_monitoring.coordinator import (
+    VictronRemoteMonitoringDataUpdateCoordinator,
+)
+from homeassistant.core import HomeAssistant
+
+from .conftest import FakeMQTTClient
+
+
+async def test_coordinator_mqtt_start_stop(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_mqtt_client: FakeMQTTClient,
+) -> None:
+    """Verify start/stop behavior."""
+    coordinator = VictronRemoteMonitoringDataUpdateCoordinator(hass, mock_config_entry)
+
+    await coordinator.start_mqtt()
+
+    assert coordinator.mqtt_client is mock_mqtt_client
+
+    await coordinator.stop_mqtt()
+
+    assert coordinator.mqtt_client is None
+
+
+async def test_coordinator_start_mqtt_failure(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_mqtt_client: FakeMQTTClient,
+) -> None:
+    """Verify start_mqtt failure handling."""
+    coordinator = VictronRemoteMonitoringDataUpdateCoordinator(hass, mock_config_entry)
+    mock_mqtt_client.connect = AsyncMock(
+        side_effect=RuntimeError("Something went wrong")
+    )
+
+    with pytest.raises(RuntimeError):
+        await coordinator.start_mqtt()
+
+    assert coordinator.mqtt_client is None
+
+
+async def test_coordinator_start_mqtt_idempotent(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_mqtt_client: FakeMQTTClient,
+) -> None:
+    """Verify start_mqtt is idempotent."""
+    coordinator = VictronRemoteMonitoringDataUpdateCoordinator(hass, mock_config_entry)
+
+    await coordinator.start_mqtt()
+    await coordinator.start_mqtt()
+
+    assert coordinator.mqtt_client is mock_mqtt_client
+
+
+async def test_coordinator_stop_mqtt_failure(
+    hass: HomeAssistant,
+    mock_config_entry,
+) -> None:
+    """Verify stop_mqtt error propagation and cleanup."""
+    coordinator = VictronRemoteMonitoringDataUpdateCoordinator(hass, mock_config_entry)
+
+    class _FailingClient:
+        async def disconnect(self) -> None:
+            raise RuntimeError("Something went wrong during disconnect")
+
+    coordinator.mqtt_client = _FailingClient()
+
+    with pytest.raises(RuntimeError):
+        await coordinator.stop_mqtt()
+
+    assert coordinator.mqtt_client is None
+
+
+async def test_coordinator_stop_mqtt_idempotent(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_mqtt_client: FakeMQTTClient,
+) -> None:
+    """Verify stop_mqtt is idempotent."""
+    coordinator = VictronRemoteMonitoringDataUpdateCoordinator(hass, mock_config_entry)
+
+    await coordinator.start_mqtt()
+    await coordinator.stop_mqtt()
+    await coordinator.stop_mqtt()
+
+    assert coordinator.mqtt_client is None
+
+
+async def test_coordinator_stop_mqtt_no_client(
+    hass: HomeAssistant,
+    mock_config_entry,
+) -> None:
+    """Verify stop_mqtt handles missing client."""
+    coordinator = VictronRemoteMonitoringDataUpdateCoordinator(hass, mock_config_entry)
+
+    await coordinator.stop_mqtt()
+
+    assert coordinator.mqtt_client is None

--- a/tests/components/victron_remote_monitoring/test_mqtt_entities.py
+++ b/tests/components/victron_remote_monitoring/test_mqtt_entities.py
@@ -1,0 +1,192 @@
+"""Tests for MQTT entities in Victron Remote Monitoring."""
+
+from __future__ import annotations
+
+import pytest
+from victron_mqtt import MetricKind, MetricNature, MetricType
+
+from homeassistant.components.victron_remote_monitoring import (
+    button as vrm_button,
+    number as vrm_number,
+    select as vrm_select,
+    switch as vrm_switch,
+    time as vrm_time,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import FakeDevice, FakeMetric, FakeWritableMetric
+
+from tests.common import MockConfigEntry
+from tests.conftest import SnapshotAssertion
+
+
+@pytest.fixture
+def mqtt_metrics() -> list[tuple[FakeDevice, FakeMetric]]:
+    """Return MQTT metrics used for entity discovery."""
+    device = FakeDevice(
+        unique_id="device_1",
+        device_id="1",
+        name="Cerbo GX",
+        manufacturer="Victron Energy",
+        model="Cerbo GX",
+        serial_number="ABC123",
+    )
+
+    return [
+        (
+            device,
+            FakeMetric(
+                metric_kind=MetricKind.SENSOR,
+                metric_type=MetricType.VOLTAGE,
+                metric_nature=MetricNature.INSTANTANEOUS,
+                unit_of_measurement="V",
+                precision=1,
+                short_id="system_voltage",
+                unique_id="system_0_voltage",
+                name="System voltage",
+                value=12.3,
+            ),
+        ),
+        (
+            device,
+            FakeMetric(
+                metric_kind=MetricKind.BINARY_SENSOR,
+                metric_type=MetricType.TIME,
+                metric_nature=MetricNature.INSTANTANEOUS,
+                unit_of_measurement=None,
+                precision=None,
+                short_id="system_relay_state",
+                unique_id="system_0_relay",
+                name="System relay",
+                value="On",
+            ),
+        ),
+        (
+            device,
+            FakeWritableMetric(
+                metric_kind=MetricKind.NUMBER,
+                metric_type=MetricType.CURRENT,
+                metric_nature=MetricNature.INSTANTANEOUS,
+                unit_of_measurement="A",
+                precision=1,
+                short_id="charge_limit",
+                unique_id="charger_0_limit",
+                name="Charge limit",
+                value=10.5,
+                min_value=0.0,
+                max_value=50.0,
+                step=0.5,
+            ),
+        ),
+        (
+            device,
+            FakeWritableMetric(
+                metric_kind=MetricKind.SELECT,
+                metric_type=MetricType.TIME,
+                metric_nature=MetricNature.INSTANTANEOUS,
+                unit_of_measurement=None,
+                precision=None,
+                short_id="system_mode",
+                unique_id="system_0_mode",
+                name="System mode",
+                value="On",
+                enum_values=["On", "Off"],
+            ),
+        ),
+        (
+            device,
+            FakeWritableMetric(
+                metric_kind=MetricKind.SWITCH,
+                metric_type=MetricType.TIME,
+                metric_nature=MetricNature.INSTANTANEOUS,
+                unit_of_measurement=None,
+                precision=None,
+                short_id="system_switch",
+                unique_id="system_0_switch",
+                name="System switch",
+                value="On",
+            ),
+        ),
+        (
+            device,
+            FakeWritableMetric(
+                metric_kind=MetricKind.BUTTON,
+                metric_type=MetricType.TIME,
+                metric_nature=MetricNature.INSTANTANEOUS,
+                unit_of_measurement=None,
+                precision=None,
+                short_id="system_reboot",
+                unique_id="system_0_reboot",
+                name="System reboot",
+                value=None,
+            ),
+        ),
+        (
+            device,
+            FakeWritableMetric(
+                metric_kind=MetricKind.TIME,
+                metric_type=MetricType.TIME,
+                metric_nature=MetricNature.INSTANTANEOUS,
+                unit_of_measurement="min",
+                precision=None,
+                short_id="quiet_hours_start",
+                unique_id="system_0_quiet_hours_start",
+                name="Quiet hours start",
+                value=480,
+            ),
+        ),
+    ]
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_mqtt_entities_snapshot(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Snapshot MQTT entities created from MQTT metrics."""
+    monkeypatch.setattr(vrm_number, "VictronWritableMetric", FakeWritableMetric)
+    monkeypatch.setattr(vrm_select, "VictronWritableMetric", FakeWritableMetric)
+    monkeypatch.setattr(vrm_switch, "VictronWritableMetric", FakeWritableMetric)
+    monkeypatch.setattr(vrm_button, "VictronWritableMetric", FakeWritableMetric)
+    monkeypatch.setattr(vrm_time, "VictronWritableMetric", FakeWritableMetric)
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    mqtt_entries = [entry for entry in entries if "|" not in entry.unique_id]
+    assert mqtt_entries
+
+    mqtt_entries_snapshot = [
+        {
+            "entity_id": entry.entity_id,
+            "unique_id": entry.unique_id,
+            "platform": entry.platform,
+            "domain": entry.domain,
+            "original_name": entry.original_name,
+        }
+        for entry in sorted(mqtt_entries, key=lambda item: item.entity_id)
+    ]
+
+    states_snapshot = {
+        state.entity_id: {
+            "state": state.state,
+            "attributes": {
+                key: value
+                for key, value in state.attributes.items()
+                if key in {"friendly_name", "unit_of_measurement", "options"}
+            },
+        }
+        for entry in mqtt_entries
+        if (state := hass.states.get(entry.entity_id)) is not None
+    }
+
+    assert mqtt_entries_snapshot == snapshot
+    assert states_snapshot == snapshot

--- a/tests/components/victron_remote_monitoring/test_mqtt_helpers.py
+++ b/tests/components/victron_remote_monitoring/test_mqtt_helpers.py
@@ -1,0 +1,367 @@
+"""Tests for MQTT helper classes and entities."""
+
+from __future__ import annotations
+
+from datetime import time as dt_time
+from types import SimpleNamespace
+
+import pytest
+from victron_mqtt import MetricKind, MetricNature, MetricType
+
+from homeassistant.components.victron_remote_monitoring import (
+    button as vrm_button,
+    number as vrm_number,
+    select as vrm_select,
+    switch as vrm_switch,
+    time as vrm_time,
+)
+from homeassistant.components.victron_remote_monitoring.binary_sensor import (
+    VRMMqttBinarySensor,
+)
+from homeassistant.components.victron_remote_monitoring.button import VRMMqttButton
+from homeassistant.components.victron_remote_monitoring.entity import VRMMqttBaseEntity
+from homeassistant.components.victron_remote_monitoring.mqtt_hub import VRMMqttHub
+from homeassistant.components.victron_remote_monitoring.number import VRMMqttNumber
+from homeassistant.components.victron_remote_monitoring.select import VRMMqttSelect
+from homeassistant.components.victron_remote_monitoring.sensor import VRMMqttSensor
+from homeassistant.components.victron_remote_monitoring.switch import VRMMqttSwitch
+from homeassistant.components.victron_remote_monitoring.time import VRMMqttTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .conftest import FakeDevice, FakeMetric, FakeWritableMetric
+
+
+class _TestEntity(VRMMqttBaseEntity):
+    def __init__(
+        self,
+        device: FakeDevice,
+        metric: FakeMetric,
+        device_info: DeviceInfo,
+        site_id: int,
+    ) -> None:
+        self.last_value = None
+        super().__init__(device, metric, device_info, site_id)
+
+    def _on_update_task(self, value) -> None:
+        self.last_value = value
+
+
+def _device_info() -> DeviceInfo:
+    return DeviceInfo(identifiers={("victron_remote_monitoring", "device")})
+
+
+def _metric(
+    *,
+    metric_type: MetricType,
+    metric_nature: MetricNature,
+    unit: str | None,
+) -> FakeMetric:
+    return FakeMetric(
+        metric_kind=MetricKind.SENSOR,
+        metric_type=metric_type,
+        metric_nature=metric_nature,
+        unit_of_measurement=unit,
+        precision=1,
+        short_id="metric",
+        unique_id="metric_1",
+        name="Metric",
+        value=1,
+    )
+
+
+def _set_entity_id(entity, domain: str) -> None:
+    """Assign an entity_id to allow state writes."""
+    entity.entity_id = f"{domain}.test_{entity._attr_unique_id}"
+
+
+@pytest.fixture(autouse=True)
+def _patch_writable_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure writable metric assertions accept test fakes."""
+    monkeypatch.setattr(vrm_number, "VictronWritableMetric", FakeWritableMetric)
+    monkeypatch.setattr(vrm_select, "VictronWritableMetric", FakeWritableMetric)
+    monkeypatch.setattr(vrm_switch, "VictronWritableMetric", FakeWritableMetric)
+    monkeypatch.setattr(vrm_button, "VictronWritableMetric", FakeWritableMetric)
+    monkeypatch.setattr(vrm_time, "VictronWritableMetric", FakeWritableMetric)
+
+
+@pytest.mark.parametrize(
+    ("metric_type", "expected"),
+    [
+        (MetricType.POWER, "power"),
+        (MetricType.APPARENT_POWER, "apparent_power"),
+        (MetricType.ENERGY, "energy"),
+        (MetricType.VOLTAGE, "voltage"),
+        (MetricType.CURRENT, "current"),
+        (MetricType.FREQUENCY, "frequency"),
+        (MetricType.ELECTRIC_STORAGE_PERCENTAGE, "battery"),
+        (MetricType.TEMPERATURE, "temperature"),
+        (MetricType.SPEED, "speed"),
+        (MetricType.LIQUID_VOLUME, "volume_storage"),
+        (MetricType.DURATION, "duration"),
+        (MetricType.TIME, None),
+    ],
+)
+def test_mqtt_entity_device_class_mapping(metric_type, expected) -> None:
+    """Verify device class mapping for MQTT metrics."""
+    metric = _metric(
+        metric_type=metric_type,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        unit="V",
+    )
+    device_class = VRMMqttBaseEntity._map_device_class(metric)
+    if expected is None:
+        assert device_class is None
+    else:
+        assert device_class.value == expected
+
+
+def test_mqtt_entity_device_class_mapping_default() -> None:
+    """Verify device class mapping default branch."""
+    metric = FakeMetric(
+        metric_kind=MetricKind.SENSOR,
+        metric_type=object(),
+        metric_nature=MetricNature.INSTANTANEOUS,
+        unit_of_measurement=None,
+        precision=None,
+        short_id="metric",
+        unique_id="metric_default",
+        name="Metric",
+        value=None,
+    )
+    assert VRMMqttBaseEntity._map_device_class(metric) is None
+
+
+@pytest.mark.parametrize(
+    ("metric_nature", "expected"),
+    [
+        (MetricNature.CUMULATIVE, "total"),
+        (MetricNature.INSTANTANEOUS, "measurement"),
+        (object(), None),
+    ],
+)
+def test_mqtt_entity_state_class_mapping(metric_nature, expected) -> None:
+    """Verify state class mapping for MQTT metrics."""
+    metric = _metric(
+        metric_type=MetricType.POWER,
+        metric_nature=metric_nature,
+        unit="W",
+    )
+    state_class = VRMMqttBaseEntity._map_state_class(metric)
+    if expected is None:
+        assert state_class is None
+    else:
+        assert state_class.value == expected
+
+
+@pytest.mark.parametrize(
+    ("unit", "expected"),
+    [
+        ("s", "s"),
+        ("min", "min"),
+        ("h", "h"),
+        ("V", "V"),
+        (None, None),
+    ],
+)
+def test_mqtt_entity_unit_mapping(unit, expected) -> None:
+    """Verify unit mapping for MQTT metrics."""
+    metric = _metric(
+        metric_type=MetricType.POWER,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        unit=unit,
+    )
+    mapped = VRMMqttBaseEntity._map_unit(metric)
+    assert mapped == expected
+
+
+async def test_mqtt_entity_update_callback(hass: HomeAssistant) -> None:
+    """Ensure update callbacks set values when hass is available."""
+    device = FakeDevice(unique_id="device", device_id="1", name="Device")
+    metric = _metric(
+        metric_type=MetricType.POWER, metric_nature=MetricNature.INSTANTANEOUS, unit="W"
+    )
+    entity = _TestEntity(device, metric, _device_info(), 123)
+
+    entity._on_update(metric, 5)
+    assert entity.last_value is None
+
+    entity.hass = hass
+    entity._on_update(metric, 5)
+    assert entity.last_value == 5
+
+    await entity.async_added_to_hass()
+    assert metric.on_update is not None
+    await entity.async_will_remove_from_hass()
+    assert metric.on_update is None
+
+
+def test_mqtt_hub_callback_registration() -> None:
+    """Verify MQTT hub callback registration and dispatch."""
+    hub = VRMMqttHub(site_id=123)
+    called = SimpleNamespace(count=0)
+
+    def callback(*_args) -> None:
+        called.count += 1
+
+    hub.register_new_metric_callback(MetricKind.SENSOR, callback)
+    hub.register_new_metric_callback(MetricKind.SENSOR, callback)
+
+    device = FakeDevice(unique_id="device", device_id="1", name="Device")
+    metric = _metric(
+        metric_type=MetricType.POWER, metric_nature=MetricNature.INSTANTANEOUS, unit="W"
+    )
+    hub._on_new_metric(SimpleNamespace(), device, metric)
+
+    assert called.count == 1
+
+
+def test_binary_sensor_update(hass: HomeAssistant) -> None:
+    """Verify binary sensor update behavior."""
+    device = FakeDevice(unique_id="device", device_id="1", name="Device")
+    metric = _metric(
+        metric_type=MetricType.TIME, metric_nature=MetricNature.INSTANTANEOUS, unit=None
+    )
+    metric.value = "Off"
+    entity = VRMMqttBinarySensor(device, metric, _device_info(), 123)
+    entity.hass = hass
+    _set_entity_id(entity, "binary_sensor")
+    entity._on_update_task("Off")
+    entity._on_update_task("On")
+    assert entity.is_on
+
+
+def test_button_press() -> None:
+    """Verify button press updates underlying metric."""
+    device = FakeDevice(unique_id="device", device_id="1", name="Device")
+    metric = FakeWritableMetric(
+        metric_kind=MetricKind.BUTTON,
+        metric_type=MetricType.TIME,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        unit_of_measurement=None,
+        precision=None,
+        short_id="button",
+        unique_id="button_1",
+        name="Button",
+        value=None,
+    )
+    entity = VRMMqttButton(device, metric, _device_info(), 123)
+    entity._on_update_task(None)
+    entity.press()
+    assert metric.value == "On"
+
+
+def test_number_updates(hass: HomeAssistant) -> None:
+    """Verify number update and set operations."""
+    device = FakeDevice(unique_id="device", device_id="1", name="Device")
+    metric = FakeWritableMetric(
+        metric_kind=MetricKind.NUMBER,
+        metric_type=MetricType.CURRENT,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        unit_of_measurement="A",
+        precision=1,
+        short_id="number",
+        unique_id="number_1",
+        name="Number",
+        value=1.0,
+        min_value=0.0,
+        max_value=10.0,
+        step=0.5,
+    )
+    entity = VRMMqttNumber(device, metric, _device_info(), 123)
+    entity.hass = hass
+    _set_entity_id(entity, "number")
+    entity._on_update_task(1.0)
+    entity._on_update_task(2.0)
+    entity.set_native_value(3.0)
+    assert metric.value == 3.0
+
+
+def test_sensor_updates(hass: HomeAssistant) -> None:
+    """Verify sensor update handling."""
+    device = FakeDevice(unique_id="device", device_id="1", name="Device")
+    metric = _metric(
+        metric_type=MetricType.VOLTAGE,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        unit="V",
+    )
+    entity = VRMMqttSensor(device, metric, _device_info(), 123)
+    entity.hass = hass
+    _set_entity_id(entity, "sensor")
+    entity._on_update_task(1)
+    entity._on_update_task(2)
+    assert entity.native_value == 2
+
+
+def test_select_updates(hass: HomeAssistant) -> None:
+    """Verify select update and option handling."""
+    device = FakeDevice(unique_id="device", device_id="1", name="Device")
+    metric = FakeWritableMetric(
+        metric_kind=MetricKind.SELECT,
+        metric_type=MetricType.TIME,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        unit_of_measurement=None,
+        precision=None,
+        short_id="select",
+        unique_id="select_1",
+        name="Select",
+        value="On",
+        enum_values=["On", "Off"],
+    )
+    entity = VRMMqttSelect(device, metric, _device_info(), 123)
+    entity.hass = hass
+    _set_entity_id(entity, "select")
+    entity._on_update_task("On")
+    entity._on_update_task("Off")
+    entity.select_option("Invalid")
+    entity.select_option("On")
+    assert metric.value == "On"
+
+
+def test_switch_updates(hass: HomeAssistant) -> None:
+    """Verify switch update and turn operations."""
+    device = FakeDevice(unique_id="device", device_id="1", name="Device")
+    metric = FakeWritableMetric(
+        metric_kind=MetricKind.SWITCH,
+        metric_type=MetricType.TIME,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        unit_of_measurement=None,
+        precision=None,
+        short_id="switch",
+        unique_id="switch_1",
+        name="Switch",
+        value="Off",
+    )
+    entity = VRMMqttSwitch(device, metric, _device_info(), 123)
+    entity.hass = hass
+    _set_entity_id(entity, "switch")
+    entity._on_update_task("Off")
+    entity._on_update_task("On")
+    entity.turn_on()
+    entity.turn_off()
+    assert metric.value == "Off"
+
+
+def test_time_updates(hass: HomeAssistant) -> None:
+    """Verify time update and set operations."""
+    assert VRMMqttTime._to_time(None) is None
+    assert VRMMqttTime._to_minutes(dt_time(hour=1, minute=0)) == 60
+    device = FakeDevice(unique_id="device", device_id="1", name="Device")
+    metric = FakeWritableMetric(
+        metric_kind=MetricKind.TIME,
+        metric_type=MetricType.TIME,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        unit_of_measurement="min",
+        precision=None,
+        short_id="time",
+        unique_id="time_1",
+        name="Time",
+        value=60,
+    )
+    entity = VRMMqttTime(device, metric, _device_info(), 123)
+    entity.hass = hass
+    _set_entity_id(entity, "time")
+    entity._on_update_task(60)
+    entity._on_update_task(90)
+    entity.set_value(dt_time(hour=2, minute=30))
+    assert metric.value == 150


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds new devices and metrics from the Victron Remote Monitoring (VRM) portal by using MQTT for communication and [victron_mqtt](https://github.com/tomer-w/victron_mqtt) library for connection and processing (the library is pinned and tied with the victron-vrm library).

Change logs:
 - [victron-vrm](https://github.com/KSoft-Si/vrm-client/compare/v0.1.8...v0.1.11)

**Note:**
This PR also adds a user configurable update frequency setting. This setting only throttles MQTT messages from VRM, because VRM sends very frequent updates that could be >50/s.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to frontend pull request: https://github.com/home-assistant/home-assistant.io/pull/43142

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
