### PR TITLE
Add support for HTTP Streamable to MCP integration

### DIFF
--- a/homeassistant/components/mcp/config_flow.py
+++ b/homeassistant/components/mcp/config_flow.py
@@ -47,7 +47,7 @@ MCP_DISCOVERY_HEADERS = {
     "MCP-Protocol-Version": "2025-03-26",
 }
 
-EXAMPLE_URL = "http://example/sse"
+EXAMPLE_URL = "http://example/mcp"
 
 
 @dataclass
@@ -122,7 +122,7 @@ async def validate_input(
     except vol.Invalid as error:
         raise InvalidUrl from error
     try:
-        async with mcp_client(url, token_manager=token_manager) as session:
+        async with mcp_client(hass, url, token_manager=token_manager) as session:
             response = await session.initialize()
     except httpx.TimeoutException as error:
         _LOGGER.info("Timeout connecting to MCP server: %s", error)

--- a/homeassistant/components/mcp/coordinator.py
+++ b/homeassistant/components/mcp/coordinator.py
@@ -9,6 +9,7 @@ import logging
 import httpx
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
+from mcp.client.streamable_http import streamable_http_client
 import voluptuous as vol
 from voluptuous_openapi import convert_to_voluptuous
 
@@ -17,6 +18,7 @@ from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import llm
+from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.json import JsonObjectType
 
@@ -32,10 +34,11 @@ type TokenManager = Callable[[], Awaitable[str]]
 
 @asynccontextmanager
 async def mcp_client(
+    hass: HomeAssistant,
     url: str,
     token_manager: TokenManager | None = None,
 ) -> AsyncGenerator[ClientSession]:
-    """Create a server-sent event MCP client.
+    """Create an MCP client.
 
     This is an asynccontext manager that exists to wrap other async context managers
     so that the coordinator has a single object to manage.
@@ -44,16 +47,39 @@ async def mcp_client(
     if token_manager is not None:
         token = await token_manager()
         headers["Authorization"] = f"Bearer {token}"
+
     try:
         async with (
-            sse_client(url=url, headers=headers) as streams,
-            ClientSession(*streams) as session,
+            streamable_http_client(
+                url=url,
+                http_client=create_async_httpx_client(hass),
+            ) as (read_stream, write_stream, _),
+            ClientSession(read_stream, write_stream) as session,
         ):
             await session.initialize()
             yield session
-    except ExceptionGroup as err:
-        _LOGGER.debug("Error creating MCP client: %s", err)
-        raise err.exceptions[0] from err
+    except ExceptionGroup as streamable_err:
+        main_error = streamable_err.exceptions[0]
+        # Method not Allowed likely means this is not a streamable HTTP server,
+        # but it may be an SSE server
+        if (
+            isinstance(main_error, httpx.HTTPStatusError)
+            and main_error.response.status_code == 405
+        ):
+            # This is an SSE Server
+            try:
+                async with (
+                    sse_client(url=url, headers=headers) as streams,
+                    ClientSession(*streams) as session,
+                ):
+                    await session.initialize()
+                    yield session
+            except ExceptionGroup as sse_err:
+                _LOGGER.debug("Error creating SSE MCP client: %s", sse_err)
+                raise sse_err.exceptions[0] from sse_err
+        else:
+            _LOGGER.debug("Error creating MCP client: %s", streamable_err)
+            raise main_error from streamable_err
 
 
 class ModelContextProtocolTool(llm.Tool):
@@ -83,7 +109,9 @@ class ModelContextProtocolTool(llm.Tool):
         """Call the tool."""
         try:
             async with asyncio.timeout(TIMEOUT):
-                async with mcp_client(self.server_url, self.token_manager) as session:
+                async with mcp_client(
+                    hass, self.server_url, self.token_manager
+                ) as session:
                     result = await session.call_tool(
                         tool_input.tool_name, tool_input.tool_args
                     )
@@ -126,7 +154,7 @@ class ModelContextProtocolCoordinator(DataUpdateCoordinator[list[llm.Tool]]):
         try:
             async with asyncio.timeout(TIMEOUT):
                 async with mcp_client(
-                    self.config_entry.data[CONF_URL], self.token_manager
+                    self.hass, self.config_entry.data[CONF_URL], self.token_manager
                 ) as session:
                     result = await session.list_tools()
         except TimeoutError as error:

--- a/homeassistant/components/mcp/coordinator.py
+++ b/homeassistant/components/mcp/coordinator.py
@@ -52,7 +52,7 @@ async def mcp_client(
         async with (
             streamable_http_client(
                 url=url,
-                http_client=create_async_httpx_client(hass),
+                http_client=create_async_httpx_client(hass, headers=headers),
             ) as (read_stream, write_stream, _),
             ClientSession(read_stream, write_stream) as session,
         ):

--- a/homeassistant/components/mcp/coordinator.py
+++ b/homeassistant/components/mcp/coordinator.py
@@ -61,12 +61,12 @@ async def mcp_client(
     except ExceptionGroup as streamable_err:
         main_error = streamable_err.exceptions[0]
         # Method not Allowed likely means this is not a streamable HTTP server,
-        # but it may be an SSE server
+        # but it may be an SSE server. This is part of the MCP Transport
+        # backwards compatibility specification.
         if (
             isinstance(main_error, httpx.HTTPStatusError)
             and main_error.response.status_code == 405
         ):
-            # This is an SSE Server
             try:
                 async with (
                     sse_client(url=url, headers=headers) as streams,

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -117,7 +117,10 @@ def create_async_httpx_client(
         kwargs.setdefault("http2", True)
     client = HassHttpXAsyncClient(
         verify=ssl_context,
-        headers={USER_AGENT: SERVER_SOFTWARE},
+        headers={
+            USER_AGENT: SERVER_SOFTWARE,
+            **kwargs.pop("headers", {}),
+        },
         limits=DEFAULT_LIMITS,
         **kwargs,
     )

--- a/tests/components/mcp/conftest.py
+++ b/tests/components/mcp/conftest.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Generator
 import datetime
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -42,10 +43,34 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_mcp_client() -> Generator[AsyncMock]:
+def mock_sse_client() -> Generator[AsyncMock]:
+    """Fixture to mock the MCP client."""
+    with patch(
+        "homeassistant.components.mcp.coordinator.sse_client"
+    ) as mock_sse_client:
+        yield mock_sse_client
+
+
+@pytest.fixture
+def mock_http_streamable_client() -> Generator[AsyncMock]:
+    """Fixture to mock the MCP client."""
+    with patch(
+        "homeassistant.components.mcp.coordinator.streamable_http_client"
+    ) as mock_streamable_client:
+        mock_streamable_client.return_value.__aenter__.return_value = (
+            AsyncMock(),
+            AsyncMock(),
+            AsyncMock(),
+        )
+        yield mock_streamable_client
+
+
+@pytest.fixture
+def mock_mcp_client(
+    mock_sse_client: Any, mock_http_streamable_client: Any
+) -> Generator[AsyncMock]:
     """Fixture to mock the MCP client."""
     with (
-        patch("homeassistant.components.mcp.coordinator.sse_client"),
         patch("homeassistant.components.mcp.coordinator.ClientSession") as mock_session,
         patch("homeassistant.components.mcp.coordinator.TIMEOUT", 1),
     ):

--- a/tests/components/mcp/test_init.py
+++ b/tests/components/mcp/test_init.py
@@ -1,7 +1,7 @@
 """Tests for the Model Context Protocol component."""
 
 import re
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
@@ -90,11 +90,88 @@ async def test_mcp_server_failure(
     mock_mcp_client: Mock,
     side_effect: Exception,
 ) -> None:
-    """Test the integration fails to setup if the server fails initialization."""
+    """Test the integration fails to setup if the server fails initialization.
+
+    This tests generic failure types that are independent of transport.
+    """
     mock_mcp_client.side_effect = side_effect
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_mcp_server_http_transport_failure(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_http_streamable_client: AsyncMock,
+) -> None:
+    """Test the integration fails to setup if the HTTP transport fails."""
+    mock_http_streamable_client.side_effect = ExceptionGroup(
+        "Connection error", [httpx.ConnectError("Connection failed")]
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_mcp_server_sse_transport_failure(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_http_streamable_client: AsyncMock,
+    mock_sse_client: AsyncMock,
+) -> None:
+    """Test the integration fails to setup if the SSE transport fails.
+
+    This exercises the case where the HTTP transport fails with method not
+    allow indicating an SSE server, then also fails with SSE.
+    """
+    http_405 = httpx.HTTPStatusError(
+        "Method not allowed", request=None, response=httpx.Response(405)
+    )
+    mock_http_streamable_client.side_effect = ExceptionGroup(
+        "Method not allowed", [http_405]
+    )
+
+    mock_sse_client.side_effect = ExceptionGroup(
+        "Connection error", [httpx.ConnectError("Connection failed")]
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_mcp_client_fallback_to_sse_success(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_http_streamable_client: AsyncMock,
+    mock_sse_client: AsyncMock,
+    mock_mcp_client: Mock,
+) -> None:
+    """Test mcp_client falls back to SSE on method not allowed error.
+
+    This exercises the backwards compatibility part of the MCP Transport
+    specification.
+    """
+    http_405 = httpx.HTTPStatusError(
+        "Method not allowed",
+        request=None,  # type: ignore[arg-type]
+        response=httpx.Response(405),
+    )
+    mock_http_streamable_client.side_effect = ExceptionGroup(
+        "Method not allowed", [http_405]
+    )
+
+    # Setup mocks for SSE fallback
+    mock_sse_client.return_value.__aenter__.return_value = ("read", "write")
+    mock_mcp_client.return_value.list_tools.return_value = ListToolsResult(
+        tools=[SEARCH_MEMORY_TOOL]
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert mock_http_streamable_client.called
+    assert mock_sse_client.called
 
 
 async def test_mcp_server_authentication_failure(

--- a/tests/components/mcp/test_init.py
+++ b/tests/components/mcp/test_init.py
@@ -123,7 +123,7 @@ async def test_mcp_server_sse_transport_failure(
     """Test the integration fails to setup if the SSE transport fails.
 
     This exercises the case where the HTTP transport fails with method not
-    allow indicating an SSE server, then also fails with SSE.
+    allowed, indicating an SSE server, then also fails with SSE.
     """
     http_405 = httpx.HTTPStatusError(
         "Method not allowed", request=None, response=httpx.Response(405)

--- a/tests/helpers/test_httpx_client.py
+++ b/tests/helpers/test_httpx_client.py
@@ -57,6 +57,26 @@ async def test_create_async_httpx_client_without_ssl_and_cookies(
     assert hass.data[client.DATA_ASYNC_CLIENT][(False, SSL_ALPN_HTTP11)] != httpx_client
 
 
+async def test_create_async_httpx_client_default_headers(
+    hass: HomeAssistant,
+) -> None:
+    """Test init async client with default headers."""
+    httpx_client = client.create_async_httpx_client(hass)
+    assert isinstance(httpx_client, httpx.AsyncClient)
+    assert httpx_client.headers[client.USER_AGENT] == client.SERVER_SOFTWARE
+
+
+async def test_create_async_httpx_client_with_headers(
+    hass: HomeAssistant,
+) -> None:
+    """Test init async client with headers."""
+    httpx_client = client.create_async_httpx_client(hass, headers={"x-test": "true"})
+    assert isinstance(httpx_client, httpx.AsyncClient)
+    assert httpx_client.headers["x-test"] == "true"
+    # Default headers are preserved
+    assert httpx_client.headers[client.USER_AGENT] == client.SERVER_SOFTWARE
+
+
 async def test_get_async_client_cleanup(hass: HomeAssistant) -> None:
     """Test init async client with ssl."""
     client.get_async_client(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for HTTP Streamable to MCP integration so Home Assistant can speak to modern MCP servers.

This prefers http streamable and falls back to SSE if http streamable is not supported by the server. See https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#backwards-compatibility for backwards compatibility behavior where Method Not Allowed is returned.

This integration was tested and was able to speak to both SSE and HTTP Streamable HTTP servers.

PR #155063 is also attempting to do this, but with significantly more code and has not been updated with reviewer feedback (e.g. removing unnecessary AI generated no-op changes)

Closes #155063
Re: https://github.com/orgs/home-assistant/discussions/1383

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x]  The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
