### PR TITLE
Expose the webOS power state

### DIFF
--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -14,6 +14,7 @@ DEFAULT_NAME = "LG webOS TV"
 
 ATTR_BUTTON = "button"
 ATTR_PAYLOAD = "payload"
+ATTR_POWER_STATE = "power_state"
 ATTR_SOUND_OUTPUT = "sound_output"
 
 CONF_ON_ACTION = "turn_on_action"

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -36,6 +36,7 @@ from homeassistant.helpers.typing import VolDictType
 from .const import (
     ATTR_BUTTON,
     ATTR_PAYLOAD,
+    ATTR_POWER_STATE,
     ATTR_SOUND_OUTPUT,
     CONF_SOURCES,
     DOMAIN,
@@ -292,9 +293,11 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
 
         self._attr_extra_state_attributes = {}
         if tv_state.sound_output is not None or self.state != MediaPlayerState.OFF:
-            self._attr_extra_state_attributes = {
-                ATTR_SOUND_OUTPUT: tv_state.sound_output
-            }
+            self._attr_extra_state_attributes[ATTR_SOUND_OUTPUT] = tv_state.sound_output
+        if tv_state.power_state is not None:
+            self._attr_extra_state_attributes[ATTR_POWER_STATE] = tv_state.power_state[
+                "state"
+            ]
 
     def _update_sources(self) -> None:
         """Update list of sources from current source, apps, inputs and configured list."""

--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -58,6 +58,7 @@ def client_fixture():
             muted=False,
             is_on=True,
             media_state=[{"playState": ""}],
+            power_state={"state": "Active"},
         )
 
         client.is_registered = Mock(return_value=True)

--- a/tests/components/webostv/snapshots/test_diagnostics.ambr
+++ b/tests/components/webostv/snapshots/test_diagnostics.ambr
@@ -66,6 +66,7 @@
         ]),
         'muted': False,
         'power_state': dict({
+          'state': 'Active',
         }),
         'sound_output': 'speaker',
         'volume': 37,

--- a/tests/components/webostv/snapshots/test_media_player.ambr
+++ b/tests/components/webostv/snapshots/test_media_player.ambr
@@ -17,6 +17,7 @@
       'is_volume_muted': False,
       'media_content_type': <MediaType.CHANNEL: 'channel'>,
       'media_title': 'Channel 1',
+      'power_state': 'Active',
       'sound_output': 'speaker',
       'source': 'Live TV',
       'source_list': list([

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -28,6 +28,7 @@ from homeassistant.components.media_player import (
 from homeassistant.components.webostv.const import (
     ATTR_BUTTON,
     ATTR_PAYLOAD,
+    ATTR_POWER_STATE,
     ATTR_SOUND_OUTPUT,
     DOMAIN,
     LIVE_TV_APP_ID,
@@ -371,6 +372,15 @@ async def test_entity_attributes(
 
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_SOUND_OUTPUT) is None
+
+    # Power state if available
+    assert state.attributes.get(ATTR_POWER_STATE) == "Active"
+
+    # Power state if unavailable
+    client.tv_state.power_state = None
+    await client.mock_state_update()
+    attrs = hass.states.get(ENTITY_ID).attributes
+    assert attrs.get(ATTR_POWER_STATE) is None
 
 
 async def test_service_entity_id_none(hass: HomeAssistant, client) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Expose the power state of webOS TVs as reported by `aiowebostv`, if available. In particular, this allows determining if the screen saver is active. No GitHub issues exist for this, but seemingly there is at least some interest in the community; see for example https://www.reddit.com/r/homeassistant/comments/glaet7/lg_tv_webos_detect_if_screensaver_is_active_turn/.

I tested this against my own C5 OLED 48", by restarting HA with an existing integration configured, as well as deleting the integration and readding it from scratch. In both cases, `power_state` properly showed up as a state attr. I do not have any other devices available for testing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A (I don't _think_ this is required given that the [current documentation](https://www.home-assistant.io/integrations/webostv/) doesn't document `sound_output` as an optional attr, and the values here are likely to be somewhat webOS version-specific anyway? But I can write something up if anyone disagrees)
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
