### PR TITLE
Add options flow to Tuya to reverse cover position

### DIFF
--- a/homeassistant/components/tuya/config_flow.py
+++ b/homeassistant/components/tuya/config_flow.py
@@ -42,7 +42,7 @@ from .const import (
     TUYA_SCHEMA,
 )
 
-_INPUT_ENTRY_CLEAR_OPTIONS = "clear_options"
+_INPUT_ENTRY_CLEAR_DEVICE_OPTIONS = "clear_device_options"
 _INPUT_ENTRY_DEVICE_SELECTION = "device_selection"
 
 
@@ -261,7 +261,7 @@ class TuyaOptionsFlowHandler(OptionsFlowWithReload):
         device_registry = dr.async_get(self.hass)
         entity_registry = er.async_get(self.hass)
         self.configurable_devices = {
-            self._get_device_friendly_name(device_entry): self._get_product_id(
+            self._get_device_friendly_name(device_entry): self._get_device_product_id(
                 device_entry
             )
             for device_entry in dr.async_entries_for_config_entry(
@@ -287,7 +287,7 @@ class TuyaOptionsFlowHandler(OptionsFlowWithReload):
         """Select what devices to configure."""
         errors = {}
         if user_input is not None:
-            if user_input.get(_INPUT_ENTRY_CLEAR_OPTIONS):
+            if user_input.get(_INPUT_ENTRY_CLEAR_DEVICE_OPTIONS):
                 # Reset all options
                 return self.async_create_entry(data={})
 
@@ -308,7 +308,7 @@ class TuyaOptionsFlowHandler(OptionsFlowWithReload):
             data_schema=vol.Schema(
                 {
                     vol.Optional(
-                        _INPUT_ENTRY_CLEAR_OPTIONS,
+                        _INPUT_ENTRY_CLEAR_DEVICE_OPTIONS,
                         default=False,
                     ): bool,
                     vol.Optional(
@@ -352,11 +352,10 @@ class TuyaOptionsFlowHandler(OptionsFlowWithReload):
         )
 
     @staticmethod
-    def _get_product_id(entry: dr.DeviceEntry) -> str:
-        for identifier in entry.identifiers:
-            if identifier[0] == DOMAIN:
-                return identifier[1]
-        raise NotImplementedError("Invalid device entry without domain identifier")
+    def _get_device_product_id(entry: dr.DeviceEntry) -> str:
+        return next(
+            identifier[1] for identifier in entry.identifiers if identifier[0] == DOMAIN
+        )
 
     @staticmethod
     def _get_device_friendly_name(entry: dr.DeviceEntry) -> str:

--- a/homeassistant/components/tuya/config_flow.py
+++ b/homeassistant/components/tuya/config_flow.py
@@ -3,20 +3,36 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from copy import deepcopy
 from typing import Any
 
 from tuya_sharing import LoginControl
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlow, ConfigFlowResult
-from homeassistant.helpers import selector
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
+from homeassistant.core import callback
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+    selector,
+)
 
+from . import TuyaConfigEntry
 from .const import (
     CONF_ENDPOINT,
     CONF_TERMINAL_ID,
     CONF_TOKEN_INFO,
     CONF_USER_CODE,
     DOMAIN,
+    OPTION_ENTRY_COVER_POSITION_REVERSED,
+    OPTION_ENTRY_DEVICE_OPTIONS,
     TUYA_CLIENT_ID,
     TUYA_RESPONSE_CODE,
     TUYA_RESPONSE_MSG,
@@ -25,6 +41,9 @@ from .const import (
     TUYA_RESPONSE_SUCCESS,
     TUYA_SCHEMA,
 )
+
+_INPUT_ENTRY_CLEAR_OPTIONS = "clear_options"
+_INPUT_ENTRY_DEVICE_SELECTION = "device_selection"
 
 
 class TuyaConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -203,3 +222,176 @@ class TuyaConfigFlow(ConfigFlow, domain=DOMAIN):
             self.__user_code = user_code
             self.__qr_code = response[TUYA_RESPONSE_RESULT][TUYA_RESPONSE_QR_CODE]
         return success, response
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: TuyaConfigEntry,
+    ) -> TuyaOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return TuyaOptionsFlowHandler(config_entry)
+
+
+class TuyaOptionsFlowHandler(OptionsFlowWithReload):
+    """Handle Tuya Config options."""
+
+    configurable_devices: dict[str, str]
+    """Mapping of the configurable devices.
+
+        `key`: friendly name
+        `value`: tuya id
+    """
+    devices_to_configure: dict[str, str]
+    """Mapping of the devices selected for configuration.
+
+        `key`: friendly name
+        `value`: tuya id
+    """
+    current_device: str
+    """Friendly name of the currently selected device."""
+
+    def __init__(self, config_entry: TuyaConfigEntry) -> None:
+        """Initialize options flow."""
+        self.options = deepcopy(dict(config_entry.options))
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        device_registry = dr.async_get(self.hass)
+        entity_registry = er.async_get(self.hass)
+        self.configurable_devices = {
+            self._get_device_friendly_name(device_entry): self._get_product_id(
+                device_entry
+            )
+            for device_entry in dr.async_entries_for_config_entry(
+                device_registry, self.config_entry.entry_id
+            )
+            if any(
+                entity_entry.domain == COVER_DOMAIN
+                for entity_entry in er.async_entries_for_config_entry(
+                    entity_registry, self.config_entry.entry_id
+                )
+                if entity_entry.device_id == device_entry.id
+            )
+        }
+
+        if not self.configurable_devices:
+            return self.async_abort(reason="no_configurable_devices")
+
+        return await self.async_step_device_selection(user_input=None)
+
+    async def async_step_device_selection(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select what devices to configure."""
+        errors = {}
+        if user_input is not None:
+            if user_input.get(_INPUT_ENTRY_CLEAR_OPTIONS):
+                # Reset all options
+                return self.async_create_entry(data={})
+
+            selected_devices: list[str] = (
+                user_input.get(_INPUT_ENTRY_DEVICE_SELECTION) or []
+            )
+            if selected_devices:
+                self.devices_to_configure = {
+                    friendly_name: self.configurable_devices[friendly_name]
+                    for friendly_name in selected_devices
+                }
+
+                return await self.async_step_configure_device(user_input=None)
+            errors["base"] = "device_not_selected"
+
+        return self.async_show_form(
+            step_id="device_selection",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        _INPUT_ENTRY_CLEAR_OPTIONS,
+                        default=False,
+                    ): bool,
+                    vol.Optional(
+                        _INPUT_ENTRY_DEVICE_SELECTION,
+                        default=self._get_current_configured_devices(),
+                        description="Multiselect with list of devices to choose from",
+                    ): cv.multi_select(dict.fromkeys(self.configurable_devices, False)),
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_configure_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Config device options."""
+        if user_input is not None:
+            self._update_device_options(user_input)
+            if self.devices_to_configure:
+                return await self.async_step_configure_device(user_input=None)
+            return self.async_create_entry(data=self.options)
+
+        self.current_device, tuya_device_id = self.devices_to_configure.popitem()
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    OPTION_ENTRY_COVER_POSITION_REVERSED,
+                    default=self._get_current_setting(
+                        tuya_device_id,
+                        OPTION_ENTRY_COVER_POSITION_REVERSED,
+                        False,
+                    ),
+                ): selector.BooleanSelector(),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="configure_device",
+            data_schema=data_schema,
+            description_placeholders={"device_id": self.current_device},
+        )
+
+    @staticmethod
+    def _get_product_id(entry: dr.DeviceEntry) -> str:
+        for identifier in entry.identifiers:
+            if identifier[0] == DOMAIN:
+                return identifier[1]
+        raise NotImplementedError("Invalid device entry without domain identifier")
+
+    @staticmethod
+    def _get_device_friendly_name(entry: dr.DeviceEntry) -> str:
+        if entry.name_by_user:
+            return f"{entry.name_by_user} ({entry.name})"
+        return entry.name or ""
+
+    def _get_current_configured_devices(self) -> list[str]:
+        """Get current list of devices that are configured."""
+        configured_devices = self.options.get(OPTION_ENTRY_DEVICE_OPTIONS)
+        if not configured_devices:
+            return []
+        return [
+            friendly_name
+            for friendly_name, tuya_device_id in self.configurable_devices.items()
+            if tuya_device_id in configured_devices
+        ]
+
+    def _get_current_setting(self, device_id: str, setting: str, default: Any) -> Any:
+        """Get current value for setting."""
+        if entry_device_options := self.options.get(OPTION_ENTRY_DEVICE_OPTIONS):
+            if device_options := entry_device_options.get(device_id):
+                return device_options.get(setting)
+        return default
+
+    def _update_device_options(self, user_input: dict[str, Any]) -> None:
+        """Update the global config with the new options for the current device."""
+        options: dict[str, dict[str, Any]] = self.options.setdefault(
+            OPTION_ENTRY_DEVICE_OPTIONS, {}
+        )
+
+        tuya_device_id = self.configurable_devices[self.current_device]
+        device_options: dict[str, Any] = options.setdefault(tuya_device_id, {})
+        device_options[OPTION_ENTRY_COVER_POSITION_REVERSED] = user_input[
+            OPTION_ENTRY_COVER_POSITION_REVERSED
+        ]
+
+        self.options.update({OPTION_ENTRY_DEVICE_OPTIONS: options})

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -39,6 +39,9 @@ CONF_USERNAME = "username"
 TUYA_CLIENT_ID = "HA_3y9q4ak7g4ephrvke"
 TUYA_SCHEMA = "haauthorize"
 
+OPTION_ENTRY_DEVICE_OPTIONS = "device_options"
+OPTION_ENTRY_COVER_POSITION_REVERSED = "cover_position_reversed"
+
 TUYA_DISCOVERY_NEW = "tuya_discovery_new"
 TUYA_HA_SIGNAL_UPDATE_ENTITY = "tuya_entry_update"
 

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -357,9 +357,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._attr_supported_features = CoverEntityFeature(0)
 
-        self._cover_position_reversed = False
-        if device_options and device_options.get(OPTION_ENTRY_COVER_POSITION_REVERSED):
-            self._cover_position_reversed = True
+        self._cover_position_reversed = device_options and device_options.get(
+            OPTION_ENTRY_COVER_POSITION_REVERSED
+        )
 
         self._current_position = current_position or set_position
         self._current_state_wrapper = current_state_wrapper

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -20,7 +21,13 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import TuyaConfigEntry
-from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .const import (
+    OPTION_ENTRY_COVER_POSITION_REVERSED,
+    OPTION_ENTRY_DEVICE_OPTIONS,
+    TUYA_DISCOVERY_NEW,
+    DeviceCategory,
+    DPCode,
+)
 from .entity import TuyaEntity
 from .models import (
     DeviceWrapper,
@@ -275,6 +282,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up Tuya cover dynamically through Tuya discovery."""
     manager = entry.runtime_data.manager
+    entry_device_options: Mapping[str, Any] = entry.options.get(
+        OPTION_ENTRY_DEVICE_OPTIONS, {}
+    )
 
     @callback
     def async_discover_device(device_ids: list[str]) -> None:
@@ -294,6 +304,7 @@ async def async_setup_entry(
                         current_state_wrapper=description.current_state_wrapper.find_dpcode(
                             device, description.current_state
                         ),
+                        device_options=entry_device_options.get(device_id),
                         instruction_wrapper=_get_instruction_wrapper(
                             device, description
                         ),
@@ -335,6 +346,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         *,
         current_position: DeviceWrapper[int] | None,
         current_state_wrapper: DeviceWrapper[bool] | None,
+        device_options: dict[str, Any] | None = None,
         instruction_wrapper: DeviceWrapper[str] | None,
         set_position: DeviceWrapper[int] | None,
         tilt_position: DeviceWrapper[int] | None,
@@ -344,6 +356,11 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._attr_supported_features = CoverEntityFeature(0)
+
+        self._cover_position_reversed = False
+        if device_options:
+            if device_options.get(OPTION_ENTRY_COVER_POSITION_REVERSED):
+                self._cover_position_reversed = True
 
         self._current_position = current_position or set_position
         self._current_state_wrapper = current_state_wrapper
@@ -367,7 +384,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
     @property
     def current_cover_position(self) -> int | None:
         """Return cover current position."""
-        return self._read_wrapper(self._current_position)
+        if (position := self._read_wrapper(self._current_position)) is None:
+            return None
+        return 100 - position if self._cover_position_reversed else position
 
     @property
     def current_cover_tilt_position(self) -> int | None:
@@ -390,7 +409,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         """Open the cover."""
         if self._set_position is not None:
             await self._async_send_commands(
-                self._set_position.get_update_commands(self.device, 100)
+                self._set_position.get_update_commands(
+                    self.device, 0 if self._cover_position_reversed else 100
+                )
             )
             return
 
@@ -405,7 +426,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         """Close cover."""
         if self._set_position is not None:
             await self._async_send_commands(
-                self._set_position.get_update_commands(self.device, 0)
+                self._set_position.get_update_commands(
+                    self.device, 100 if self._cover_position_reversed else 0
+                )
             )
             return
 
@@ -418,8 +441,10 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
+        position = kwargs[ATTR_POSITION]
         await self._async_send_wrapper_updates(
-            self._set_position, kwargs[ATTR_POSITION]
+            self._set_position,
+            100 - position if self._cover_position_reversed else position,
         )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -358,9 +358,8 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         self._attr_supported_features = CoverEntityFeature(0)
 
         self._cover_position_reversed = False
-        if device_options:
-            if device_options.get(OPTION_ENTRY_COVER_POSITION_REVERSED):
-                self._cover_position_reversed = True
+        if device_options and device_options.get(OPTION_ENTRY_COVER_POSITION_REVERSED):
+            self._cover_position_reversed = True
 
         self._current_position = current_position or set_position
         self._current_state_wrapper = current_state_wrapper

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -1103,5 +1103,37 @@
       "description": "The Tuya entity `{entity}` is deprecated, replaced by a new valve entity.\nPlease update your dashboards, automations and scripts, disable `{entity}` and reload the integration/restart Home Assistant to fix this issue.",
       "title": "{name} is deprecated"
     }
+  },
+  "options": {
+    "abort": {
+      "no_configurable_devices": "No configurable devices found"
+    },
+    "error": {
+      "device_not_selected": "Select devices to configure"
+    },
+    "step": {
+      "configure_device": {
+        "data": {
+          "cover_position_reversed": "Cover position reversed"
+        },
+        "data_description": {
+          "cover_position_reversed": "Set this to True if the cover position is reversed."
+        },
+        "description": "Select options for {device_id}",
+        "title": "Tuya device options"
+      },
+      "device_selection": {
+        "data": {
+          "clear_device_options": "Reset all device customizations",
+          "device_selection": "Customize specific devices"
+        },
+        "data_description": {
+          "clear_device_options": "Use this to reset all device-specific options to default values.",
+          "device_selection": "Customize behavior of individual devices."
+        },
+        "description": "Select what configuration steps to process",
+        "title": "Tuya device options"
+      }
+    }
   }
 }

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -1114,10 +1114,10 @@
     "step": {
       "configure_device": {
         "data": {
-          "cover_position_reversed": "Cover position reversed"
+          "cover_position_reversed": "Reverse cover position direction"
         },
         "data_description": {
-          "cover_position_reversed": "Set this to True if the cover position is reversed."
+          "cover_position_reversed": "Enable this if your cover shows 100% when fully closed instead of fully open."
         },
         "description": "Select options for {device_id}",
         "title": "Tuya device options"
@@ -1131,7 +1131,7 @@
           "clear_device_options": "Use this to reset all device-specific options to default values.",
           "device_selection": "Customize behavior of individual devices."
         },
-        "description": "Select what configuration steps to process",
+        "description": "Choose how you want to configure your Tuya devices",
         "title": "Tuya device options"
       }
     }

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -20,6 +20,8 @@ from homeassistant.components.tuya.const import (
     CONF_TOKEN_INFO,
     CONF_USER_CODE,
     DOMAIN,
+    OPTION_ENTRY_COVER_POSITION_REVERSED,
+    OPTION_ENTRY_DEVICE_OPTIONS,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import json_dumps
@@ -41,6 +43,11 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_TERMINAL_ID: "test_terminal",
             CONF_TOKEN_INFO: "test_token",
             CONF_USER_CODE: "test_user_code",
+        },
+        options={
+            OPTION_ENTRY_DEVICE_OPTIONS: {
+                "jzpap0inhkykqtlwgklc": {OPTION_ENTRY_COVER_POSITION_REVERSED: False}
+            },
         },
         unique_id="12345",
     )

--- a/tests/components/tuya/snapshots/test_config_flow.ambr
+++ b/tests/components/tuya/snapshots/test_config_flow.ambr
@@ -20,6 +20,11 @@
     'entry_id': <ANY>,
     'minor_version': 1,
     'options': dict({
+      'device_options': dict({
+        'jzpap0inhkykqtlwgklc': dict({
+          'cover_position_reversed': False,
+        }),
+      }),
     }),
     'pref_disable_new_entities': False,
     'pref_disable_polling': False,

--- a/tests/components/tuya/test_config_flow.py
+++ b/tests/components/tuya/test_config_flow.py
@@ -332,8 +332,8 @@ async def test_user_options_set_single(
     # Verify that first config step comes back with a selection list of
     # all configurable devices
     # Clear config options to certify functionality when starting from scratch
+    object.__setattr__(mock_config_entry, "options", {})
     result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
-    hass.config_entries.async_update_entry(mock_config_entry, options={})
     assert result["type"] is FlowResultType.FORM
     assert result["data_schema"].schema["device_selection"].options == {
         "Roller shutter Living Room": False,

--- a/tests/components/tuya/test_config_flow.py
+++ b/tests/components/tuya/test_config_flow.py
@@ -10,7 +10,7 @@ from tuya_sharing import Manager
 
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.tuya.config_flow import (
-    _INPUT_ENTRY_CLEAR_OPTIONS,
+    _INPUT_ENTRY_CLEAR_DEVICE_OPTIONS,
     _INPUT_ENTRY_DEVICE_SELECTION,
 )
 from homeassistant.components.tuya.const import CONF_USER_CODE, DOMAIN
@@ -270,7 +270,7 @@ async def test_user_options_clear(
     # Verify that the clear-input action clears the options dict
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={_INPUT_ENTRY_CLEAR_OPTIONS: True},
+        user_input={_INPUT_ENTRY_CLEAR_DEVICE_OPTIONS: True},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {}

--- a/tests/components/tuya/test_config_flow.py
+++ b/tests/components/tuya/test_config_flow.py
@@ -6,15 +6,65 @@ from unittest.mock import MagicMock
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tuya_sharing import Manager
 
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.tuya.config_flow import (
+    _INPUT_ENTRY_CLEAR_OPTIONS,
+    _INPUT_ENTRY_DEVICE_SELECTION,
+)
 from homeassistant.components.tuya.const import CONF_USER_CODE, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import initialize_entry
 
 from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+
+
+@pytest.fixture
+async def filled_device_registry(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> dr.DeviceRegistry:
+    """Fill device registry with mock devices."""
+    await initialize_entry(hass, mock_manager, mock_config_entry, [])
+    for specs in (
+        (
+            "jzpap0inhkykqtlwgklc",
+            "wltqkykhni0papzj",
+            "Roller shutter Living Room",
+            "tuya.jzpap0inhkykqtlwgklccontrol",
+        ),
+        (
+            "2w46jyhngklc",
+            "nhyj64w2",
+            "Tapparelle studio",
+            "tuya.2w46jyhngklccontrol",
+        ),
+    ):
+        device_entry = device_registry.async_get_or_create(
+            config_entry_id=mock_config_entry.entry_id,
+            identifiers={(DOMAIN, specs[0])},
+            manufacturer="Tuya",
+            model_id=specs[1],
+            name=specs[2],
+        )
+        entity_registry.async_get_or_create(
+            config_entry=mock_config_entry,
+            domain=COVER_DOMAIN,
+            platform=DOMAIN,
+            device_id=device_entry.id,
+            unique_id=specs[3],
+        )
+    return device_registry
 
 
 @pytest.mark.usefixtures("mock_tuya_login_control")
@@ -201,3 +251,193 @@ async def test_reauth_flow_failed_qr_code(
 
     assert result3.get("type") is FlowResultType.ABORT
     assert result3.get("reason") == "reauth_successful"
+
+
+@pytest.mark.usefixtures("filled_device_registry")
+async def test_user_options_clear(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test clearing the options."""
+    # Verify that first config step comes back with a selection list of
+    # all configurable devices
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["data_schema"].schema["device_selection"].options == {
+        "Roller shutter Living Room": False,
+        "Tapparelle studio": False,
+    }
+
+    # Verify that the clear-input action clears the options dict
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={_INPUT_ENTRY_CLEAR_OPTIONS: True},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {}
+
+
+@pytest.mark.usefixtures("filled_device_registry")
+async def test_user_options_empty_selection_recovery(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test leaving the selection of devices empty."""
+    # Verify that first config step comes back with a selection list of
+    # all configurable devices
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["data_schema"].schema["device_selection"].options == {
+        "Roller shutter Living Room": False,
+        "Tapparelle studio": False,
+    }
+
+    # Verify that an empty selection shows the form again
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={_INPUT_ENTRY_DEVICE_SELECTION: []},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "device_selection"
+    assert result["errors"] == {"base": "device_not_selected"}
+
+    # Verify that a single selected device to configure comes back as a form with the device to configure
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={_INPUT_ENTRY_DEVICE_SELECTION: ["Roller shutter Living Room"]},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert (
+        result["description_placeholders"]["device_id"] == "Roller shutter Living Room"
+    )
+
+    # Verify that the setting for the device comes back as default when no input is given
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert (
+        result["data"]["device_options"]["jzpap0inhkykqtlwgklc"][
+            "cover_position_reversed"
+        ]
+        is False
+    )
+
+
+@pytest.mark.usefixtures("filled_device_registry")
+async def test_user_options_set_single(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test configuring a single device."""
+    # Verify that first config step comes back with a selection list of
+    # all configurable devices
+    # Clear config options to certify functionality when starting from scratch
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    hass.config_entries.async_update_entry(mock_config_entry, options={})
+    assert result["type"] is FlowResultType.FORM
+    assert result["data_schema"].schema["device_selection"].options == {
+        "Roller shutter Living Room": False,
+        "Tapparelle studio": False,
+    }
+
+    # Verify that a single selected device to configure comes back as a form with the device to configure
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={_INPUT_ENTRY_DEVICE_SELECTION: ["Roller shutter Living Room"]},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert (
+        result["description_placeholders"]["device_id"] == "Roller shutter Living Room"
+    )
+
+    # Verify that the setting for the device comes back as default when no input is given
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert (
+        result["data"]["device_options"]["jzpap0inhkykqtlwgklc"][
+            "cover_position_reversed"
+        ]
+        is False
+    )
+
+
+@pytest.mark.usefixtures("filled_device_registry")
+async def test_user_options_set_multiple(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test configuring multiple consecutive devices in a row."""
+    # Verify that first config step comes back with a selection list of
+    # all configurable devices
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    for entry in dr.async_entries_for_config_entry(
+        device_registry, mock_config_entry.entry_id
+    ):
+        device_registry.async_update_device(entry.id, name_by_user="Given Name")
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    assert result["data_schema"].schema["device_selection"].options == {
+        "Given Name (Roller shutter Living Room)": False,
+        "Given Name (Tapparelle studio)": False,
+    }
+
+    # Verify that selecting two devices to configure comes back as a
+    #  form with the first device to configure using it's long name as entry
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            _INPUT_ENTRY_DEVICE_SELECTION: [
+                "Given Name (Roller shutter Living Room)",
+                "Given Name (Tapparelle studio)",
+            ]
+        },
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert (
+        result["description_placeholders"]["device_id"]
+        == "Given Name (Tapparelle studio)"
+    )
+
+    # Verify that next device is coming up for configuration after the first
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"cover_position_reversed": True},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert (
+        result["description_placeholders"]["device_id"]
+        == "Given Name (Roller shutter Living Room)"
+    )
+
+    # Verify that the setting for the device comes back as default when no input is given
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"cover_position_reversed": False},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert (
+        result["data"]["device_options"]["jzpap0inhkykqtlwgklc"][
+            "cover_position_reversed"
+        ]
+        is False
+    )
+    assert (
+        result["data"]["device_options"]["2w46jyhngklc"]["cover_position_reversed"]
+        is True
+    )
+
+
+async def test_user_options_no_devices(
+    hass: HomeAssistant, mock_manager: Manager, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test that options does not change when no devices are available."""
+    await initialize_entry(hass, mock_manager, mock_config_entry, [])
+    await hass.async_block_till_done()
+    # Verify that first config step comes back with an empty list of possible devices to choose from
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_configurable_devices"

--- a/tests/components/tuya/test_cover.py
+++ b/tests/components/tuya/test_cover.py
@@ -19,6 +19,10 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
 )
+from homeassistant.components.tuya.const import (
+    OPTION_ENTRY_COVER_POSITION_REVERSED,
+    OPTION_ENTRY_DEVICE_OPTIONS,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_CLOSED,
@@ -30,7 +34,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceNotSupported
 from homeassistant.helpers import entity_registry as er
 
-from . import initialize_entry
+from . import MockDeviceListener, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -312,3 +316,144 @@ async def test_cl_n3xgr5pdmpinictg_state(
     state = hass.states.get(entity_id)
     assert state is not None, f"{entity_id} does not exist"
     assert state.state == expected_state
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["clkg_wltqkykhni0papzj"],
+)
+@pytest.mark.parametrize(
+    (
+        "entry_options",
+        "initial_position",
+        "after_set_position",
+        "after_close",
+        "after_open",
+    ),
+    [
+        (
+            {},
+            25,  # 25 => 25% open
+            65,  # set position to 65 => send 65 => 65% open
+            0,  # close service => send 0 => 0% closed
+            100,  # open service => send 100 => 100% open
+        ),
+        (
+            {
+                OPTION_ENTRY_DEVICE_OPTIONS: {
+                    "jzpap0inhkykqtlwgklc": {
+                        OPTION_ENTRY_COVER_POSITION_REVERSED: False
+                    }
+                }
+            },
+            25,  # 25 => 25% open
+            65,  # set position to 65 => send 65 => 65% open
+            0,  # close service => send 0 => 0% closed
+            100,  # open service => send 100 => 100% open
+        ),
+        (
+            {
+                OPTION_ENTRY_DEVICE_OPTIONS: {
+                    "jzpap0inhkykqtlwgklc": {OPTION_ENTRY_COVER_POSITION_REVERSED: True}
+                }
+            },
+            75,  # 25 => 75% open
+            35,  # set position to 65 => send 35 => 65% open
+            100,  # close service => send 100 => 0% closed
+            0,  # open service => send 0 => 100% open
+        ),
+    ],
+)
+@patch("homeassistant.components.tuya.PLATFORMS", [Platform.COVER])
+async def test_cover_position_reversed_config_flow_option(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
+    entry_options: dict[str, Any],
+    initial_position: int,
+    after_set_position: int,
+    after_close: int,
+    after_open: int,
+) -> None:
+    """Test cover_position_reversed from options flow."""
+    object.__setattr__(mock_config_entry, "options", entry_options)
+    entity_id = "cover.roller_shutter_living_room_curtain"
+    mock_device.status["percent_control"] = 25
+
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    assert state.state == STATE_OPEN
+    assert state.attributes[ATTR_CURRENT_POSITION] == initial_position
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_SET_COVER_POSITION,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_POSITION: 65,
+        },
+        blocking=True,
+    )
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [
+            {"code": "percent_control", "value": after_set_position},
+        ],
+    )
+    await mock_listener.async_send_device_update(
+        hass, mock_device, {"percent_control": after_set_position}
+    )
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    assert state.state == STATE_OPEN
+    assert state.attributes[ATTR_CURRENT_POSITION] == 65
+
+    mock_manager.send_commands.reset_mock()
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {
+            ATTR_ENTITY_ID: entity_id,
+        },
+        blocking=True,
+    )
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [
+            {"code": "percent_control", "value": after_close},
+        ],
+    )
+    await mock_listener.async_send_device_update(
+        hass, mock_device, {"percent_control": after_close}
+    )
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    # assert state.state == STATE_CLOSED
+    assert state.attributes[ATTR_CURRENT_POSITION] == 0
+
+    mock_manager.send_commands.reset_mock()
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {
+            ATTR_ENTITY_ID: entity_id,
+        },
+        blocking=True,
+    )
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [
+            {"code": "percent_control", "value": after_open},
+        ],
+    )
+    await mock_listener.async_send_device_update(
+        hass, mock_device, {"percent_control": after_open}
+    )
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    assert state.state == STATE_OPEN
+    assert state.attributes[ATTR_CURRENT_POSITION] == 100

--- a/tests/components/tuya/test_cover.py
+++ b/tests/components/tuya/test_cover.py
@@ -432,7 +432,7 @@ async def test_cover_position_reversed_config_flow_option(
     )
     state = hass.states.get(entity_id)
     assert state is not None, f"{entity_id} does not exist"
-    # assert state.state == STATE_CLOSED
+    assert state.state == STATE_CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
     mock_manager.send_commands.reset_mock()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a workaround for a long-time issue with Tuya covers which can be installed in both direction (0% can be fully open, or it can be fully closed)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
