### PR TITLE
Replace soft-deprecated os.popen

### DIFF
--- a/homeassistant/scripts/macos/__init__.py
+++ b/homeassistant/scripts/macos/__init__.py
@@ -1,6 +1,7 @@
 """Script to install/uninstall HA into OS X."""
 
 import os
+import subprocess
 import time
 
 # mypy: allow-untyped-calls, allow-untyped-defs
@@ -8,11 +9,11 @@ import time
 
 def install_osx():
     """Set up to run via launchd on OS X."""
-    with os.popen("which hass") as inp:
-        hass_path = inp.read().strip()
+    p = subprocess.run(["which", "hass"], check=False, text=True, capture_output=True)
+    hass_path = p.stdout.strip()
 
-    with os.popen("whoami") as inp:
-        user = inp.read().strip()
+    p = subprocess.run(["whoami"], check=False, text=True, capture_output=True)
+    user = p.stdout.strip()
 
     template_path = os.path.join(os.path.dirname(__file__), "launchd.plist")
 
@@ -31,7 +32,7 @@ def install_osx():
         print(f"Unable to write to {path}", err)
         return
 
-    os.popen(f"launchctl load -w -F {path}")
+    subprocess.run(["launchctl", "load", "-w", "-F", path], check=True)
 
     print("Home Assistant has been installed. Open it here: http://localhost:8123")
 
@@ -39,7 +40,7 @@ def install_osx():
 def uninstall_osx():
     """Unload from launchd on OS X."""
     path = os.path.expanduser("~/Library/LaunchAgents/org.homeassistant.plist")
-    os.popen(f"launchctl unload {path}")
+    subprocess.run(["launchctl", "unload", path], check=True)
 
     print("Home Assistant has been uninstalled.")
 


### PR DESCRIPTION
## Proposed change
In Python 3.14 `os.popen` is considered soft-deprecated. Internally it's just an alias for `subprocess.Popen` with some arguments.

https://github.com/python/cpython/blob/v3.14.2/Lib/os.py#L1023-L1036

Replace it with calls to `subprocess.run`. Changed `cmd` from string to list to be able to remove `shell=True`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
