### PR TITLE
Fix Tuya device registry cleanup

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -82,7 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
     entry.runtime_data = HomeAssistantTuyaData(manager=manager, listener=listener)
 
     # Cleanup device registry
-    await cleanup_device_registry(hass, manager)
+    await cleanup_device_registry(hass, manager, entry)
 
     # Register known device IDs
     device_registry = dr.async_get(hass)
@@ -114,13 +114,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
     return True
 
 
-async def cleanup_device_registry(hass: HomeAssistant, device_manager: Manager) -> None:
-    """Remove deleted device registry entry if there are no remaining entities."""
+async def cleanup_device_registry(
+    hass: HomeAssistant, device_manager: Manager, entry: TuyaConfigEntry
+) -> None:
+    """Unlink device registry entry if there are no remaining entities."""
     device_registry = dr.async_get(hass)
-    for dev_id, device_entry in list(device_registry.devices.items()):
+    for device_entry in dr.async_entries_for_config_entry(
+        device_registry, entry.entry_id
+    ):
         for item in device_entry.identifiers:
             if item[0] == DOMAIN and item[1] not in device_manager.device_map:
-                device_registry.async_remove_device(dev_id)
+                device_registry.async_update_device(
+                    device_entry.id, remove_config_entry_id=entry.entry_id
+                )
                 break
 
 

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -4,15 +4,23 @@ from __future__ import annotations
 
 import pathlib
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-from tuya_sharing import CustomerDevice, Manager
+from tuya_sharing import (
+    CustomerApi,
+    CustomerDevice,
+    DeviceFunction,
+    DeviceStatusRange,
+    Manager,
+)
 
-from homeassistant.components.tuya import DeviceListener
+from homeassistant.components.tuya import DOMAIN, DeviceListener
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.json import json_dumps
+from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 DEVICE_MOCKS = sorted(
@@ -42,6 +50,98 @@ class MockDeviceListener(DeviceListener):
                 property_list.append(key)
         self.update_device(device, property_list)
         await hass.async_block_till_done()
+
+
+async def create_device(hass: HomeAssistant, mock_device_code: str) -> CustomerDevice:
+    """Mock a Tuya CustomerDevice."""
+    details = await async_load_json_object_fixture(
+        hass, f"{mock_device_code}.json", DOMAIN
+    )
+    device = MagicMock(spec=CustomerDevice)
+
+    # Use reverse of the product_id for testing
+    device.id = mock_device_code.replace("_", "")[::-1]
+
+    device.name = details["name"]
+    device.category = details["category"]
+    device.product_id = details["product_id"]
+    device.product_name = details["product_name"]
+    device.online = details["online"]
+    device.sub = details.get("sub")
+    device.time_zone = details.get("time_zone")
+    device.active_time = details.get("active_time")
+    if device.active_time:
+        device.active_time = int(dt_util.as_timestamp(device.active_time))
+    device.create_time = details.get("create_time")
+    if device.create_time:
+        device.create_time = int(dt_util.as_timestamp(device.create_time))
+    device.update_time = details.get("update_time")
+    if device.update_time:
+        device.update_time = int(dt_util.as_timestamp(device.update_time))
+    device.support_local = details.get("support_local")
+    device.local_strategy = details.get("local_strategy")
+    device.mqtt_connected = details.get("mqtt_connected")
+
+    device.function = {
+        key: DeviceFunction(
+            code=key,
+            type=value["type"],
+            values=(
+                values
+                if isinstance(values := value["value"], str)
+                else json_dumps(values)
+            ),
+        )
+        for key, value in details["function"].items()
+    }
+    device.status_range = {
+        key: DeviceStatusRange(
+            code=key,
+            report_type=value.get("report_type"),
+            type=value["type"],
+            values=(
+                values
+                if isinstance(values := value["value"], str)
+                else json_dumps(values)
+            ),
+        )
+        for key, value in details["status_range"].items()
+    }
+    device.status = details["status"]
+    for key, value in device.status.items():
+        # Some devices do not provide a status_range for all status DPs
+        # Others set the type as String in status_range and as Json in function
+        if ((dp_type := device.status_range.get(key)) and dp_type.type == "Json") or (
+            (dp_type := device.function.get(key)) and dp_type.type == "Json"
+        ):
+            device.status[key] = json_dumps(value)
+        if value == "**REDACTED**":
+            # It was redacted, which may cause issue with b64decode
+            device.status[key] = ""
+    return device
+
+
+def create_listener(hass: HomeAssistant, manager: Manager) -> MockDeviceListener:
+    """Create a DeviceListener for testing."""
+    listener = MockDeviceListener(hass, manager)
+    manager.add_device_listener(listener)
+    return listener
+
+
+def create_manager(
+    terminal_id: str = "7cd96aff-6ec8-4006-b093-3dbff7947591",
+) -> Manager:
+    """Create a Manager for testing."""
+    manager = MagicMock(spec=Manager)
+    manager.device_map = {}
+    manager.mq = MagicMock()
+    manager.mq.client = MagicMock()
+    manager.mq.client.is_connected = MagicMock(return_value=True)
+    manager.customer_api = MagicMock(spec=CustomerApi)
+    # Meaningless URL / UUIDs
+    manager.customer_api.endpoint = "https://apigw.tuyaeu.com"
+    manager.terminal_id = terminal_id
+    return manager
 
 
 async def initialize_entry(

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -53,7 +53,7 @@ class MockDeviceListener(DeviceListener):
 
 
 async def create_device(hass: HomeAssistant, mock_device_code: str) -> CustomerDevice:
-    """Mock a Tuya CustomerDevice."""
+    """Create a CustomerDevice for testing."""
     details = await async_load_json_object_fixture(
         hass, f"{mock_device_code}.json", DOMAIN
     )

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -6,13 +6,7 @@ from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
-from tuya_sharing import (
-    CustomerApi,
-    CustomerDevice,
-    DeviceFunction,
-    DeviceStatusRange,
-    Manager,
-)
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.tuya.const import (
     CONF_ENDPOINT,
@@ -22,12 +16,16 @@ from homeassistant.components.tuya.const import (
     DOMAIN,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.json import json_dumps
-from homeassistant.util import dt as dt_util
 
-from . import DEVICE_MOCKS, MockDeviceListener
+from . import (
+    DEVICE_MOCKS,
+    MockDeviceListener,
+    create_device,
+    create_listener,
+    create_manager,
+)
 
-from tests.common import MockConfigEntry, async_load_json_object_fixture
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -108,17 +106,8 @@ def mock_tuya_login_control() -> Generator[MagicMock]:
 
 @pytest.fixture
 def mock_manager() -> Manager:
-    """Mock Tuya Manager."""
-    manager = MagicMock(spec=Manager)
-    manager.device_map = {}
-    manager.mq = MagicMock()
-    manager.mq.client = MagicMock()
-    manager.mq.client.is_connected = MagicMock(return_value=True)
-    manager.customer_api = MagicMock(spec=CustomerApi)
-    # Meaningless URL / UUIDs
-    manager.customer_api.endpoint = "https://apigw.tuyaeu.com"
-    manager.terminal_id = "7cd96aff-6ec8-4006-b093-3dbff7947591"
-    return manager
+    """Fixture for Tuya Manager."""
+    return create_manager()
 
 
 @pytest.fixture
@@ -137,7 +126,7 @@ async def mock_devices(hass: HomeAssistant) -> list[CustomerDevice]:
 
     Use this to generate global snapshots for each platform.
     """
-    return [await _create_device(hass, device_code) for device_code in DEVICE_MOCKS]
+    return [await create_device(hass, device_code) for device_code in DEVICE_MOCKS]
 
 
 @pytest.fixture
@@ -146,81 +135,10 @@ async def mock_device(hass: HomeAssistant, mock_device_code: str) -> CustomerDev
 
     Use this for testing behavior on a specific device.
     """
-    return await _create_device(hass, mock_device_code)
-
-
-async def _create_device(hass: HomeAssistant, mock_device_code: str) -> CustomerDevice:
-    """Mock a Tuya CustomerDevice."""
-    details = await async_load_json_object_fixture(
-        hass, f"{mock_device_code}.json", DOMAIN
-    )
-    device = MagicMock(spec=CustomerDevice)
-
-    # Use reverse of the product_id for testing
-    device.id = mock_device_code.replace("_", "")[::-1]
-
-    device.name = details["name"]
-    device.category = details["category"]
-    device.product_id = details["product_id"]
-    device.product_name = details["product_name"]
-    device.online = details["online"]
-    device.sub = details.get("sub")
-    device.time_zone = details.get("time_zone")
-    device.active_time = details.get("active_time")
-    if device.active_time:
-        device.active_time = int(dt_util.as_timestamp(device.active_time))
-    device.create_time = details.get("create_time")
-    if device.create_time:
-        device.create_time = int(dt_util.as_timestamp(device.create_time))
-    device.update_time = details.get("update_time")
-    if device.update_time:
-        device.update_time = int(dt_util.as_timestamp(device.update_time))
-    device.support_local = details.get("support_local")
-    device.local_strategy = details.get("local_strategy")
-    device.mqtt_connected = details.get("mqtt_connected")
-
-    device.function = {
-        key: DeviceFunction(
-            code=key,
-            type=value["type"],
-            values=(
-                values
-                if isinstance(values := value["value"], str)
-                else json_dumps(values)
-            ),
-        )
-        for key, value in details["function"].items()
-    }
-    device.status_range = {
-        key: DeviceStatusRange(
-            code=key,
-            report_type=value.get("report_type"),
-            type=value["type"],
-            values=(
-                values
-                if isinstance(values := value["value"], str)
-                else json_dumps(values)
-            ),
-        )
-        for key, value in details["status_range"].items()
-    }
-    device.status = details["status"]
-    for key, value in device.status.items():
-        # Some devices do not provide a status_range for all status DPs
-        # Others set the type as String in status_range and as Json in function
-        if ((dp_type := device.status_range.get(key)) and dp_type.type == "Json") or (
-            (dp_type := device.function.get(key)) and dp_type.type == "Json"
-        ):
-            device.status[key] = json_dumps(value)
-        if value == "**REDACTED**":
-            # It was redacted, which may cause issue with b64decode
-            device.status[key] = ""
-    return device
+    return await create_device(hass, mock_device_code)
 
 
 @pytest.fixture
 def mock_listener(hass: HomeAssistant, mock_manager: Manager) -> MockDeviceListener:
-    """Create a DeviceListener for testing."""
-    listener = MockDeviceListener(hass, mock_manager)
-    mock_manager.add_device_listener(listener)
-    return listener
+    """Fixture for Tuya DeviceListener."""
+    return create_listener(hass, mock_manager)

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -28,16 +28,18 @@ async def test_multiple_entries(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Ensure multiple config entries do not remove items from other entries."""
+    main_entity_id = "sensor.boite_aux_lettres_arriere_battery"
+    second_entity_id = "binary_sensor.window_downstairs_door"
 
     main_manager = create_manager()
     main_device = await create_device(hass, "mcs_8yhypbo7")
     await initialize_entry(hass, main_manager, mock_config_entry, main_device)
 
-    # Ensure initial setup is correct
-    main_entity_id = "sensor.boite_aux_lettres_arriere_battery"
+    # Ensure initial setup is correct (main present, second absent)
     assert hass.states.get(main_entity_id)
-    assert (e := entity_registry.async_get(main_entity_id))
-    assert device_registry.async_get(e.device_id)
+    assert entity_registry.async_get(main_entity_id)
+    assert not hass.states.get(second_entity_id)
+    assert not entity_registry.async_get(second_entity_id)
 
     # Create a second config entry
     second_config_entry = MockConfigEntry(
@@ -55,16 +57,11 @@ async def test_multiple_entries(
     second_device = await create_device(hass, "mcs_oxslv1c9")
     await initialize_entry(hass, second_manager, second_config_entry, second_device)
 
-    # Ensure second setup is correct
-    second_entity_id = "binary_sensor.door_sensor_1_doorcontact_state"
-    assert hass.states.get(second_entity_id)
-    assert (e := entity_registry.async_get(second_entity_id))
-    assert device_registry.async_get(e.device_id)
-
-    # Ensure main setup is STILL correct
+    # Ensure setup is correct (both present)
     assert hass.states.get(main_entity_id)
-    assert (e := entity_registry.async_get(main_entity_id))
-    assert device_registry.async_get(e.device_id)
+    assert entity_registry.async_get(main_entity_id)
+    assert hass.states.get(second_entity_id)
+    assert entity_registry.async_get(second_entity_id)
 
 
 async def test_device_registry(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes a long-time bug where loading a second config entry removes all devices (and therefore entities) from the first config entry.

See #100516

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #100516
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
