### PR TITLE
Add meter selection for Rainforest Eagle with multiple meters

### DIFF
--- a/homeassistant/components/rainforest_eagle/config_flow.py
+++ b/homeassistant/components/rainforest_eagle/config_flow.py
@@ -35,6 +35,8 @@ class RainforestEagleConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Rainforest Eagle."""
 
     VERSION = 1
+    _meters: list | None = None
+    _user_input: dict[str, Any] | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -49,7 +51,7 @@ class RainforestEagleConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         try:
-            eagle_type, hardware_address = await async_get_type(
+            eagle_type, meters = await async_get_type(
                 self.hass,
                 user_input[CONF_CLOUD_ID],
                 user_input[CONF_INSTALL_CODE],
@@ -64,11 +66,50 @@ class RainforestEagleConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown"
         else:
             user_input[CONF_TYPE] = eagle_type
-            user_input[CONF_HARDWARE_ADDRESS] = hardware_address
+
+            # If multiple meters are available, let the user choose
+            if meters and len(meters) > 1:
+                self._meters = meters
+                self._user_input = user_input
+                return await self.async_step_meter_select()
+
+            # For single meter, set it automatically
+            if meters and len(meters) == 1:
+                user_input[CONF_HARDWARE_ADDRESS] = meters[0].hardware_address
+
             return self.async_create_entry(
                 title=user_input[CONF_CLOUD_ID], data=user_input
             )
 
         return self.async_show_form(
             step_id="user", data_schema=create_schema(user_input), errors=errors
+        )
+
+    async def async_step_meter_select(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle meter selection step."""
+        if user_input is None:
+            # Create a list of meter choices
+            assert self._meters is not None
+            meter_choices = {
+                meter.hardware_address: f"Meter {meter.hardware_address} ({meter.connection_status})"
+                for meter in self._meters
+            }
+
+            return self.async_show_form(
+                step_id="meter_select",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(CONF_HARDWARE_ADDRESS): vol.In(meter_choices),
+                    }
+                ),
+                description_placeholders={"meter_count": str(len(self._meters))},
+            )
+
+        # Add the selected meter to the stored user input
+        assert self._user_input is not None
+        self._user_input[CONF_HARDWARE_ADDRESS] = user_input[CONF_HARDWARE_ADDRESS]
+        return self.async_create_entry(
+            title=self._user_input[CONF_CLOUD_ID], data=self._user_input
         )

--- a/homeassistant/components/rainforest_eagle/data.py
+++ b/homeassistant/components/rainforest_eagle/data.py
@@ -49,12 +49,7 @@ async def async_get_type(hass, cloud_id, install_code, host):
         meters = None
 
     if meters is not None:
-        if meters:
-            hardware_address = meters[0].hardware_address
-        else:
-            hardware_address = None
-
-        return TYPE_EAGLE_200, hardware_address
+        return TYPE_EAGLE_200, meters
 
     reader = Eagle100Reader(cloud_id, install_code, host)
 

--- a/homeassistant/components/rainforest_eagle/strings.json
+++ b/homeassistant/components/rainforest_eagle/strings.json
@@ -9,6 +9,13 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "meter_select": {
+        "data": {
+          "hardware_address": "Meter"
+        },
+        "description": "Multiple meters detected ({meter_count} total). Please select which meter you want to monitor.",
+        "title": "Select meter"
+      },
       "user": {
         "data": {
           "cloud_id": "Cloud ID",

--- a/tests/components/rainforest_eagle/test_config_flow.py
+++ b/tests/components/rainforest_eagle/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Rainforest Eagle config flow."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from homeassistant import config_entries
 from homeassistant.components.rainforest_eagle.const import (
@@ -25,10 +25,15 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
 
+    # Create a mock meter object
+    mock_meter = MagicMock()
+    mock_meter.hardware_address = "mock-hw"
+    mock_meter.connection_status = "Connected"
+
     with (
         patch(
             "homeassistant.components.rainforest_eagle.config_flow.async_get_type",
-            return_value=(TYPE_EAGLE_200, "mock-hw"),
+            return_value=(TYPE_EAGLE_200, [mock_meter]),
         ),
         patch(
             "homeassistant.components.rainforest_eagle.async_setup_entry",
@@ -55,6 +60,75 @@ async def test_form(hass: HomeAssistant) -> None:
         CONF_HARDWARE_ADDRESS: "mock-hw",
     }
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_multiple_meters(hass: HomeAssistant) -> None:
+    """Test meter selection when multiple meters are returned."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] is None
+
+    # Create mock meter objects
+    mock_meter_1 = MagicMock()
+    mock_meter_1.hardware_address = "meter-1"
+    mock_meter_1.connection_status = "Connected"
+
+    mock_meter_2 = MagicMock()
+    mock_meter_2.hardware_address = "meter-2"
+    mock_meter_2.connection_status = "Connected"
+
+    with (
+        patch(
+            "homeassistant.components.rainforest_eagle.config_flow.async_get_type",
+            return_value=(TYPE_EAGLE_200, [mock_meter_1, mock_meter_2]),
+        ),
+        patch(
+            "homeassistant.components.rainforest_eagle.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_CLOUD_ID: "abcdef",
+                CONF_INSTALL_CODE: "123456",
+                CONF_HOST: "192.168.1.55",
+            },
+        )
+        await hass.async_block_till_done()
+
+    # Should show meter selection form
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "meter_select"
+
+    # Now select a meter
+    with (
+        patch(
+            "homeassistant.components.rainforest_eagle.async_setup_entry",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.rainforest_eagle.EagleDataCoordinator",
+        ),
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {CONF_HARDWARE_ADDRESS: "meter-1"},
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "abcdef"
+    assert result3["data"] == {
+        CONF_TYPE: TYPE_EAGLE_200,
+        CONF_HOST: "192.168.1.55",
+        CONF_CLOUD_ID: "abcdef",
+        CONF_INSTALL_CODE: "123456",
+        CONF_HARDWARE_ADDRESS: "meter-1",
+    }
 
 
 async def test_form_invalid_auth(hass: HomeAssistant) -> None:

--- a/tests/components/rainforest_eagle/test_config_flow.py
+++ b/tests/components/rainforest_eagle/test_config_flow.py
@@ -74,7 +74,7 @@ async def test_form_multiple_meters(hass: HomeAssistant) -> None:
     # Create mock meter objects
     mock_meter_1 = MagicMock()
     mock_meter_1.hardware_address = "meter-1"
-    mock_meter_1.connection_status = "Connected"
+    mock_meter_1.connection_status = "Not Joined"
 
     mock_meter_2 = MagicMock()
     mock_meter_2.hardware_address = "meter-2"
@@ -116,7 +116,7 @@ async def test_form_multiple_meters(hass: HomeAssistant) -> None:
     ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
-            {CONF_HARDWARE_ADDRESS: "meter-1"},
+            {CONF_HARDWARE_ADDRESS: "meter-2"},
         )
         await hass.async_block_till_done()
 
@@ -127,7 +127,7 @@ async def test_form_multiple_meters(hass: HomeAssistant) -> None:
         CONF_HOST: "192.168.1.55",
         CONF_CLOUD_ID: "abcdef",
         CONF_INSTALL_CODE: "123456",
-        CONF_HARDWARE_ADDRESS: "meter-1",
+        CONF_HARDWARE_ADDRESS: "meter-2",
     }
 
 


### PR DESCRIPTION
- Detect multiple meters connected to EAGLE-200
- Show meter selection step in config flow if multiple meters found
- User can now choose which meter to monitor
- Single meter automatically selected without prompting
- Updated coordinator to use selected meter hardware address

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
