### PR TITLE
Put Velux integration on quality scale

### DIFF
--- a/homeassistant/components/velux/quality_scale.yaml
+++ b/homeassistant/components/velux/quality_scale.yaml
@@ -6,9 +6,7 @@ rules:
   common-modules: done
   config-flow-test-coverage: done
   config-flow: done
-  dependency-transparency:
-    status: todo
-    comment: release-builds need CI
+  dependency-transparency: done
   docs-actions: done
   docs-high-level-description: done
   docs-installation-instructions: done
@@ -24,21 +22,17 @@ rules:
   # Silver
   action-exceptions: done
   config-entry-unloading: done
-  docs-configuration-parameters: todo
-  docs-installation-parameters: todo
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
-  test-coverage:
-    status: todo
-    comment: add tests where missing
+  test-coverage: done
 
   # Gold
-  devices:
-    status: todo
-    comment: scenes need devices
+  devices: done
   diagnostics: todo
   discovery-update-info: todo
   discovery: done


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR should finally bring the velux integration on the quality scale, let's see if anything is missing to hopefully move this to silver. 

This is an annotated checklist with links to PRs that have been merged, if no link is provided then things were already OK when https://github.com/home-assistant/core/pull/154615 was created. Note that most of this was documented in quality_scale.yml along the way already. 

## Bronze
- [x] `action-setup` - Service actions are registered in async_setup: https://github.com/home-assistant/core/pull/159502
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval:
- [x] `brands` - Has branding assets available for the integration
- [x] `common-modules` - Place common patterns in common modules
- [x] `config-flow-test-coverage` - Full test coverage for the config flow: https://github.com/home-assistant/core/pull/159596
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data_description` to give context to fields: https://github.com/home-assistant/core/pull/155832 & https://github.com/home-assistant/core/pull/155854
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `dependency-transparency` - Dependency transparency: done when https://github.com/home-assistant/core/pull/161495 is merged, which is the first pyvlx release built and published with a CI workflow, see https://github.com/Julius2342/pyvlx/pull/569
- [x] `docs-actions` - The documentation describes the provided service actions that can be used: no (undeprecated) actions exist
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites: https://github.com/home-assistant/home-assistant.io/pull/41359
- [x] `docs-removal-instructions` - The documentation provides removal instructions: https://github.com/home-assistant/home-assistant.io/pull/41359
- [x] `entity-event-setup` - Entity events are subscribed in the correct lifecycle methods
- [x] `entity-unique-id` - Entities have a unique ID : https://github.com/home-assistant/core/pull/156436
- [x] `has-entity-name` - Entities use has_entity_name = True: https://github.com/home-assistant/core/pull/155850 & https://github.com/home-assistant/core/pull/156436 
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data: https://github.com/home-assistant/core/pull/155207
- [x] `test-before-configure` - Test a connection in the config flow
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly: https://github.com/home-assistant/core/pull/159231
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice

## Silver
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures: https://github.com/home-assistant/core/pull/159585 & https://github.com/home-assistant/core/pull/160430
- [x] `config-entry-unloading` - Support config entry unloading: https://github.com/home-assistant/core/pull/156525 & https://github.com/home-assistant/core/pull/159497
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options: https://github.com/home-assistant/home-assistant.io/pull/41359
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters: https://github.com/home-assistant/home-assistant.io/pull/41359
- [x] `entity-unavailable` - Mark entity unavailable if appropriate:  https://github.com/home-assistant/core/pull/159520 & https://github.com/home-assistant/core/pull/159523
- [x] `integration-owner` - Has an integration owner
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected: https://github.com/home-assistant/core/pull/159520 & https://github.com/home-assistant/core/pull/159523
- [x] `parallel-updates` - Number of parallel updates is specified: https://github.com/home-assistant/core/pull/156437
- [x] `reauthentication-flow` - Reauthentication needs to be available via the UI: https://github.com/home-assistant/core/pull/159596
- [x] `test-coverage` - Above 95% test coverage for all integration modules: https://github.com/home-assistant/core/pull/156770

## Gold
- [x] `devices` - The integration creates devices: https://github.com/home-assistant/core/pull/149575 & https://github.com/home-assistant/core/pull/156436 & https://github.com/home-assistant/core/pull/155434
- [ ] `diagnostics` - Implements diagnostics
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [ ] `discovery` - Devices can be discovered
- [ ] `docs-data-update` - The documentation describes how data is updated
- [ ] `docs-examples` - The documentation provides automation examples the user can use.
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [ ] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [ ] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [ ] `dynamic-devices` - Devices added after integration setup
- [ ] `entity-category` - Entities are assigned an appropriate EntityCategory
- [ ] `entity-device-class` - Entities use device classes where possible
- [ ] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [ ] `entity-translations` - Entities have translated names
- [ ] `exception-translations` - Exception messages are translatable
- [ ] `icon-translations` - Entities implement icon translations
- [ ] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `stale-devices` - Stale devices are removed

## Platinum
- [ ] `async-dependency` - Dependency is async
- [ ] `inject-websession` - The integration dependency supports passing in a websession
- [ ] `strict-typing` - Strict typing




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/154615
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
