### PR TITLE
Fix TriggerEntity's _handle_rendered_results for loop exiting early

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -295,7 +295,13 @@ class TriggerBinarySensorEntity(TriggerEntity, AbstractTemplateBinarySensor):
         self._last_delay_to: bool | None = None
         self._auto_off_cancel: CALLBACK_TYPE | None = None
         self._auto_off_time: datetime | None = None
-        self.setup_template(CONF_AUTO_OFF, "_auto_off_time", cv.positive_time_period)
+
+        # Auto off should not render the result as a stand alone template, it should
+        # only be render when the binary sensor state updates. The validator for
+        # Auto off is built into self._set_state.
+        if isinstance(config.get(CONF_AUTO_OFF), template.Template):
+            self._to_render_simple.append(CONF_AUTO_OFF)
+            self._parse_result.add(CONF_AUTO_OFF)
 
     async def async_added_to_hass(self) -> None:
         """Restore last state."""

--- a/tests/components/template/test_trigger_entity.py
+++ b/tests/components/template/test_trigger_entity.py
@@ -2,13 +2,17 @@
 
 import pytest
 
-from homeassistant.components.template import trigger_entity
+from homeassistant.components.template import DOMAIN, trigger_entity
 from homeassistant.components.template.coordinator import TriggerUpdateCoordinator
 from homeassistant.const import CONF_ICON, CONF_NAME, CONF_STATE, STATE_OFF, STATE_ON
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import template
-from homeassistant.helpers.script_variables import ScriptVariables
 from homeassistant.helpers.trigger_template_entity import CONF_PICTURE
+from homeassistant.setup import async_setup_component
+
+from .conftest import async_trigger
+
+from tests.common import assert_setup_component
 
 _ICON_TEMPLATE = 'mdi:o{{ "n" if value=="on" else "ff" }}'
 _PICTURE_TEMPLATE = '/local/picture_o{{ "n" if value=="on" else "ff" }}'
@@ -122,44 +126,58 @@ async def test_template_state_syntax_error(
     assert entity.entity_picture is None
 
 
-async def test_script_variables_from_coordinator(hass: HomeAssistant) -> None:
+async def test_script_variables_from_coordinator(
+    hass: HomeAssistant, calls: list[ServiceCall], caplog: pytest.LogCaptureFixture
+) -> None:
     """Test script variables."""
+    await async_trigger(hass, "sensor.start", "1")
+    with assert_setup_component(1, DOMAIN):
+        assert await async_setup_component(
+            hass,
+            DOMAIN,
+            {
+                "template": {
+                    "variables": {"a": "{{ states('sensor.start') }}", "c": 0},
+                    "triggers": {
+                        "trigger": "state",
+                        "entity_id": ["sensor.trigger"],
+                    },
+                    "actions": [
+                        {
+                            "action": "test.automation",
+                            "data": {
+                                "a": "{{ a }}",
+                                "b": "{{ b }}",
+                                "c": "{{ c }}",
+                            },
+                        }
+                    ],
+                    "sensor": {
+                        "name": "test",
+                        "state": "{{ 'on' }}",
+                        "variables": {"b": "{{ a + 1 }}", "c": 1},
+                        "attributes": {
+                            "a": "{{ a }}",
+                            "b": "{{ b }}",
+                            "c": "{{ c }}",
+                        },
+                    },
+                },
+            },
+        )
+    await async_trigger(hass, "sensor.trigger", "anything")
 
-    hass.states.async_set("sensor.test", "1")
+    assert len(calls) == 1
+    assert calls[0].data["a"] == 1
+    assert calls[0].data["c"] == 0
+    assert "'b' is undefined when rendering '{{ b }}'" in caplog.text
 
-    coordinator = TriggerUpdateCoordinator(
-        hass,
-        {
-            "variables": ScriptVariables(
-                {"a": template.Template("{{ states('sensor.test') }}", hass), "c": 0}
-            )
-        },
-    )
-    entity = TestEntity(
-        hass,
-        coordinator,
-        {
-            "state": template.Template("{{ 'on' }}", hass),
-            "variables": ScriptVariables(
-                {"b": template.Template("{{ a + 1 }}", hass), "c": 1}
-            ),
-        },
-    )
-    await coordinator._handle_triggered({})
-    entity._process_data()
-    assert entity._render_script_variables() == {"a": 1, "b": 2, "c": 1}
-
-    hass.states.async_set("sensor.test", "2")
-
-    await coordinator._handle_triggered({"value": STATE_ON})
-    entity._process_data()
-
-    assert entity._render_script_variables() == {
-        "value": STATE_ON,
-        "a": 2,
-        "b": 3,
-        "c": 1,
-    }
+    state = hass.states.get("sensor.test")
+    assert state
+    assert state.state == "on"
+    assert state.attributes["a"] == 1
+    assert state.attributes["b"] == 2
+    assert state.attributes["c"] == 1
 
 
 async def test_default_entity_id(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When implementing https://github.com/home-assistant/core/pull/161481, I found an issue with the new template framework.  The new entity framework is only resolving a single template because of a return inside the for loop in `TriggerEntity._handle_rendered_results`.  When fixing this, it exposed a mistake in binary_sensor template entities.  This mistake was not breaking, however it created an additional exception in the logs because `auto_off` was being resolved.  `auto_off` should only be resolved when the state updates.  This PR addresses that.

Secondly, when updating `TriggerEntity._handle_rendered_results`, this forced the rewrite of a `test_trigger_entity.test_script_variables_from_coordinator` test because Entity.async_write_ha_state()` is now being called during `TriggerEntity._populate_data(...)`.  The rewrite is needed to ensure the entity is properly created so that the entity has a platform and the test executes without an exception.  The exception was happening due to a missing `Entity.platform` when `Entity.async_write_ha_state()` was called.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
