### PR TITLE
Lazy load native VAD libraries to fix SIGSEGV on component dependency load

### DIFF
--- a/homeassistant/components/assist_pipeline/audio_enhancer.py
+++ b/homeassistant/components/assist_pipeline/audio_enhancer.py
@@ -1,13 +1,17 @@
 """Audio enhancement for Assist."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import logging
-
-from pymicro_vad import MicroVad
-from pyspeex_noise import AudioProcessor
+from typing import TYPE_CHECKING
 
 from .const import BYTES_PER_CHUNK
+
+if TYPE_CHECKING:
+    from pymicro_vad import MicroVad
+    from pyspeex_noise import AudioProcessor
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,6 +64,9 @@ class MicroVadSpeexEnhancer(AudioEnhancer):
         self.auto_gain = auto_gain * 300
 
         if (self.auto_gain != 0) or (self.noise_suppression != 0):
+            # Lazy import to avoid loading native library at module import time
+            from pyspeex_noise import AudioProcessor  # noqa: PLC0415
+
             self.audio_processor = AudioProcessor(
                 self.auto_gain, self.noise_suppression
             )
@@ -72,6 +79,9 @@ class MicroVadSpeexEnhancer(AudioEnhancer):
         self.vad: MicroVad | None = None
 
         if self.is_vad_enabled:
+            # Lazy import to avoid loading native library at module import time
+            from pymicro_vad import MicroVad  # noqa: PLC0415
+
             self.vad = MicroVad()
             _LOGGER.debug("Initialized microVAD")
 


### PR DESCRIPTION
## Summary
- Lazy load `pymicro_vad` native library to prevent SIGSEGV when `assist_pipeline` is loaded as an implicit dependency
- The native library was being loaded at module import time, causing crashes when ESPHome (or other integrations depending on assist_pipeline) tried to load the component

Fixes #161166

## Test plan
- [ ] Verify ESPHome integration loads without crash when devices are unreachable
- [ ] Verify VAD functionality still works when actually used
- [ ] Run assist_pipeline tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)