### PR TITLE
Add timeout parameter to Squeezebox call_query action

### DIFF
--- a/homeassistant/components/squeezebox/services.yaml
+++ b/homeassistant/components/squeezebox/services.yaml
@@ -30,3 +30,9 @@ call_query:
       advanced: true
       selector:
         object:
+    timeout:
+      required: false
+      example: 10
+      selector:
+        number:
+          unit_of_measurement: seconds

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -280,6 +280,10 @@
         "parameters": {
           "description": "[%key:component::squeezebox::services::call_method::fields::parameters::description%]",
           "name": "Parameters"
+        },
+        "timeout": {
+          "description": "The number of seconds to wait for a response to the query before timing out",
+          "name": "Timeout"
         }
       },
       "name": "Call query"

--- a/homeassistant/components/squeezebox/util.py
+++ b/homeassistant/components/squeezebox/util.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+import logging
 from typing import Any
 
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def safe_library_call(
@@ -20,6 +23,7 @@ async def safe_library_call(
     """Call a player method safely and raise HomeAssistantError on failure."""
     try:
         result = await method(*args, **kwargs)
+
     except ValueError:
         result = None
 

--- a/homeassistant/components/squeezebox/util.py
+++ b/homeassistant/components/squeezebox/util.py
@@ -20,7 +20,6 @@ async def safe_library_call(
     """Call a player method safely and raise HomeAssistantError on failure."""
     try:
         result = await method(*args, **kwargs)
-
     except ValueError:
         result = None
 

--- a/homeassistant/components/squeezebox/util.py
+++ b/homeassistant/components/squeezebox/util.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-import logging
 from typing import Any
 
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def safe_library_call(


### PR DESCRIPTION

## Proposed change
In the Squeezebox integration, we provide an action call_query to allow the user to query and return results from the squeezebox api.  Currently, this has a default timeout of 10 seconds.  Some users have requested the ability to specify the timeout.  This PR adds a new optional timeout parameter to the action.

Tests and doc updates will be required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
