### PR TITLE
Fix Reolink camera updates persisting in UI

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -144,7 +144,7 @@ async def async_setup_entry(
     update_timeout = max(min_timeout, min_timeout * host.api.num_cameras / 10)
 
     # Track firmware versions to detect external updates (e.g., via Reolink app)
-    last_known_firmware: dict[int | None, str] = {}
+    last_known_firmware: dict[int | None, str | None] = {}
 
     async def async_device_config_update() -> None:
         """Update the host state cache and renew the ONVIF-subscription."""
@@ -172,7 +172,11 @@ async def async_setup_entry(
         for ch in (*host.api.channels, None):
             new_version = host.api.camera_sw_version(ch)
             old_version = last_known_firmware.get(ch)
-            if old_version is not None and new_version != old_version:
+            if (
+                old_version is not None
+                and new_version is not None
+                and new_version != old_version
+            ):
                 firmware_changed = True
             last_known_firmware[ch] = new_version
 

--- a/homeassistant/components/reolink/update.py
+++ b/homeassistant/components/reolink/update.py
@@ -116,7 +116,6 @@ class ReolinkUpdateBaseEntity(
         self._cancel_progress: CALLBACK_TYPE | None = None
         self._installing: bool = False
         self._reolink_data = reolink_data
-        self._last_installed_version: str | None = None
 
     @property
     def installed_version(self) -> str | None:
@@ -246,35 +245,10 @@ class ReolinkUpdateBaseEntity(
         finally:
             self._cancel_update = None
 
-    def _handle_device_coordinator_update(self) -> None:
-        """Handle updated data from the device coordinator.
-
-        Detect when firmware version changes (e.g., after external update via Reolink app)
-        and trigger a firmware check to update the available update status.
-        """
-        current_version = self._host.api.camera_sw_version(self._channel)
-        if (
-            self._last_installed_version is not None
-            and current_version != self._last_installed_version
-        ):
-            # Firmware version changed, refresh firmware status
-            self.hass.async_create_task(
-                self._reolink_data.firmware_coordinator.async_request_refresh()
-            )
-        self._last_installed_version = current_version
-
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
         self._host.firmware_ch_list.append(self._channel)
-        # Track initial version
-        self._last_installed_version = self._host.api.camera_sw_version(self._channel)
-        # Listen to device coordinator to detect version changes from external updates
-        self.async_on_remove(
-            self._reolink_data.device_coordinator.async_add_listener(
-                self._handle_device_coordinator_update
-            )
-        )
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity removed."""

--- a/tests/components/reolink/test_update.py
+++ b/tests/components/reolink/test_update.py
@@ -206,3 +206,39 @@ async def test_update_firm_keeps_available(
 
     # still available
     assert hass.states.get(entity_id).state == STATE_ON
+
+
+@pytest.mark.parametrize("entity_name", [TEST_NVR_NAME, TEST_CAM_NAME])
+async def test_external_firmware_update_detected(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_host: MagicMock,
+    entity_name: str,
+) -> None:
+    """Test that external firmware updates (via Reolink app) are detected."""
+    reolink_host.camera_sw_version.return_value = "v1.1.0.0.0.0000"
+    new_firmware = NewSoftwareVersion(
+        version_string="v3.3.0.226_23031644",
+        download_url=TEST_DOWNLOAD_URL,
+        release_notes=TEST_RELEASE_NOTES,
+    )
+    reolink_host.firmware_update_available.return_value = new_firmware
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.UPDATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.UPDATE}.{entity_name}_firmware"
+    assert hass.states.get(entity_id).state == STATE_ON
+
+    # Simulate external firmware update via Reolink app
+    reolink_host.camera_sw_version.return_value = "v3.3.0.226_23031644"
+    reolink_host.firmware_update_available.return_value = False
+
+    # Trigger device coordinator update (simulates regular polling)
+    await config_entry.runtime_data.device_coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # The firmware coordinator should have been refreshed, and update should be cleared
+    assert hass.states.get(entity_id).state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When firmware is updated externally via the Reolink app, the Home Assistant update entity would still show an update as available because the firmware coordinator only checks every 24 hours.

This fix:
- Tracks the installed firmware version in the update entity
- Listens to device coordinator updates (every ~60s) to detect version changes
- Triggers a firmware coordinator refresh when the installed version changes, clearing the stale "update available" state


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #156779 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
