### PR TITLE
Pass timestamps to Tuya wrapper skip_update

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -165,7 +165,7 @@ class DeviceListener(SharingDeviceListener):
         self,
         device: CustomerDevice,
         updated_status_properties: list[str] | None = None,
-        dp_timestamps: dict | None = None,
+        dp_timestamps: dict[str, int] | None = None,
     ) -> None:
         """Update device status with optional DP timestamps."""
         LOGGER.debug(

--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -471,9 +471,11 @@ class TuyaBinarySensorEntity(TuyaEntity, BinarySensorEntity):
     async def _handle_state_update(
         self,
         updated_status_properties: list[str] | None,
-        dp_timestamps: dict | None = None,
+        dp_timestamps: dict[str, int] | None,
     ) -> None:
         """Handle state update, only if this entity's dpcode was actually updated."""
-        if self._dpcode_wrapper.skip_update(self.device, updated_status_properties):
+        if self._dpcode_wrapper.skip_update(
+            self.device, updated_status_properties, dp_timestamps
+        ):
             return
         self.async_write_ha_state()

--- a/homeassistant/components/tuya/entity.py
+++ b/homeassistant/components/tuya/entity.py
@@ -57,7 +57,7 @@ class TuyaEntity(Entity):
     async def _handle_state_update(
         self,
         updated_status_properties: list[str] | None,
-        dp_timestamps: dict | None = None,
+        dp_timestamps: dict[str, int] | None,
     ) -> None:
         self.async_write_ha_state()
 

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -218,10 +218,10 @@ class TuyaEventEntity(TuyaEntity, EventEntity):
     async def _handle_state_update(
         self,
         updated_status_properties: list[str] | None,
-        dp_timestamps: dict | None = None,
+        dp_timestamps: dict[str, int] | None,
     ) -> None:
         if self._dpcode_wrapper.skip_update(
-            self.device, updated_status_properties
+            self.device, updated_status_properties, dp_timestamps
         ) or not (event_data := self._dpcode_wrapper.read_device_status(self.device)):
             return
 

--- a/homeassistant/components/tuya/models.py
+++ b/homeassistant/components/tuya/models.py
@@ -31,7 +31,10 @@ class DeviceWrapper[T]:
     options: list[str]
 
     def skip_update(
-        self, device: CustomerDevice, updated_status_properties: list[str] | None
+        self,
+        device: CustomerDevice,
+        updated_status_properties: list[str] | None,
+        dp_timestamps: dict[str, int] | None,
     ) -> bool:
         """Determine if the wrapper should skip an update.
 
@@ -62,7 +65,10 @@ class DPCodeWrapper(DeviceWrapper):
         self.dpcode = dpcode
 
     def skip_update(
-        self, device: CustomerDevice, updated_status_properties: list[str] | None
+        self,
+        device: CustomerDevice,
+        updated_status_properties: list[str] | None,
+        dp_timestamps: dict[str, int] | None,
     ) -> bool:
         """Determine if the wrapper should skip an update.
 

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -554,10 +554,12 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
     async def _handle_state_update(
         self,
         updated_status_properties: list[str] | None,
-        dp_timestamps: dict | None = None,
+        dp_timestamps: dict[str, int] | None,
     ) -> None:
         """Handle state update, only if this entity's dpcode was actually updated."""
-        if self._dpcode_wrapper.skip_update(self.device, updated_status_properties):
+        if self._dpcode_wrapper.skip_update(
+            self.device, updated_status_properties, dp_timestamps
+        ):
             return
         self.async_write_ha_state()
 

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -410,10 +410,12 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
     async def _handle_state_update(
         self,
         updated_status_properties: list[str] | None,
-        dp_timestamps: dict | None = None,
+        dp_timestamps: dict[str, int] | None,
     ) -> None:
         """Handle state update, only if this entity's dpcode was actually updated."""
-        if self._dpcode_wrapper.skip_update(self.device, updated_status_properties):
+        if self._dpcode_wrapper.skip_update(
+            self.device, updated_status_properties, dp_timestamps
+        ):
             return
         self.async_write_ha_state()
 

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -1853,9 +1853,11 @@ class TuyaSensorEntity(TuyaEntity, SensorEntity):
     async def _handle_state_update(
         self,
         updated_status_properties: list[str] | None,
-        dp_timestamps: dict | None = None,
+        dp_timestamps: dict[str, int] | None,
     ) -> None:
         """Handle state update, only if this entity's dpcode was actually updated."""
-        if self._dpcode_wrapper.skip_update(self.device, updated_status_properties):
+        if self._dpcode_wrapper.skip_update(
+            self.device, updated_status_properties, dp_timestamps
+        ):
             return
         self.async_write_ha_state()

--- a/homeassistant/components/tuya/siren.py
+++ b/homeassistant/components/tuya/siren.py
@@ -110,10 +110,12 @@ class TuyaSirenEntity(TuyaEntity, SirenEntity):
     async def _handle_state_update(
         self,
         updated_status_properties: list[str] | None,
-        dp_timestamps: dict | None = None,
+        dp_timestamps: dict[str, int] | None,
     ) -> None:
         """Handle state update, only if this entity's dpcode was actually updated."""
-        if self._dpcode_wrapper.skip_update(self.device, updated_status_properties):
+        if self._dpcode_wrapper.skip_update(
+            self.device, updated_status_properties, dp_timestamps
+        ):
             return
         self.async_write_ha_state()
 

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -1043,10 +1043,12 @@ class TuyaSwitchEntity(TuyaEntity, SwitchEntity):
     async def _handle_state_update(
         self,
         updated_status_properties: list[str] | None,
-        dp_timestamps: dict | None = None,
+        dp_timestamps: dict[str, int] | None,
     ) -> None:
         """Handle state update, only if this entity's dpcode was actually updated."""
-        if self._dpcode_wrapper.skip_update(self.device, updated_status_properties):
+        if self._dpcode_wrapper.skip_update(
+            self.device, updated_status_properties, dp_timestamps
+        ):
             return
         self.async_write_ha_state()
 

--- a/homeassistant/components/tuya/valve.py
+++ b/homeassistant/components/tuya/valve.py
@@ -140,10 +140,12 @@ class TuyaValveEntity(TuyaEntity, ValveEntity):
     async def _handle_state_update(
         self,
         updated_status_properties: list[str] | None,
-        dp_timestamps: dict | None = None,
+        dp_timestamps: dict[str, int] | None,
     ) -> None:
         """Handle state update, only if this entity's dpcode was actually updated."""
-        if self._dpcode_wrapper.skip_update(self.device, updated_status_properties):
+        if self._dpcode_wrapper.skip_update(
+            self.device, updated_status_properties, dp_timestamps
+        ):
             return
         self.async_write_ha_state()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows wrappers to ignore duplicate events (if the timestamp is identical to the previous timestamp)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
