### PR TITLE
Script: Enforce quality scale definition file existence

### DIFF
--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -2222,30 +2222,29 @@ def validate_iqs_file(config: Config, integration: Integration) -> None:
 
     declared_quality_scale = QUALITY_SCALE_TIERS.get(integration.quality_scale)
 
-    iqs_file = integration.path / "quality_scale.yaml"
-    has_file = iqs_file.is_file()
-    if not has_file:
+    if not integration.quality_scale:
         if (
-            integration.domain not in INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE
+            integration.domain not in INTEGRATIONS_WITHOUT_SCALE
             and integration.domain not in NO_QUALITY_SCALE
             and integration.integration_type != "virtual"
         ):
             integration.add_error(
                 "quality_scale",
-                (
-                    "New integrations marked as internal should be added to NO_QUALITY_SCALE in script/hassfest/quality_scale.py."
-                    if integration.quality_scale == "internal"
-                    else "Quality scale definition not found. New integrations are required to at least reach the Bronze tier."
-                ),
+                "Quality scale definition not found. New integrations are required to at least reach the Bronze tier.",
             )
             return
-        if declared_quality_scale is not None:
+
+    iqs_file = integration.path / "quality_scale.yaml"
+    has_file = iqs_file.is_file()
+    if not has_file:
+        if declared_quality_scale:
             integration.add_error(
                 "quality_scale",
-                "Quality scale definition not found. Integrations that set a manifest quality scale must have a quality scale definition.",
+                "Quality scale definition YAML not found. Integrations that set a manifest quality scale must have a quality scale definition.",
             )
             return
         return
+
     if integration.integration_type == "virtual":
         integration.add_error(
             "quality_scale",

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -2237,7 +2237,10 @@ def validate_iqs_file(config: Config, integration: Integration) -> None:
     iqs_file = integration.path / "quality_scale.yaml"
     has_file = iqs_file.is_file()
     if not has_file:
-        if declared_quality_scale:
+        if (
+            declared_quality_scale
+            and integration.domain not in INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE
+        ):
             integration.add_error(
                 "quality_scale",
                 "Quality scale definition YAML not found. Integrations that set a manifest quality scale must have a quality scale definition.",

--- a/tests/hassfest/test_quality_scale.py
+++ b/tests/hassfest/test_quality_scale.py
@@ -1,0 +1,89 @@
+"""Tests for quality_scale validation."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from script.hassfest import quality_scale
+from script.hassfest.model import Config
+
+from . import get_integration
+
+
+@pytest.fixture
+def config():
+    """Fixture for hassfest Config."""
+    return Config(
+        root=Path(".").absolute(),
+        specific_integrations=None,
+        action="validate",
+        requirements=True,
+    )
+
+
+def test_validate_no_quality_scale_key(config: Config, mock_core_integration) -> None:
+    """Test integration with no quality_scale key in manifest."""
+    integration = get_integration("test_integration", config)
+    # Ensure quality_scale is None (default in get_integration is just basic manifest)
+    assert integration.quality_scale is None
+
+    # Mock that it's not in exemption list
+    with patch("script.hassfest.quality_scale.INTEGRATIONS_WITHOUT_SCALE", set()):
+        quality_scale.validate_iqs_file(config, integration)
+
+    assert len(integration.errors) == 1
+    assert "Quality scale definition not found" in integration.errors[0].error
+
+
+def test_validate_quality_scale_internal_no_file(
+    config: Config, mock_core_integration
+) -> None:
+    """Test internal integration with no quality_scale file."""
+    integration = get_integration("test_integration", config)
+    integration._manifest["quality_scale"] = "internal"
+
+    # Mock that file does not exist
+    with patch("pathlib.Path.is_file", return_value=False):
+        quality_scale.validate_iqs_file(config, integration)
+
+    # Internal integrations don't require a quality scale file, so this should pass.
+    assert len(integration.errors) == 0
+
+
+def test_validate_quality_scale_bronze_no_file(
+    config: Config, mock_core_integration
+) -> None:
+    """Test bronze integration with no quality_scale file."""
+    integration = get_integration("test_integration", config)
+    integration._manifest["quality_scale"] = "bronze"
+
+    with patch("pathlib.Path.is_file", return_value=False):
+        quality_scale.validate_iqs_file(config, integration)
+
+    assert len(integration.errors) == 1
+    assert "Quality scale definition YAML not found" in integration.errors[0].error
+
+
+def test_validate_quality_scale_file_present(
+    config: Config, mock_core_integration
+) -> None:
+    """Test integration with quality scale file present."""
+    integration = get_integration("test_integration", config)
+    integration._manifest["quality_scale"] = "bronze"
+
+    with (
+        patch("pathlib.Path.is_file", return_value=True),
+        patch(
+            "script.hassfest.quality_scale.load_yaml_dict", return_value={"rules": {}}
+        ),
+        patch("script.hassfest.quality_scale.SCHEMA"),
+    ):
+        quality_scale.validate_iqs_file(config, integration)
+
+    # Should not have the "not found" error.
+    # Might have other errors if rules are missing, but we are testing the file existence check.
+
+    # Check that we didn't get the "Quality scale definition YAML not found" error
+    for error in integration.errors:
+        assert "Quality scale definition YAML not found" not in error.error


### PR DESCRIPTION
Updates the hassfest quality_scale script to ensure that if an integration declares a quality scale in its manifest, a corresponding quality_scale.yaml file must exist.

Also adds a new test suite to cover these validation scenarios.

Fixes #153133.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Fix the quality_scale script, as described in #153133.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #153133
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
