### PR TITLE
Migrate Orvibo integration to config flow

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1199,6 +1199,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/oralb/ @bdraco @Lash-L
 /tests/components/oralb/ @bdraco @Lash-L
 /homeassistant/components/oru/ @bvlaicu
+/homeassistant/components/orvibo/ @ryanep
+/tests/components/orvibo/ @ryanep
 /homeassistant/components/osoenergy/ @osohotwateriot
 /tests/components/osoenergy/ @osohotwateriot
 /homeassistant/components/otbr/ @home-assistant/core

--- a/homeassistant/components/orvibo/__init__.py
+++ b/homeassistant/components/orvibo/__init__.py
@@ -1,1 +1,46 @@
-"""The orvibo component."""
+"""The Orvibo integration."""
+
+from dataclasses import dataclass
+
+from orvibo.s20 import S20, S20Exception
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_MAC, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+
+@dataclass
+class OrviboData:
+    """State of integration."""
+
+    switch: S20
+
+
+type OrviboConfigEntry = ConfigEntry[OrviboData]
+
+PLATFORMS = [Platform.SWITCH]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: OrviboConfigEntry) -> bool:
+    """Set up Orvibo from a config entry."""
+
+    try:
+        switch = await hass.async_add_executor_job(
+            S20, entry.data[CONF_HOST], entry.data[CONF_MAC]
+        )
+    except S20Exception:
+        raise ConfigEntryNotReady(
+            f"Failed to connect to switch at {entry.data[CONF_HOST]}"
+        ) from None
+
+    entry.runtime_data = OrviboData(switch=switch)
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/orvibo/config_flow.py
+++ b/homeassistant/components/orvibo/config_flow.py
@@ -1,0 +1,101 @@
+"""Config flow for the Orvibo integration."""
+
+import logging
+import re
+from typing import Any
+
+from orvibo.s20 import S20, S20Exception
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_MAC
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.util.network import is_host_valid
+
+from .const import DEFAULT_NAME, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_MAC): str,
+    }
+)
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]):
+    """Validate the user input allows us to connect."""
+
+    if not is_host_valid(data[CONF_HOST]):
+        raise InvalidHost
+
+    if not _is_mac_valid(data[CONF_MAC]):
+        raise InvalidMac
+
+    try:
+        await hass.async_add_executor_job(S20, data[CONF_HOST], data[CONF_MAC])
+    except S20Exception:
+        raise CannotConnect from None
+    except Exception:
+        _LOGGER.exception("Error connecting to S20 switch")
+        raise CannotConnect from None
+
+
+def _is_mac_valid(value):
+    """Validate MAC address format."""
+
+    mac_address_pattern = r"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$"
+    return re.match(mac_address_pattern, value) is not None
+
+
+class OrviboConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Orvibo config flow."""
+
+    VERSION = 1
+    MINOR_VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a flow initialized by the user."""
+
+        errors: dict[str, str] = {}
+
+        if user_input:
+            user_input[CONF_MAC] = format_mac(user_input[CONF_MAC])
+
+            self._async_abort_entries_match({CONF_MAC: user_input[CONF_MAC]})
+
+            try:
+                await validate_input(self.hass, user_input)
+            except InvalidHost:
+                errors["base"] = "invalid_host"
+            except InvalidMac:
+                errors["base"] = "invalid_mac"
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title=DEFAULT_NAME,
+                    data={
+                        CONF_HOST: user_input[CONF_HOST],
+                        CONF_MAC: user_input[CONF_MAC],
+                    },
+                )
+
+        return self.async_show_form(step_id="user", data_schema=SCHEMA, errors=errors)
+
+
+class InvalidHost(HomeAssistantError):
+    """Error to indicate an invalid hostname."""
+
+
+class InvalidMac(HomeAssistantError):
+    """Error to indicate an invalid mac address."""
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/orvibo/const.py
+++ b/homeassistant/components/orvibo/const.py
@@ -1,0 +1,7 @@
+"""Constants for the Orvibo integration."""
+
+DOMAIN = "orvibo"
+MANUFACTURER = "Orvibo"
+MODEL = "S20"
+
+DEFAULT_NAME = "S20 Smart Switch"

--- a/homeassistant/components/orvibo/manifest.json
+++ b/homeassistant/components/orvibo/manifest.json
@@ -1,9 +1,11 @@
 {
   "domain": "orvibo",
   "name": "Orvibo",
-  "codeowners": [],
+  "codeowners": ["@ryanep"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/orvibo",
-  "iot_class": "local_push",
+  "integration_type": "device",
+  "iot_class": "local_polling",
   "loggers": ["orvibo"],
   "quality_scale": "legacy",
   "requirements": ["orvibo==1.1.2"]

--- a/homeassistant/components/orvibo/strings.json
+++ b/homeassistant/components/orvibo/strings.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
+      "invalid_mac": "Invalid MAC address"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "Host",
+          "mac": "MAC address"
+        },
+        "data_description": {
+          "host": "The hostname or IP address of your Orvibo S20 device",
+          "mac": "The MAC address of your Orvibo S20 device"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -499,6 +499,7 @@ FLOWS = {
         "openweathermap",
         "opower",
         "oralb",
+        "orvibo",
         "osoenergy",
         "otbr",
         "otp",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4885,9 +4885,9 @@
     },
     "orvibo": {
       "name": "Orvibo",
-      "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "local_push"
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "local_polling"
     },
     "osoenergy": {
       "name": "OSO Energy",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1462,6 +1462,9 @@ opower==0.16.4
 # homeassistant.components.oralb
 oralb-ble==1.0.2
 
+# homeassistant.components.orvibo
+orvibo==1.1.2
+
 # homeassistant.components.ourgroceries
 ourgroceries==1.5.4
 

--- a/tests/components/orvibo/__init__.py
+++ b/tests/components/orvibo/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Orvibo integration."""

--- a/tests/components/orvibo/test_config_flow.py
+++ b/tests/components/orvibo/test_config_flow.py
@@ -1,0 +1,111 @@
+"""Test the Orvibo config flow."""
+
+from unittest.mock import MagicMock, patch
+
+from orvibo.s20 import S20Exception
+
+from homeassistant import config_entries
+from homeassistant.components.orvibo.const import DEFAULT_NAME, DOMAIN
+from homeassistant.const import CONF_HOST, CONF_MAC
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+MODULE = "homeassistant.components.orvibo.config_flow.S20"
+
+
+async def test_user_step_invalid_host(hass: HomeAssistant) -> None:
+    """Test we show invalid_host error when entering an invalid host."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "__INVALID_HOST__", CONF_MAC: "AA:BB:CC:DD:EE:FF"},
+    )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_host"}
+
+
+async def test_user_step_invalid_mac_address(hass: HomeAssistant) -> None:
+    """Test we show invalid_mac error when entering an invalid mac address."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "1.2.3.4", CONF_MAC: "__INVALID_MAC__"},
+    )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_mac"}
+
+
+async def test_user_step_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we show cannot_connect error on connection error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    with patch(
+        MODULE,
+        side_effect=S20Exception("fail"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "1.2.3.4", CONF_MAC: "AA:BB:CC:DD:EE:FF"}
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_step_unexpected_error(hass: HomeAssistant) -> None:
+    """Test we show cannot_connect error on unexpected error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    with patch(
+        MODULE,
+        side_effect=Exception("fail"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "1.2.3.4", CONF_MAC: "AA:BB:CC:DD:EE:FF"}
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_step_success(hass: HomeAssistant) -> None:
+    """Test we can finish a config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with (
+        patch(MODULE, return_value=MagicMock()),
+        patch(
+            "homeassistant.components.orvibo.async_setup_entry", return_value=True
+        ) as mock_setup_entry,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "1.2.3.4", CONF_MAC: "AA:BB:CC:DD:EE:FF"}
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == DEFAULT_NAME
+    assert result2["data"] == {
+        CONF_HOST: "1.2.3.4",
+        CONF_MAC: "aa:bb:cc:dd:ee:ff",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
Migrate the Orvibo integration from the legacy YAML-based integration to the modern config flow-based system.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Users with existing YAML configuration will have to add devices manually via the new config flow.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Update __init__.py to add `async_setup_entry` flow and add entry `runtime_data`.
- Add config_flow.py to allow device configuration from the UI.
- Add const.py with domain, manufacturer and model constants.
- Update switch.py to:
  - Replace `setup_platform` with `async_setup_entry`.
  - Add device registry support with `DeviceInfo`.
  - Explicitly set `SCAN_INTERVAL` to 30 seconds.
- Add strings.json for config flow translations.
- Add config flow tests.
- Update manifest to enable config flow and correct `iot_class` to `local_polling`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
