### PR TITLE
Use same code path for friendly name as for entity ID

### DIFF
--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -435,7 +435,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
                 translation_key="source_not_found",
                 translation_placeholders={
                     "source": source,
-                    "name": str(self._friendly_name_internal()),
+                    "name": self.entity_id,
                 },
             )
         if source_dict.get("title"):

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -418,7 +418,7 @@ def _async_get_full_entity_name(
     hass: HomeAssistant,
     *,
     device_id: str | None,
-    fallback: str | None = None,
+    fallback: str,
     has_entity_name: bool,
     name: str | None,
     original_name: str | None,
@@ -451,7 +451,7 @@ def _async_get_full_entity_name(
             name = f"{device_name} {name}"
 
     if not name:
-        return fallback or ""
+        return fallback
 
     return name
 
@@ -1017,11 +1017,11 @@ class EntityRegistry(BaseRegistry):
         object_id = _async_get_full_entity_name(
             self.hass,
             device_id=device_id,
+            fallback=f"{platform}_{unique_id}",
             has_entity_name=has_entity_name,
             name=name,
             original_name=object_id_base,
             overridden_name=suggested_object_id,
-            fallback=f"{platform}_{unique_id}",
         )
         return self.async_get_available_entity_id(
             domain,
@@ -1068,6 +1068,7 @@ class EntityRegistry(BaseRegistry):
         return _async_get_full_entity_name(
             self.hass,
             device_id=entry.device_id,
+            fallback="",
             has_entity_name=entry.has_entity_name,
             name=entry.name,
             original_name=original_name,

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -415,25 +415,43 @@ class RegistryEntry:
 
 @callback
 def _async_get_full_entity_name(
-    name: str | None,
+    hass: HomeAssistant,
     *,
-    device: dr.DeviceEntry | None = None,
-    platform: str,
-    unique_id: str,
+    device_id: str | None,
+    fallback: str | None = None,
+    has_entity_name: bool,
+    name: str | None,
+    original_name: str | None,
+    overridden_name: str | None = None,
 ) -> str:
     """Get full name for an entity.
 
     This includes the device name if appropriate.
     """
+    use_device = False
+    if name is None:
+        if overridden_name is not None:
+            name = overridden_name
+        else:
+            name = original_name
+            if has_entity_name:
+                use_device = True
+
+    device = (
+        dr.async_get(hass).async_get(device_id)
+        if use_device and device_id is not None
+        else None
+    )
+
     if device is not None:
         device_name = device.name_by_user or device.name
         if not name:
             name = device_name
-        else:
+        elif device_name:
             name = f"{device_name} {name}"
 
     if not name:
-        name = f"{platform}_{unique_id}"
+        return fallback or ""
 
     return name
 
@@ -996,28 +1014,14 @@ class EntityRegistry(BaseRegistry):
         Entity ID conflicts are checked against registered and currently
         existing entities, as well as provided `reserved_entity_ids`.
         """
-        object_id: str | None
-        use_device = False
-        if name is not None:
-            object_id = name
-        elif suggested_object_id is not None:
-            object_id = suggested_object_id
-        else:
-            object_id = object_id_base
-            if has_entity_name:
-                use_device = True
-
-        device = (
-            dr.async_get(self.hass).async_get(device_id)
-            if use_device and device_id is not None
-            else None
-        )
-
         object_id = _async_get_full_entity_name(
-            object_id,
-            device=device,
-            platform=platform,
-            unique_id=unique_id,
+            self.hass,
+            device_id=device_id,
+            has_entity_name=has_entity_name,
+            name=name,
+            original_name=object_id_base,
+            overridden_name=suggested_object_id,
+            fallback=f"{platform}_{unique_id}",
         )
         return self.async_get_available_entity_id(
             domain,
@@ -1049,6 +1053,24 @@ class EntityRegistry(BaseRegistry):
             reserved_entity_ids=reserved_entity_ids,
             suggested_object_id=entry.suggested_object_id,
             unique_id=entry.unique_id,
+        )
+
+    @callback
+    def async_generate_full_name(
+        self,
+        entry: RegistryEntry,
+        original_name: str | None | UndefinedType = UNDEFINED,
+    ) -> str:
+        """Generate a friendly name for an entry."""
+        original_name = (
+            original_name if original_name is not UNDEFINED else entry.original_name
+        )
+        return _async_get_full_entity_name(
+            self.hass,
+            device_id=entry.device_id,
+            has_entity_name=entry.has_entity_name,
+            name=entry.name,
+            original_name=original_name,
         )
 
     @callback

--- a/homeassistant/helpers/trigger_template_entity.py
+++ b/homeassistant/helpers/trigger_template_entity.py
@@ -285,7 +285,10 @@ class TriggerBaseEntity(Entity):
                     variables, parse_result=True, strict=True
                 )
             ) is False:
+                name = self._rendered.get(CONF_NAME)
                 self._rendered = dict(self._static_rendered)
+                if name is not None and CONF_NAME not in self._static_rendered:
+                    self._rendered[CONF_NAME] = name
 
             self._available = result_as_boolean(available)
 

--- a/tests/components/daikin/test_init.py
+++ b/tests/components/daikin/test_init.py
@@ -91,9 +91,7 @@ async def test_duplicate_removal(
         assert device_registry.async_get_device({}, {(KEY_MAC, HOST)}).name is None
 
         assert entity_registry.async_get("climate.daikin_127_0_0_1").unique_id == HOST
-        assert entity_registry.async_get("switch.none_zone_1").unique_id.startswith(
-            HOST
-        )
+        assert entity_registry.async_get("switch.zone_1").unique_id.startswith(HOST)
 
         assert entity_registry.async_get("climate.daikinap00000").unique_id == MAC
         assert entity_registry.async_get(
@@ -111,7 +109,7 @@ async def test_duplicate_removal(
     assert entity_registry.async_get("switch.daikinap00000_zone_1") is None
 
     assert entity_registry.async_get("climate.daikin_127_0_0_1").unique_id == MAC
-    assert entity_registry.async_get("switch.none_zone_1").unique_id.startswith(MAC)
+    assert entity_registry.async_get("switch.zone_1").unique_id.startswith(MAC)
 
 
 async def test_unique_id_migrate(
@@ -143,7 +141,7 @@ async def test_unique_id_migrate(
     assert entity.unique_id == HOST
     assert update_unique_id(entity, MAC) is not None
 
-    assert entity_registry.async_get("switch.none_zone_1").unique_id.startswith(HOST)
+    assert entity_registry.async_get("switch.zone_1").unique_id.startswith(HOST)
 
     type(mock_daikin).mac = PropertyMock(return_value=MAC)
     type(mock_daikin).values = PropertyMock(return_value=DATA)
@@ -164,7 +162,7 @@ async def test_unique_id_migrate(
     assert entity.unique_id == MAC
     assert update_unique_id(entity, MAC) is None
 
-    assert entity_registry.async_get("switch.none_zone_1").unique_id.startswith(MAC)
+    assert entity_registry.async_get("switch.zone_1").unique_id.startswith(MAC)
 
 
 async def test_client_update_connection_error(

--- a/tests/components/devolo_home_network/snapshots/test_device_tracker.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_device_tracker.ambr
@@ -3,7 +3,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'band': '5 GHz',
-      'friendly_name': 'AA:BB:CC:DD:EE:FF',
+      'friendly_name': 'Mock Title AA:BB:CC:DD:EE:FF',
       'mac': 'AA:BB:CC:DD:EE:FF',
       'source_type': <SourceType.ROUTER: 'router'>,
       'wifi': 'Main',

--- a/tests/components/homewizard/snapshots/test_sensor.ambr
+++ b/tests/components/homewizard/snapshots/test_sensor.ambr
@@ -8455,7 +8455,7 @@
 # name: test_sensors[HWE-P1-entity_ids0][sensor.inlet_heat_meter:state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Inlet heat meter None',
+      'friendly_name': 'Inlet heat meter',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfVolume.CUBIC_METERS: 'm³'>,
     }),
@@ -12375,7 +12375,7 @@
 # name: test_sensors[HWE-P1-invalid-EAN-entity_ids9][sensor.inlet_heat_meter:state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Inlet heat meter None',
+      'friendly_name': 'Inlet heat meter',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfVolume.CUBIC_METERS: 'm³'>,
     }),

--- a/tests/components/knx/test_switch.py
+++ b/tests/components/knx/test_switch.py
@@ -181,6 +181,6 @@ async def test_switch_ui_load(knx: KNXTestKit) -> None:
     # unrelated light in config store
     await knx.assert_read("1/0/21", response=True, ignore_order=True)
     knx.assert_state(
-        "switch.none_test",  # has_entity_name with unregistered device -> none_test
+        "switch.test",  # has_entity_name with unregistered device
         STATE_ON,
     )

--- a/tests/components/miele/snapshots/test_sensor.ambr
+++ b/tests/components/miele/snapshots/test_sensor.ambr
@@ -355,7 +355,7 @@
     'state': 'own_program',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_rinse_aid_level-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -368,7 +368,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -391,21 +391,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_rinse_aid_level-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Rinse aid level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_salt_level-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -418,7 +418,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -441,21 +441,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_salt_level-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Salt level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_twindos_1_level-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -468,7 +468,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -491,21 +491,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_twindos_1_level-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_twindos_1_level_2-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_1_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -518,7 +518,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level_2',
+    'entity_id': 'sensor.twindos_1_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -541,21 +541,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_twindos_1_level_2-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_1_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level_2',
+    'entity_id': 'sensor.twindos_1_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_twindos_2_level-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -568,7 +568,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -591,21 +591,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_twindos_2_level-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_twindos_2_level_2-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_2_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -618,7 +618,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level_2',
+    'entity_id': 'sensor.twindos_2_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -641,14 +641,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.none_twindos_2_level_2-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_2_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level_2',
+    'entity_id': 'sensor.twindos_2_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1828,7 +1828,7 @@
     'state': 'off',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_rinse_aid_level-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1841,7 +1841,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1864,21 +1864,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_rinse_aid_level-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Rinse aid level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_salt_level-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1891,7 +1891,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1914,21 +1914,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_salt_level-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Salt level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_twindos_1_level-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1941,7 +1941,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1964,21 +1964,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_twindos_1_level-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_twindos_1_level_2-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_1_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1991,7 +1991,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level_2',
+    'entity_id': 'sensor.twindos_1_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2014,21 +2014,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_twindos_1_level_2-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_1_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level_2',
+    'entity_id': 'sensor.twindos_1_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_twindos_2_level-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2041,7 +2041,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2064,21 +2064,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_twindos_2_level-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_twindos_2_level_2-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_2_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2091,7 +2091,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level_2',
+    'entity_id': 'sensor.twindos_2_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2114,14 +2114,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.none_twindos_2_level_2-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_2_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level_2',
+    'entity_id': 'sensor.twindos_2_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2487,7 +2487,7 @@
     'state': '-18.0',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_rinse_aid_level-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2500,7 +2500,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2523,21 +2523,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_rinse_aid_level-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Rinse aid level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_salt_level-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2550,7 +2550,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2573,21 +2573,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_salt_level-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Salt level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_twindos_1_level-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2600,7 +2600,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2623,21 +2623,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_twindos_1_level-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_twindos_1_level_2-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_1_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2650,7 +2650,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level_2',
+    'entity_id': 'sensor.twindos_1_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2673,21 +2673,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_twindos_1_level_2-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_1_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level_2',
+    'entity_id': 'sensor.twindos_1_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_twindos_2_level-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2700,7 +2700,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2723,21 +2723,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_twindos_2_level-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_twindos_2_level_2-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_2_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2750,7 +2750,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level_2',
+    'entity_id': 'sensor.twindos_2_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2773,14 +2773,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.none_twindos_2_level_2-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_2_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level_2',
+    'entity_id': 'sensor.twindos_2_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3376,7 +3376,7 @@
     'state': 'plate_step_boost',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_rinse_aid_level-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3389,7 +3389,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3412,21 +3412,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_rinse_aid_level-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Rinse aid level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_salt_level-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3439,7 +3439,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3462,21 +3462,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_salt_level-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Salt level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_twindos_1_level-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3489,7 +3489,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3512,21 +3512,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_twindos_1_level-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_twindos_1_level_2-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_1_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3539,7 +3539,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level_2',
+    'entity_id': 'sensor.twindos_1_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3562,21 +3562,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_twindos_1_level_2-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_1_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level_2',
+    'entity_id': 'sensor.twindos_1_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_twindos_2_level-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3589,7 +3589,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3612,21 +3612,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_twindos_2_level-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_twindos_2_level_2-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_2_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3639,7 +3639,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level_2',
+    'entity_id': 'sensor.twindos_2_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3662,14 +3662,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.none_twindos_2_level_2-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_2_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level_2',
+    'entity_id': 'sensor.twindos_2_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3921,7 +3921,7 @@
     'state': 'off',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.none_rinse_aid_level-entry]
+# name: test_sensor_states[platforms0][sensor.rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3934,7 +3934,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3957,21 +3957,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.none_rinse_aid_level-state]
+# name: test_sensor_states[platforms0][sensor.rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Rinse aid level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.none_salt_level-entry]
+# name: test_sensor_states[platforms0][sensor.salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3984,7 +3984,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4007,21 +4007,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.none_salt_level-state]
+# name: test_sensor_states[platforms0][sensor.salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Salt level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.none_twindos_1_level-entry]
+# name: test_sensor_states[platforms0][sensor.twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -4034,7 +4034,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4057,21 +4057,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.none_twindos_1_level-state]
+# name: test_sensor_states[platforms0][sensor.twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.none_twindos_2_level-entry]
+# name: test_sensor_states[platforms0][sensor.twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -4084,7 +4084,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4107,14 +4107,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.none_twindos_2_level-state]
+# name: test_sensor_states[platforms0][sensor.twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -6633,7 +6633,7 @@
     'state': 'off',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.none_rinse_aid_level-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -6646,7 +6646,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -6669,21 +6669,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.none_rinse_aid_level-state]
+# name: test_sensor_states_api_push[platforms0][sensor.rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Rinse aid level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.none_salt_level-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -6696,7 +6696,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -6719,21 +6719,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.none_salt_level-state]
+# name: test_sensor_states_api_push[platforms0][sensor.salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Salt level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.none_twindos_1_level-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -6746,7 +6746,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -6769,21 +6769,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.none_twindos_1_level-state]
+# name: test_sensor_states_api_push[platforms0][sensor.twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.none_twindos_2_level-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -6796,7 +6796,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -6819,14 +6819,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.none_twindos_2_level-state]
+# name: test_sensor_states_api_push[platforms0][sensor.twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -9100,7 +9100,7 @@
     'state': '0.0',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_rinse_aid_level-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -9113,7 +9113,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9136,21 +9136,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_rinse_aid_level-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Rinse aid level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_rinse_aid_level',
+    'entity_id': 'sensor.rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_salt_level-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -9163,7 +9163,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9186,21 +9186,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_salt_level-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Salt level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_salt_level',
+    'entity_id': 'sensor.salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_twindos_1_level-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -9213,7 +9213,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9236,21 +9236,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_twindos_1_level-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level',
+    'entity_id': 'sensor.twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_twindos_1_level_2-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_1_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -9263,7 +9263,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_1_level_2',
+    'entity_id': 'sensor.twindos_1_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9286,21 +9286,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_twindos_1_level_2-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_1_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 1 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_1_level_2',
+    'entity_id': 'sensor.twindos_1_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_twindos_2_level-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -9313,7 +9313,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9336,21 +9336,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_twindos_2_level-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level',
+    'entity_id': 'sensor.twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_twindos_2_level_2-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_2_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -9363,7 +9363,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.none_twindos_2_level_2',
+    'entity_id': 'sensor.twindos_2_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9386,14 +9386,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.none_twindos_2_level_2-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_2_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'TwinDos 2 level',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.none_twindos_2_level_2',
+    'entity_id': 'sensor.twindos_2_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/mqtt/test_diagnostics.py
+++ b/tests/components/mqtt/test_diagnostics.py
@@ -73,7 +73,7 @@ async def test_entry_diagnostics(
     expected_debug_info = {
         "entities": [
             {
-                "entity_id": "sensor.none_mqtt_sensor",
+                "entity_id": "sensor.mqtt_sensor",
                 "subscriptions": [{"topic": "foobar/sensor", "messages": []}],
                 "discovery_data": {
                     "payload": config_sensor,
@@ -102,13 +102,13 @@ async def test_entry_diagnostics(
                 "disabled": False,
                 "disabled_by": None,
                 "entity_category": None,
-                "entity_id": "sensor.none_mqtt_sensor",
+                "entity_id": "sensor.mqtt_sensor",
                 "icon": None,
                 "original_device_class": None,
                 "original_icon": None,
                 "state": {
                     "attributes": {"friendly_name": "MQTT Sensor"},
-                    "entity_id": "sensor.none_mqtt_sensor",
+                    "entity_id": "sensor.mqtt_sensor",
                     "last_changed": ANY,
                     "last_reported": ANY,
                     "last_updated": ANY,

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -1151,7 +1151,7 @@ async def test_discovery_component_availability_overridden(
         payload,
     )
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.none_beer")
+    state = hass.states.get("binary_sensor.beer")
     assert state is not None
     assert state.name == "Beer"
     assert state.state == STATE_UNAVAILABLE
@@ -1162,7 +1162,7 @@ async def test_discovery_component_availability_overridden(
         "online",
     )
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.none_beer")
+    state = hass.states.get("binary_sensor.beer")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
@@ -1172,7 +1172,7 @@ async def test_discovery_component_availability_overridden(
         "online",
     )
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.none_beer")
+    state = hass.states.get("binary_sensor.beer")
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
@@ -1182,7 +1182,7 @@ async def test_discovery_component_availability_overridden(
         "ON",
     )
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.none_beer")
+    state = hass.states.get("binary_sensor.beer")
     assert state is not None
     assert state.state == STATE_ON
 
@@ -1261,7 +1261,7 @@ async def test_discovery_with_invalid_integration_info(
     async_fire_mqtt_message(hass, discovery_topic, config_message)
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.none_beer")
+    state = hass.states.get("binary_sensor.beer")
 
     assert state is None
     assert error_message in caplog.text
@@ -1945,7 +1945,7 @@ async def test_duplicate_removal(
                 '"name": "sensor2"'
                 "}",
             },
-            ["sensor.none_sensor1", "sensor.none_sensor2"],
+            ["sensor.sensor1", "sensor.sensor2"],
         ),
         (
             {
@@ -1964,7 +1964,7 @@ async def test_duplicate_removal(
                 '"unique_id": "unique2"'
                 "}}}"
             },
-            ["sensor.none_sensor1", "sensor.none_sensor2"],
+            ["sensor.sensor1", "sensor.sensor2"],
         ),
     ],
 )
@@ -2012,7 +2012,7 @@ async def test_cleanup_device_manual(
     # Verify device and registry entries are cleared
     device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is None
-    entity_entry = entity_registry.async_get("sensor.none_mqtt_sensor")
+    entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
     assert entity_entry is None
 
     # Verify state is removed
@@ -2036,7 +2036,7 @@ async def test_cleanup_device_manual(
             '{ "device":{"identifiers":["0AFFD2"]},'
             '  "state_topic": "foobar/sensor",'
             '  "unique_id": "unique" }',
-            ["sensor.none_mqtt_sensor"],
+            ["sensor.mqtt_sensor"],
         ),
         (
             "homeassistant/device/bla/config",
@@ -2053,7 +2053,7 @@ async def test_cleanup_device_manual(
             '  "state_topic": "foobar/sensor2",'
             '  "unique_id": "unique2"'
             "}}}",
-            ["sensor.none_sensor1", "sensor.none_sensor2"],
+            ["sensor.sensor1", "sensor.sensor2"],
         ),
     ],
 )
@@ -2077,7 +2077,7 @@ async def test_cleanup_device_mqtt(
         '  "unique_id": "unique_base" }'
     )
     base_discovery_topic = "homeassistant/sensor/bla_base/config"
-    base_entity_id = "sensor.none_sensor_base"
+    base_entity_id = "sensor.sensor_base"
     async_fire_mqtt_message(hass, base_discovery_topic, data)
     await hass.async_block_till_done()
 
@@ -2161,7 +2161,7 @@ async def test_cleanup_device_mqtt_device_discovery(
         '  "unique_id": "unique2"'
         "}}}"
     )
-    entity_ids = ["sensor.none_sensor1", "sensor.none_sensor2"]
+    entity_ids = ["sensor.sensor1", "sensor.sensor2"]
     async_fire_mqtt_message(hass, discovery_topic, discovery_payload)
     await hass.async_block_till_done()
 
@@ -2299,10 +2299,10 @@ async def test_cleanup_device_multiple_config_entries(
         mqtt_config_entry.entry_id,
         config_entry.entry_id,
     }
-    entity_entry = entity_registry.async_get("sensor.none_mqtt_sensor")
+    entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
     assert entity_entry is not None
 
-    state = hass.states.get("sensor.none_mqtt_sensor")
+    state = hass.states.get("sensor.mqtt_sensor")
     assert state is not None
 
     # Remove MQTT from the device
@@ -2320,12 +2320,12 @@ async def test_cleanup_device_multiple_config_entries(
         connections={("mac", "12:34:56:AB:CD:EF")}
     )
     assert device_entry is not None
-    entity_entry = entity_registry.async_get("sensor.none_mqtt_sensor")
+    entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
     assert device_entry.config_entries == {config_entry.entry_id}
     assert entity_entry is None
 
     # Verify state is removed
-    state = hass.states.get("sensor.none_mqtt_sensor")
+    state = hass.states.get("sensor.mqtt_sensor")
     assert state is None
     await hass.async_block_till_done()
 
@@ -2399,10 +2399,10 @@ async def test_cleanup_device_multiple_config_entries_mqtt(
         mqtt_config_entry.entry_id,
         config_entry.entry_id,
     }
-    entity_entry = entity_registry.async_get("sensor.none_mqtt_sensor")
+    entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
     assert entity_entry is not None
 
-    state = hass.states.get("sensor.none_mqtt_sensor")
+    state = hass.states.get("sensor.mqtt_sensor")
     assert state is not None
 
     # Send MQTT messages to remove
@@ -2418,12 +2418,12 @@ async def test_cleanup_device_multiple_config_entries_mqtt(
         connections={("mac", "12:34:56:AB:CD:EF")}
     )
     assert device_entry is not None
-    entity_entry = entity_registry.async_get("sensor.none_mqtt_sensor")
+    entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
     assert device_entry.config_entries == {config_entry.entry_id}
     assert entity_entry is None
 
     # Verify state is removed
-    state = hass.states.get("sensor.none_mqtt_sensor")
+    state = hass.states.get("sensor.mqtt_sensor")
     assert state is None
     await hass.async_block_till_done()
 
@@ -3262,7 +3262,7 @@ async def test_discovery_dispatcher_signal_type_messages(
             '  "state_topic": "foobar/sensor3",'
             '  "unique_id": "unique3"'
             "}}}",
-            ["sensor.none_sensor1", "sensor.none_sensor2", "sensor.none_sensor3"],
+            ["sensor.sensor1", "sensor.sensor2", "sensor.sensor3"],
         ),
     ],
 )

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1095,7 +1095,7 @@ async def test_mqtt_ws_get_device_debug_info(
     expected_result = {
         "entities": [
             {
-                "entity_id": "sensor.none_mqtt_sensor",
+                "entity_id": "sensor.mqtt_sensor",
                 "subscriptions": [{"topic": "foobar/sensor", "messages": []}],
                 "discovery_data": {
                     "payload": config_sensor,
@@ -1156,7 +1156,7 @@ async def test_mqtt_ws_get_device_debug_info_binary(
     expected_result = {
         "entities": [
             {
-                "entity_id": "camera.none_mqtt_camera",
+                "entity_id": "camera.mqtt_camera",
                 "subscriptions": [
                     {
                         "topic": "foobar/image",

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -111,7 +111,7 @@ async def test_availability_with_shared_state_topic(
                     }
                 }
             },
-            "sensor.none_mqtt_sensor",
+            "sensor.mqtt_sensor",
             DEFAULT_SENSOR_NAME,
             None,
             True,
@@ -158,7 +158,7 @@ async def test_availability_with_shared_state_topic(
                     }
                 }
             },
-            "sensor.none_humidity",
+            "sensor.humidity",
             "Humidity",
             None,
             True,
@@ -192,7 +192,7 @@ async def test_availability_with_shared_state_topic(
                     }
                 }
             },
-            "sensor.none_mysensor",
+            "sensor.mysensor",
             "MySensor",
             None,
             True,

--- a/tests/components/netatmo/snapshots/test_sensor.ambr
+++ b/tests/components/netatmo/snapshots/test_sensor.ambr
@@ -1224,7 +1224,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Cold water None',
+      'friendly_name': 'Cold water',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.cold_water',
@@ -1274,7 +1274,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Consumption meter None',
+      'friendly_name': 'Consumption meter',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.consumption_meter',
@@ -1437,7 +1437,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Écocompteur None',
+      'friendly_name': 'Écocompteur',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.ecocompteur',
@@ -1487,7 +1487,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Gas None',
+      'friendly_name': 'Gas',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.gas',
@@ -3319,7 +3319,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Hot water None',
+      'friendly_name': 'Hot water',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hot_water',
@@ -3942,7 +3942,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Line 1 None',
+      'friendly_name': 'Line 1',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.line_1',
@@ -3992,7 +3992,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Line 2 None',
+      'friendly_name': 'Line 2',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.line_2',
@@ -4042,7 +4042,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Line 3 None',
+      'friendly_name': 'Line 3',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.line_3',
@@ -4092,7 +4092,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Line 4 None',
+      'friendly_name': 'Line 4',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.line_4',
@@ -4142,7 +4142,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Line 5 None',
+      'friendly_name': 'Line 5',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.line_5',
@@ -5393,7 +5393,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Prise None',
+      'friendly_name': 'Prise',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.prise',
@@ -5501,7 +5501,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'Total None',
+      'friendly_name': 'Total',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.total',

--- a/tests/components/nextcloud/snapshots/test_update.ambr
+++ b/tests/components/nextcloud/snapshots/test_update.ambr
@@ -41,7 +41,7 @@
       'auto_update': False,
       'display_precision': 0,
       'entity_picture': 'https://brands.home-assistant.io/_/nextcloud/icon.png',
-      'friendly_name': 'my.nc_url.local None',
+      'friendly_name': 'my.nc_url.local',
       'in_progress': False,
       'installed_version': '28.0.4.1',
       'latest_version': '28.0.4.1',

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -1317,7 +1317,7 @@ async def test_availability_in_config(
 
     state = hass.states.get("sensor.rest_sensor")
     assert state.state == STATE_UNAVAILABLE
-    assert "friendly_name" not in state.attributes
+    assert state.attributes["friendly_name"] == "rest_sensor"
     assert "icon" not in state.attributes
     assert "entity_picture" not in state.attributes
 

--- a/tests/components/squeezebox/snapshots/test_switch.ambr
+++ b/tests/components/squeezebox/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_entity_registry[switch.none_alarm_1-entry]
+# name: test_entity_registry[switch.alarm_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -12,7 +12,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.none_alarm_1',
+    'entity_id': 'switch.alarm_1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -35,21 +35,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entity_registry[switch.none_alarm_1-state]
+# name: test_entity_registry[switch.alarm_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'alarm_id': '1',
       'friendly_name': 'Alarm (1)',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.none_alarm_1',
+    'entity_id': 'switch.alarm_1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_entity_registry[switch.none_alarms_enabled-entry]
+# name: test_entity_registry[switch.alarms_enabled-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -62,7 +62,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.none_alarms_enabled',
+    'entity_id': 'switch.alarms_enabled',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -85,13 +85,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entity_registry[switch.none_alarms_enabled-state]
+# name: test_entity_registry[switch.alarms_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Alarms enabled',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.none_alarms_enabled',
+    'entity_id': 'switch.alarms_enabled',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/squeezebox/test_binary_sensor.py
+++ b/tests/components/squeezebox/test_binary_sensor.py
@@ -72,19 +72,19 @@ async def test_player_alarm_sensors_device_class(
     """Test player alarm binary sensors have correct device class."""
 
     # Test alarm upcoming sensor device class
-    upcoming_state = hass.states.get("binary_sensor.none_alarm_upcoming")
+    upcoming_state = hass.states.get("binary_sensor.alarm_upcoming")
     assert upcoming_state is not None
     assert upcoming_state.attributes.get("device_class") is None
 
     # Test alarm active sensor device class
-    active_state = hass.states.get("binary_sensor.none_alarm_active")
+    active_state = hass.states.get("binary_sensor.alarm_active")
     assert active_state is not None
     assert (
         active_state.attributes.get("device_class") == BinarySensorDeviceClass.RUNNING
     )
 
     # Test alarm snooze sensor device class
-    snooze_state = hass.states.get("binary_sensor.none_alarm_snoozed")
+    snooze_state = hass.states.get("binary_sensor.alarm_snoozed")
     assert snooze_state is not None
     assert (
         snooze_state.attributes.get("device_class") == BinarySensorDeviceClass.RUNNING
@@ -101,17 +101,17 @@ async def test_player_alarm_sensors_state(
     player = mock_player
 
     # Test alarm upcoming sensor
-    upcoming_state = hass.states.get("binary_sensor.none_alarm_upcoming")
+    upcoming_state = hass.states.get("binary_sensor.alarm_upcoming")
     assert upcoming_state is not None
     assert upcoming_state.state == STATE_ON
 
     # Test alarm active sensor
-    active_state = hass.states.get("binary_sensor.none_alarm_active")
+    active_state = hass.states.get("binary_sensor.alarm_active")
     assert active_state is not None
     assert active_state.state == STATE_OFF
 
     # Test alarm snooze sensor
-    snooze_state = hass.states.get("binary_sensor.none_alarm_snoozed")
+    snooze_state = hass.states.get("binary_sensor.alarm_snoozed")
     assert snooze_state is not None
     assert snooze_state.state == STATE_OFF
 
@@ -123,10 +123,10 @@ async def test_player_alarm_sensors_state(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    upcoming_state = hass.states.get("binary_sensor.none_alarm_upcoming")
+    upcoming_state = hass.states.get("binary_sensor.alarm_upcoming")
     assert upcoming_state is not None
     assert upcoming_state.state == STATE_OFF
 
-    active_state = hass.states.get("binary_sensor.none_alarm_active")
+    active_state = hass.states.get("binary_sensor.alarm_active")
     assert active_state is not None
     assert active_state.state == STATE_ON

--- a/tests/components/squeezebox/test_button.py
+++ b/tests/components/squeezebox/test_button.py
@@ -23,7 +23,7 @@ async def test_squeezebox_press(
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.none_preset_1"},
+        {ATTR_ENTITY_ID: "button.preset_1"},
         blocking=True,
     )
 

--- a/tests/components/squeezebox/test_sensor.py
+++ b/tests/components/squeezebox/test_sensor.py
@@ -60,7 +60,7 @@ async def test_player_sensor_next_alarm(
     player = (await lms.async_get_players())[0]
 
     # test alarm time is set from player
-    state = hass.states.get("sensor.none_next_alarm")
+    state = hass.states.get("sensor.next_alarm")
     assert state is not None
     assert state.state == TEST_ALARM_NEXT_TIME.isoformat()
 
@@ -70,6 +70,6 @@ async def test_player_sensor_next_alarm(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.none_next_alarm")
+    state = hass.states.get("sensor.next_alarm")
     assert state is not None
     assert state.state == STATE_UNKNOWN

--- a/tests/components/squeezebox/test_switch.py
+++ b/tests/components/squeezebox/test_switch.py
@@ -74,13 +74,13 @@ async def test_switch_state(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test the state of the switch."""
-    assert hass.states.get(f"switch.none_alarm_{TEST_ALARM_ID}").state == "on"
+    assert hass.states.get(f"switch.alarm_{TEST_ALARM_ID}").state == "on"
 
     mock_alarms_player.alarms[0]["enabled"] = False
     freezer.tick(timedelta(seconds=PLAYER_UPDATE_INTERVAL))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert hass.states.get(f"switch.none_alarm_{TEST_ALARM_ID}").state == "off"
+    assert hass.states.get(f"switch.alarm_{TEST_ALARM_ID}").state == "off"
 
 
 async def test_switch_deleted(
@@ -89,13 +89,13 @@ async def test_switch_deleted(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test detecting switch deleted."""
-    assert hass.states.get(f"switch.none_alarm_{TEST_ALARM_ID}").state == "on"
+    assert hass.states.get(f"switch.alarm_{TEST_ALARM_ID}").state == "on"
 
     mock_alarms_player.alarms = []
     freezer.tick(timedelta(seconds=PLAYER_UPDATE_INTERVAL))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert hass.states.get(f"switch.none_alarm_{TEST_ALARM_ID}") is None
+    assert hass.states.get(f"switch.alarm_{TEST_ALARM_ID}") is None
 
 
 async def test_turn_on(
@@ -106,7 +106,7 @@ async def test_turn_on(
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_ON,
-        {CONF_ENTITY_ID: f"switch.none_alarm_{TEST_ALARM_ID}"},
+        {CONF_ENTITY_ID: f"switch.alarm_{TEST_ALARM_ID}"},
         blocking=True,
     )
     mock_alarms_player.async_update_alarm.assert_called_once_with(
@@ -122,7 +122,7 @@ async def test_turn_off(
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,
-        {CONF_ENTITY_ID: f"switch.none_alarm_{TEST_ALARM_ID}"},
+        {CONF_ENTITY_ID: f"switch.alarm_{TEST_ALARM_ID}"},
         blocking=True,
     )
     mock_alarms_player.async_update_alarm.assert_called_once_with(
@@ -137,14 +137,14 @@ async def test_alarms_enabled_state(
 ) -> None:
     """Test the alarms enabled switch."""
 
-    assert hass.states.get("switch.none_alarms_enabled").state == "on"
+    assert hass.states.get("switch.alarms_enabled").state == "on"
 
     mock_alarms_player.alarms_enabled = False
     freezer.tick(timedelta(seconds=PLAYER_UPDATE_INTERVAL))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert hass.states.get("switch.none_alarms_enabled").state == "off"
+    assert hass.states.get("switch.alarms_enabled").state == "off"
 
 
 async def test_alarms_enabled_turn_on(
@@ -155,7 +155,7 @@ async def test_alarms_enabled_turn_on(
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_ON,
-        {CONF_ENTITY_ID: "switch.none_alarms_enabled"},
+        {CONF_ENTITY_ID: "switch.alarms_enabled"},
         blocking=True,
     )
     mock_alarms_player.async_set_alarms_enabled.assert_called_once_with(True)
@@ -169,7 +169,7 @@ async def test_alarms_enabled_turn_off(
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,
-        {CONF_ENTITY_ID: "switch.none_alarms_enabled"},
+        {CONF_ENTITY_ID: "switch.alarms_enabled"},
         blocking=True,
     )
     mock_alarms_player.async_set_alarms_enabled.assert_called_once_with(False)

--- a/tests/components/threshold/snapshots/test_config_flow.ambr
+++ b/tests/components/threshold/snapshots/test_config_flow.ambr
@@ -2,7 +2,6 @@
 # name: test_config_flow_preview_success[missing_entity_id]
   dict({
     'attributes': dict({
-      'friendly_name': '',
     }),
     'state': 'unavailable',
   })

--- a/tests/components/unifi/snapshots/test_device_tracker.ambr
+++ b/tests/components/unifi/snapshots/test_device_tracker.ambr
@@ -38,7 +38,7 @@
 # name: test_entity_and_device_data[site_payload0-device_payload0-client_payload0][device_tracker.switch_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Switch 1',
+      'friendly_name': 'Device 6 Switch 1',
       'ip': '10.0.1.1',
       'mac': '00:00:00:00:01:01',
       'source_type': <SourceType.ROUTER: 'router'>,
@@ -90,7 +90,7 @@
 # name: test_entity_and_device_data[site_payload0-device_payload0-client_payload0][device_tracker.wd_client_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'wd_client_1',
+      'friendly_name': 'Device 1 wd_client_1',
       'host_name': 'wd_client_1',
       'mac': '00:00:00:00:00:02',
       'source_type': <SourceType.ROUTER: 'router'>,
@@ -142,7 +142,7 @@
 # name: test_entity_and_device_data[site_payload0-device_payload0-client_payload0][device_tracker.ws_client_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'ws_client_1',
+      'friendly_name': 'Device 0 ws_client_1',
       'host_name': 'ws_client_1',
       'ip': '10.0.0.1',
       'mac': '00:00:00:00:00:01',

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -188,7 +188,7 @@ async def test_select_source_with_empty_source_list(
     }
     with pytest.raises(
         HomeAssistantError,
-        match=f"Source nonexistent not found in the sources list for {TV_NAME}",
+        match=f"Source nonexistent not found in the sources list for {ENTITY_ID}",
     ):
         await hass.services.async_call(MP_DOMAIN, SERVICE_SELECT_SOURCE, data, True)
 

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1068,7 +1068,7 @@ async def test_friendly_name_attr(
         (False, UNDEFINED, None),
         (True, "Entity Blu", "Device Bla Entity Blu"),
         (True, None, "Device Bla"),
-        (True, UNDEFINED, "Device Bla None"),
+        (True, UNDEFINED, "Device Bla"),
     ],
 )
 async def test_friendly_name_description(
@@ -1372,7 +1372,7 @@ async def test_entity_name_translation_placeholder_errors(
         (False, UNDEFINED, None),
         (True, "Entity Blu", "Device Bla Entity Blu"),
         (True, None, "Device Bla"),
-        (True, UNDEFINED, "Device Bla None"),
+        (True, UNDEFINED, "Device Bla"),
     ],
 )
 async def test_friendly_name_property(
@@ -1409,7 +1409,7 @@ async def test_friendly_name_property(
         (True, "Entity Blu", "Device Bla Entity Blu"),
         (True, None, "Device Bla"),
         # Won't use the device class name because the entity overrides the name property
-        (True, UNDEFINED, "Device Bla None"),
+        (True, UNDEFINED, "Device Bla"),
     ],
 )
 async def test_friendly_name_property_device_class_name(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use same code path for friendly name as for entity ID.

After #160302 entity ID can be generated from the entity registry information. The goal is for the entity registry to become authoritative when it comes to entity naming too. In order to achieve that original name (set by integrations) will now be kept up-to-date in the entity registry.

This refactor also fixes some bugs with `friendly_name` and `entity_id`:
- Wrongly added "None" suffix or prefix.
- Not included device name.
- Accepted empty value.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
