### PR TITLE
Avoid polling in wled integration

### DIFF
--- a/homeassistant/components/wled/coordinator.py
+++ b/homeassistant/components/wled/coordinator.py
@@ -73,8 +73,10 @@ class WLEDDataUpdateCoordinator(DataUpdateCoordinator[WLEDDevice]):
             LOGGER,
             config_entry=entry,
             name=DOMAIN,
-            update_interval=SCAN_INTERVAL,
         )
+        # Init manually to work around pylint warnings.
+        self.last_update_success = True
+        self.update_interval = SCAN_INTERVAL
 
     @property
     def has_main_light(self) -> bool:
@@ -90,29 +92,35 @@ class WLEDDataUpdateCoordinator(DataUpdateCoordinator[WLEDDevice]):
         async def listen() -> None:
             """Listen for state changes via WebSocket."""
             try:
-                await self.wled.connect()
-            except WLEDError as err:
-                self.logger.info(err)
+                try:
+                    await self.wled.connect()
+                except WLEDError as err:
+                    self.logger.info(err)
+                    return
+
+                try:
+                    # Stop polling as long as we have a websocket. WS will push
+                    # updates to us
+                    self.update_interval = None
+                    await self.wled.listen(callback=self.async_set_updated_data)
+                except WLEDConnectionClosedError as err:
+                    self.last_update_success = False
+                    self.logger.info(err)
+                except WLEDError as err:
+                    self.last_update_success = False
+                    self.async_update_listeners()
+                    self.logger.error(err)
+                finally:
+                    # Pull data immediately and restart polling
+                    self.update_interval = SCAN_INTERVAL
+                    self.hass.async_create_task(self.async_request_refresh())
+
+                # Ensure we are disconnected
+                await self.wled.disconnect()
+            finally:
                 if self.unsub:
                     self.unsub()
                     self.unsub = None
-                return
-
-            try:
-                await self.wled.listen(callback=self.async_set_updated_data)
-            except WLEDConnectionClosedError as err:
-                self.last_update_success = False
-                self.logger.info(err)
-            except WLEDError as err:
-                self.last_update_success = False
-                self.async_update_listeners()
-                self.logger.error(err)
-
-            # Ensure we are disconnected
-            await self.wled.disconnect()
-            if self.unsub:
-                self.unsub()
-                self.unsub = None
 
         async def close_websocket(_: Event) -> None:
             """Close WebSocket connection."""

--- a/homeassistant/components/wled/coordinator.py
+++ b/homeassistant/components/wled/coordinator.py
@@ -73,10 +73,8 @@ class WLEDDataUpdateCoordinator(DataUpdateCoordinator[WLEDDevice]):
             LOGGER,
             config_entry=entry,
             name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
         )
-        # Init manually to work around pylint warnings.
-        self.last_update_success = True
-        self.update_interval = SCAN_INTERVAL
 
     @property
     def has_main_light(self) -> bool:

--- a/tests/components/wled/test_coordinator.py
+++ b/tests/components/wled/test_coordinator.py
@@ -145,7 +145,7 @@ async def test_websocket(
         await hass.async_block_till_done()
     assert mock_wled.update.call_count == num_updates_before_websocket
 
-    # Resolve Future with a connection losed.
+    # Resolve Future with a closed connection.
     connection_finished.set_exception(WLEDConnectionClosedError)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Avoid polling /json and /presets.json every 10 seconds of the WLED devices if we already have a websocket connection to these devices.

WLED provides a Websocket API to allow device to push changes to HASS, and the integration supports this. The integration however also polls the device state even if we have this websocket connection open. This PR disables state polling if we have a websocket connection established.

WLED devices are often low-performance devices running latency sensitive load. The constant polling from HomeAssistant is problematic as it's causing animations to stutter and even visual glitching. In my personal use-case, reading the `presets.json` requires reading from the Flash storage of the ESP32 chip, which can take a significant amount of time, breaking my beautiful animations.

WLED community is very aware of the HASS polling behavior, and has attempted to work around it with some [caching tricks](https://github.com/wled/WLED/blob/0_15_x/wled00/file.cpp#L379-L383). These only reduce the issues and require special hardware (PSRAM) to be installed. Some users have switched to [MQTT based HASS integration](https://github.com/dmonty2/homeassistant_wled_mqtt/) to avoid the this default HASS integration's issues.

~The library used for listening state changes, `wled-python`, currently does not detect changes to Presets when listening changes over websocket. A fix has been proposed, https://github.com/frenck/python-wled/pull/1931, but in this PR we add a workaround for the issue. When presets are updated, we manually perform one poll operation and continue listening to the websocket. Previously the constant polling had hidden this latent bug. This workaround is added as a separate commit, with the intention it will be reverted when upstream `python-wled` fixes the behavior.~
Upstream fixed, workaround removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/161182  https://github.com/home-assistant/core/issues/90676 https://github.com/home-assistant/core/issues/134863
- This PR is related to issue:  https://github.com/home-assistant/core/issues/132996 https://github.com/MoonModules/WLED-MM/issues/307 https://github.com/wled/WLED/issues/2480
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
