### PR TITLE
Consider missing togrill device okey to log real errors

### DIFF
--- a/homeassistant/components/togrill/coordinator.py
+++ b/homeassistant/components/togrill/coordinator.py
@@ -146,6 +146,10 @@ class ToGrillCoordinator(DataUpdateCoordinator[dict[tuple[int, int | None], Pack
             self.logger.debug("Connection failed", exc_info=True)
             raise DeviceFailed("Unable to connect to device") from exc
 
+        # Ensure the device has completed
+        # notification registrations.
+        await asyncio.sleep(0.5)
+
         try:
             async with asyncio.timeout(10):
                 packet_a0 = await client.read(PacketA0Notify)

--- a/homeassistant/components/togrill/coordinator.py
+++ b/homeassistant/components/togrill/coordinator.py
@@ -146,10 +146,6 @@ class ToGrillCoordinator(DataUpdateCoordinator[dict[tuple[int, int | None], Pack
             self.logger.debug("Connection failed", exc_info=True)
             raise DeviceFailed("Unable to connect to device") from exc
 
-        # Ensure the device has completed
-        # notification registrations.
-        await asyncio.sleep(0.5)
-
         try:
             async with asyncio.timeout(10):
                 packet_a0 = await client.read(PacketA0Notify)

--- a/homeassistant/components/togrill/entity.py
+++ b/homeassistant/components/togrill/entity.py
@@ -49,3 +49,10 @@ class ToGrillEntity(CoordinatorEntity[ToGrillCoordinator]):
                 translation_domain=DOMAIN, translation_key="rejected"
             ) from exc
         await self.coordinator.async_request_refresh()
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.client is not None
+        )

--- a/tests/components/togrill/conftest.py
+++ b/tests/components/togrill/conftest.py
@@ -19,6 +19,15 @@ from . import TOGRILL_SERVICE_INFO
 from tests.common import MockConfigEntry
 
 
+@pytest.fixture(autouse=True)
+def mock_sleep():
+    """Time is frozen, so ignore the sleeps."""
+    with patch(
+        "homeassistant.components.togrill.coordinator.asyncio.sleep", new=AsyncMock()
+    ):
+        yield
+
+
 @pytest.fixture
 def mock_entry() -> MockConfigEntry:
     """Create hass config fixture."""

--- a/tests/components/togrill/conftest.py
+++ b/tests/components/togrill/conftest.py
@@ -19,15 +19,6 @@ from . import TOGRILL_SERVICE_INFO
 from tests.common import MockConfigEntry
 
 
-@pytest.fixture(autouse=True)
-def mock_sleep():
-    """Time is frozen, so ignore the sleeps."""
-    with patch(
-        "homeassistant.components.togrill.coordinator.asyncio.sleep", new=AsyncMock()
-    ):
-        yield
-
-
 @pytest.fixture
 def mock_entry() -> MockConfigEntry:
     """Create hass config fixture."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

An unavailable device is not a error condition, so we should let the coordinator be in
successfull state, to ensure we actually log failure to connect to devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
