### PR TITLE
Add Energy Tracker integration v1.0.0

### DIFF
--- a/homeassistant/components/energy_tracker/__init__.py
+++ b/homeassistant/components/energy_tracker/__init__.py
@@ -1,0 +1,214 @@
+"""Initialization for the Energy Tracker integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant, ServiceCall, State
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+import voluptuous as vol
+
+from .api import EnergyTrackerApi
+from .const import CONF_API_TOKEN, DOMAIN, SERVICE_SEND_METER_READING
+
+type EnergyTrackerConfigEntry = ConfigEntry[str]
+
+LOGGER = logging.getLogger(__name__)
+
+SERVICE_SEND_METER_READING_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): cv.string,
+        vol.Required("source_entity_id"): cv.entity_id,
+        vol.Required("entry_id"): cv.string,
+        vol.Optional("allow_rounding", default=True): cv.boolean,
+    }
+)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Energy Tracker integration (YAML-based, legacy)."""
+    LOGGER.debug("async_setup called for Energy Tracker (YAML not supported)")
+    return True
+
+
+def _select_token_for_service(hass: HomeAssistant, call: ServiceCall) -> str | None:
+    """Select the API token for a service call.
+
+    Retrieves the API token for the Energy Tracker integration based on the
+    config entry ID provided in the service call data.
+
+    Args:
+        hass: The Home Assistant instance.
+        call: The service call containing the 'entry_id'.
+
+    Returns:
+        The API token as a string if found, otherwise None.
+    """
+    entry_id: str | None = call.data.get("entry_id")
+    if not entry_id:
+        LOGGER.debug("No entry ID provided")
+        return None
+
+    entry: EnergyTrackerConfigEntry | None = hass.config_entries.async_get_entry(
+        entry_id
+    )
+    if not entry:
+        LOGGER.debug("Integration with ID %s was deleted", entry_id)
+        return None
+
+    token = entry.runtime_data
+    if not token:
+        LOGGER.error("API token not found for entry ID %s", entry_id)
+        return None
+
+    return token
+
+
+async def async_handle_send_meter_reading(
+    hass: HomeAssistant,
+    call: ServiceCall,
+) -> None:
+    """Handle the send_meter_reading service.
+
+    Reads the current value from a Home Assistant entity and sends it
+    as a meter reading to the Energy Tracker backend.
+
+    Raises:
+        HomeAssistantError: If the meter reading could not be sent.
+    """
+    device_id: str = call.data["device_id"].strip()
+    source_entity_id: str = call.data["source_entity_id"]
+    allow_rounding: bool = call.data.get("allow_rounding", True)
+
+    state_obj: State | None = hass.states.get(source_entity_id)
+    if state_obj is None:
+        LOGGER.error("Source entity %s not found", source_entity_id)
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="entity_not_found",
+            translation_placeholders={"entity_id": source_entity_id},
+        )
+
+    raw_state = state_obj.state
+    if raw_state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+        LOGGER.warning("Source entity %s is %s", source_entity_id, raw_state)
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="entity_unavailable",
+            translation_placeholders={
+                "entity_id": source_entity_id,
+                "state": raw_state,
+            },
+        )
+
+    try:
+        value = float(raw_state)
+    except (TypeError, ValueError) as err:
+        LOGGER.error(
+            "Could not convert state '%s' of %s to number", raw_state, source_entity_id
+        )
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_number",
+            translation_placeholders={
+                "entity_id": source_entity_id,
+                "state": raw_state,
+            },
+        ) from err
+
+    if state_obj.last_updated is None:
+        LOGGER.error("Source entity %s has no last_updated timestamp", source_entity_id)
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="missing_timestamp",
+            translation_placeholders={"entity_id": source_entity_id},
+        )
+    timestamp = state_obj.last_updated
+
+    token = _select_token_for_service(hass, call)
+    if not token:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="no_api_token",
+        )
+
+    api = EnergyTrackerApi(hass=hass, token=token)
+
+    await api.send_meter_reading(
+        source_entity_id=source_entity_id,
+        device_id=device_id,
+        value=value,
+        timestamp=timestamp,
+        allow_rounding=allow_rounding,
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: EnergyTrackerConfigEntry
+) -> bool:
+    """Set up the Energy Tracker integration from a config entry.
+
+    Args:
+        hass: The Home Assistant instance.
+        entry: The configuration entry to set up.
+
+    Returns:
+        True if setup was successful, False otherwise.
+    """
+    LOGGER.debug("Setting up config entry %s", entry.entry_id)
+
+    entry.runtime_data = entry.data[CONF_API_TOKEN]
+
+    if not hass.services.has_service(DOMAIN, SERVICE_SEND_METER_READING):
+
+        async def _handle_send_meter_reading(call: ServiceCall) -> None:
+            await async_handle_send_meter_reading(hass, call)
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            _handle_send_meter_reading,
+            schema=SERVICE_SEND_METER_READING_SCHEMA,
+        )
+        LOGGER.debug("Registered service %s/%s", DOMAIN, SERVICE_SEND_METER_READING)
+
+    return True
+
+
+async def async_unload_entry(
+    hass: HomeAssistant, entry: EnergyTrackerConfigEntry
+) -> bool:
+    """Unload a config entry for the Energy Tracker integration.
+
+    Unregisters the service if this was the last loaded config entry.
+
+    Args:
+        hass: The Home Assistant instance.
+        entry: The config entry to unload.
+
+    Returns:
+        True if the unload was successful.
+    """
+    LOGGER.debug("Unloading config entry %s", entry.entry_id)
+
+    # Check if there are other loaded entries for this domain
+    loaded_entries = [
+        e
+        for e in hass.config_entries.async_entries(DOMAIN)
+        if e.entry_id != entry.entry_id and e.state.recoverable
+    ]
+
+    if not loaded_entries:
+        if hass.services.has_service(DOMAIN, SERVICE_SEND_METER_READING):
+            hass.services.async_remove(DOMAIN, SERVICE_SEND_METER_READING)
+            LOGGER.debug(
+                "Removed service %s.%s after last config entry was unloaded",
+                DOMAIN,
+                SERVICE_SEND_METER_READING,
+            )
+
+    return True

--- a/homeassistant/components/energy_tracker/api.py
+++ b/homeassistant/components/energy_tracker/api.py
@@ -1,0 +1,172 @@
+"""Home Assistant wrapper for Energy Tracker API client."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+
+from energy_tracker_api import (
+    AuthenticationError,
+    ConflictError,
+    CreateMeterReadingDto,
+    EnergyTrackerAPIError,
+    EnergyTrackerClient,
+    ForbiddenError,
+    NetworkError,
+    RateLimitError,
+    ResourceNotFoundError,
+    TimeoutError,
+    ValidationError,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN
+
+LOGGER = logging.getLogger(__name__)
+
+
+class EnergyTrackerApi:
+    """Home Assistant wrapper for the Energy Tracker API client.
+
+    Handles sending meter readings and error translation to Home Assistant exceptions.
+    """
+
+    def __init__(self, hass: HomeAssistant, token: str) -> None:
+        """Initialize the EnergyTrackerApi wrapper.
+
+        Args:
+            hass: The Home Assistant instance.
+            token: The Energy Tracker API access token.
+        """
+        self._hass = hass
+        self._token = token
+        self._client = EnergyTrackerClient(access_token=token)
+
+    async def send_meter_reading(
+        self,
+        *,
+        source_entity_id: str,
+        device_id: str,
+        value: float,
+        timestamp: datetime,
+        allow_rounding: bool = False,
+    ) -> None:
+        """Send a single meter reading to the Energy Tracker backend.
+
+        Args:
+            source_entity_id: Entity ID for logging purposes.
+            device_id: The standard device ID in Energy Tracker.
+            value: The meter reading value.
+            timestamp: Timestamp for the reading.
+            allow_rounding: Allow rounding to match meter precision.
+
+        Raises:
+            HomeAssistantError: If the API request fails.
+        """
+        meter_reading = CreateMeterReadingDto(
+            value=value,
+            timestamp=timestamp,
+        )
+
+        try:
+            await self._client.meter_readings.create(
+                device_id=device_id,
+                meter_reading=meter_reading,
+                allow_rounding=allow_rounding,
+            )
+            LOGGER.info("Reading sent: %g", value)
+
+        except ValidationError as err:
+            # HTTP 400 - Bad Request
+            LOGGER.warning("Validation error: %s", err)
+            msg = "; ".join(err.api_message) if err.api_message else "Invalid input"
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="bad_request",
+                translation_placeholders={"error": msg},
+            ) from err
+
+        except AuthenticationError as err:
+            # HTTP 401 - Unauthorized
+            LOGGER.error("Authentication failed: %s", err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="auth_failed",
+            ) from err
+
+        except ForbiddenError as err:
+            # HTTP 403 - Forbidden
+            LOGGER.error("Access forbidden: %s", err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="auth_failed",
+            ) from err
+
+        except ResourceNotFoundError as err:
+            # HTTP 404 - Not Found
+            LOGGER.warning("Device not found: %s", err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+            ) from err
+
+        except ConflictError as err:
+            # HTTP 409 - Conflict
+            LOGGER.warning("Conflict: %s", err)
+            msg = "; ".join(err.api_message) if err.api_message else str(err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="conflict",
+                translation_placeholders={"error": msg},
+            ) from err
+
+        except RateLimitError as err:
+            # HTTP 429 - Rate Limit
+            LOGGER.warning("Rate limit exceeded: %s", err)
+
+            if err.retry_after:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="rate_limit",
+                    translation_placeholders={"retry_after": str(err.retry_after)},
+                ) from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="rate_limit_no_time",
+            ) from err
+
+        except TimeoutError as err:
+            # Request timeout
+            LOGGER.error("Request timeout: %s", err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="timeout",
+            ) from err
+
+        except NetworkError as err:
+            # Network/connection errors
+            LOGGER.error("Network error: %s", err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="network_error",
+            ) from err
+
+        except EnergyTrackerAPIError as err:
+            # Other API errors
+            LOGGER.error("API error: %s", err)
+            msg = "; ".join(err.api_message) if err.api_message else str(err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="server_error",
+                translation_placeholders={"error": msg},
+            ) from err
+
+        except Exception as err:
+            # Unexpected errors
+            LOGGER.exception("Unexpected error")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="unknown_error",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/homeassistant/components/energy_tracker/config_flow.py
+++ b/homeassistant/components/energy_tracker/config_flow.py
@@ -1,0 +1,77 @@
+"""Config flow for the Energy Tracker integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers import config_validation as cv
+import voluptuous as vol
+
+from .const import CONF_API_TOKEN, DOMAIN
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_API_TOKEN): cv.string,
+    }
+)
+
+
+class EnergyTrackerConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Config flow handler for the Energy Tracker integration.
+
+    This class manages the configuration and reconfiguration steps for the integration.
+    """
+
+    async def async_step_user(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        if user_input is not None:
+            await self.async_set_unique_id(user_input[CONF_API_TOKEN])
+            self._abort_if_unique_id_configured()
+
+            return self.async_create_entry(
+                title=user_input[CONF_NAME],
+                data={CONF_API_TOKEN: user_input[CONF_API_TOKEN]},
+            )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+        )
+
+    async def async_step_reconfigure(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            if user_input[CONF_API_TOKEN] != entry.data[CONF_API_TOKEN]:
+                await self.async_set_unique_id(user_input[CONF_API_TOKEN])
+                self._abort_if_unique_id_configured()
+                self.hass.config_entries.async_update_entry(
+                    entry, unique_id=user_input[CONF_API_TOKEN]
+                )
+
+            return self.async_update_reload_and_abort(
+                entry,
+                data={CONF_API_TOKEN: user_input[CONF_API_TOKEN]},
+                reason="reconfigure_successful",
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_API_TOKEN, default=entry.data[CONF_API_TOKEN]
+                    ): cv.string,
+                }
+            ),
+        )

--- a/homeassistant/components/energy_tracker/const.py
+++ b/homeassistant/components/energy_tracker/const.py
@@ -1,0 +1,11 @@
+"""Constants for the Energy Tracker integration."""
+
+from __future__ import annotations
+
+DOMAIN = "energy_tracker"
+
+CONF_API_TOKEN = "api_token"
+
+DEFAULT_API_BASE_URL = "https://public-api.energy-tracker.best-ios-apps.de"
+
+SERVICE_SEND_METER_READING = "send_meter_reading"

--- a/homeassistant/components/energy_tracker/manifest.json
+++ b/homeassistant/components/energy_tracker/manifest.json
@@ -1,0 +1,17 @@
+{
+  "domain": "energy_tracker",
+  "name": "Energy Tracker",
+  "documentation": "https://www.home-assistant.io/integrations/energy_tracker/",
+  "issue_tracker": "https://github.com/energy-tracker/home-assistant-energy-tracker/issues",
+  "requirements": [
+    "energy-tracker-api==1.0.0"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@energy-tracker"
+  ],
+  "config_flow": true,
+  "integration_type": "service",
+  "iot_class": "cloud_push",
+  "quality_scale": "bronze"
+}

--- a/homeassistant/components/energy_tracker/quality_scale.yaml
+++ b/homeassistant/components/energy_tracker/quality_scale.yaml
@@ -1,0 +1,36 @@
+# Quality scale definition for Energy Tracker integration
+# https://developers.home-assistant.io/docs/integration_quality_scale_index/
+
+integration_type: service
+
+rules:
+  # Bronze tier (mandatory)
+  action-setup:
+    status: exempt
+    comment: Integration provides services but does not register custom actions.
+
+  async-dependency: done
+  brands: done
+  config-flow: done
+  config-flow-test-coverage: done
+
+  entity-event-setup:
+    status: exempt
+    comment: Integration does not create entities.
+
+  entity-unique-id:
+    status: exempt
+    comment: Integration does not create entities.
+
+  exception-translations: done
+
+  has-entity-name:
+    status: exempt
+    comment: Integration does not create entities.
+
+  integration-owner: done
+  iot-class-set: done
+  logged-errors: done
+  runtime-data: done
+  test-coverage: done
+  unique-config-entry: done

--- a/homeassistant/components/energy_tracker/services.yaml
+++ b/homeassistant/components/energy_tracker/services.yaml
@@ -1,0 +1,36 @@
+send_meter_reading:
+  name: Send meter reading
+  description: Send the current value of a sensor to Energy Tracker.
+  fields:
+    entry_id:
+      name: Account
+      description: Your Energy Tracker account
+      required: true
+      selector:
+        config_entry:
+          integration: energy_tracker
+    device_id:
+      name: Standard measuring device ID
+      description: ID of the standard measuring device in your Energy Tracker account
+      required: true
+      example: "deadbeef-dead-beef-dead-beefdeadbeef"
+      selector:
+        text:
+          type: text
+    source_entity_id:
+      name: Sensor
+      description: Sensor that provides the meter reading
+      required: true
+      selector:
+        entity:
+          domain:
+            - sensor
+            - input_number
+            - number
+    allow_rounding:
+      name: Allow rounding
+      description: Round value to match meter precision
+      required: false
+      default: true
+      selector:
+        boolean:

--- a/homeassistant/components/energy_tracker/strings.json
+++ b/homeassistant/components/energy_tracker/strings.json
@@ -1,0 +1,106 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up Energy Tracker",
+        "description": "Enter your account details to connect to Energy Tracker.",
+        "data": {
+          "name": "Account name",
+          "api_token": "Personal access token"
+        },
+        "data_description": {
+          "name": "A recognizable name for this account (e.g., 'John's Account').",
+          "api_token": "Your personal access token from the Energy Tracker app."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Energy Tracker",
+        "description": "Update your Energy Tracker personal access token.",
+        "data": {
+          "api_token": "Personal access token"
+        },
+        "data_description": {
+          "api_token": "Your personal access token from the Energy Tracker app."
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+    }
+  },
+  "exceptions": {
+    "timeout": {
+      "message": "Request timed out. Please check network connection and try again."
+    },
+    "network_error": {
+      "message": "Network error during request. Please check internet connection and try again."
+    },
+    "bad_request": {
+      "message": "Invalid input. Please check input data. ({error})"
+    },
+    "auth_failed": {
+      "message": "Authentication failed. Please check your Personal access token in integration settings."
+    },
+    "device_not_found": {
+      "message": "Standard measuring device not found. Please check device ID."
+    },
+    "conflict": {
+      "message": "A reading for this timestamp already exists. ({error})"
+    },
+    "rate_limit": {
+      "message": "Too many requests. Please try again in {retry_after} seconds."
+    },
+    "rate_limit_no_time": {
+      "message": "Too many requests. Please try again later."
+    },
+    "server_error": {
+      "message": "A server error has occurred. Please try again later. ({error})"
+    },
+    "unknown_error": {
+      "message": "An unexpected error has occurred. Please try again later. ({error})"
+    },
+    "device_id_empty": {
+      "message": "Standard measuring device ID is required."
+    },
+    "entity_not_found": {
+      "message": "Entity {entity_id} not found."
+    },
+    "entity_unavailable": {
+      "message": "Entity {entity_id} is {state}."
+    },
+    "invalid_number": {
+      "message": "Entity {entity_id} value '{state}' is not a number."
+    },
+    "missing_timestamp": {
+      "message": "Entity {entity_id} has no timestamp."
+    },
+    "no_api_token": {
+      "message": "No personal access token configured. Check account settings."
+    }
+  },
+  "services": {
+    "send_meter_reading": {
+      "name": "Send meter reading",
+      "description": "Sends the current value of a sensor to Energy Tracker.",
+      "fields": {
+        "entry_id": {
+          "name": "Account",
+          "description": "Your Energy Tracker account"
+        },
+        "device_id": {
+          "name": "Standard measuring device ID",
+          "description": "ID of the standard measuring device in your Energy Tracker account"
+        },
+        "source_entity_id": {
+          "name": "Sensor",
+          "description": "Sensor that provides the meter reading"
+        },
+        "allow_rounding": {
+          "name": "Allow rounding",
+          "description": "Round value to match meter precision"
+        }
+      }
+    }
+  }
+}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -888,6 +888,9 @@ emoji==2.8.0
 # homeassistant.components.emulated_roku
 emulated-roku==0.3.0
 
+# homeassistant.components.energy_tracker
+energy-tracker-api==1.0.0
+
 # homeassistant.components.huisbaasje
 energyflip-client==0.2.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -782,6 +782,9 @@ elvia==0.1.0
 # homeassistant.components.emulated_roku
 emulated-roku==0.3.0
 
+# homeassistant.components.energy_tracker
+energy-tracker-api==1.0.0
+
 # homeassistant.components.huisbaasje
 energyflip-client==0.2.2
 

--- a/tests/components/energy_tracker/__init__.py
+++ b/tests/components/energy_tracker/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Energy Tracker integration."""

--- a/tests/components/energy_tracker/conftest.py
+++ b/tests/components/energy_tracker/conftest.py
@@ -1,0 +1,19 @@
+"""Common fixtures for Energy Tracker tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+
+
+@pytest.fixture
+def api_token() -> str:
+    """Return a test API token."""
+    return "test-token-12345678"
+
+
+@pytest.fixture
+def device_id() -> str:
+    """Return a valid UUID device ID."""
+    return "12345678-1234-1234-1234-123456789abc"

--- a/tests/components/energy_tracker/test_api.py
+++ b/tests/components/energy_tracker/test_api.py
@@ -1,0 +1,443 @@
+"""Tests for the Energy Tracker API wrapper."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from energy_tracker_api import (
+    AuthenticationError,
+    ConflictError,
+    EnergyTrackerAPIError,
+    ForbiddenError,
+    NetworkError,
+    RateLimitError,
+    ResourceNotFoundError,
+    TimeoutError,
+    ValidationError,
+)
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+
+from homeassistant.components.energy_tracker.api import EnergyTrackerApi
+
+
+class TestEnergyTrackerApiInit:
+    """Test EnergyTrackerApi initialization."""
+
+    def test_init_stores_hass_and_token(self, hass, api_token):
+        """Test that __init__ stores hass and token."""
+        # Arrange & Act
+        with patch("homeassistant.components.energy_tracker.api.EnergyTrackerClient"):
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+        # Assert
+        assert api._hass == hass
+        assert api._token == api_token
+
+    def test_init_creates_client(self, hass, api_token):
+        """Test that __init__ creates EnergyTrackerClient."""
+        # Arrange & Act
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client:
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Assert
+            mock_client.assert_called_once_with(access_token=api_token)
+            assert api._client == mock_client.return_value
+
+
+class TestSendMeterReading:
+    """Test send_meter_reading method."""
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_success(self, hass, api_token, device_id):
+        """Test successful meter reading submission."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.meter_readings.create = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act
+            await api.send_meter_reading(
+                source_entity_id="sensor.power_meter",
+                device_id=device_id,
+                value=1234.5,
+                timestamp=timestamp,
+                allow_rounding=True,
+            )
+
+            # Assert
+            mock_client.meter_readings.create.assert_called_once()
+            call_args = mock_client.meter_readings.create.call_args
+            assert call_args[1]["device_id"] == device_id
+            assert call_args[1]["meter_reading"].value == 1234.5
+            assert call_args[1]["meter_reading"].timestamp == timestamp
+            assert call_args[1]["allow_rounding"] is True
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_without_rounding(
+        self, hass, api_token, device_id
+    ):
+        """Test meter reading submission without rounding."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.meter_readings.create = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act
+            await api.send_meter_reading(
+                source_entity_id="sensor.power_meter",
+                device_id=device_id,
+                value=1234.5,
+                timestamp=timestamp,
+                allow_rounding=False,
+            )
+
+            # Assert
+            call_args = mock_client.meter_readings.create.call_args
+            assert call_args[1]["allow_rounding"] is False
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_validation_error(
+        self, hass, api_token, device_id
+    ):
+        """Test meter reading with validation error (HTTP 400)."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            error = ValidationError(
+                "Bad Request", api_message=["Invalid timestamp", "Value required"]
+            )
+            mock_client.meter_readings.create = AsyncMock(side_effect=error)
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act & Assert
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await api.send_meter_reading(
+                    source_entity_id="sensor.power_meter",
+                    device_id=device_id,
+                    value=1234.5,
+                    timestamp=timestamp,
+                )
+
+            assert exc_info.value.translation_key == "bad_request"
+            assert (
+                exc_info.value.translation_placeholders["error"]
+                == "Invalid timestamp; Value required"
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_authentication_error(
+        self, hass, api_token, device_id
+    ):
+        """Test meter reading with authentication error (HTTP 401)."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            error = AuthenticationError("Unauthorized")
+            mock_client.meter_readings.create = AsyncMock(side_effect=error)
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act & Assert
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await api.send_meter_reading(
+                    source_entity_id="sensor.power_meter",
+                    device_id=device_id,
+                    value=1234.5,
+                    timestamp=timestamp,
+                )
+
+            assert exc_info.value.translation_key == "auth_failed"
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_forbidden_error(self, hass, api_token, device_id):
+        """Test meter reading with forbidden error (HTTP 403)."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            error = ForbiddenError("Forbidden")
+            mock_client.meter_readings.create = AsyncMock(side_effect=error)
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act & Assert
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await api.send_meter_reading(
+                    source_entity_id="sensor.power_meter",
+                    device_id=device_id,
+                    value=1234.5,
+                    timestamp=timestamp,
+                )
+
+            assert exc_info.value.translation_key == "auth_failed"
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_not_found_error(self, hass, api_token, device_id):
+        """Test meter reading with not found error (HTTP 404)."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            error = ResourceNotFoundError("Not Found")
+            mock_client.meter_readings.create = AsyncMock(side_effect=error)
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act & Assert
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await api.send_meter_reading(
+                    source_entity_id="sensor.power_meter",
+                    device_id=device_id,
+                    value=1234.5,
+                    timestamp=timestamp,
+                )
+
+            assert exc_info.value.translation_key == "device_not_found"
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_conflict_error(self, hass, api_token, device_id):
+        """Test meter reading with conflict error (HTTP 409)."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            error = ConflictError("Duplicate reading")
+            error.api_message = ["Reading already exists"]
+            mock_client.meter_readings.create = AsyncMock(side_effect=error)
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act & Assert
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await api.send_meter_reading(
+                    source_entity_id="sensor.power_meter",
+                    device_id=device_id,
+                    value=1234.5,
+                    timestamp=timestamp,
+                )
+
+            assert exc_info.value.translation_key == "conflict"
+            assert (
+                "Reading already exists"
+                in exc_info.value.translation_placeholders["error"]
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_rate_limit_with_retry(
+        self, hass, api_token, device_id
+    ):
+        """Test meter reading with rate limit error including retry_after."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            error = RateLimitError("Too Many Requests", retry_after=60)
+            mock_client.meter_readings.create = AsyncMock(side_effect=error)
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act & Assert
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await api.send_meter_reading(
+                    source_entity_id="sensor.power_meter",
+                    device_id=device_id,
+                    value=1234.5,
+                    timestamp=timestamp,
+                )
+
+            assert exc_info.value.translation_key == "rate_limit"
+            assert exc_info.value.translation_placeholders["retry_after"] == "60"
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_rate_limit_without_retry(
+        self, hass, api_token, device_id
+    ):
+        """Test meter reading with rate limit error without retry_after."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            error = RateLimitError("Too Many Requests", retry_after=None)
+            mock_client.meter_readings.create = AsyncMock(side_effect=error)
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act & Assert
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await api.send_meter_reading(
+                    source_entity_id="sensor.power_meter",
+                    device_id=device_id,
+                    value=1234.5,
+                    timestamp=timestamp,
+                )
+
+            assert exc_info.value.translation_key == "rate_limit_no_time"
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_timeout_error(self, hass, api_token, device_id):
+        """Test meter reading with timeout error."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            error = TimeoutError("Request timeout")
+            mock_client.meter_readings.create = AsyncMock(side_effect=error)
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act & Assert
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await api.send_meter_reading(
+                    source_entity_id="sensor.power_meter",
+                    device_id=device_id,
+                    value=1234.5,
+                    timestamp=timestamp,
+                )
+
+            assert exc_info.value.translation_key == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_network_error(self, hass, api_token, device_id):
+        """Test meter reading with network error."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            error = NetworkError("Network unreachable")
+            mock_client.meter_readings.create = AsyncMock(side_effect=error)
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act & Assert
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await api.send_meter_reading(
+                    source_entity_id="sensor.power_meter",
+                    device_id=device_id,
+                    value=1234.5,
+                    timestamp=timestamp,
+                )
+
+            assert exc_info.value.translation_key == "network_error"
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_server_error(self, hass, api_token, device_id):
+        """Test meter reading with server error (5xx)."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            error = EnergyTrackerAPIError(
+                "Server error: 500", api_message=["Database unavailable"]
+            )
+            mock_client.meter_readings.create = AsyncMock(side_effect=error)
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act & Assert
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await api.send_meter_reading(
+                    source_entity_id="sensor.power_meter",
+                    device_id=device_id,
+                    value=1234.5,
+                    timestamp=timestamp,
+                )
+
+            assert exc_info.value.translation_key == "server_error"
+            assert (
+                exc_info.value.translation_placeholders["error"]
+                == "Database unavailable"
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_meter_reading_unexpected_error(
+        self, hass, api_token, device_id
+    ):
+        """Test meter reading with unexpected error."""
+        # Arrange
+        timestamp = datetime(2025, 11, 28, 10, 30, 0, tzinfo=UTC)
+
+        with patch(
+            "homeassistant.components.energy_tracker.api.EnergyTrackerClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            error = RuntimeError("Something went wrong")
+            mock_client.meter_readings.create = AsyncMock(side_effect=error)
+            mock_client_class.return_value = mock_client
+
+            api = EnergyTrackerApi(hass=hass, token=api_token)
+
+            # Act & Assert
+            with pytest.raises(HomeAssistantError) as exc_info:
+                await api.send_meter_reading(
+                    source_entity_id="sensor.power_meter",
+                    device_id=device_id,
+                    value=1234.5,
+                    timestamp=timestamp,
+                )
+
+            assert exc_info.value.translation_key == "unknown_error"
+            assert (
+                exc_info.value.translation_placeholders["error"]
+                == "Something went wrong"
+            )

--- a/tests/components/energy_tracker/test_config_flow.py
+++ b/tests/components/energy_tracker/test_config_flow.py
@@ -1,0 +1,148 @@
+"""Test the Energy Tracker config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from tests.common import MockConfigEntry
+
+from homeassistant.components.energy_tracker.const import CONF_API_TOKEN, DOMAIN
+
+
+async def test_user_form_create_entry(hass: HomeAssistant) -> None:
+    """Test creating a new config entry via user flow."""
+    # Arrange
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Act
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "John's Account",
+            CONF_API_TOKEN: "test-token-123",
+        },
+    )
+
+    # Assert
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "John's Account"
+    assert result2["data"] == {
+        CONF_API_TOKEN: "test-token-123",
+    }
+
+
+async def test_user_form_duplicate_token(hass: HomeAssistant) -> None:
+    """Test abort when token already configured."""
+    # Arrange
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Energy Tracker",
+        data={CONF_API_TOKEN: "duplicate-token"},
+        unique_id="duplicate-token",
+    )
+    existing_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # Act
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Test Account",
+            CONF_API_TOKEN: "duplicate-token",
+        },
+    )
+
+    # Assert
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+
+async def test_reconfigure_form_update_token(hass: HomeAssistant) -> None:
+    """Test reconfiguring to update the token."""
+    # Arrange
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Energy Tracker",
+        data={CONF_API_TOKEN: "old-token"},
+        unique_id="old-token",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": "reconfigure",
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    # Act
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload"
+    ) as mock_reload:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_TOKEN: "new-token-456",
+            },
+        )
+
+    # Assert
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "reconfigure_successful"
+    assert entry.data == {
+        CONF_API_TOKEN: "new-token-456",
+    }
+    assert entry.unique_id == "new-token-456"
+    mock_reload.assert_called_once_with(entry.entry_id)
+
+
+async def test_reconfigure_form_duplicate_token(hass: HomeAssistant) -> None:
+    """Test abort when reconfigure token conflicts with another entry."""
+    # Arrange
+    entry1 = MockConfigEntry(
+        domain=DOMAIN,
+        title="Energy Tracker",
+        data={CONF_API_TOKEN: "token-1"},
+        unique_id="token-1",
+    )
+    entry1.add_to_hass(hass)
+
+    entry2 = MockConfigEntry(
+        domain=DOMAIN,
+        title="Energy Tracker",
+        data={CONF_API_TOKEN: "token-2"},
+        unique_id="token-2",
+    )
+    entry2.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": "reconfigure",
+            "entry_id": entry2.entry_id,
+        },
+    )
+
+    # Act
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_API_TOKEN: "token-1",
+        },
+    )
+
+    # Assert
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"

--- a/tests/components/energy_tracker/test_init.py
+++ b/tests/components/energy_tracker/test_init.py
@@ -1,0 +1,611 @@
+"""Tests for the Energy Tracker __init__ module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+from tests.common import MockConfigEntry
+
+from homeassistant.components.energy_tracker import (
+    async_handle_send_meter_reading,
+    async_setup,
+    async_setup_entry,
+    async_unload_entry,
+)
+from homeassistant.components.energy_tracker.const import (
+    CONF_API_TOKEN,
+    DOMAIN,
+    SERVICE_SEND_METER_READING,
+)
+
+
+def create_service_call(
+    hass: HomeAssistant,
+    domain: str,
+    service: str,
+    data: dict,
+) -> ServiceCall:
+    """Create a ServiceCall instance for testing."""
+    return ServiceCall(hass, domain, service, data=data)
+
+
+class TestAsyncSetup:
+    """Test async_setup function."""
+
+    async def test_async_setup_returns_true(self, hass: HomeAssistant):
+        """Test that async_setup returns True (YAML not supported)."""
+        # Arrange
+        config = {}
+
+        # Act
+        result = await async_setup(hass, config)
+
+        # Assert
+        assert result is True
+
+
+class TestAsyncSetupEntry:
+    """Test async_setup_entry function."""
+
+    async def test_setup_entry_stores_token_in_runtime_data(self, hass: HomeAssistant):
+        """Test that setup_entry stores API token in runtime_data."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token-123"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+
+        # Act
+        result = await async_setup_entry(hass, entry)
+
+        # Assert
+        assert result is True
+        assert entry.runtime_data == "test-token-123"
+
+    async def test_setup_entry_registers_service_once(self, hass: HomeAssistant):
+        """Test that service is registered only once for multiple entries."""
+        # Arrange
+        entry1 = MockConfigEntry(
+            domain=DOMAIN,
+            title="Account 1",
+            data={CONF_API_TOKEN: "token-1"},
+            entry_id="entry-1",
+        )
+        entry1.add_to_hass(hass)
+
+        entry2 = MockConfigEntry(
+            domain=DOMAIN,
+            title="Account 2",
+            data={CONF_API_TOKEN: "token-2"},
+            entry_id="entry-2",
+        )
+        entry2.add_to_hass(hass)
+
+        # Act
+        await async_setup_entry(hass, entry1)
+        await async_setup_entry(hass, entry2)
+
+        # Assert
+        assert hass.services.has_service(DOMAIN, SERVICE_SEND_METER_READING)
+        # Service should only be registered once
+        assert len(list(hass.services.async_services()[DOMAIN])) == 1
+
+
+class TestAsyncUnloadEntry:
+    """Test async_unload_entry function."""
+
+    async def test_unload_entry_returns_true(self, hass: HomeAssistant):
+        """Test that unload_entry returns True."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        # Act
+        result = await async_unload_entry(hass, entry)
+
+        # Assert
+        assert result is True
+
+    async def test_unload_last_entry_removes_service(self, hass: HomeAssistant):
+        """Test that unloading last entry removes service."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+        assert hass.services.has_service(DOMAIN, SERVICE_SEND_METER_READING)
+
+        # Act
+        await async_unload_entry(hass, entry)
+
+        # Assert
+        assert not hass.services.has_service(DOMAIN, SERVICE_SEND_METER_READING)
+
+    async def test_unload_one_of_multiple_entries_keeps_service(
+        self, hass: HomeAssistant
+    ):
+        """Test that unloading one entry keeps service when others exist."""
+        # Arrange
+        entry1 = MockConfigEntry(
+            domain=DOMAIN,
+            title="Account 1",
+            data={CONF_API_TOKEN: "token-1"},
+            entry_id="entry-1",
+        )
+        entry1.add_to_hass(hass)
+
+        entry2 = MockConfigEntry(
+            domain=DOMAIN,
+            title="Account 2",
+            data={CONF_API_TOKEN: "token-2"},
+            entry_id="entry-2",
+        )
+        entry2.add_to_hass(hass)
+
+        await async_setup_entry(hass, entry1)
+        await async_setup_entry(hass, entry2)
+
+        # Act
+        await async_unload_entry(hass, entry1)
+
+        # Assert
+        assert hass.services.has_service(DOMAIN, SERVICE_SEND_METER_READING)
+        # entry2 still has its runtime_data
+        assert entry2.runtime_data == "token-2"
+
+
+class TestAsyncHandleSendMeterReading:
+    """Test async_handle_send_meter_reading function."""
+
+    async def test_send_meter_reading_success(self, hass: HomeAssistant):
+        """Test successful meter reading submission."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        # Set up entity state
+        hass.states.async_set(
+            "sensor.energy_meter",
+            "123.45",
+            {"unit_of_measurement": "kWh"},
+        )
+
+        call = create_service_call(
+            hass,
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            {
+                "entry_id": "test-entry-id",
+                "device_id": "device-123",
+                "source_entity_id": "sensor.energy_meter",
+                "allow_rounding": True,
+            },
+        )
+
+        # Act
+        with patch(
+            "homeassistant.components.energy_tracker.EnergyTrackerApi.send_meter_reading",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await async_handle_send_meter_reading(hass, call)
+
+        # Assert
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args.kwargs
+        assert call_kwargs["source_entity_id"] == "sensor.energy_meter"
+        assert call_kwargs["device_id"] == "device-123"
+        assert call_kwargs["value"] == 123.45
+        assert call_kwargs["allow_rounding"] is True
+
+    async def test_entity_not_found_raises_error(self, hass: HomeAssistant):
+        """Test that non-existent entity raises localized error."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        call = create_service_call(
+            hass,
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            {
+                "entry_id": "test-entry-id",
+                "device_id": "device-123",
+                "source_entity_id": "sensor.nonexistent",
+                "allow_rounding": True,
+            },
+        )
+
+        # Act & Assert
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await async_handle_send_meter_reading(hass, call)
+
+        assert exc_info.value.translation_domain == DOMAIN
+        assert exc_info.value.translation_key == "entity_not_found"
+        assert (
+            exc_info.value.translation_placeholders["entity_id"] == "sensor.nonexistent"
+        )
+
+    async def test_entity_unavailable_raises_error(self, hass: HomeAssistant):
+        """Test that unavailable entity raises localized error."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        hass.states.async_set("sensor.energy_meter", STATE_UNAVAILABLE)
+
+        call = create_service_call(
+            hass,
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            {
+                "entry_id": "test-entry-id",
+                "device_id": "device-123",
+                "source_entity_id": "sensor.energy_meter",
+                "allow_rounding": True,
+            },
+        )
+
+        # Act & Assert
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await async_handle_send_meter_reading(hass, call)
+
+        assert exc_info.value.translation_domain == DOMAIN
+        assert exc_info.value.translation_key == "entity_unavailable"
+        assert (
+            exc_info.value.translation_placeholders["entity_id"]
+            == "sensor.energy_meter"
+        )
+        assert exc_info.value.translation_placeholders["state"] == STATE_UNAVAILABLE
+
+    async def test_entity_unknown_raises_error(self, hass: HomeAssistant):
+        """Test that unknown entity state raises localized error."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        hass.states.async_set("sensor.energy_meter", STATE_UNKNOWN)
+
+        call = create_service_call(
+            hass,
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            {
+                "entry_id": "test-entry-id",
+                "device_id": "device-123",
+                "source_entity_id": "sensor.energy_meter",
+                "allow_rounding": True,
+            },
+        )
+
+        # Act & Assert
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await async_handle_send_meter_reading(hass, call)
+
+        assert exc_info.value.translation_domain == DOMAIN
+        assert exc_info.value.translation_key == "entity_unavailable"
+        assert exc_info.value.translation_placeholders["state"] == STATE_UNKNOWN
+
+    async def test_invalid_number_raises_error(self, hass: HomeAssistant):
+        """Test that non-numeric entity state raises localized error."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        hass.states.async_set("sensor.energy_meter", "not_a_number")
+
+        call = create_service_call(
+            hass,
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            {
+                "entry_id": "test-entry-id",
+                "device_id": "device-123",
+                "source_entity_id": "sensor.energy_meter",
+                "allow_rounding": True,
+            },
+        )
+
+        # Act & Assert
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await async_handle_send_meter_reading(hass, call)
+
+        assert exc_info.value.translation_domain == DOMAIN
+        assert exc_info.value.translation_key == "invalid_number"
+        assert (
+            exc_info.value.translation_placeholders["entity_id"]
+            == "sensor.energy_meter"
+        )
+        assert exc_info.value.translation_placeholders["state"] == "not_a_number"
+
+    async def test_missing_timestamp_raises_error(self, hass: HomeAssistant):
+        """Test that entity without timestamp raises localized error."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        # Create state with None timestamp
+        mock_state = MagicMock()
+        mock_state.state = "123.45"
+        mock_state.last_updated = None
+
+        call = create_service_call(
+            hass,
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            {
+                "entry_id": "test-entry-id",
+                "device_id": "device-123",
+                "source_entity_id": "sensor.energy_meter",
+                "allow_rounding": True,
+            },
+        )
+
+        # Act & Assert
+        # Patch the hass.states.get call at module level
+        with (
+            patch("homeassistant.core.StateMachine.get", return_value=mock_state),
+            pytest.raises(HomeAssistantError) as exc_info,
+        ):
+            await async_handle_send_meter_reading(hass, call)
+
+        assert exc_info.value.translation_domain == DOMAIN
+        assert exc_info.value.translation_key == "missing_timestamp"
+        assert (
+            exc_info.value.translation_placeholders["entity_id"]
+            == "sensor.energy_meter"
+        )
+
+    async def test_no_api_token_raises_error(self, hass: HomeAssistant):
+        """Test that missing API token raises localized error."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "valid-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        # Simulate runtime_data being empty/missing
+        entry.runtime_data = ""
+
+        hass.states.async_set("sensor.energy_meter", "123.45")
+
+        call = create_service_call(
+            hass,
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            {
+                "entry_id": "test-entry-id",
+                "device_id": "device-123",
+                "source_entity_id": "sensor.energy_meter",
+                "allow_rounding": True,
+            },
+        )
+
+        # Act & Assert
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await async_handle_send_meter_reading(hass, call)
+
+        assert exc_info.value.translation_domain == DOMAIN
+        assert exc_info.value.translation_key == "no_api_token"
+
+    async def test_deleted_integration_raises_error(self, hass: HomeAssistant):
+        """Test that deleted integration entry raises localized error."""
+        # Arrange
+        hass.states.async_set("sensor.energy_meter", "123.45")
+
+        call = create_service_call(
+            hass,
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            {
+                "entry_id": "nonexistent-entry-id",
+                "device_id": "device-123",
+                "source_entity_id": "sensor.energy_meter",
+                "allow_rounding": True,
+            },
+        )
+
+        # Act & Assert
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await async_handle_send_meter_reading(hass, call)
+
+        assert exc_info.value.translation_domain == DOMAIN
+        assert exc_info.value.translation_key == "no_api_token"
+
+    async def test_device_id_whitespace_stripped(self, hass: HomeAssistant):
+        """Test that device_id whitespace is properly stripped."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        hass.states.async_set("sensor.energy_meter", "123.45")
+
+        call = create_service_call(
+            hass,
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            {
+                "entry_id": "test-entry-id",
+                "device_id": "  device-123  ",
+                "source_entity_id": "sensor.energy_meter",
+                "allow_rounding": True,
+            },
+        )
+
+        # Act
+        with patch(
+            "homeassistant.components.energy_tracker.EnergyTrackerApi.send_meter_reading",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await async_handle_send_meter_reading(hass, call)
+
+        # Assert
+        call_kwargs = mock_send.call_args.kwargs
+        assert call_kwargs["device_id"] == "device-123"
+
+    async def test_empty_entry_id_logs_debug(self, hass: HomeAssistant):
+        """Test that empty entry_id logs debug message."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        hass.states.async_set("sensor.energy_meter", "123.45")
+
+        call = create_service_call(
+            hass,
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            {
+                "entry_id": "",  # Empty entry_id
+                "device_id": "device-123",
+                "source_entity_id": "sensor.energy_meter",
+                "allow_rounding": True,
+            },
+        )
+
+        # Act & Assert
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await async_handle_send_meter_reading(hass, call)
+
+        assert exc_info.value.translation_domain == DOMAIN
+        assert exc_info.value.translation_key == "no_api_token"
+
+    async def test_deleted_entry_logs_debug(self, hass: HomeAssistant):
+        """Test that deleted integration logs debug message."""
+        # Arrange
+        # Set up one entry, but try to use a different (deleted) one
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="existing-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        hass.states.async_set("sensor.energy_meter", "123.45")
+
+        call = create_service_call(
+            hass,
+            DOMAIN,
+            SERVICE_SEND_METER_READING,
+            {
+                "entry_id": "deleted-entry-id",  # Different entry that was deleted
+                "device_id": "device-123",
+                "source_entity_id": "sensor.energy_meter",
+                "allow_rounding": True,
+            },
+        )
+
+        # Act & Assert
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await async_handle_send_meter_reading(hass, call)
+
+        assert exc_info.value.translation_domain == DOMAIN
+        assert exc_info.value.translation_key == "no_api_token"
+
+    async def test_service_wrapper_function(self, hass: HomeAssistant):
+        """Test that registered service wrapper calls handler correctly."""
+        # Arrange
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Account",
+            data={CONF_API_TOKEN: "test-token"},
+            entry_id="test-entry-id",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_entry(hass, entry)
+
+        hass.states.async_set("sensor.energy_meter", "123.45")
+
+        # Act
+        with patch(
+            "homeassistant.components.energy_tracker.EnergyTrackerApi.send_meter_reading",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            # Call via the registered service (which uses the wrapper)
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_SEND_METER_READING,
+                {
+                    "entry_id": "test-entry-id",
+                    "device_id": "device-123",
+                    "source_entity_id": "sensor.energy_meter",
+                    "allow_rounding": True,
+                },
+                blocking=True,
+            )
+
+        # Assert
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args.kwargs
+        assert call_kwargs["device_id"] == "device-123"
+        assert call_kwargs["value"] == 123.45


### PR DESCRIPTION
## Proposed change
This PR adds the Energy Tracker integration which allows users to automatically send meter readings from Home Assistant sensors to their Energy Tracker account at https://www.energy-tracker.best-ios-apps.de.

Energy Tracker is an established energy monitoring service with over 100,000 users. This integration enables automated meter reading submissions directly from Home Assistant entities with config flow support, multi-account capability, and full localization for 26 languages.
## Type of change
- [x] New integration (thank you!)

## Additional information
- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- **Link to documentation pull request:** Will be reopened upon positive signal 
  (previous PR [home-assistant.io#42031](https://github.com/home-assistant/home-assistant.io/pull/42031) was approved)
- **Link to brand assets pull request:** Will be reopened upon positive signal 
  (previous PR [brands#8580](https://github.com/home-assistant/brands/pull/8580) was ready)

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x]  The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
    *(PR [#42031](https://github.com/home-assistant/home-assistant.io/pull/42031) was approved; will be reopened)*

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

> **Note:** This is a resubmission following #157571. The concerns raised have been addressed 
> (see comment below for details).