### PR TITLE
Fix nobo_hub options flow unload mocking

### DIFF
--- a/tests/components/nobo_hub/conftest.py
+++ b/tests/components/nobo_hub/conftest.py
@@ -1,0 +1,24 @@
+"""Common fixtures for the Nobø Ecohub tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.nobo_hub.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_unload_entry() -> Generator[AsyncMock]:
+    """Override async_unload_entry."""
+    with patch(
+        "homeassistant.components.nobo_hub.async_unload_entry", return_value=True
+    ) as mock_unload_entry:
+        yield mock_unload_entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- The options flow test wasn't patching the config entry unload function, so it was erroring when the options flow triggered a reload, since the integration wasn't set up due to patching config entry setup function. The test didn't fail but there was an error logged in a task.

```
ERROR:homeassistant:Error doing job: Task exception was never retrieved (task: None):   File "/home/martin/dev/home-assistant/core/.venv/bin/pytest", line 10, in <module>
    sys.exit(console_main())
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/config/__init__.py", line 221, in console_main
    code = main()
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/config/__init__.py", line 197, in main
    ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/main.py", line 365, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/main.py", line 318, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/main.py", line 372, in _main
    config.hook.pytest_runtestloop(session=session)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/main.py", line 396, in pytest_runtestloop
    item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/runner.py", line 118, in pytest_runtest_protocol
    runtestprotocol(item, nextitem=nextitem)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/runner.py", line 137, in runtestprotocol
    reports.append(call_and_report(item, "call", log))
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/runner.py", line 244, in call_and_report
    call = CallInfo.from_call(
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/runner.py", line 353, in from_call
    result: TResult | None = func()
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/runner.py", line 245, in <lambda>
    lambda: runtest_hook(item=item, **kwds),
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/runner.py", line 179, in pytest_runtest_call
    item.runtest()
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pytest_asyncio/plugin.py", line 469, in runtest
    super().runtest()
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/python.py", line 1720, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/_pytest/python.py", line 166, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/home/martin/dev/home-assistant/core/.venv/lib/python3.13/site-packages/pytest_asyncio/plugin.py", line 716, in inner
    runner.run(coro, context=context)
  File "/usr/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/usr/lib/python3.13/asyncio/base_events.py", line 712, in run_until_complete
    self.run_forever()
  File "/usr/lib/python3.13/asyncio/base_events.py", line 683, in run_forever
    self._run_once()
  File "/usr/lib/python3.13/asyncio/base_events.py", line 2042, in _run_once
    handle._run()
  File "/usr/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/home/martin/dev/home-assistant/core/tests/components/nobo_hub/test_config_flow.py", line 287, in test_options_flow
    result = await hass.config_entries.options.async_configure(
  File "/home/martin/dev/home-assistant/core/homeassistant/data_entry_flow.py", line 336, in async_configure
    result = await self._async_configure(flow_id, user_input)
  File "/home/martin/dev/home-assistant/core/homeassistant/data_entry_flow.py", line 383, in _async_configure
    result = await self._async_handle_step(
  File "/home/martin/dev/home-assistant/core/tests/components/conftest.py", line 1009, in _flow_manager_async_handle_step
    result = await _original_flow_manager_async_handle_step(self, flow, *args)
  File "/home/martin/dev/home-assistant/core/homeassistant/data_entry_flow.py", line 544, in _async_handle_step
    result = await self.async_finish_flow(flow, result.copy())
  File "/home/martin/dev/home-assistant/core/homeassistant/config_entries.py", line 3738, in async_finish_flow
    self.hass.config_entries.async_schedule_reload(entry.entry_id)
  File "/home/martin/dev/home-assistant/core/homeassistant/config_entries.py", line 2280, in async_schedule_reload
    self.hass.async_create_task(
  File "/home/martin/dev/home-assistant/core/homeassistant/core.py", line 772, in async_create_task
    return self.async_create_task_internal(target, name, eager_start)
  File "/home/martin/dev/home-assistant/core/tests/common.py", line 265, in async_create_task_internal
    return orig_async_create_task_internal(coroutine, name, eager_start)
  File "/home/martin/dev/home-assistant/core/homeassistant/core.py", line 794, in async_create_task_internal
    task = create_eager_task(target, name=name, loop=self.loop)
  File "/home/martin/dev/home-assistant/core/homeassistant/util/async_.py", line 44, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
Traceback (most recent call last):
  File "/home/martin/dev/home-assistant/core/homeassistant/config_entries.py", line 2315, in async_reload
    unload_result = await self.async_unload(entry_id, _lock=False)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/martin/dev/home-assistant/core/homeassistant/config_entries.py", line 2263, in async_unload
    raise OperationNotAllowed(
    ...<3 lines>...
    )
homeassistant.config_entries.OperationNotAllowed: The config entry 'Mock Title' (nobo_hub) with entry_id '01KFDRWJDVJ86R6KKGB36GV3B5' cannot be unloaded because it is in the non recoverable state ConfigEntryState.FAILED_UNLOAD
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
