### PR TITLE
Hassfest: Don't allow placeholders in state translations

### DIFF
--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -127,22 +127,37 @@ def translation_key_validator(value: str) -> str:
     return value
 
 
-def translation_value_validator(value: Any) -> str:
+def validate_translation_value(value: Any, allow_placeholders=True) -> str:
     """Validate that the value is a valid translation.
 
     - prevents string with HTML
     - prevents strings with single quoted placeholders
     - prevents strings with placeholders using invalid identifiers
+    - prevents placeholders where they are not allowed
     - prevents combined translations
     """
     string_value = cv.string_with_no_html(value)
     string_value = string_no_single_quoted_placeholders(string_value)
-    string_value = validate_placeholders(string_value)
+    string_value = validate_placeholders(string_value, allow_placeholders)
     if RE_COMBINED_REFERENCE.search(string_value):
         raise vol.Invalid("the string should not contain combined translations")
     if string_value != string_value.strip():
         raise vol.Invalid("the string should not contain leading or trailing spaces")
     return string_value
+
+
+def translation_value_validator(value: Any) -> str:
+    """Validate translation value with default options."""
+    return validate_translation_value(value)
+
+
+def custom_translation_value_validator(allow_placeholders=True):
+    """Validate translation value with custom options."""
+
+    def _validator(value: Any) -> str:
+        return validate_translation_value(value, allow_placeholders)
+
+    return _validator
 
 
 def string_no_single_quoted_placeholders(value: str) -> str:
@@ -154,12 +169,14 @@ def string_no_single_quoted_placeholders(value: str) -> str:
     return value
 
 
-def validate_placeholders(value: str) -> str:
+def validate_placeholders(value: str, allow_placeholders: bool) -> str:
     """Validate that placeholders in translations use valid identifiers."""
     formatter = string.Formatter()
 
     for _, field_name, _, _ in formatter.parse(value):
         if field_name:  # skip literal text segments
+            if not allow_placeholders:
+                raise vol.Invalid("placeholders are not supported in this value")
             if not field_name.isidentifier():
                 raise vol.Invalid(
                     "placeholders must be valid identifiers ([a-zA-Z_][a-zA-Z0-9_]*)"
@@ -404,14 +421,16 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                 {
                     vol.Optional("name"): str,
                     vol.Optional("state"): cv.schema_with_slug_keys(
-                        translation_value_validator,
+                        custom_translation_value_validator(allow_placeholders=False),
                         slug_validator=translation_key_validator,
                     ),
                     vol.Optional("state_attributes"): cv.schema_with_slug_keys(
                         {
                             vol.Optional("name"): str,
                             vol.Optional("state"): cv.schema_with_slug_keys(
-                                translation_value_validator,
+                                custom_translation_value_validator(
+                                    allow_placeholders=False
+                                ),
                                 slug_validator=translation_key_validator,
                             ),
                         },
@@ -431,14 +450,22 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                     {
                         vol.Optional("name"): translation_value_validator,
                         vol.Optional("state"): cv.schema_with_slug_keys(
-                            translation_value_validator,
+                            custom_translation_value_validator(
+                                allow_placeholders=False
+                            ),
                             slug_validator=translation_key_validator,
                         ),
                         vol.Optional("state_attributes"): cv.schema_with_slug_keys(
                             {
-                                vol.Optional("name"): translation_value_validator,
+                                vol.Optional(
+                                    "name"
+                                ): custom_translation_value_validator(
+                                    allow_placeholders=False
+                                ),
                                 vol.Optional("state"): cv.schema_with_slug_keys(
-                                    translation_value_validator,
+                                    custom_translation_value_validator(
+                                        allow_placeholders=False
+                                    ),
                                     slug_validator=translation_key_validator,
                                 ),
                             },
@@ -446,7 +473,7 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                         ),
                         vol.Optional(
                             "unit_of_measurement"
-                        ): translation_value_validator,
+                        ): custom_translation_value_validator(allow_placeholders=False),
                     },
                     slug_validator=translation_key_validator,
                 ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I do not believe placeholders are supported in state translations. Hassfest validates translation strings, but it assumes placeholders are allowed in every case. 

Instead we can flag a validation error if a placeholder is discovered in a state, attribute name, attribute value, or unit_of_measurement translation. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/frontend/issues/29064
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
