### PR TITLE
2026.1.3

### DIFF
--- a/homeassistant/components/arve/__init__.py
+++ b/homeassistant/components/arve/__init__.py
@@ -2,12 +2,33 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .coordinator import ArveConfigEntry, ArveCoordinator
 
+_LOGGER = logging.getLogger(__name__)
+
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ArveConfigEntry) -> bool:
+    """Migrate entry."""
+    _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
+
+    if entry.version == 1:
+        # 1 -> 1.2: Unique ID from integer to string
+        if entry.minor_version == 1:
+            minor_version = 2
+            hass.config_entries.async_update_entry(
+                entry, unique_id=str(entry.unique_id), minor_version=minor_version
+            )
+
+    _LOGGER.debug("Migration successful")
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ArveConfigEntry) -> bool:

--- a/homeassistant/components/arve/config_flow.py
+++ b/homeassistant/components/arve/config_flow.py
@@ -19,6 +19,9 @@ _LOGGER = logging.getLogger(__name__)
 class ArveConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Arve."""
 
+    VERSION = 1
+    MINOR_VERSION = 2
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -35,7 +38,7 @@ class ArveConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             except ArveConnectionError:
                 errors["base"] = "cannot_connect"
             else:
-                await self.async_set_unique_id(customer.customerId)
+                await self.async_set_unique_id(str(customer.customerId))
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
                     title="Arve",

--- a/homeassistant/components/binary_sensor/icons.json
+++ b/homeassistant/components/binary_sensor/icons.json
@@ -85,9 +85,9 @@
       }
     },
     "moving": {
-      "default": "mdi:arrow-right",
+      "default": "mdi:octagon",
       "state": {
-        "on": "mdi:octagon"
+        "on": "mdi:arrow-right"
       }
     },
     "occupancy": {

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -108,7 +108,6 @@ _DEFAULT_BIND = ["0.0.0.0", "::"] if _HAS_IPV6 else ["0.0.0.0"]
 
 HTTP_SCHEMA: Final = vol.All(
     cv.deprecated(CONF_BASE_URL),
-    cv.deprecated(CONF_SERVER_HOST),  # Deprecated in HA Core 2025.12
     vol.Schema(
         {
             vol.Optional(CONF_SERVER_HOST): vol.All(
@@ -209,20 +208,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if conf is None:
         conf = cast(ConfData, HTTP_SCHEMA({}))
 
-    if CONF_SERVER_HOST in conf:
-        if is_hassio(hass):
-            issue_id = "server_host_deprecated_hassio"
-            severity = ir.IssueSeverity.ERROR
-        else:
-            issue_id = "server_host_deprecated"
-            severity = ir.IssueSeverity.WARNING
+    if CONF_SERVER_HOST in conf and is_hassio(hass):
+        issue_id = "server_host_deprecated_hassio"
         ir.async_create_issue(
             hass,
             DOMAIN,
             issue_id,
             breaks_in_ha_version="2026.6.0",
             is_fixable=False,
-            severity=severity,
+            severity=ir.IssueSeverity.ERROR,
             translation_key=issue_id,
         )
 

--- a/homeassistant/components/http/strings.json
+++ b/homeassistant/components/http/strings.json
@@ -1,9 +1,5 @@
 {
   "issues": {
-    "server_host_deprecated": {
-      "description": "The `server_host` configuration option in the HTTP integration is deprecated and will be removed.\n\nIf you are using this option to bind Home Assistant to specific network interfaces, please remove it from your configuration. Home Assistant will automatically bind to all available interfaces by default.\n\nIf you have specific networking requirements, consider using firewall rules or other network configuration to control access to Home Assistant.",
-      "title": "The `server_host` HTTP configuration option is deprecated"
-    },
     "server_host_deprecated_hassio": {
       "description": "The deprecated `server_host` configuration option in the HTTP integration is prone to break the communication between Home Assistant Core and Supervisor, and will be removed.\n\nIf you are using this option to bind Home Assistant to specific network interfaces, please remove it from your configuration. Home Assistant will automatically bind to all available interfaces by default.\n\nIf you have specific networking requirements, consider using firewall rules or other network configuration to control access to Home Assistant.",
       "title": "The `server_host` HTTP configuration may break Home Assistant Core - Supervisor communication"

--- a/homeassistant/components/insteon/manifest.json
+++ b/homeassistant/components/insteon/manifest.json
@@ -19,7 +19,7 @@
   "loggers": ["pyinsteon", "pypubsub"],
   "requirements": [
     "pyinsteon==1.6.4",
-    "insteon-frontend-home-assistant==0.6.0"
+    "insteon-frontend-home-assistant==0.6.1"
   ],
   "single_config_entry": true,
   "usb": [

--- a/homeassistant/components/london_air/sensor.py
+++ b/homeassistant/components/london_air/sensor.py
@@ -27,6 +27,7 @@ SCAN_INTERVAL = timedelta(minutes=30)
 
 AUTHORITIES = [
     "Barking and Dagenham",
+    "Barnet",
     "Bexley",
     "Brent",
     "Bromley",
@@ -49,11 +50,13 @@ AUTHORITIES = [
     "Lambeth",
     "Lewisham",
     "Merton",
+    "Newham",
     "Redbridge",
     "Richmond",
     "Southwark",
     "Sutton",
     "Tower Hamlets",
+    "Waltham Forest",
     "Wandsworth",
     "Westminster",
 ]

--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -442,6 +442,9 @@ DISCOVERY_SCHEMAS = [
             key="PowerSourceBatVoltage",
             translation_key="battery_voltage",
             native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
+            # Battery voltages are low-voltage diagnostics; use 2 decimals in volts
+            # to provide finer granularity than mains-level voltage sensors.
+            suggested_display_precision=2,
             suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
             device_class=SensorDeviceClass.VOLTAGE,
             entity_category=EntityCategory.DIAGNOSTIC,

--- a/homeassistant/components/microbees/__init__.py
+++ b/homeassistant/components/microbees/__init__.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from http import HTTPStatus
+import logging
 
 import aiohttp
 from microBeesPy import MicroBees
@@ -15,6 +16,8 @@ from homeassistant.helpers import config_entry_oauth2_flow
 from .const import DOMAIN, PLATFORMS
 from .coordinator import MicroBeesUpdateCoordinator
 
+_LOGGER = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True, kw_only=True)
 class HomeAssistantMicroBeesData:
@@ -23,6 +26,23 @@ class HomeAssistantMicroBeesData:
     connector: MicroBees
     coordinator: MicroBeesUpdateCoordinator
     session: config_entry_oauth2_flow.OAuth2Session
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate entry."""
+    _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
+
+    if entry.version == 1:
+        # 1 -> 1.2: Unique ID from integer to string
+        if entry.minor_version == 1:
+            minor_version = 2
+            hass.config_entries.async_update_entry(
+                entry, unique_id=str(entry.unique_id), minor_version=minor_version
+            )
+
+    _LOGGER.debug("Migration successful")
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/microbees/config_flow.py
+++ b/homeassistant/components/microbees/config_flow.py
@@ -19,6 +19,8 @@ class OAuth2FlowHandler(
     """Handle a config flow for microBees."""
 
     DOMAIN = DOMAIN
+    VERSION = 1
+    MINOR_VERSION = 2
 
     @property
     def logger(self) -> logging.Logger:
@@ -47,7 +49,7 @@ class OAuth2FlowHandler(
             self.logger.exception("Unexpected error")
             return self.async_abort(reason="unknown")
 
-        await self.async_set_unique_id(current_user.id)
+        await self.async_set_unique_id(str(current_user.id))
         if self.source != SOURCE_REAUTH:
             self._abort_if_unique_id_configured()
             return self.async_create_entry(

--- a/homeassistant/components/monzo/__init__.py
+++ b/homeassistant/components/monzo/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -15,7 +17,26 @@ from .api import AuthenticatedMonzoAPI
 from .const import DOMAIN
 from .coordinator import MonzoCoordinator
 
+_LOGGER = logging.getLogger(__name__)
+
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate entry."""
+    _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
+
+    if entry.version == 1:
+        # 1 -> 1.2: Unique ID from integer to string
+        if entry.minor_version == 1:
+            minor_version = 2
+            hass.config_entries.async_update_entry(
+                entry, unique_id=str(entry.unique_id), minor_version=minor_version
+            )
+
+    _LOGGER.debug("Migration successful")
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/monzo/config_flow.py
+++ b/homeassistant/components/monzo/config_flow.py
@@ -21,6 +21,8 @@ class MonzoFlowHandler(
     """Handle a config flow."""
 
     DOMAIN = DOMAIN
+    VERSION = 1
+    MINOR_VERSION = 2
 
     oauth_data: dict[str, Any]
 
@@ -51,7 +53,7 @@ class MonzoFlowHandler(
         """Create an entry for the flow."""
         self.oauth_data = data
         user_id = data[CONF_TOKEN]["user_id"]
-        await self.async_set_unique_id(user_id)
+        await self.async_set_unique_id(str(user_id))
         if self.source != SOURCE_REAUTH:
             self._abort_if_unique_id_configured()
         else:

--- a/homeassistant/components/music_assistant/manifest.json
+++ b/homeassistant/components/music_assistant/manifest.json
@@ -10,6 +10,6 @@
   "iot_class": "local_push",
   "loggers": ["music_assistant"],
   "quality_scale": "bronze",
-  "requirements": ["music-assistant-client==1.3.2"],
+  "requirements": ["music-assistant-client==1.3.3"],
   "zeroconf": ["_mass._tcp.local."]
 }

--- a/homeassistant/components/onedrive/manifest.json
+++ b/homeassistant/components/onedrive/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["onedrive_personal_sdk"],
   "quality_scale": "platinum",
-  "requirements": ["onedrive-personal-sdk==0.1.0"]
+  "requirements": ["onedrive-personal-sdk==0.1.1"]
 }

--- a/homeassistant/components/onedrive/manifest.json
+++ b/homeassistant/components/onedrive/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["onedrive_personal_sdk"],
   "quality_scale": "platinum",
-  "requirements": ["onedrive-personal-sdk==0.0.17"]
+  "requirements": ["onedrive-personal-sdk==0.1.0"]
 }

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
   "quality_scale": "bronze",
-  "requirements": ["opower==0.16.4"]
+  "requirements": ["opower==0.16.5"]
 }

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
   "quality_scale": "bronze",
-  "requirements": ["opower==0.16.3"]
+  "requirements": ["opower==0.16.4"]
 }

--- a/homeassistant/components/toon/__init__.py
+++ b/homeassistant/components/toon/__init__.py
@@ -83,6 +83,14 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         return False
 
+    if entry.version == 2:
+        # 2 -> 2.2: Unique ID from integer to string
+        if entry.minor_version == 1:
+            minor_version = 2
+            hass.config_entries.async_update_entry(
+                entry, unique_id=str(entry.unique_id), minor_version=minor_version
+            )
+
     return True
 
 

--- a/homeassistant/components/toon/config_flow.py
+++ b/homeassistant/components/toon/config_flow.py
@@ -20,6 +20,7 @@ class ToonFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
 
     DOMAIN = DOMAIN
     VERSION = 2
+    MINOR_VERSION = 2
 
     agreements: list[Agreement]
     data: dict[str, Any]
@@ -92,7 +93,7 @@ class ToonFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
         if self.migrate_entry:
             await self.hass.config_entries.async_remove(self.migrate_entry)
 
-        await self.async_set_unique_id(agreement.agreement_id)
+        await self.async_set_unique_id(str(agreement.agreement_id))
         self._abort_if_unique_id_configured()
 
         self.data[CONF_AGREEMENT_ID] = agreement.agreement_id

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -8,6 +8,7 @@ import dataclasses
 from uiprotect.data import (
     NVR,
     Camera,
+    Event,
     ModelType,
     MountType,
     ProtectAdoptableDeviceModel,
@@ -645,15 +646,46 @@ class ProtectEventBinarySensor(EventEntityMixin, BinarySensorEntity):
         self._attr_extra_state_attributes = {}
 
     @callback
+    def _find_active_event_with_object_type(
+        self, device: ProtectDeviceType
+    ) -> Event | None:
+        """Find an active event containing this sensor's object type.
+
+        Fallback for issue #152133: last_smart_detect_event_ids may not update
+        immediately when a new detection type is added to an ongoing event.
+        """
+        obj_type = self.entity_description.ufp_obj_type
+        if obj_type is None or not isinstance(device, Camera):
+            return None
+
+        # Check known active event IDs from camera first (fast path)
+        for event_id in device.last_smart_detect_event_ids.values():
+            if (
+                event_id
+                and (event := self.data.api.bootstrap.events.get(event_id))
+                and event.end is None
+                and obj_type in event.smart_detect_types
+            ):
+                return event
+
+        return None
+
+    @callback
     def _async_update_device_from_protect(self, device: ProtectDeviceType) -> None:
         description = self.entity_description
 
         prev_event = self._event
         prev_event_end = self._event_end
         super()._async_update_device_from_protect(device)
-        if event := description.get_event_obj(device):
+
+        event = description.get_event_obj(device)
+        if event is None:
+            # Fallback for #152133: check active events directly
+            event = self._find_active_event_with_object_type(device)
+
+        if event:
             self._event = event
-            self._event_end = event.end if event else None
+            self._event_end = event.end
 
         if not (
             event

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -41,7 +41,7 @@
   "iot_class": "local_push",
   "loggers": ["uiprotect", "unifi_discovery"],
   "quality_scale": "platinum",
-  "requirements": ["uiprotect==10.0.0", "unifi-discovery==1.2.0"],
+  "requirements": ["uiprotect==10.0.1", "unifi-discovery==1.2.0"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -41,7 +41,7 @@
   "iot_class": "local_push",
   "loggers": ["uiprotect", "unifi_discovery"],
   "quality_scale": "platinum",
-  "requirements": ["uiprotect==8.0.0", "unifi-discovery==1.2.0"],
+  "requirements": ["uiprotect==8.1.1", "unifi-discovery==1.2.0"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -41,7 +41,7 @@
   "iot_class": "local_push",
   "loggers": ["uiprotect", "unifi_discovery"],
   "quality_scale": "platinum",
-  "requirements": ["uiprotect==8.1.1", "unifi-discovery==1.2.0"],
+  "requirements": ["uiprotect==10.0.0", "unifi-discovery==1.2.0"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/wiz/light.py
+++ b/homeassistant/components/wiz/light.py
@@ -80,6 +80,9 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
             color_modes.add(RGB_WHITE_CHANNELS_COLOR_MODE[bulb_type.white_channels])
         if features.color_tmp:
             color_modes.add(ColorMode.COLOR_TEMP)
+            kelvin = bulb_type.kelvin_range
+            self._attr_max_color_temp_kelvin = kelvin.max
+            self._attr_min_color_temp_kelvin = kelvin.min
         if features.brightness:
             color_modes.add(ColorMode.BRIGHTNESS)
         self._attr_supported_color_modes = filter_supported_color_modes(color_modes)
@@ -87,10 +90,6 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
             # If the light supports only a single color mode, set it now
             self._attr_color_mode = next(iter(self._attr_supported_color_modes))
         self._attr_effect_list = wiz_data.scenes
-        if bulb_type.bulb_type != BulbClass.DW:
-            kelvin = bulb_type.kelvin_range
-            self._attr_max_color_temp_kelvin = kelvin.max
-            self._attr_min_color_temp_kelvin = kelvin.min
         if bulb_type.features.effect:
             self._attr_supported_features = LightEntityFeature.EFFECT
         self._async_update_attrs()

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -25,5 +25,5 @@
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_ble",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["xiaomi-ble==1.4.1"]
+  "requirements": ["xiaomi-ble==1.4.3"]
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2026
 MINOR_VERSION: Final = 1
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant"
-version = "2026.1.2"
+version = "2026.1.3"
 license = "Apache-2.0"
 license-files = ["LICENSE*", "homeassistant/backports/LICENSE*"]
 description = "Open-source home automation platform running on Python 3."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3078,7 +3078,7 @@ typedmonarchmoney==0.4.4
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==8.1.1
+uiprotect==10.0.0
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1644,7 +1644,7 @@ omnilogic==0.4.5
 ondilo==0.5.0
 
 # homeassistant.components.onedrive
-onedrive-personal-sdk==0.0.17
+onedrive-personal-sdk==0.1.0
 
 # homeassistant.components.onvif
 onvif-zeep-async==4.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1684,7 +1684,7 @@ openwrt-luci-rpc==1.1.17
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.opower
-opower==0.16.4
+opower==0.16.5
 
 # homeassistant.components.oralb
 oralb-ble==1.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1684,7 +1684,7 @@ openwrt-luci-rpc==1.1.17
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.opower
-opower==0.16.3
+opower==0.16.4
 
 # homeassistant.components.oralb
 oralb-ble==1.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3078,7 +3078,7 @@ typedmonarchmoney==0.4.4
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==8.0.0
+uiprotect==8.1.1
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1644,7 +1644,7 @@ omnilogic==0.4.5
 ondilo==0.5.0
 
 # homeassistant.components.onedrive
-onedrive-personal-sdk==0.1.0
+onedrive-personal-sdk==0.1.1
 
 # homeassistant.components.onvif
 onvif-zeep-async==4.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1524,7 +1524,7 @@ mozart-api==5.3.1.108.0
 mullvad-api==1.0.0
 
 # homeassistant.components.music_assistant
-music-assistant-client==1.3.2
+music-assistant-client==1.3.3
 
 # homeassistant.components.tts
 mutagen==1.47.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3213,7 +3213,7 @@ wsdot==0.0.1
 wyoming==1.7.2
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==1.4.1
+xiaomi-ble==1.4.3
 
 # homeassistant.components.knx
 xknx==3.13.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1294,7 +1294,7 @@ influxdb==5.3.1
 inkbird-ble==1.1.1
 
 # homeassistant.components.insteon
-insteon-frontend-home-assistant==0.6.0
+insteon-frontend-home-assistant==0.6.1
 
 # homeassistant.components.intellifire
 intellifire4py==4.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3078,7 +3078,7 @@ typedmonarchmoney==0.4.4
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==10.0.0
+uiprotect==10.0.1
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1427,7 +1427,7 @@ omnilogic==0.4.5
 ondilo==0.5.0
 
 # homeassistant.components.onedrive
-onedrive-personal-sdk==0.0.17
+onedrive-personal-sdk==0.1.0
 
 # homeassistant.components.onvif
 onvif-zeep-async==4.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2569,7 +2569,7 @@ typedmonarchmoney==0.4.4
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==8.0.0
+uiprotect==8.1.1
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2569,7 +2569,7 @@ typedmonarchmoney==0.4.4
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==10.0.0
+uiprotect==10.0.1
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1331,7 +1331,7 @@ mozart-api==5.3.1.108.0
 mullvad-api==1.0.0
 
 # homeassistant.components.music_assistant
-music-assistant-client==1.3.2
+music-assistant-client==1.3.3
 
 # homeassistant.components.tts
 mutagen==1.47.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2683,7 +2683,7 @@ wsdot==0.0.1
 wyoming==1.7.2
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==1.4.1
+xiaomi-ble==1.4.3
 
 # homeassistant.components.knx
 xknx==3.13.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1455,7 +1455,7 @@ openrgb-python==0.3.6
 openwebifpy==4.3.1
 
 # homeassistant.components.opower
-opower==0.16.4
+opower==0.16.5
 
 # homeassistant.components.oralb
 oralb-ble==1.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1140,7 +1140,7 @@ influxdb==5.3.1
 inkbird-ble==1.1.1
 
 # homeassistant.components.insteon
-insteon-frontend-home-assistant==0.6.0
+insteon-frontend-home-assistant==0.6.1
 
 # homeassistant.components.intellifire
 intellifire4py==4.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1427,7 +1427,7 @@ omnilogic==0.4.5
 ondilo==0.5.0
 
 # homeassistant.components.onedrive
-onedrive-personal-sdk==0.1.0
+onedrive-personal-sdk==0.1.1
 
 # homeassistant.components.onvif
 onvif-zeep-async==4.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2569,7 +2569,7 @@ typedmonarchmoney==0.4.4
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==8.1.1
+uiprotect==10.0.0
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1455,7 +1455,7 @@ openrgb-python==0.3.6
 openwebifpy==4.3.1
 
 # homeassistant.components.opower
-opower==0.16.3
+opower==0.16.4
 
 # homeassistant.components.oralb
 oralb-ble==1.0.2

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -224,6 +224,11 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
     "sense": {"sense-energy": {"async-timeout"}},
     "slimproto": {"aioslimproto": {"async-timeout"}},
     "surepetcare": {"surepy": {"async-timeout"}},
+    "tami4": {
+        # https://github.com/SeleniumHQ/selenium/issues/16943
+        # tami4 > selenium > types*
+        "selenium": {"types-certifi", "types-urllib3"},
+    },
     "travisci": {
         # https://github.com/menegazzo/travispy seems to be unmaintained
         # and unused https://www.home-assistant.io/integrations/travisci

--- a/tests/components/arve/conftest.py
+++ b/tests/components/arve/conftest.py
@@ -27,7 +27,10 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 def mock_config_entry(hass: HomeAssistant, mock_arve: MagicMock) -> MockConfigEntry:
     """Return the default mocked config entry."""
     return MockConfigEntry(
-        title="Arve", domain=DOMAIN, data=USER_INPUT, unique_id=mock_arve.customer_id
+        title="Arve",
+        domain=DOMAIN,
+        data=USER_INPUT,
+        unique_id=str(mock_arve.customer_id),
     )
 
 

--- a/tests/components/arve/test_config_flow.py
+++ b/tests/components/arve/test_config_flow.py
@@ -34,7 +34,7 @@ async def test_correct_flow(
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["data"] == USER_INPUT
     assert len(mock_setup_entry.mock_calls) == 1
-    assert result2["result"].unique_id == 12345
+    assert result2["result"].unique_id == "12345"
 
 
 async def test_form_cannot_connect(

--- a/tests/components/arve/test_init.py
+++ b/tests/components/arve/test_init.py
@@ -1,0 +1,26 @@
+"""Tests for the Arve component."""
+
+from unittest.mock import patch
+
+from homeassistant.components.arve.const import DOMAIN
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_migrate_entry_minor_version_1_2(hass: HomeAssistant) -> None:
+    """Test migrating a 1.1 config entry to 1.2."""
+    with patch("homeassistant.components.arve.async_setup_entry", return_value=True):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_ACCESS_TOKEN: "mock", CONF_CLIENT_SECRET: "mock"},
+            version=1,
+            minor_version=1,
+            unique_id=12345,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert entry.version == 1
+        assert entry.minor_version == 2
+        assert entry.unique_id == "12345"

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -683,26 +683,18 @@ async def test_ssl_issue_urls_configured(
         "hassio",
         "http_config",
         "expected_serverhost",
-        "expected_warning_count",
         "expected_issues",
     ),
     [
-        (False, {}, ["0.0.0.0", "::"], 0, set()),
-        (
-            False,
-            {"server_host": "0.0.0.0"},
-            ["0.0.0.0"],
-            1,
-            {("http", "server_host_deprecated")},
-        ),
-        (True, {}, ["0.0.0.0", "::"], 0, set()),
+        (False, {}, ["0.0.0.0", "::"], set()),
+        (False, {"server_host": "0.0.0.0"}, ["0.0.0.0"], set()),
+        (True, {}, ["0.0.0.0", "::"], set()),
         (
             True,
             {"server_host": "0.0.0.0"},
             [
                 "0.0.0.0",
             ],
-            1,
             {("http", "server_host_deprecated_hassio")},
         ),
     ],
@@ -713,7 +705,6 @@ async def test_server_host(
     issue_registry: ir.IssueRegistry,
     http_config: dict,
     expected_serverhost: list,
-    expected_warning_count: int,
     expected_issues: set[tuple[str, str]],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -741,13 +732,6 @@ async def test_server_host(
         backlog=128,
         reuse_address=None,
         reuse_port=None,
-    )
-
-    assert (
-        caplog.text.count(
-            "The 'server_host' option is deprecated, please remove it from your configuration"
-        )
-        == expected_warning_count
     )
 
     assert set(issue_registry.issues) == expected_issues

--- a/tests/components/matter/snapshots/test_sensor.ambr
+++ b/tests/components/matter/snapshots/test_sensor.ambr
@@ -1375,7 +1375,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -1535,7 +1535,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -1748,7 +1748,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -2070,7 +2070,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -2612,7 +2612,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -2847,7 +2847,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -4137,7 +4137,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -4982,7 +4982,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -5199,7 +5199,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -5847,7 +5847,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -6313,7 +6313,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -6919,7 +6919,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -11404,7 +11404,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
@@ -12661,7 +12661,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 0,
+        'suggested_display_precision': 2,
       }),
       'sensor.private': dict({
         'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,

--- a/tests/components/microbees/conftest.py
+++ b/tests/components/microbees/conftest.py
@@ -59,7 +59,7 @@ def mock_config_entry(expires_at: int, scopes: list[str]) -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title=TITLE,
-        unique_id=54321,
+        unique_id="54321",
         data={
             "auth_implementation": DOMAIN,
             "token": {

--- a/tests/components/microbees/test_config_flow.py
+++ b/tests/components/microbees/test_config_flow.py
@@ -74,7 +74,7 @@ async def test_full_flow(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "test@microbees.com"
     assert "result" in result
-    assert result["result"].unique_id == 54321
+    assert result["result"].unique_id == "54321"
     assert "token" in result["result"].data
     assert result["result"].data["token"]["access_token"] == "mock-access-token"
     assert result["result"].data["token"]["refresh_token"] == "mock-refresh-token"
@@ -197,7 +197,7 @@ async def test_config_reauth_wrong_account(
 ) -> None:
     """Test reauth with wrong account."""
     await setup_integration(hass, config_entry)
-    microbees.return_value.getMyProfile.return_value.id = 12345
+    microbees.return_value.getMyProfile.return_value.id = "12345"
     result = await config_entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"

--- a/tests/components/microbees/test_init.py
+++ b/tests/components/microbees/test_init.py
@@ -1,0 +1,35 @@
+"""Tests for the microBees component."""
+
+from unittest.mock import patch
+
+from homeassistant.components.microbees.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_migrate_entry_minor_version_1_2(hass: HomeAssistant) -> None:
+    """Test migrating a 1.1 config entry to 1.2."""
+    with patch(
+        "homeassistant.components.microbees.async_setup_entry", return_value=True
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "auth_implementation": DOMAIN,
+                "token": {
+                    "refresh_token": "mock-refresh-token",
+                    "access_token": "mock-access-token",
+                    "type": "Bearer",
+                    "expires_in": 60,
+                },
+            },
+            version=1,
+            minor_version=1,
+            unique_id=54321,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert entry.version == 1
+        assert entry.minor_version == 2
+        assert entry.unique_id == "54321"

--- a/tests/components/monzo/test_config_flow.py
+++ b/tests/components/monzo/test_config_flow.py
@@ -244,7 +244,7 @@ async def test_config_reauth_wrong_account(
             "access_token": "mock-access-token",
             "type": "Bearer",
             "expires_in": 60,
-            "user_id": 12346,
+            "user_id": "12346",
         },
     )
 

--- a/tests/components/music_assistant/test_media_player.py
+++ b/tests/components/music_assistant/test_media_player.py
@@ -538,8 +538,9 @@ async def test_media_player_play_announcement_action(
         "players/cmd/play_announcement",
         player_id=mass_player_id,
         url="http://blah.com/announcement.mp3",
-        use_pre_announce=True,
+        pre_announce=True,
         volume_level=50,
+        pre_announce_url=None,
     )
 
 

--- a/tests/components/toon/test_config_flow.py
+++ b/tests/components/toon/test_config_flow.py
@@ -213,7 +213,7 @@ async def test_agreement_already_set_up(
 ) -> None:
     """Test showing display form again if display already exists."""
     await setup_component(hass)
-    MockConfigEntry(domain=DOMAIN, unique_id=123).add_to_hass(hass)
+    MockConfigEntry(domain=DOMAIN, unique_id="123").add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -312,7 +312,7 @@ async def test_import_migration(
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test if importing step with migration works."""
-    old_entry = MockConfigEntry(domain=DOMAIN, unique_id=123, version=1)
+    old_entry = MockConfigEntry(domain=DOMAIN, unique_id="123", version=1)
     old_entry.add_to_hass(hass)
 
     await setup_component(hass)

--- a/tests/components/toon/test_init.py
+++ b/tests/components/toon/test_init.py
@@ -40,3 +40,29 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_migrate_entry_minor_version_2_2(hass: HomeAssistant) -> None:
+    """Test migrating a 2.1 config entry to 2.2."""
+    with patch("homeassistant.components.toon.async_setup_entry", return_value=True):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "auth_implementation": DOMAIN,
+                "token": {
+                    "refresh_token": "mock-refresh-token",
+                    "access_token": "mock-access-token",
+                    "type": "Bearer",
+                    "expires_in": 60,
+                },
+                "agreement_id": 123,
+            },
+            version=2,
+            minor_version=1,
+            unique_id=123,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert entry.version == 2
+        assert entry.minor_version == 2
+        assert entry.unique_id == "123"

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -721,3 +721,179 @@ async def test_binary_sensor_person_detected(
     ufp.ws_msg(mock_msg)
     await hass.async_block_till_done()
     assert len(state_changes) == 2
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_binary_sensor_simultaneous_person_and_vehicle_detection(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    doorbell: Camera,
+    unadopted_camera: Camera,
+    fixed_now: datetime,
+) -> None:
+    """Test that when an event is updated with additional detection types, both trigger.
+
+    This is a regression test for https://github.com/home-assistant/core/issues/152133
+    where an event starting with vehicle detection gets updated to also include person
+    detection (e.g., someone getting out of a car). Both sensors should be ON
+    simultaneously, not queued.
+    """
+
+    await init_entry(hass, ufp, [doorbell, unadopted_camera])
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 15, 15)
+
+    doorbell.smart_detect_settings.object_types.append(SmartDetectObjectType.PERSON)
+    doorbell.smart_detect_settings.object_types.append(SmartDetectObjectType.VEHICLE)
+
+    # Get entity IDs for both person and vehicle detection
+    _, person_entity_id = await ids_from_device_description(
+        hass,
+        Platform.BINARY_SENSOR,
+        doorbell,
+        EVENT_SENSORS[3],  # person detected
+    )
+    _, vehicle_entity_id = await ids_from_device_description(
+        hass,
+        Platform.BINARY_SENSOR,
+        doorbell,
+        EVENT_SENSORS[4],  # vehicle detected
+    )
+
+    # Step 1: Initial event with only VEHICLE detection (car arriving)
+    event = Event(
+        model=ModelType.EVENT,
+        id="combined_event_id",
+        type=EventType.SMART_DETECT,
+        start=fixed_now - timedelta(seconds=5),
+        end=None,  # Event is ongoing
+        score=90,
+        smart_detect_types=[SmartDetectObjectType.VEHICLE],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+        api=ufp.api,
+    )
+
+    new_camera = doorbell.model_copy()
+    new_camera.is_smart_detected = True
+    new_camera.last_smart_detect_event_ids[SmartDetectObjectType.VEHICLE] = event.id
+
+    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
+    ufp.api.bootstrap.events = {event.id: event}
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = event
+    ufp.ws_msg(mock_msg)
+
+    await hass.async_block_till_done()
+
+    # Vehicle sensor should be ON
+    vehicle_state = hass.states.get(vehicle_entity_id)
+    assert vehicle_state
+    assert vehicle_state.state == STATE_ON, "Vehicle detection should be ON"
+
+    # Person sensor should still be OFF (no person detected yet)
+    person_state = hass.states.get(person_entity_id)
+    assert person_state
+    assert person_state.state == STATE_OFF, "Person detection should be OFF initially"
+
+    # Step 2: Same event gets updated to include PERSON detection
+    # (someone gets out of the car - Protect adds PERSON to the same event)
+    #
+    # BUG SCENARIO: UniFi Protect updates the event to include PERSON in
+    # smart_detect_types, BUT does NOT update last_smart_detect_event_ids[PERSON]
+    # until the event ends. This is the core issue reported in #152133.
+    updated_event = Event(
+        model=ModelType.EVENT,
+        id="combined_event_id",  # Same event ID!
+        type=EventType.SMART_DETECT,
+        start=fixed_now - timedelta(seconds=5),
+        end=None,  # Event still ongoing
+        score=90,
+        smart_detect_types=[
+            SmartDetectObjectType.VEHICLE,
+            SmartDetectObjectType.PERSON,
+        ],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+        api=ufp.api,
+    )
+
+    # IMPORTANT: The camera's last_smart_detect_event_ids is NOT updated for PERSON!
+    # This simulates the real bug where UniFi Protect doesn't immediately update
+    # the camera's last_smart_detect_event_ids when a new detection type is added
+    # to an ongoing event.
+    new_camera = doorbell.model_copy()
+    new_camera.is_smart_detected = True
+    # Only VEHICLE has the event ID - PERSON does not (simulating the bug)
+    new_camera.last_smart_detect_event_ids[SmartDetectObjectType.VEHICLE] = (
+        updated_event.id
+    )
+    # NOTE: We're NOT setting last_smart_detect_event_ids[PERSON] to simulate the bug!
+
+    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
+    ufp.api.bootstrap.events = {updated_event.id: updated_event}
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = updated_event
+    ufp.ws_msg(mock_msg)
+
+    await hass.async_block_till_done()
+
+    # CRITICAL: Both sensors should now be ON simultaneously
+    vehicle_state = hass.states.get(vehicle_entity_id)
+    assert vehicle_state
+    assert vehicle_state.state == STATE_ON, (
+        "Vehicle detection should still be ON after event update"
+    )
+
+    person_state = hass.states.get(person_entity_id)
+    assert person_state
+    assert person_state.state == STATE_ON, (
+        "Person detection should be ON immediately when added to event, "
+        "not waiting for vehicle detection to end"
+    )
+
+    # Verify both have correct attributes
+    assert vehicle_state.attributes[ATTR_EVENT_SCORE] == 90
+    assert person_state.attributes[ATTR_EVENT_SCORE] == 90
+
+    # Step 3: Event ends - both sensors should turn OFF
+    ended_event = Event(
+        model=ModelType.EVENT,
+        id="combined_event_id",
+        type=EventType.SMART_DETECT,
+        start=fixed_now - timedelta(seconds=5),
+        end=fixed_now,  # Event ended now
+        score=90,
+        smart_detect_types=[
+            SmartDetectObjectType.VEHICLE,
+            SmartDetectObjectType.PERSON,
+        ],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+        api=ufp.api,
+    )
+
+    ufp.api.bootstrap.events = {ended_event.id: ended_event}
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = ended_event
+    ufp.ws_msg(mock_msg)
+
+    await hass.async_block_till_done()
+
+    # Both should be OFF now
+    vehicle_state = hass.states.get(vehicle_entity_id)
+    assert vehicle_state
+    assert vehicle_state.state == STATE_OFF, (
+        "Vehicle detection should be OFF after event ends"
+    )
+
+    person_state = hass.states.get(person_entity_id)
+    assert person_state
+    assert person_state.state == STATE_OFF, (
+        "Person detection should be OFF after event ends"
+    )

--- a/tests/components/wiz/__init__.py
+++ b/tests/components/wiz/__init__.py
@@ -183,7 +183,7 @@ FAKE_DIMMABLE_FAN = BulbType(
     features=Features(
         color=False,
         color_tmp=False,
-        effect=True,
+        effect=False,
         brightness=True,
         dual_head=False,
         fan=True,
@@ -191,9 +191,28 @@ FAKE_DIMMABLE_FAN = BulbType(
         fan_reverse=True,
     ),
     kelvin_range=KelvinRange(max=2700, min=2700),
-    fw_version="1.31.32",
+    fw_version="1.34.1",
     white_channels=1,
     white_to_color_ratio=20,
+    fan_speed_range=6,
+)
+FAKE_DIMMABLE_FAN_2 = BulbType(
+    bulb_type=BulbClass.FANDIM,
+    name="ESP20_FANDIMS_31",
+    features=Features(
+        color=False,
+        color_tmp=False,
+        effect=False,
+        brightness=True,
+        dual_head=False,
+        fan=True,
+        fan_breeze_mode=True,
+        fan_reverse=True,
+    ),
+    kelvin_range=None,
+    fw_version="1.34.0",
+    white_channels=None,
+    white_to_color_ratio=None,
     fan_speed_range=6,
 )
 

--- a/tests/components/wiz/snapshots/test_fan.ambr
+++ b/tests/components/wiz/snapshots/test_fan.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_entity[fan.mock_title-entry]
+# name: test_entity[bulb_type0][fan.mock_title-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -38,7 +38,68 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entity[fan.mock_title-state]
+# name: test_entity[bulb_type0][fan.mock_title-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'direction': 'forward',
+      'friendly_name': 'Mock Title',
+      'percentage': 16,
+      'percentage_step': 16.666666666666668,
+      'preset_mode': None,
+      'preset_modes': list([
+        'breeze',
+      ]),
+      'supported_features': <FanEntityFeature: 61>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.mock_title',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entity[bulb_type1][fan.mock_title-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'preset_modes': list([
+        'breeze',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'fan',
+    'entity_category': None,
+    'entity_id': 'fan.mock_title',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'wiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <FanEntityFeature: 61>,
+    'translation_key': None,
+    'unique_id': 'abcabcabcabc',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[bulb_type1][fan.mock_title-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'direction': 'forward',

--- a/tests/components/wiz/snapshots/test_fan.ambr
+++ b/tests/components/wiz/snapshots/test_fan.ambr
@@ -84,7 +84,6 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,

--- a/tests/components/wiz/test_fan.py
+++ b/tests/components/wiz/test_fan.py
@@ -3,6 +3,8 @@
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+from pywizlight import BulbType
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.fan import (
@@ -28,7 +30,13 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import FAKE_DIMMABLE_FAN, FAKE_MAC, async_push_update, async_setup_integration
+from . import (
+    FAKE_DIMMABLE_FAN,
+    FAKE_DIMMABLE_FAN_2,
+    FAKE_MAC,
+    async_push_update,
+    async_setup_integration,
+)
 
 from tests.common import snapshot_platform
 
@@ -43,12 +51,16 @@ INITIAL_PARAMS = {
 }
 
 
+@pytest.mark.parametrize("bulb_type", [FAKE_DIMMABLE_FAN, FAKE_DIMMABLE_FAN_2])
 @patch("homeassistant.components.wiz.PLATFORMS", [Platform.FAN])
 async def test_entity(
-    hass: HomeAssistant, snapshot: SnapshotAssertion, entity_registry: er.EntityRegistry
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    bulb_type: BulbType,
 ) -> None:
     """Test the fan entity."""
-    entry = (await async_setup_integration(hass, bulb_type=FAKE_DIMMABLE_FAN))[1]
+    entry = (await async_setup_integration(hass, bulb_type=bulb_type))[1]
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
 


### PR DESCRIPTION
- Bump uiprotect to 8.1.1 ([@RaHehl] - [#160816]) ([unifiprotect docs]) (dependency)
- Update list of supported locations for London Air ([@allanlewis] - [#160884]) ([london_air docs])
- Bump onedrive-personal-sdk to 0.1.0 ([@zweckj] - [#160976]) ([onedrive docs]) (dependency)
- Adjust battery voltage sensor display precision for Matter devices ([@lboue] - [#161088]) ([matter docs])
- Fix color temperature attributes in wiz ([@arturpragacz] - [#161125]) ([wiz docs])
- Bump xiaomi-ble to 1.4.3 ([@terop] - [#161132]) ([xiaomi_ble docs])
- Bump opower to 0.16.4 ([@tronikos] - [#161153]) ([opower docs]) (dependency)
- Fix detection of multiple smart object types in single event ([@RaHehl] - [#161189]) ([unifiprotect docs])
- Fix icons for 'moving' state ([@stickpin] - [#161194]) ([binary_sensor docs])
- Bump onedrive-personal-sdk to 0.1.1 ([@zweckj] - [#161337]) ([onedrive docs]) (dependency)
- Bump uiprotect to 10.0.0 ([@RaHehl] - [#161350]) ([unifiprotect docs]) (dependency)
- Migrate config entries to string unique id ([@edenhaus] - [#161370]) ([toon docs]) ([monzo docs]) ([microBees docs]) ([arve docs])
- Bump uiprotect to 10.0.1 ([@RaHehl] - [#161397]) ([unifiprotect docs]) (dependency)
- Bump Insteon panel to 0.6.1 ([@teharris1] - [#161411]) ([insteon docs]) (dependency)
- Bump music-assistant-client to 1.3.3 ([@arturpragacz] - [#161438]) ([music_assistant docs]) (dependency)
- Revert deprecation of `server_host` for container installations ([@emontnemery] - [#161443]) ([http docs])
- Bump opower to 0.16.5 ([@tronikos] - [#161450]) ([opower docs]) (dependency)

[#159957]: https://github.com/home-assistant/core/pull/159957
[#160771]: https://github.com/home-assistant/core/pull/160771
[#160816]: https://github.com/home-assistant/core/pull/160816
[#160884]: https://github.com/home-assistant/core/pull/160884
[#160976]: https://github.com/home-assistant/core/pull/160976
[#161085]: https://github.com/home-assistant/core/pull/161085
[#161088]: https://github.com/home-assistant/core/pull/161088
[#161125]: https://github.com/home-assistant/core/pull/161125
[#161132]: https://github.com/home-assistant/core/pull/161132
[#161153]: https://github.com/home-assistant/core/pull/161153
[#161189]: https://github.com/home-assistant/core/pull/161189
[#161194]: https://github.com/home-assistant/core/pull/161194
[#161337]: https://github.com/home-assistant/core/pull/161337
[#161350]: https://github.com/home-assistant/core/pull/161350
[#161370]: https://github.com/home-assistant/core/pull/161370
[#161397]: https://github.com/home-assistant/core/pull/161397
[#161411]: https://github.com/home-assistant/core/pull/161411
[#161438]: https://github.com/home-assistant/core/pull/161438
[#161443]: https://github.com/home-assistant/core/pull/161443
[#161450]: https://github.com/home-assistant/core/pull/161450
[@RaHehl]: https://github.com/RaHehl
[@allanlewis]: https://github.com/allanlewis
[@arturpragacz]: https://github.com/arturpragacz
[@bramkragten]: https://github.com/bramkragten
[@edenhaus]: https://github.com/edenhaus
[@emontnemery]: https://github.com/emontnemery
[@frenck]: https://github.com/frenck
[@lboue]: https://github.com/lboue
[@stickpin]: https://github.com/stickpin
[@teharris1]: https://github.com/teharris1
[@terop]: https://github.com/terop
[@tronikos]: https://github.com/tronikos
[@zweckj]: https://github.com/zweckj
[accuweather docs]: https://www.home-assistant.io/integrations/accuweather/
[actron_air docs]: https://www.home-assistant.io/integrations/actron_air/
[adax docs]: https://www.home-assistant.io/integrations/adax/
[arve docs]: https://www.home-assistant.io/integrations/arve/
[binary_sensor docs]: https://www.home-assistant.io/integrations/binary_sensor/
[http docs]: https://www.home-assistant.io/integrations/http/
[insteon docs]: https://www.home-assistant.io/integrations/insteon/
[london_air docs]: https://www.home-assistant.io/integrations/london_air/
[matter docs]: https://www.home-assistant.io/integrations/matter/
[microBees docs]: https://www.home-assistant.io/integrations/microBees/
[monzo docs]: https://www.home-assistant.io/integrations/monzo/
[music_assistant docs]: https://www.home-assistant.io/integrations/music_assistant/
[onedrive docs]: https://www.home-assistant.io/integrations/onedrive/
[opower docs]: https://www.home-assistant.io/integrations/opower/
[toon docs]: https://www.home-assistant.io/integrations/toon/
[unifiprotect docs]: https://www.home-assistant.io/integrations/unifiprotect/
[wiz docs]: https://www.home-assistant.io/integrations/wiz/
[xiaomi_ble docs]: https://www.home-assistant.io/integrations/xiaomi_ble/