### PR TITLE
Conversation prompt config entry for LLM in cloud integration

### DIFF
--- a/homeassistant/components/cloud/config_flow.py
+++ b/homeassistant/components/cloud/config_flow.py
@@ -4,9 +4,18 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+import voluptuous as vol
 
-from .const import DOMAIN
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
+from homeassistant.helpers import llm
+from homeassistant.helpers.selector import TemplateSelector
+
+from .const import CONF_PROMPT, DOMAIN
 
 
 class CloudConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -14,8 +23,44 @@ class CloudConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @staticmethod
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Get the options flow for this handler."""
+        return CloudOptionsFlow(config_entry)
+
     async def async_step_system(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the system step."""
         return self.async_create_entry(title="Home Assistant Cloud", data={})
+
+
+class CloudOptionsFlow(OptionsFlow):
+    """Handle Home Assistant Cloud options."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize the options flow."""
+        self._config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage Cloud options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_PROMPT,
+                        description={
+                            "suggested_value": self._config_entry.options.get(
+                                CONF_PROMPT, llm.DEFAULT_INSTRUCTIONS_PROMPT
+                            )
+                        },
+                    ): TemplateSelector(),
+                }
+            ),
+        )

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -83,6 +83,8 @@ CONF_RELAYER_SERVER = "relayer_server"
 CONF_REMOTESTATE_SERVER = "remotestate_server"
 CONF_SERVICEHANDLERS_SERVER = "servicehandlers_server"
 
+CONF_PROMPT = "prompt"
+
 MODE_DEV = "development"
 MODE_PROD = "production"
 

--- a/homeassistant/components/cloud/conversation.py
+++ b/homeassistant/components/cloud/conversation.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CONVERSATION_ENTITY_UNIQUE_ID, DATA_CLOUD, DOMAIN
+from .const import CONF_PROMPT, CONVERSATION_ENTITY_UNIQUE_ID, DATA_CLOUD, DOMAIN
 from .entity import BaseCloudLLMEntity
 
 
@@ -57,7 +57,7 @@ class CloudConversationEntity(
             await chat_log.async_provide_llm_data(
                 user_input.as_llm_context(DOMAIN),
                 llm.LLM_API_ASSIST,
-                None,
+                self._entry.options.get(CONF_PROMPT),
                 user_input.extra_system_prompt,
             )
         except conversation.ConverseError as err:

--- a/homeassistant/components/cloud/strings.json
+++ b/homeassistant/components/cloud/strings.json
@@ -72,6 +72,18 @@
       "title": "Detected wrong custom domain configuration"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "prompt": "[%key:common::config_flow::data::prompt%]"
+        },
+        "data_description": {
+          "prompt": "Instruct how the LLM should respond. This can be a template."
+        }
+      }
+    }
+  },
   "services": {
     "remote_connect": {
       "description": "Makes the instance UI accessible from outside of the local network by enabling your Home Assistant Cloud connection.",

--- a/tests/components/cloud/test_config_flow.py
+++ b/tests/components/cloud/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from homeassistant.components.cloud.const import DOMAIN
+from homeassistant.components.cloud.const import CONF_PROMPT, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -43,3 +43,24 @@ async def test_multiple_entries(hass: HomeAssistant) -> None:
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
+
+
+async def test_options_flow_prompt(hass: HomeAssistant) -> None:
+    """Test updating the Cloud prompt via options flow."""
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    prompt = "My custom prompt"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_PROMPT: prompt}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_PROMPT: prompt}
+
+    updated_entry = hass.config_entries.async_get_entry(config_entry.entry_id)
+    assert updated_entry
+    assert updated_entry.options[CONF_PROMPT] == prompt

--- a/tests/components/cloud/test_conversation.py
+++ b/tests/components/cloud/test_conversation.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from homeassistant.components import conversation
-from homeassistant.components.cloud.const import DOMAIN
+from homeassistant.components.cloud.const import CONF_PROMPT, DOMAIN
 from homeassistant.components.cloud.conversation import CloudConversationEntity
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import intent, llm
@@ -22,7 +22,7 @@ def cloud_conversation_entity(hass: HomeAssistant) -> CloudConversationEntity:
     cloud.llm = MagicMock()
     cloud.is_logged_in = True
     cloud.valid_subscription = True
-    entry = MockConfigEntry(domain=DOMAIN)
+    entry = MockConfigEntry(domain=DOMAIN, options={CONF_PROMPT: "Custom prompt"})
     entry.add_to_hass(hass)
     entity = CloudConversationEntity(cloud, entry)
     entity.entity_id = "conversation.home_assistant_cloud"
@@ -87,7 +87,7 @@ async def test_async_handle_message(
     chat_log.async_provide_llm_data.assert_awaited_once_with(
         user_input.as_llm_context(DOMAIN),
         llm.LLM_API_ASSIST,
-        None,
+        "Custom prompt",
         user_input.extra_system_prompt,
     )
     handle_chat_log.assert_awaited_once_with("conversation", chat_log)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a new config entry for the conversation agent prompt for the cloud integration
<img width="518" height="254" alt="imagen" src="https://github.com/user-attachments/assets/0356f9d0-37bc-4462-9684-6b79f9f8aed2" />
<img width="561" height="847" alt="imagen" src="https://github.com/user-attachments/assets/17726067-9edf-4122-9913-6f5a9a012595" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
