### PR TITLE
Update template select test framework

### DIFF
--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -49,8 +49,8 @@ DEFAULT_NAME = "Template Select"
 
 SELECT_COMMON_SCHEMA = vol.Schema(
     {
-        vol.Optional(ATTR_OPTIONS): cv.template,
-        vol.Optional(CONF_SELECT_OPTION): cv.SCRIPT_SCHEMA,
+        vol.Required(ATTR_OPTIONS): cv.template,
+        vol.Required(CONF_SELECT_OPTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_STATE): cv.template,
     }
 )

--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -52,10 +52,13 @@ def make_test_trigger(*entities: str) -> dict:
 
 
 async def async_trigger(
-    hass: HomeAssistant, entity_id: str, state: str | None = None
+    hass: HomeAssistant,
+    entity_id: str,
+    state: str | None = None,
+    attributes: dict | None = None,
 ) -> None:
     """Trigger a state change."""
-    hass.states.async_set(entity_id, state)
+    hass.states.async_set(entity_id, state, attributes)
     await hass.async_block_till_done()
 
 

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -236,8 +236,8 @@ BINARY_SENSOR_OPTIONS = {
             "on",
             {"one": "on", "two": "off"},
             {},
-            {"options": "{{ ['off', 'on', 'auto'] }}"},
-            {"options": "{{ ['off', 'on', 'auto'] }}"},
+            {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
+            {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
             {},
         ),
         (
@@ -458,8 +458,8 @@ async def test_config_flow(
         (
             "select",
             {"state": "{{ states('select.one') }}"},
-            {"options": "{{ ['off', 'on', 'auto'] }}"},
-            {"options": "{{ ['off', 'on', 'auto'] }}"},
+            {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
+            {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
         ),
         (
             "update",
@@ -734,8 +734,8 @@ async def test_config_flow_device(
             {"state": "{{ states('select.two') }}"},
             ["on", "off"],
             {"one": "on", "two": "off"},
-            {"options": "{{ ['off', 'on', 'auto'] }}"},
-            {"options": "{{ ['off', 'on', 'auto'] }}"},
+            {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
+            {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
             "state",
         ),
         (
@@ -1606,8 +1606,8 @@ async def test_option_flow_sensor_preview_config_entry_removed(
         (
             "select",
             {"state": "{{ states('select.one') }}"},
-            {"options": "{{ ['off', 'on', 'auto'] }}"},
-            {"options": "{{ ['off', 'on', 'auto'] }}"},
+            {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
+            {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
         ),
         (
             "switch",

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -405,10 +405,12 @@ async def async_yaml_patch_helper(hass: HomeAssistant, filename: str) -> None:
                 "name": "My template",
                 "state": "{{ 'on' }}",
                 "options": "{{ ['off', 'on', 'auto'] }}",
+                "select_option": [],
             },
             {
                 "state": "{{ 'on' }}",
                 "options": "{{ ['off', 'on', 'auto'] }}",
+                "select_option": [],
             },
         ),
         (

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -6,14 +6,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant import setup
-from homeassistant.components import select, template
-from homeassistant.components.input_select import (
-    ATTR_OPTION as INPUT_SELECT_ATTR_OPTION,
-    ATTR_OPTIONS as INPUT_SELECT_ATTR_OPTIONS,
-    DOMAIN as INPUT_SELECT_DOMAIN,
-    SERVICE_SELECT_OPTION as INPUT_SELECT_SERVICE_SELECT_OPTION,
-    SERVICE_SET_OPTIONS,
-)
+from homeassistant.components import select
 from homeassistant.components.select import (
     ATTR_OPTION as SELECT_ATTR_OPTION,
     ATTR_OPTIONS as SELECT_ATTR_OPTIONS,
@@ -31,77 +24,46 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Context, HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.setup import async_setup_component
 
-from .conftest import ConfigurationStyle, async_get_flow_preview_state
+from .conftest import (
+    ConfigurationStyle,
+    TemplatePlatformSetup,
+    async_get_flow_preview_state,
+    async_trigger,
+    make_test_trigger,
+    setup_and_test_nested_unique_id,
+    setup_and_test_unique_id,
+    setup_entity,
+)
 
-from tests.common import MockConfigEntry, assert_setup_component, async_capture_events
+from tests.common import MockConfigEntry, assert_setup_component
 from tests.conftest import WebSocketGenerator
 
-_TEST_OBJECT_ID = "template_select"
-_TEST_SELECT = f"select.{_TEST_OBJECT_ID}"
-# Represent for select's current_option
-_OPTION_INPUT_SELECT = "input_select.option"
 TEST_STATE_ENTITY_ID = "select.test_state"
 TEST_AVAILABILITY_ENTITY_ID = "binary_sensor.test_availability"
-TEST_STATE_TRIGGER = {
-    "trigger": {
-        "trigger": "state",
-        "entity_id": [
-            _OPTION_INPUT_SELECT,
-            TEST_STATE_ENTITY_ID,
-            TEST_AVAILABILITY_ENTITY_ID,
-        ],
-    },
-    "variables": {"triggering_entity": "{{ trigger.entity_id }}"},
-    "action": [
-        {"event": "action_event", "event_data": {"what": "{{ triggering_entity }}"}}
-    ],
-}
 
-TEST_OPTIONS = {
-    "state": "test",
+TEST_SELECT = TemplatePlatformSetup(
+    select.DOMAIN,
+    None,
+    "template_select",
+    make_test_trigger(TEST_STATE_ENTITY_ID, TEST_AVAILABILITY_ENTITY_ID),
+)
+
+TEST_OPTIONS_WITHOUT_STATE = {
     "options": "{{ ['test', 'yes', 'no'] }}",
     "select_option": [],
 }
-
-
-async def async_setup_modern_format(
-    hass: HomeAssistant, count: int, select_config: dict[str, Any]
-) -> None:
-    """Do setup of select integration via new format."""
-    config = {"template": {"select": select_config}}
-
-    with assert_setup_component(count, template.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            template.DOMAIN,
-            config,
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-
-async def async_setup_trigger_format(
-    hass: HomeAssistant, count: int, select_config: dict[str, Any]
-) -> None:
-    """Do setup of select integration via trigger format."""
-    config = {"template": {**TEST_STATE_TRIGGER, "select": select_config}}
-
-    with assert_setup_component(count, template.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            template.DOMAIN,
-            config,
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
+TEST_OPTIONS = {"state": "test", **TEST_OPTIONS_WITHOUT_STATE}
+TEST_OPTION_ACTION = {
+    "action": "test.automation",
+    "data": {
+        "action": "select_option",
+        "caller": "{{ this.entity_id }}",
+        "option": "{{ option }}",
+    },
+}
 
 
 @pytest.fixture
@@ -109,17 +71,10 @@ async def setup_select(
     hass: HomeAssistant,
     count: int,
     style: ConfigurationStyle,
-    select_config: dict[str, Any],
+    config: dict[str, Any],
 ) -> None:
     """Do setup of select integration."""
-    if style == ConfigurationStyle.MODERN:
-        await async_setup_modern_format(
-            hass, count, {"name": _TEST_OBJECT_ID, **select_config}
-        )
-    if style == ConfigurationStyle.TRIGGER:
-        await async_setup_trigger_format(
-            hass, count, {"name": _TEST_OBJECT_ID, **select_config}
-        )
+    await setup_entity(hass, TEST_SELECT, style, count, config)
 
 
 async def test_setup_config_entry(
@@ -136,6 +91,7 @@ async def test_setup_config_entry(
             "template_type": "select",
             "state": "{{ 'on' }}",
             "options": "{{ ['off', 'on', 'auto'] }}",
+            "select_option": [],
         },
         title="My template",
     )
@@ -149,27 +105,24 @@ async def test_setup_config_entry(
     assert state == snapshot
 
 
+@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "state": "{{ 'a' }}",
+            "select_option": {"service": "script.select_option"},
+            "options": "{{ ['a', 'b'] }}",
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.usefixtures("setup_select")
 async def test_missing_optional_config(hass: HomeAssistant) -> None:
     """Test: missing optional template is ok."""
-    with assert_setup_component(1, "template"):
-        assert await setup.async_setup_component(
-            hass,
-            "template",
-            {
-                "template": {
-                    "select": {
-                        "state": "{{ 'a' }}",
-                        "select_option": {"service": "script.select_option"},
-                        "options": "{{ ['a', 'b'] }}",
-                    }
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
     _verify(hass, "a", ["a", "b"])
 
 
@@ -202,231 +155,85 @@ async def test_multiple_configs(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     _verify(hass, "a", ["a", "b"])
-    _verify(hass, "a", ["a", "b"], f"{_TEST_SELECT}_2")
+    _verify(hass, "a", ["a", "b"], f"{TEST_SELECT.entity_id}_2")
 
 
+@pytest.mark.parametrize("count", [0])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "state": "{{ 'a' }}",
+            "select_option": {"service": "script.select_option"},
+        },
+        {
+            "state": "{{ 'a' }}",
+            "options": "{{ ['a', 'b'] }}",
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.usefixtures("setup_select")
 async def test_missing_required_keys(hass: HomeAssistant) -> None:
     """Test: missing required fields will fail."""
-    with assert_setup_component(0, "select"):
-        assert await setup.async_setup_component(
-            hass,
-            "select",
-            {
-                "template": {
-                    "select": {
-                        "state": "{{ 'a' }}",
-                        "select_option": {"service": "script.select_option"},
-                    }
-                }
-            },
-        )
-
-    with assert_setup_component(0, "select"):
-        assert await setup.async_setup_component(
-            hass,
-            "select",
-            {
-                "template": {
-                    "select": {
-                        "state": "{{ 'a' }}",
-                        "options": "{{ ['a', 'b'] }}",
-                    }
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
     assert hass.states.async_all("select") == []
 
 
-async def test_templates_with_entities(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls: list[ServiceCall]
-) -> None:
+@pytest.mark.parametrize(
+    ("count", "config"),
+    [
+        (
+            1,
+            {
+                "options": "{{ state_attr('select.test_state', 'options') or [] }}",
+                "select_option": [TEST_OPTION_ACTION],
+                "state": "{{ states('select.test_state') }}",
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.usefixtures("setup_select")
+async def test_template_select(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test templates with values from other entities."""
-    with assert_setup_component(1, "input_select"):
-        assert await setup.async_setup_component(
-            hass,
-            "input_select",
-            {
-                "input_select": {
-                    "option": {
-                        "options": ["a", "b"],
-                        "initial": "a",
-                        "name": "Option",
-                    },
-                }
-            },
-        )
 
-    with assert_setup_component(1, "template"):
-        assert await setup.async_setup_component(
-            hass,
-            "template",
-            {
-                "template": {
-                    "unique_id": "b",
-                    "select": {
-                        "state": f"{{{{ states('{_OPTION_INPUT_SELECT}') }}}}",
-                        "options": f"{{{{ state_attr('{_OPTION_INPUT_SELECT}', '{INPUT_SELECT_ATTR_OPTIONS}') }}}}",
-                        "select_option": [
-                            {
-                                "service": "input_select.select_option",
-                                "data_template": {
-                                    "entity_id": _OPTION_INPUT_SELECT,
-                                    "option": "{{ option }}",
-                                },
-                            },
-                            {
-                                "service": "test.automation",
-                                "data_template": {
-                                    "action": "select_option",
-                                    "caller": "{{ this.entity_id }}",
-                                    "option": "{{ option }}",
-                                },
-                            },
-                        ],
-                        "optimistic": True,
-                        "unique_id": "a",
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    entry = entity_registry.async_get(_TEST_SELECT)
-    assert entry
-    assert entry.unique_id == "b-a"
-
+    attributes = {"options": ["a", "b"]}
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "a", attributes)
     _verify(hass, "a", ["a", "b"])
 
-    await hass.services.async_call(
-        INPUT_SELECT_DOMAIN,
-        INPUT_SELECT_SERVICE_SELECT_OPTION,
-        {CONF_ENTITY_ID: _OPTION_INPUT_SELECT, INPUT_SELECT_ATTR_OPTION: "b"},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "b", attributes)
     _verify(hass, "b", ["a", "b"])
 
-    await hass.services.async_call(
-        INPUT_SELECT_DOMAIN,
-        SERVICE_SET_OPTIONS,
-        {
-            CONF_ENTITY_ID: _OPTION_INPUT_SELECT,
-            INPUT_SELECT_ATTR_OPTIONS: ["a", "b", "c"],
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    attributes = {"options": ["a", "b", "c"]}
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "b", attributes)
     _verify(hass, "b", ["a", "b", "c"])
 
     await hass.services.async_call(
         SELECT_DOMAIN,
         SELECT_SERVICE_SELECT_OPTION,
-        {CONF_ENTITY_ID: _TEST_SELECT, SELECT_ATTR_OPTION: "c"},
+        {CONF_ENTITY_ID: TEST_SELECT.entity_id, SELECT_ATTR_OPTION: "c"},
         blocking=True,
     )
-    _verify(hass, "c", ["a", "b", "c"])
 
     # Check this variable can be used in set_value script
     assert len(calls) == 1
     assert calls[-1].data["action"] == "select_option"
-    assert calls[-1].data["caller"] == _TEST_SELECT
+    assert calls[-1].data["caller"] == TEST_SELECT.entity_id
     assert calls[-1].data["option"] == "c"
 
-
-async def test_trigger_select(hass: HomeAssistant) -> None:
-    """Test trigger based template select."""
-    events = async_capture_events(hass, "test_number_event")
-    action_events = async_capture_events(hass, "action_event")
-    assert await setup.async_setup_component(
-        hass,
-        "template",
-        {
-            "template": [
-                {"invalid": "config"},
-                # Config after invalid should still be set up
-                {
-                    "unique_id": "listening-test-event",
-                    "trigger": {"platform": "event", "event_type": "test_event"},
-                    "variables": {"beer": "{{ trigger.event.data.beer }}"},
-                    "action": [
-                        {"event": "action_event", "event_data": {"beer": "{{ beer }}"}}
-                    ],
-                    "select": [
-                        {
-                            "name": "Hello Name",
-                            "unique_id": "hello_name-id",
-                            "state": "{{ trigger.event.data.beer }}",
-                            "options": "{{ trigger.event.data.beers }}",
-                            "select_option": {
-                                "event": "test_number_event",
-                                "event_data": {
-                                    "entity_id": "{{ this.entity_id }}",
-                                    "beer": "{{ beer }}",
-                                },
-                            },
-                            "optimistic": True,
-                        },
-                    ],
-                },
-            ],
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    state = hass.states.get("select.hello_name")
-    assert state is not None
-    assert state.state == STATE_UNKNOWN
-
-    context = Context()
-    hass.bus.async_fire(
-        "test_event", {"beer": "duff", "beers": ["duff", "alamo"]}, context=context
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("select.hello_name")
-    assert state is not None
-    assert state.state == "duff"
-    assert state.attributes["options"] == ["duff", "alamo"]
-
-    assert len(action_events) == 1
-    assert action_events[0].event_type == "action_event"
-    beer = action_events[0].data.get("beer")
-    assert beer is not None
-    assert beer == "duff"
-
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SELECT_SERVICE_SELECT_OPTION,
-        {CONF_ENTITY_ID: "select.hello_name", SELECT_ATTR_OPTION: "alamo"},
-        blocking=True,
-    )
-    assert len(events) == 1
-    assert events[0].event_type == "test_number_event"
-    entity_id = events[0].data.get("entity_id")
-    assert entity_id is not None
-    assert entity_id == "select.hello_name"
-
-    beer = events[0].data.get("beer")
-    assert beer is not None
-    assert beer == "duff"
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "c", attributes)
+    _verify(hass, "c", ["a", "b", "c"])
 
 
 def _verify(
     hass: HomeAssistant,
     expected_current_option: str,
     expected_options: list[str],
-    entity_name: str = _TEST_SELECT,
+    entity_name: str = TEST_SELECT.entity_id,
 ) -> None:
     """Verify select's state."""
     state = hass.states.get(entity_name)
@@ -441,7 +248,7 @@ def _verify(
     [(ConfigurationStyle.MODERN, ""), (ConfigurationStyle.TRIGGER, None)],
 )
 @pytest.mark.parametrize(
-    ("select_config", "attribute", "expected"),
+    ("config", "attribute", "expected"),
     [
         (
             {
@@ -469,13 +276,13 @@ async def test_templated_optional_config(
     initial_expected_state: str | None,
 ) -> None:
     """Test optional config templates."""
-    state = hass.states.get(_TEST_SELECT)
+    state = hass.states.get(TEST_SELECT.entity_id)
     assert state.attributes.get(attribute) == initial_expected_state
 
     state = hass.states.async_set(TEST_STATE_ENTITY_ID, "yes")
     await hass.async_block_till_done()
 
-    state = hass.states.get(_TEST_SELECT)
+    state = hass.states.get(TEST_SELECT.entity_id)
 
     assert state.attributes[attribute] == expected
 
@@ -506,6 +313,7 @@ async def test_device_id(
             "template_type": "select",
             "state": "{{ 'on' }}",
             "options": "{{ ['off', 'on', 'auto'] }}",
+            "select_option": [],
             "device_id": device_entry.id,
         },
         title="My template",
@@ -521,7 +329,7 @@ async def test_device_id(
 
 
 @pytest.mark.parametrize(
-    ("count", "select_config"),
+    ("count", "config"),
     [
         (
             1,
@@ -540,21 +348,22 @@ async def test_device_id(
         ConfigurationStyle.MODERN,
     ],
 )
-async def test_empty_action_config(hass: HomeAssistant, setup_select) -> None:
+@pytest.mark.usefixtures("setup_select")
+async def test_empty_action_config(hass: HomeAssistant) -> None:
     """Test configuration with empty script."""
     await hass.services.async_call(
         select.DOMAIN,
         select.SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: _TEST_SELECT, "option": "a"},
+        {ATTR_ENTITY_ID: TEST_SELECT.entity_id, "option": "a"},
         blocking=True,
     )
 
-    state = hass.states.get(_TEST_SELECT)
+    state = hass.states.get(TEST_SELECT.entity_id)
     assert state.state == "a"
 
 
 @pytest.mark.parametrize(
-    ("count", "select_config"),
+    ("count", "config"),
     [
         (
             1,
@@ -573,7 +382,7 @@ async def test_empty_action_config(hass: HomeAssistant, setup_select) -> None:
 async def test_optimistic(hass: HomeAssistant) -> None:
     """Test configuration with optimistic state."""
 
-    state = hass.states.get(_TEST_SELECT)
+    state = hass.states.get(TEST_SELECT.entity_id)
     assert state.state == STATE_UNKNOWN
 
     # Ensure Trigger template entities update.
@@ -583,26 +392,26 @@ async def test_optimistic(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         select.DOMAIN,
         select.SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: _TEST_SELECT, "option": "test"},
+        {ATTR_ENTITY_ID: TEST_SELECT.entity_id, "option": "test"},
         blocking=True,
     )
 
-    state = hass.states.get(_TEST_SELECT)
+    state = hass.states.get(TEST_SELECT.entity_id)
     assert state.state == "test"
 
     await hass.services.async_call(
         select.DOMAIN,
         select.SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: _TEST_SELECT, "option": "yes"},
+        {ATTR_ENTITY_ID: TEST_SELECT.entity_id, "option": "yes"},
         blocking=True,
     )
 
-    state = hass.states.get(_TEST_SELECT)
+    state = hass.states.get(TEST_SELECT.entity_id)
     assert state.state == "yes"
 
 
 @pytest.mark.parametrize(
-    ("count", "select_config"),
+    ("count", "config"),
     [
         (
             1,
@@ -629,16 +438,16 @@ async def test_not_optimistic(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         select.DOMAIN,
         select.SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: _TEST_SELECT, "option": "test"},
+        {ATTR_ENTITY_ID: TEST_SELECT.entity_id, "option": "test"},
         blocking=True,
     )
 
-    state = hass.states.get(_TEST_SELECT)
+    state = hass.states.get(TEST_SELECT.entity_id)
     assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(
-    ("count", "select_config"),
+    ("count", "config"),
     [
         (
             1,
@@ -662,25 +471,25 @@ async def test_availability(hass: HomeAssistant) -> None:
     hass.states.async_set(TEST_STATE_ENTITY_ID, "test")
     await hass.async_block_till_done()
 
-    state = hass.states.get(_TEST_SELECT)
+    state = hass.states.get(TEST_SELECT.entity_id)
     assert state.state == "test"
 
     hass.states.async_set(TEST_AVAILABILITY_ENTITY_ID, "off")
     await hass.async_block_till_done()
 
-    state = hass.states.get(_TEST_SELECT)
+    state = hass.states.get(TEST_SELECT.entity_id)
     assert state.state == STATE_UNAVAILABLE
 
     hass.states.async_set(TEST_STATE_ENTITY_ID, "yes")
     await hass.async_block_till_done()
 
-    state = hass.states.get(_TEST_SELECT)
+    state = hass.states.get(TEST_SELECT.entity_id)
     assert state.state == STATE_UNAVAILABLE
 
     hass.states.async_set(TEST_AVAILABILITY_ENTITY_ID, "on")
     await hass.async_block_till_done()
 
-    state = hass.states.get(_TEST_SELECT)
+    state = hass.states.get(TEST_SELECT.entity_id)
     assert state.state == "yes"
 
 
@@ -698,3 +507,36 @@ async def test_flow_preview(
     )
 
     assert state["state"] == "test"
+
+
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+async def test_unique_id(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+) -> None:
+    """Test unique_id option only creates one vacuum per id."""
+    await setup_and_test_unique_id(
+        hass, TEST_SELECT, style, TEST_OPTIONS_WITHOUT_STATE, "{{ 'test' }}"
+    )
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+async def test_nested_unique_id(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a template unique_id propagates to vacuum unique_ids."""
+    await setup_and_test_nested_unique_id(
+        hass,
+        TEST_SELECT,
+        style,
+        entity_registry,
+        TEST_OPTIONS_WITHOUT_STATE,
+        "{{ 'test' }}",
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update the template select tests to use the new framework.  This exposed an issue broken by https://github.com/home-assistant/core/pull/149018.  During the previous refactor in July 2025, 2 vol.Required tags were changed to vol.Optional.  This PR addresses that issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
