### PR TITLE
Use public API for RTSPS streams in UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -159,7 +159,7 @@ async def _async_setup_entry(
     bootstrap: Bootstrap,
 ) -> None:
     await async_migrate_data(hass, entry, data_service.api, bootstrap)
-    data_service.async_setup()
+    await data_service.async_setup()
 
     # Create the NVR device before loading platforms
     # This ensures via_device references work for all device entities

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -1,4 +1,12 @@
-"""Support for Ubiquiti's UniFi Protect NVR."""
+"""Support for Ubiquiti's UniFi Protect NVR.
+
+Camera entities use the public API (get_rtsps_streams) exclusively for obtaining
+RTSPS stream URLs. This provides stable, authenticated stream URLs that work
+reliably with Home Assistant's stream integration.
+
+Insecure (unencrypted RTSP) camera variants have been removed in favor of
+secure RTSPS streams only.
+"""
 
 from __future__ import annotations
 
@@ -11,6 +19,7 @@ from uiprotect.data import (
     ProtectAdoptableDeviceModel,
     StateType,
 )
+from uiprotect.exceptions import ClientError, NotAuthorized, NvrError
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.core import HomeAssistant, callback
@@ -33,6 +42,15 @@ from .utils import async_ufp_instance_command, get_camera_base_name
 
 _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
+
+# Mapping of channel IDs to quality names for the public API (get_rtsps_streams)
+# The public API returns stream URLs by quality name, not by channel ID
+CHANNEL_ID_TO_QUALITY: dict[int, str] = {
+    0: "high",
+    1: "medium",
+    2: "low",
+    3: "package",
+}
 
 
 @callback
@@ -67,8 +85,11 @@ def _get_camera_channels(
     data: ProtectData,
     ufp_device: UFPCamera | None = None,
 ) -> Generator[tuple[UFPCamera, CameraChannel, bool]]:
-    """Get all the camera channels."""
+    """Get all the camera channels.
 
+    Creates camera entities for all available channels (high, medium, low, package).
+    Stream availability is determined by the public API at runtime.
+    """
     cameras = data.get_cameras() if ufp_device is None else [ufp_device]
     for camera in cameras:
         if not camera.channels:
@@ -84,22 +105,13 @@ def _get_camera_channels(
 
         is_default = True
         for channel in camera.channels:
+            # Package channel is created if available, but disabled by default
             if channel.is_package:
-                yield camera, channel, True
-            elif channel.is_rtsp_enabled:
+                yield camera, channel, False
+            # For regular channels, create entities for all known quality levels
+            elif channel.id in CHANNEL_ID_TO_QUALITY:
                 yield camera, channel, is_default
                 is_default = False
-
-        # no RTSP enabled use first channel with no stream
-        if is_default and not camera.is_third_party_camera:
-            # Only create repair issue if RTSP is not disabled globally
-            if not data.disable_stream:
-                _create_rtsp_repair(hass, entry, data, camera)
-            else:
-                ir.async_delete_issue(hass, DOMAIN, f"rtsp_disabled_{camera.id}")
-            yield camera, camera.channels[0], True
-        else:
-            ir.async_delete_issue(hass, DOMAIN, f"rtsp_disabled_{camera.id}")
 
 
 def _async_camera_entities(
@@ -121,22 +133,9 @@ def _async_camera_entities(
                 camera,
                 channel,
                 is_default,
-                True,
                 disable_stream or channel.is_package,
             )
         )
-
-        if channel.is_rtsp_enabled and not channel.is_package:
-            entities.append(
-                ProtectCamera(
-                    data,
-                    camera,
-                    channel,
-                    is_default,
-                    False,
-                    disable_stream,
-                )
-            )
     return entities
 
 
@@ -175,48 +174,137 @@ class ProtectCamera(ProtectDeviceEntity, Camera):
         "_attr_motion_detection_enabled",
     )
 
+    @property
+    def _rtsp_issue_id(self) -> str:
+        """Return the repair issue ID for RTSP disabled."""
+        return f"rtsp_disabled_{self.device.id}"
+
+    @property
+    def _should_stream(self) -> bool:
+        """Return whether streaming should be attempted."""
+        return not self._disable_stream and self._quality is not None
+
     def __init__(
         self,
         data: ProtectData,
         camera: UFPCamera,
         channel: CameraChannel,
         is_default: bool,
-        secure: bool,
         disable_stream: bool,
     ) -> None:
         """Initialize an UniFi camera."""
         self.channel = channel
-        self._secure = secure
         self._disable_stream = disable_stream
         self._last_image: bytes | None = None
+        self._quality = CHANNEL_ID_TO_QUALITY.get(channel.id)
         super().__init__(data, camera)
         device = self.device
 
-        camera_name = get_camera_base_name(channel)
-        if self._secure:
-            self._attr_unique_id = f"{device.mac}_{channel.id}"
-            self._attr_name = camera_name
-        else:
-            self._attr_unique_id = f"{device.mac}_{channel.id}_insecure"
-            self._attr_name = f"{camera_name} (insecure)"
+        self._attr_unique_id = f"{device.mac}_{channel.id}"
+        self._attr_name = get_camera_base_name(channel)
         # only the default (first) channel is enabled by default
-        self._attr_entity_registry_enabled_default = is_default and secure
+        self._attr_entity_registry_enabled_default = is_default
         # Set the stream source before finishing the init
         # because async_added_to_hass is too late and camera
         # integration uses async_internal_added_to_hass to access
         # the stream source which is called before async_added_to_hass
         self._async_set_stream_source()
 
+    async def async_added_to_hass(self) -> None:
+        """Run when entity is added to hass."""
+        await super().async_added_to_hass()
+        # Listen for stream cache invalidation signals
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, self.data.streams_signal, self._async_handle_streams_signal
+            )
+        )
+        # Fetch or create RTSPS streams from public API
+        await self._async_refresh_rtsps_streams()
+
+    @callback
+    def _async_handle_streams_signal(self, camera_id: str | None = None) -> None:
+        """Handle streams signal - refresh if our camera is affected."""
+        if camera_id is None or camera_id == self.device.id:
+            self.hass.async_create_task(
+                self._async_refresh_rtsps_streams(), eager_start=True
+            )
+
+    async def _async_refresh_rtsps_streams(self) -> None:
+        """Refresh RTSPS streams from cache or API."""
+        if not self._should_stream:
+            # Delete any existing repair issue if streaming is disabled
+            ir.async_delete_issue(self.hass, DOMAIN, self._rtsp_issue_id)
+            return
+
+        # Type narrowing - _should_stream ensures _quality is not None
+        quality = self._quality
+        assert quality is not None
+
+        # Check if camera has been checked during setup (pre-fetched sequentially)
+        if self.data.is_camera_rtsps_checked(self.device.id):
+            cached_streams = self.data.get_camera_rtsps_streams(self.device.id)
+            if cached_streams is not None and cached_streams.get_stream_url(quality):
+                self._async_set_stream_source()
+                self.async_write_ha_state()
+                ir.async_delete_issue(self.hass, DOMAIN, self._rtsp_issue_id)
+            else:
+                # No streams or this quality not available - create repair
+                self._maybe_create_rtsp_repair()
+            return
+
+        # Not yet checked - fetch from API (individual camera refresh after signal)
+        try:
+            streams = await self.device.get_rtsps_streams()
+            self.data.set_camera_rtsps_streams(self.device.id, streams)
+            if streams is not None and streams.get_stream_url(quality):
+                self._async_set_stream_source()
+                self.async_write_ha_state()
+                ir.async_delete_issue(self.hass, DOMAIN, self._rtsp_issue_id)
+            else:
+                self._maybe_create_rtsp_repair()
+        except NotAuthorized:
+            _LOGGER.warning(
+                "Cannot fetch RTSPS streams without API key, streaming will be disabled"
+            )
+        except (ClientError, NvrError):
+            _LOGGER.exception("Error fetching RTSPS streams from public API")
+
+    @callback
+    def _maybe_create_rtsp_repair(self) -> None:
+        """Create RTSP repair issue if applicable."""
+        if not self.device.is_third_party_camera and not self.data.disable_stream:
+            _create_rtsp_repair(
+                self.hass,
+                self.data.config_entry,
+                self.data,
+                self.device,
+            )
+
     @callback
     def _async_set_stream_source(self) -> None:
-        channel = self.channel
-        enable_stream = not self._disable_stream and channel.is_rtsp_enabled
-        # SRTP disabled because go2rtc does not support it
-        # https://github.com/AlexxIT/go2rtc/#source-rtsp
-        rtsp_url = channel.rtsps_no_srtp_url if self._secure else channel.rtsp_url
-        source = rtsp_url if enable_stream else None
-        self._attr_supported_features = _ENABLE_FEATURE if source else _DISABLE_FEATURE
-        self._stream_source = source
+        """Set stream source from public API cache."""
+        if not self._should_stream:
+            self._attr_supported_features = _DISABLE_FEATURE
+            self._stream_source = None
+            return
+
+        # Type narrowing - _should_stream ensures _quality is not None
+        quality = self._quality
+        assert quality is not None
+
+        # Use public API URL from central RTSPS streams cache
+        cached_streams = self.data.get_camera_rtsps_streams(self.device.id)
+        if cached_streams is not None:
+            stream_url = cached_streams.get_stream_url(quality)
+            if stream_url is not None:
+                self._attr_supported_features = _ENABLE_FEATURE
+                self._stream_source = stream_url
+                return
+
+        # No public API stream available
+        self._attr_supported_features = _DISABLE_FEATURE
+        self._stream_source = None
 
     @callback
     def _async_update_device_from_protect(self, device: ProtectDeviceType) -> None:

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -1,11 +1,8 @@
 """Support for Ubiquiti's UniFi Protect NVR.
 
 Camera entities use the public API (get_rtsps_streams) exclusively for obtaining
-RTSPS stream URLs. This provides stable, authenticated stream URLs that work
+RTSPS stream URLs. This provides stable stream URLs that work
 reliably with Home Assistant's stream integration.
-
-Insecure (unencrypted RTSP) camera variants have been removed in favor of
-secure RTSPS streams only.
 """
 
 from __future__ import annotations

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -267,8 +267,12 @@ class ProtectCamera(ProtectDeviceEntity, Camera):
             _LOGGER.warning(
                 "Cannot fetch RTSPS streams without API key, streaming will be disabled"
             )
+            # Mark as checked to prevent repeated API calls
+            self.data.set_camera_rtsps_streams(self.device.id, None)
         except (ClientError, NvrError):
             _LOGGER.exception("Error fetching RTSPS streams from public API")
+            # Mark as checked to prevent repeated API calls
+            self.data.set_camera_rtsps_streams(self.device.id, None)
 
     @callback
     def _maybe_create_rtsp_repair(self) -> None:

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -78,6 +78,7 @@ PLATFORMS = [
 DISPATCH_ADD = "add_device"
 DISPATCH_ADOPT = "adopt_device"
 DISPATCH_CHANNELS = "new_camera_channels"
+DISPATCH_STREAMS = "refresh_streams"
 
 EVENT_TYPE_FINGERPRINT_IDENTIFIED: Final = "identified"
 EVENT_TYPE_FINGERPRINT_NOT_IDENTIFIED: Final = "not_identified"

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -756,10 +756,6 @@ class ProtectMediaSource(MediaSource):
             entity_id = entity_registry.async_get_entity_id(
                 Platform.CAMERA, DOMAIN, base_id
             )
-            if entity_id is None:
-                entity_id = entity_registry.async_get_entity_id(
-                    Platform.CAMERA, DOMAIN, f"{base_id}_insecure"
-                )
 
             if entity_id:
                 # verify entity is available

--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -1,4 +1,10 @@
-"""UniFi Protect data migrations."""
+"""UniFi Protect data migrations.
+
+Migrations include:
+- HDR mode switch deprecation (2024.4.0)
+- Insecure camera entity removal (2025.2.0): Removes unencrypted RTSP camera
+  entities in favor of secure RTSPS streams via the public API exclusively.
+"""
 
 from __future__ import annotations
 
@@ -111,6 +117,10 @@ async def async_migrate_data(
     async_deprecate_hdr(hass, entry)
     _LOGGER.debug("Completed Migrate: async_deprecate_hdr")
 
+    _LOGGER.debug("Start Migrate: async_migrate_insecure_cameras")
+    async_migrate_insecure_cameras(hass, entry)
+    _LOGGER.debug("Completed Migrate: async_migrate_insecure_cameras")
+
 
 @callback
 def async_deprecate_hdr(hass: HomeAssistant, entry: UFPConfigEntry) -> None:
@@ -128,3 +138,50 @@ def async_deprecate_hdr(hass: HomeAssistant, entry: UFPConfigEntry) -> None:
         "2024.10.0",
         {"hdr_switch": {"id": "hdr_mode", "platform": Platform.SWITCH}},
     )
+
+
+@callback
+def async_migrate_insecure_cameras(hass: HomeAssistant, entry: UFPConfigEntry) -> None:
+    """Remove deprecated insecure camera entities.
+
+    Insecure (unencrypted RTSP) camera entities have been removed in favor of
+    using only secure RTSPS streams via the public API. The insecure entities
+    had unique_ids ending with '_insecure'.
+
+    Added in 2025.2.0
+    """
+
+    entity_registry = er.async_get(hass)
+    entities_to_remove: list[str] = []
+
+    for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
+        if entity.domain == Platform.CAMERA and entity.unique_id.endswith("_insecure"):
+            # Check if entity is used in automations/scripts
+            entity_automations = automations_with_entity(hass, entity.entity_id)
+            entity_scripts = scripts_with_entity(hass, entity.entity_id)
+
+            if entity_automations or entity_scripts:
+                # Create a repair issue for used insecure camera entities
+                items = sorted(set(chain(entity_automations, entity_scripts)))
+                ir.async_create_issue(
+                    hass,
+                    DOMAIN,
+                    f"insecure_camera_removed_{entity.unique_id}",
+                    is_fixable=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key="insecure_camera_removed",
+                    translation_placeholders={
+                        "camera": entity.entity_id,
+                        "items": "* `" + "`\n* `".join(items) + "`\n",
+                    },
+                )
+                _LOGGER.warning(
+                    "Insecure camera entity %s is used in automations/scripts and will be removed",
+                    entity.entity_id,
+                )
+
+            entities_to_remove.append(entity.entity_id)
+
+    for entity_id in entities_to_remove:
+        _LOGGER.debug("Removing deprecated insecure camera entity: %s", entity_id)
+        entity_registry.async_remove(entity_id)

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -700,6 +700,10 @@
       "description": "UniFi Protect v3 added a new state for HDR (auto). As a result, the HDR Mode switch has been replaced with an HDR Mode select, and it is deprecated.\n\nBelow are the detected automations or scripts that use one or more of the deprecated entities:\n{items}\nThe above list may be incomplete and it does not include any template usages inside of dashboards. Please update any templates, automations or scripts accordingly.",
       "title": "HDR Mode switch deprecated"
     },
+    "insecure_camera_removed": {
+      "description": "The insecure (unencrypted RTSP) camera entity `{camera}` has been removed. UniFi Protect now uses only secure RTSPS streams via the public API.\n\nThe following automations or scripts reference this entity and need to be updated to use the secure camera entity instead:\n{items}\nPlease update your automations and scripts to use the corresponding secure camera entity (same entity ID without the `_insecure` suffix).",
+      "title": "Insecure camera entity removed"
+    },
     "rtsp_disabled_readonly": {
       "fix_flow": {
         "step": {
@@ -723,7 +727,7 @@
             "title": "[%key:component::unifiprotect::issues::rtsp_disabled_readonly::fix_flow::step::start::title%]"
           },
           "start": {
-            "description": "RTSPS is disabled on the camera {camera}. RTSPS is required to live stream your camera within Home Assistant. If you do not enable RTSPS, it may create an additional load on your UniFi Protect NVR as any live video players will default to rapidly pulling snapshots from the camera.\n\nYou may manually [enable RTSPS]({learn_more}) on your selected camera quality channel or Home Assistant can automatically enable the highest quality channel for you. Confirm this repair once you have enabled the RTSPS channel or if you want Home Assistant to enable the highest quality automatically.",
+            "description": "RTSPS is disabled on the camera {camera}. RTSPS is required to live stream your camera within Home Assistant. If you do not enable RTSPS, it may create an additional load on your UniFi Protect NVR as any live video players will default to rapidly pulling snapshots from the camera.\n\nYou may manually [enable RTSPS]({learn_more}) on the camera or Home Assistant can automatically enable all quality channels for you. Confirm this repair once you have enabled RTSPS or if you want Home Assistant to enable it automatically.",
             "title": "[%key:component::unifiprotect::issues::rtsp_disabled_readonly::fix_flow::step::start::title%]"
           }
         }

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, Mock
+import logging
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from uiprotect.api import DEVICE_UPDATE_INTERVAL
 from uiprotect.data import Camera as ProtectCamera, CameraChannel, StateType
-from uiprotect.exceptions import NvrError
+from uiprotect.exceptions import ClientError, NotAuthorized, NvrError
 from uiprotect.websocket import WebsocketState
 from webrtc_models import RTCIceCandidateInit
 
@@ -45,6 +46,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from . import patch_ufp_method
+from .conftest import create_mock_rtsps_streams
 from .utils import (
     Camera,
     MockUFPFixture,
@@ -136,31 +138,10 @@ def validate_rtsps_camera_entity(
 
     channel = camera_obj.channels[channel_id]
 
-    entity_name = f"{camera_obj.name} {channel.name} Resolution Channel"
+    camera_name = get_camera_base_name(channel)
+    entity_name = f"{camera_obj.name} {camera_name}"
     unique_id = f"{camera_obj.mac}_{channel.id}"
     entity_id = f"camera.{entity_name.replace(' ', '_').lower()}"
-
-    entity_registry = er.async_get(hass)
-    entity = entity_registry.async_get(entity_id)
-    assert entity
-    assert entity.disabled is True
-    assert entity.unique_id == unique_id
-
-    return entity_id
-
-
-def validate_rtsp_camera_entity(
-    hass: HomeAssistant,
-    camera_obj: ProtectCamera,
-    channel_id: int,
-) -> str:
-    """Validate a disabled RTSP camera entity."""
-
-    channel = camera_obj.channels[channel_id]
-
-    entity_name = f"{camera_obj.name} {channel.name} Resolution Channel (Insecure)"
-    unique_id = f"{camera_obj.mac}_{channel.id}_insecure"
-    entity_id = f"camera.{entity_name.replace(' ', '_').replace('(', '').replace(')', '').lower()}"
 
     entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(entity_id)
@@ -199,21 +180,10 @@ async def validate_rtsps_camera_state(
     """Validate a camera's state."""
     channel = camera_obj.channels[channel_id]
 
-    assert await async_get_stream_source(hass, entity_id) == channel.rtsps_no_srtp_url
-    validate_common_camera_state(hass, channel, entity_id, features)
-
-
-async def validate_rtsp_camera_state(
-    hass: HomeAssistant,
-    camera_obj: ProtectCamera,
-    channel_id: int,
-    entity_id: str,
-    features: int = CameraEntityFeature.STREAM,
-):
-    """Validate a camera's state."""
-    channel = camera_obj.channels[channel_id]
-
-    assert await async_get_stream_source(hass, entity_id) == channel.rtsp_url
+    # Stream source comes from public API - check that it has a valid RTSPS URL
+    stream_source = await async_get_stream_source(hass, entity_id)
+    assert stream_source is not None
+    assert stream_source.startswith("rtsps://")
     validate_common_camera_state(hass, channel, entity_id, features)
 
 
@@ -239,98 +209,67 @@ async def test_basic_setup(
 ) -> None:
     """Test working setup of unifiprotect entry."""
 
-    camera_high_only = camera_all.model_copy()
-    camera_high_only.channels = [c.model_copy() for c in camera_all.channels]
-    camera_high_only.name = "Test Camera 1"
-    camera_high_only.channels[0].is_rtsp_enabled = True
-    camera_high_only.channels[1].is_rtsp_enabled = False
-    camera_high_only.channels[2].is_rtsp_enabled = False
+    # All cameras get entities for all channels regardless of is_rtsp_enabled
+    # Stream availability is determined by the public API, not is_rtsp_enabled
 
-    camera_medium_only = camera_all.model_copy()
-    camera_medium_only.channels = [c.model_copy() for c in camera_all.channels]
-    camera_medium_only.name = "Test Camera 2"
-    camera_medium_only.channels[0].is_rtsp_enabled = False
-    camera_medium_only.channels[1].is_rtsp_enabled = True
-    camera_medium_only.channels[2].is_rtsp_enabled = False
+    camera1 = camera_all.model_copy()
+    camera1.channels = [c.model_copy() for c in camera_all.channels]
+    camera1.name = "Test Camera 1"
+
+    camera2 = camera_all.model_copy()
+    camera2.channels = [c.model_copy() for c in camera_all.channels]
+    camera2.name = "Test Camera 2"
 
     camera_all.name = "Test Camera 3"
 
-    camera_no_channels = camera_all.model_copy()
-    camera_no_channels.channels = [c.model_copy() for c in camera_all.channels]
-    camera_no_channels.name = "Test Camera 4"
-    camera_no_channels.channels[0].is_rtsp_enabled = False
-    camera_no_channels.channels[1].is_rtsp_enabled = False
-    camera_no_channels.channels[2].is_rtsp_enabled = False
-
+    # Doorbell with package camera
     doorbell.name = "Test Camera 5"
+    doorbell.feature_flags.has_package_camera = True
 
     devices = [
-        camera_high_only,
-        camera_medium_only,
+        camera1,
+        camera2,
         camera_all,
-        camera_no_channels,
         doorbell,
     ]
     await init_entry(hass, ufp, devices)
 
-    assert_entity_counts(hass, Platform.CAMERA, 14, 6)
+    # All cameras get all channels as entities:
+    # camera1: 3 entities (high enabled, medium disabled, low disabled)
+    # camera2: 3 entities (high enabled, medium disabled, low disabled)
+    # camera_all: 3 entities (high enabled, medium disabled, low disabled)
+    # doorbell: 4 entities (high enabled, medium disabled, low disabled, package disabled)
+    # Total: 13 entities, 4 enabled by default (one "high" per camera)
+    assert_entity_counts(hass, Platform.CAMERA, 13, 4)
 
-    # test camera 1
-    entity_id = validate_default_camera_entity(hass, camera_high_only, 0)
-    await validate_rtsps_camera_state(hass, camera_high_only, 0, entity_id)
+    # test camera 1 - high channel should be enabled
+    entity_id = validate_default_camera_entity(hass, camera1, 0)
+    await validate_rtsps_camera_state(hass, camera1, 0, entity_id)
 
-    entity_id = validate_rtsp_camera_entity(hass, camera_high_only, 0)
-    await enable_entity(hass, ufp.entry.entry_id, entity_id)
-    await validate_rtsp_camera_state(hass, camera_high_only, 0, entity_id)
-
-    # test camera 2
-    entity_id = validate_default_camera_entity(hass, camera_medium_only, 1)
-    await validate_rtsps_camera_state(hass, camera_medium_only, 1, entity_id)
-
-    entity_id = validate_rtsp_camera_entity(hass, camera_medium_only, 1)
-    await enable_entity(hass, ufp.entry.entry_id, entity_id)
-    await validate_rtsp_camera_state(hass, camera_medium_only, 1, entity_id)
+    # verify medium and low channels exist but are disabled
+    validate_rtsps_camera_entity(hass, camera1, 1)
+    validate_rtsps_camera_entity(hass, camera1, 2)
 
     # test camera 3
     entity_id = validate_default_camera_entity(hass, camera_all, 0)
     await validate_rtsps_camera_state(hass, camera_all, 0, entity_id)
 
-    entity_id = validate_rtsp_camera_entity(hass, camera_all, 0)
-    await enable_entity(hass, ufp.entry.entry_id, entity_id)
-    await validate_rtsp_camera_state(hass, camera_all, 0, entity_id)
-
+    # enable medium channel and verify
     entity_id = validate_rtsps_camera_entity(hass, camera_all, 1)
     await enable_entity(hass, ufp.entry.entry_id, entity_id)
     await validate_rtsps_camera_state(hass, camera_all, 1, entity_id)
 
-    entity_id = validate_rtsp_camera_entity(hass, camera_all, 1)
-    await enable_entity(hass, ufp.entry.entry_id, entity_id)
-    await validate_rtsp_camera_state(hass, camera_all, 1, entity_id)
-
+    # enable low channel and verify
     entity_id = validate_rtsps_camera_entity(hass, camera_all, 2)
     await enable_entity(hass, ufp.entry.entry_id, entity_id)
     await validate_rtsps_camera_state(hass, camera_all, 2, entity_id)
 
-    entity_id = validate_rtsp_camera_entity(hass, camera_all, 2)
-    await enable_entity(hass, ufp.entry.entry_id, entity_id)
-    await validate_rtsp_camera_state(hass, camera_all, 2, entity_id)
-
-    # test camera 4
-    entity_id = validate_default_camera_entity(hass, camera_no_channels, 0)
-    await validate_no_stream_camera_state(
-        hass, camera_no_channels, 0, entity_id, features=0
-    )
-
-    # test camera 5
+    # test doorbell - high channel should be enabled
     entity_id = validate_default_camera_entity(hass, doorbell, 0)
     await validate_rtsps_camera_state(hass, doorbell, 0, entity_id)
 
-    entity_id = validate_rtsp_camera_entity(hass, doorbell, 0)
-    await enable_entity(hass, ufp.entry.entry_id, entity_id)
-    await validate_rtsp_camera_state(hass, doorbell, 0, entity_id)
-
-    entity_id = validate_default_camera_entity(hass, doorbell, 3)
-    await validate_no_stream_camera_state(hass, doorbell, 3, entity_id, features=0)
+    # verify package channel exists but is disabled (index 3)
+    validate_rtsps_camera_entity(hass, doorbell, 3)
 
 
 @pytest.mark.usefixtures("web_rtc_provider")
@@ -381,12 +320,13 @@ async def test_adopt(
     mock_msg.new_obj = camera1
     ufp.ws_msg(mock_msg)
     await hass.async_block_till_done()
-    assert_entity_counts(hass, Platform.CAMERA, 2, 1)
+    # With all channels (high, medium, low), we get 3 entities total, 1 enabled
+    assert_entity_counts(hass, Platform.CAMERA, 3, 1)
 
     await remove_entities(hass, ufp, [camera1])
     assert_entity_counts(hass, Platform.CAMERA, 0, 0)
     await adopt_devices(hass, ufp, [camera1])
-    assert_entity_counts(hass, Platform.CAMERA, 2, 1)
+    assert_entity_counts(hass, Platform.CAMERA, 3, 1)
 
 
 async def test_camera_image(
@@ -395,7 +335,8 @@ async def test_camera_image(
     """Test retrieving camera image."""
 
     await init_entry(hass, ufp, [camera])
-    assert_entity_counts(hass, Platform.CAMERA, 2, 1)
+    # Camera with 3 channels (high, medium, low), only high enabled by default
+    assert_entity_counts(hass, Platform.CAMERA, 3, 1)
 
     ufp.api.get_public_api_camera_snapshot = AsyncMock()
 
@@ -403,13 +344,15 @@ async def test_camera_image(
     ufp.api.get_public_api_camera_snapshot.assert_called_once()
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_package_camera_image(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: ProtectCamera
 ) -> None:
     """Test retrieving package camera image."""
 
     await init_entry(hass, ufp, [doorbell])
-    assert_entity_counts(hass, Platform.CAMERA, 3, 2)
+    # All channels enabled via entity_registry_enabled_by_default fixture
+    assert_entity_counts(hass, Platform.CAMERA, 4, 4)
 
     ufp.api.get_package_camera_snapshot = AsyncMock()
 
@@ -423,7 +366,7 @@ async def test_camera_generic_update(
     """Tests generic entity update service."""
 
     await init_entry(hass, ufp, [camera])
-    assert_entity_counts(hass, Platform.CAMERA, 2, 1)
+    assert_entity_counts(hass, Platform.CAMERA, 3, 1)
     entity_id = "camera.test_camera_high_resolution_channel"
 
     assert await async_setup_component(hass, "homeassistant", {})
@@ -449,7 +392,7 @@ async def test_camera_interval_update(
     """Interval updates updates camera entity."""
 
     await init_entry(hass, ufp, [camera])
-    assert_entity_counts(hass, Platform.CAMERA, 2, 1)
+    assert_entity_counts(hass, Platform.CAMERA, 3, 1)
     entity_id = "camera.test_camera_high_resolution_channel"
 
     state = hass.states.get(entity_id)
@@ -472,7 +415,7 @@ async def test_camera_bad_interval_update(
     """Interval updates marks camera unavailable."""
 
     await init_entry(hass, ufp, [camera])
-    assert_entity_counts(hass, Platform.CAMERA, 2, 1)
+    assert_entity_counts(hass, Platform.CAMERA, 3, 1)
     entity_id = "camera.test_camera_high_resolution_channel"
 
     state = hass.states.get(entity_id)
@@ -499,7 +442,7 @@ async def test_camera_websocket_disconnected(
     """Test the websocket gets disconnected and reconnected."""
 
     await init_entry(hass, ufp, [camera])
-    assert_entity_counts(hass, Platform.CAMERA, 2, 1)
+    assert_entity_counts(hass, Platform.CAMERA, 3, 1)
     entity_id = "camera.test_camera_high_resolution_channel"
 
     state = hass.states.get(entity_id)
@@ -526,7 +469,7 @@ async def test_camera_ws_update(
     """WS update updates camera entity."""
 
     await init_entry(hass, ufp, [camera])
-    assert_entity_counts(hass, Platform.CAMERA, 2, 1)
+    assert_entity_counts(hass, Platform.CAMERA, 3, 1)
     entity_id = "camera.test_camera_high_resolution_channel"
 
     state = hass.states.get(entity_id)
@@ -561,7 +504,7 @@ async def test_camera_ws_update_offline(
     """WS updates marks camera unavailable."""
 
     await init_entry(hass, ufp, [camera])
-    assert_entity_counts(hass, Platform.CAMERA, 2, 1)
+    assert_entity_counts(hass, Platform.CAMERA, 3, 1)
     entity_id = "camera.test_camera_high_resolution_channel"
 
     state = hass.states.get(entity_id)
@@ -613,7 +556,7 @@ async def test_camera_motion_detection(
 ) -> None:
     """Test enabling/disabling motion detection on camera."""
     await init_entry(hass, ufp, [camera])
-    assert_entity_counts(hass, Platform.CAMERA, 2, 1)
+    assert_entity_counts(hass, Platform.CAMERA, 3, 1)
     entity_id = "camera.test_camera_high_resolution_channel"
 
     with patch_ufp_method(
@@ -627,3 +570,56 @@ async def test_camera_motion_detection(
         )
 
         mock_method.assert_called_once_with(expected_value)
+
+
+async def test_camera_rtsps_not_authorized(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    camera: ProtectCamera,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test camera handles NotAuthorized exception when fetching RTSPS streams."""
+    with patch.object(
+        ProtectCamera, "get_rtsps_streams", AsyncMock(side_effect=NotAuthorized)
+    ):
+        await init_entry(hass, ufp, [camera])
+
+    assert "Cannot fetch RTSPS streams without API key" in caplog.text
+
+
+async def test_camera_rtsps_client_error(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    camera: ProtectCamera,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test camera handles ClientError exception when fetching RTSPS streams."""
+    # Override the fixture mock to raise ClientError using object.__setattr__ for pydantic
+    object.__setattr__(
+        camera, "get_rtsps_streams", AsyncMock(side_effect=ClientError("test"))
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        await init_entry(hass, ufp, [camera])
+
+    # Error is logged at DEBUG level during pre-fetch in async_setup
+    assert "Error fetching RTSPS streams for" in caplog.text
+
+
+async def test_camera_rtsps_cache_clear_on_none(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    camera: ProtectCamera,
+) -> None:
+    """Test that setting RTSPS streams to None clears the cache."""
+    await init_entry(hass, ufp, [camera])
+    data = ufp.entry.runtime_data
+
+    # First set streams to a value
+    mock_streams = create_mock_rtsps_streams(["high"])
+    data.set_camera_rtsps_streams(camera.id, mock_streams)
+    assert data.get_camera_rtsps_streams(camera.id) is not None
+
+    # Now set to None to trigger the elif branch (line 122-123 in data.py)
+    data.set_camera_rtsps_streams(camera.id, None)
+    assert data.get_camera_rtsps_streams(camera.id) is None

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 from copy import deepcopy
 from unittest.mock import AsyncMock
 
+import pytest
 from uiprotect.data import Camera, CloudAccount, Version
 
 from homeassistant.components.unifiprotect.const import CONF_DISABLE_RTSP, DOMAIN
+from homeassistant.components.unifiprotect.repairs import async_create_fix_flow
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
+from .conftest import create_mock_rtsps_streams
 from .utils import MockUFPFixture, init_entry
 
 from tests.components.repairs import (
@@ -20,6 +23,40 @@ from tests.components.repairs import (
     start_repair_fix_flow,
 )
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
+
+
+def _setup_camera_with_active_streams(
+    camera: Camera, include_create: bool = True
+) -> Camera:
+    """Create a camera copy with active RTSPS streams mocked.
+
+    Args:
+        camera: The source camera to copy
+        include_create: If True, also mock create_rtsps_streams (for writable users)
+    """
+    new_camera = deepcopy(camera)
+    new_camera.channels[0].is_rtsp_enabled = True
+    mock_streams = create_mock_rtsps_streams(["high", "medium", "low"])
+    object.__setattr__(
+        new_camera, "get_rtsps_streams", AsyncMock(return_value=mock_streams)
+    )
+    if include_create:
+        object.__setattr__(
+            new_camera, "create_rtsps_streams", AsyncMock(return_value=mock_streams)
+        )
+    return new_camera
+
+
+def _disable_all_rtsp_channels(camera: Camera) -> None:
+    """Disable RTSP on all channels of a camera."""
+    for channel in camera.channels:
+        channel.is_rtsp_enabled = False
+
+
+def _make_users_read_only(ufp: MockUFPFixture) -> None:
+    """Remove all permissions from users to simulate read-only access."""
+    for user in ufp.api.bootstrap.users.values():
+        user.all_permissions = []
 
 
 async def test_cloud_user_fix(
@@ -63,22 +100,25 @@ async def test_cloud_user_fix(
     assert any(ufp.entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
 
 
+@pytest.fixture
+def rtsps_disabled() -> bool:
+    """Disable RTSPS streams for this test."""
+    return True
+
+
 async def test_rtsp_read_only_ignore(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
     doorbell: Camera,
     hass_client: ClientSessionGenerator,
     hass_ws_client: WebSocketGenerator,
+    rtsps_disabled: bool,
 ) -> None:
     """Test RTSP disabled warning if camera is read-only and it is ignored."""
-
-    for channel in doorbell.channels:
-        channel.is_rtsp_enabled = False
-    for user in ufp.api.bootstrap.users.values():
-        user.all_permissions = []
+    _disable_all_rtsp_channels(doorbell)
+    _make_users_read_only(ufp)
 
     ufp.api.get_camera = AsyncMock(return_value=doorbell)
-    ufp.api.create_camera_rtsps_streams = AsyncMock(return_value=None)
 
     await init_entry(hass, ufp, [doorbell])
     await async_process_repairs_platforms(hass)
@@ -119,23 +159,25 @@ async def test_rtsp_read_only_fix(
     doorbell: Camera,
     hass_client: ClientSessionGenerator,
     hass_ws_client: WebSocketGenerator,
+    rtsps_disabled: bool,
 ) -> None:
-    """Test RTSP disabled warning if camera is read-only and it is fixed."""
+    """Test RTSP disabled warning if camera is read-only and it is fixed.
 
-    for channel in doorbell.channels:
-        channel.is_rtsp_enabled = False
-    for user in ufp.api.bootstrap.users.values():
-        user.all_permissions = []
+    Scenario: User has read-only permissions but someone else activated streams.
+    The repair flow should detect this and complete successfully.
+    """
+    _disable_all_rtsp_channels(doorbell)
+    _make_users_read_only(ufp)
 
     await init_entry(hass, ufp, [doorbell])
     await async_process_repairs_platforms(hass)
     ws_client = await hass_ws_client(hass)
     client = await hass_client()
 
-    new_doorbell = deepcopy(doorbell)
+    # After init, simulate that someone else activated the streams
+    new_doorbell = _setup_camera_with_active_streams(doorbell, include_create=False)
     new_doorbell.channels[1].is_rtsp_enabled = True
     ufp.api.get_camera = AsyncMock(return_value=new_doorbell)
-    ufp.api.create_camera_rtsps_streams = AsyncMock(return_value=None)
     issue_id = f"rtsp_disabled_{doorbell.id}"
 
     await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
@@ -165,22 +207,18 @@ async def test_rtsp_writable_fix(
     doorbell: Camera,
     hass_client: ClientSessionGenerator,
     hass_ws_client: WebSocketGenerator,
+    rtsps_disabled: bool,
 ) -> None:
-    """Test RTSP disabled warning if camera is writable and it is ignored."""
-
-    for channel in doorbell.channels:
-        channel.is_rtsp_enabled = False
+    """Test RTSP disabled warning if camera is writable and streams are activated."""
+    _disable_all_rtsp_channels(doorbell)
 
     await init_entry(hass, ufp, [doorbell])
     await async_process_repairs_platforms(hass)
     ws_client = await hass_ws_client(hass)
     client = await hass_client()
 
-    new_doorbell = deepcopy(doorbell)
-    new_doorbell.channels[0].is_rtsp_enabled = True
-
-    ufp.api.get_camera = AsyncMock(side_effect=[doorbell, new_doorbell])
-    ufp.api.create_camera_rtsps_streams = AsyncMock(return_value=None)
+    new_doorbell = _setup_camera_with_active_streams(doorbell)
+    ufp.api.get_camera = AsyncMock(return_value=new_doorbell)
     issue_id = f"rtsp_disabled_{doorbell.id}"
 
     await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
@@ -203,8 +241,6 @@ async def test_rtsp_writable_fix(
 
     assert data["type"] == "create_entry"
 
-    ufp.api.create_camera_rtsps_streams.assert_called_with(doorbell.id, "high")
-
 
 async def test_rtsp_writable_fix_when_not_setup(
     hass: HomeAssistant,
@@ -212,22 +248,18 @@ async def test_rtsp_writable_fix_when_not_setup(
     doorbell: Camera,
     hass_client: ClientSessionGenerator,
     hass_ws_client: WebSocketGenerator,
+    rtsps_disabled: bool,
 ) -> None:
     """Test RTSP disabled warning if the integration is no longer set up."""
-
-    for channel in doorbell.channels:
-        channel.is_rtsp_enabled = False
+    _disable_all_rtsp_channels(doorbell)
 
     await init_entry(hass, ufp, [doorbell])
     await async_process_repairs_platforms(hass)
     ws_client = await hass_ws_client(hass)
     client = await hass_client()
 
-    new_doorbell = deepcopy(doorbell)
-    new_doorbell.channels[0].is_rtsp_enabled = True
-
-    ufp.api.get_camera = AsyncMock(side_effect=[doorbell, new_doorbell])
-    ufp.api.create_camera_rtsps_streams = AsyncMock(return_value=None)
+    new_doorbell = _setup_camera_with_active_streams(doorbell)
+    ufp.api.get_camera = AsyncMock(return_value=new_doorbell)
     issue_id = f"rtsp_disabled_{doorbell.id}"
 
     await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
@@ -255,21 +287,17 @@ async def test_rtsp_writable_fix_when_not_setup(
 
     assert data["type"] == "create_entry"
 
-    ufp.api.create_camera_rtsps_streams.assert_called_with(doorbell.id, "high")
-
 
 async def test_rtsp_no_fix_if_third_party(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
     doorbell: Camera,
     hass_ws_client: WebSocketGenerator,
+    rtsps_disabled: bool,
 ) -> None:
     """Test no RTSP disabled warning if camera is third-party."""
-
-    for channel in doorbell.channels:
-        channel.is_rtsp_enabled = False
-    for user in ufp.api.bootstrap.users.values():
-        user.all_permissions = []
+    _disable_all_rtsp_channels(doorbell)
+    _make_users_read_only(ufp)
 
     ufp.api.get_camera = AsyncMock(return_value=doorbell)
     doorbell.is_third_party_camera = True
@@ -290,11 +318,10 @@ async def test_rtsp_no_fix_if_globally_disabled(
     ufp: MockUFPFixture,
     doorbell: Camera,
     issue_registry: ir.IssueRegistry,
+    rtsps_disabled: bool,
 ) -> None:
     """Test no RTSP disabled warning if RTSP is globally disabled on integration."""
-
-    for channel in doorbell.channels:
-        channel.is_rtsp_enabled = False
+    _disable_all_rtsp_channels(doorbell)
 
     # Set RTSP globally disabled in config entry options
     hass.config_entries.async_update_entry(
@@ -306,3 +333,28 @@ async def test_rtsp_no_fix_if_globally_disabled(
     await async_process_repairs_platforms(hass)
 
     assert len(issue_registry.issues) == 0
+
+
+async def test_unknown_issue_returns_confirm_flow(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test that unknown issue_id returns ConfirmRepairFlow."""
+    await init_entry(hass, ufp, [])
+
+    # Test with None data
+    flow = await async_create_fix_flow(hass, "unknown_issue", None)
+    assert flow.__class__.__name__ == "ConfirmRepairFlow"
+
+    # Test with invalid entry_id
+    flow = await async_create_fix_flow(
+        hass, "unknown_issue", {"entry_id": "nonexistent"}
+    )
+    assert flow.__class__.__name__ == "ConfirmRepairFlow"
+
+    # Test with valid entry but unknown issue_id
+    flow = await async_create_fix_flow(
+        hass, "unknown_issue", {"entry_id": ufp.entry.entry_id}
+    )
+    assert flow.__class__.__name__ == "ConfirmRepairFlow"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Insecure (unencrypted RTSP) camera entities have been removed. These entities had names ending with "(insecure)" and unique IDs ending with `_insecure`.

**What breaks:** If you were using insecure camera entities in automations, scripts, or dashboards, they will no longer exist after this update.

**How to fix:** Use the corresponding secure camera entity instead (same entity ID without the `_insecure` suffix). The secure cameras now exclusively use RTSPS streams obtained via the UniFi Protect public API.

**Why this change:** The public API provides stable, authenticated stream URLs that work more reliably with Home Assistant's stream integration. Insecure streams offered no meaningful benefit and added complexity.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR switches UniFi Protect camera entities to use the public API (`get_rtsps_streams()`) exclusively for obtaining RTSPS stream URLs, instead of using the internal channel properties.

**Key changes:**
- Camera entities now fetch stream URLs via the public API
- Centralized RTSPS stream cache in ProtectData with automatic refresh on WebSocket reconnect or IP/channel changes
- Pre-fetch streams sequentially during setup to avoid API rate limiting (429 errors)
- Repair flow updated to activate all quality channels (high, medium, low, package) via public API
- Migration removes deprecated insecure camera entities with repair issue creation when used in automations/scripts

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
