### PR TITLE
Add API server endpoint to options for Telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -87,7 +87,9 @@ from .const import (
     CHAT_ACTION_UPLOAD_VIDEO,
     CHAT_ACTION_UPLOAD_VIDEO_NOTE,
     CHAT_ACTION_UPLOAD_VOICE,
+    CONF_API_ENDPOINT,
     CONF_CONFIG_ENTRY_ID,
+    DEFAULT_API_ENDPOINT,
     DOMAIN,
     PLATFORM_BROADCAST,
     PLATFORM_POLLING,
@@ -549,6 +551,26 @@ def _deprecate_timeout(hass: HomeAssistant, service: ServiceCall) -> None:
         },
         learn_more_url="https://github.com/home-assistant/core/pull/155198",
     )
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: TelegramBotConfigEntry
+) -> bool:
+    """Migrate Telegram Bot config entry."""
+
+    # Minor version 2: add default API endpoint to data
+    if not config_entry.data.get(CONF_API_ENDPOINT):
+        new_data = {**config_entry.data}
+        new_data[CONF_API_ENDPOINT] = DEFAULT_API_ENDPOINT
+        updated = hass.config_entries.async_update_entry(
+            config_entry, data=new_data, minor_version=2
+        )
+        _LOGGER.debug(
+            "Migrated Telegram Bot config entry to minor version 2, entry updated: %s",
+            updated,
+        )
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: TelegramBotConfigEntry) -> bool:

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -558,15 +558,29 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate Telegram Bot config entry."""
 
-    # Minor version 2: add default API endpoint to data
-    if not config_entry.data.get(CONF_API_ENDPOINT):
+    version = config_entry.version
+    minor_version = config_entry.minor_version
+    _LOGGER.debug(
+        "Migrating configuration from version %s.%s",
+        version,
+        minor_version,
+    )
+
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
+    # version 1.1: to add default API endpoint
+    if version == 1 and minor_version == 1:
         new_data = {**config_entry.data}
         new_data[CONF_API_ENDPOINT] = DEFAULT_API_ENDPOINT
         updated = hass.config_entries.async_update_entry(
             config_entry, data=new_data, minor_version=2
         )
         _LOGGER.debug(
-            "Migrated Telegram Bot config entry to minor version 2, entry updated: %s",
+            "Migrated Telegram Bot config entry to %s.%s, entry updated: %s",
+            config_entry.version,
+            config_entry.minor_version,
             updated,
         )
 

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -553,7 +553,9 @@ def _deprecate_timeout(hass: HomeAssistant, service: ServiceCall) -> None:
 
 async def async_setup_entry(hass: HomeAssistant, entry: TelegramBotConfigEntry) -> bool:
     """Create the Telegram bot from config entry."""
-    bot: Bot = await hass.async_add_executor_job(initialize_bot, hass, entry.data)
+    bot: Bot = await hass.async_add_executor_job(
+        initialize_bot, hass, entry.data, entry.options
+    )
     try:
         await bot.get_me()
     except InvalidToken as err:
@@ -578,18 +580,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TelegramBotConfigEntry) 
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    entry.async_on_unload(entry.add_update_listener(update_listener))
-
     return True
-
-
-async def update_listener(hass: HomeAssistant, entry: TelegramBotConfigEntry) -> None:
-    """Handle config changes."""
-    entry.runtime_data.parse_mode = entry.options[ATTR_PARSER]
-
-    # reload entities
-    await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
 
 async def async_unload_entry(

--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -1113,7 +1113,12 @@ def initialize_bot(hass: HomeAssistant, p_config: MappingProxyType[str, Any]) ->
 
     base_url: str = p_config.get(CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT)
 
-    return Bot(token=api_key, base_url=base_url, request=request)
+    return Bot(
+        token=api_key,
+        base_url=f"{base_url}/bot",
+        base_file_url=f"{base_url}/file/bot",
+        request=request,
+    )
 
 
 async def load_data(

--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -52,7 +52,6 @@ from homeassistant.util.json import JsonValueType
 from homeassistant.util.ssl import get_default_context, get_default_no_verify_context
 
 from .const import (
-    ATTR_API_ENDPOINT,
     ATTR_ARGS,
     ATTR_AUTHENTICATION,
     ATTR_CAPTION,
@@ -95,6 +94,7 @@ from .const import (
     ATTR_USER_ID,
     ATTR_USERNAME,
     ATTR_VERIFY_SSL,
+    CONF_API_ENDPOINT,
     CONF_CHAT_ID,
     CONF_PROXY_URL,
     DEFAULT_API_ENDPOINT,
@@ -1099,23 +1099,19 @@ class TelegramNotificationService:
             os.makedirs(directory_path, exist_ok=True)
 
 
-def initialize_bot(
-    hass: HomeAssistant,
-    data: MappingProxyType[str, Any],
-    options: MappingProxyType[str, Any],
-) -> Bot:
+def initialize_bot(hass: HomeAssistant, p_config: MappingProxyType[str, Any]) -> Bot:
     """Initialize telegram bot with proxy support."""
 
-    api_key: str = data[CONF_API_KEY]
+    api_key: str = p_config[CONF_API_KEY]
 
-    proxy_url: str | None = data.get(CONF_PROXY_URL)
+    proxy_url: str | None = p_config.get(CONF_PROXY_URL)
     if proxy_url is not None:
         proxy = httpx.Proxy(proxy_url)
         request = HTTPXRequest(connection_pool_size=8, proxy=proxy)
     else:
         request = HTTPXRequest(connection_pool_size=8)
 
-    base_url = options.get(ATTR_API_ENDPOINT, DEFAULT_API_ENDPOINT)
+    base_url: str = p_config.get(CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT)
 
     return Bot(token=api_key, base_url=base_url, request=request)
 

--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -97,7 +97,6 @@ from .const import (
     CONF_API_ENDPOINT,
     CONF_CHAT_ID,
     CONF_PROXY_URL,
-    DEFAULT_API_ENDPOINT,
     DOMAIN,
     EVENT_TELEGRAM_ATTACHMENT,
     EVENT_TELEGRAM_CALLBACK,
@@ -1111,7 +1110,7 @@ def initialize_bot(hass: HomeAssistant, p_config: MappingProxyType[str, Any]) ->
     else:
         request = HTTPXRequest(connection_pool_size=8)
 
-    base_url: str = p_config.get(CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT)
+    base_url: str = p_config[CONF_API_ENDPOINT]
 
     return Bot(
         token=api_key,

--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -52,6 +52,7 @@ from homeassistant.util.json import JsonValueType
 from homeassistant.util.ssl import get_default_context, get_default_no_verify_context
 
 from .const import (
+    ATTR_API_ENDPOINT,
     ATTR_ARGS,
     ATTR_AUTHENTICATION,
     ATTR_CAPTION,
@@ -96,6 +97,7 @@ from .const import (
     ATTR_VERIFY_SSL,
     CONF_CHAT_ID,
     CONF_PROXY_URL,
+    DEFAULT_API_ENDPOINT,
     DOMAIN,
     EVENT_TELEGRAM_ATTACHMENT,
     EVENT_TELEGRAM_CALLBACK,
@@ -1097,17 +1099,25 @@ class TelegramNotificationService:
             os.makedirs(directory_path, exist_ok=True)
 
 
-def initialize_bot(hass: HomeAssistant, p_config: MappingProxyType[str, Any]) -> Bot:
+def initialize_bot(
+    hass: HomeAssistant,
+    data: MappingProxyType[str, Any],
+    options: MappingProxyType[str, Any],
+) -> Bot:
     """Initialize telegram bot with proxy support."""
-    api_key: str = p_config[CONF_API_KEY]
-    proxy_url: str | None = p_config.get(CONF_PROXY_URL)
 
+    api_key: str = data[CONF_API_KEY]
+
+    proxy_url: str | None = data.get(CONF_PROXY_URL)
     if proxy_url is not None:
         proxy = httpx.Proxy(proxy_url)
         request = HTTPXRequest(connection_pool_size=8, proxy=proxy)
     else:
         request = HTTPXRequest(connection_pool_size=8)
-    return Bot(token=api_key, request=request)
+
+    base_url = options.get(ATTR_API_ENDPOINT, DEFAULT_API_ENDPOINT)
+
+    return Bot(token=api_key, base_url=base_url, request=request)
 
 
 async def load_data(

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -263,6 +263,7 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
                 title=bot_name,
                 data={
                     CONF_PLATFORM: user_input[CONF_PLATFORM],
+                    CONF_API_ENDPOINT: user_input[CONF_API_ENDPOINT],
                     CONF_API_KEY: user_input[CONF_API_KEY],
                     CONF_PROXY_URL: user_input[SECTION_ADVANCED_SETTINGS].get(
                         CONF_PROXY_URL

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -191,6 +191,7 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Telegram."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     @staticmethod
     @callback
@@ -378,9 +379,9 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
             data={
                 CONF_PLATFORM: self._step_user_data[CONF_PLATFORM],
                 CONF_API_KEY: self._step_user_data[CONF_API_KEY],
-                CONF_API_ENDPOINT: self._step_user_data[SECTION_ADVANCED_SETTINGS].get(
-                    CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT
-                ),
+                CONF_API_ENDPOINT: self._step_user_data[SECTION_ADVANCED_SETTINGS][
+                    CONF_API_ENDPOINT
+                ],
                 CONF_PROXY_URL: self._step_user_data[SECTION_ADVANCED_SETTINGS].get(
                     CONF_PROXY_URL
                 ),
@@ -452,9 +453,9 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
                     {
                         **self._get_reconfigure_entry().data,
                         SECTION_ADVANCED_SETTINGS: {
-                            CONF_API_ENDPOINT: self._get_reconfigure_entry().data.get(
-                                CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT
-                            ),
+                            CONF_API_ENDPOINT: self._get_reconfigure_entry().data[
+                                CONF_API_ENDPOINT
+                            ],
                             CONF_PROXY_URL: self._get_reconfigure_entry().data.get(
                                 CONF_PROXY_URL
                             ),
@@ -467,9 +468,9 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
             CONF_PROXY_URL
         )
 
-        user_input[CONF_API_ENDPOINT] = user_input[SECTION_ADVANCED_SETTINGS].get(
+        user_input[CONF_API_ENDPOINT] = user_input[SECTION_ADVANCED_SETTINGS][
             CONF_API_ENDPOINT
-        )
+        ]
 
         errors: dict[str, str] = {}
         description_placeholders: dict[str, str] = DESCRIPTION_PLACEHOLDERS.copy()
@@ -480,9 +481,9 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         self._bot_name = bot_name
 
-        existing_api_endpoint: str = self._get_reconfigure_entry().data.get(
-            CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT
-        )
+        existing_api_endpoint: str = self._get_reconfigure_entry().data[
+            CONF_API_ENDPOINT
+        ]
         if (
             self._get_reconfigure_entry().state == ConfigEntryState.LOADED
             and user_input[CONF_API_ENDPOINT] != DEFAULT_API_ENDPOINT
@@ -516,7 +517,7 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
                     {
                         **user_input,
                         SECTION_ADVANCED_SETTINGS: {
-                            CONF_API_ENDPOINT: user_input.get(CONF_API_ENDPOINT),
+                            CONF_API_ENDPOINT: user_input[CONF_API_ENDPOINT],
                             CONF_PROXY_URL: user_input.get(CONF_PROXY_URL),
                         },
                     },
@@ -556,8 +557,10 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         description_placeholders: dict[str, str] = {}
 
+        updated_data = {**self._get_reauth_entry().data}
+        updated_data[CONF_API_KEY] = user_input[CONF_API_KEY]
         bot_name = await self._validate_bot(
-            user_input, errors, description_placeholders
+            updated_data, errors, description_placeholders
         )
         await self._shutdown_bot()
 
@@ -572,7 +575,7 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_update_reload_and_abort(
-            self._get_reauth_entry(), title=bot_name, data_updates=user_input
+            self._get_reauth_entry(), title=bot_name, data_updates=updated_data
         )
 
 

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -180,14 +180,18 @@ class OptionsFlowHandler(OptionsFlowWithReload):
 
                 # validation ok
                 # logout existing bot only if the API endpoint is changed from the default to a custom value
-                service: TelegramNotificationService = self.config_entry.runtime_data
+                # logout will lockout the bot temporarily so we only want to do this when necessary
+                current_api_endpoint = self.config_entry.options.get(
+                    ATTR_API_ENDPOINT, DEFAULT_API_ENDPOINT
+                )
                 if (
                     user_input[ATTR_API_ENDPOINT] != DEFAULT_API_ENDPOINT
-                    and self.config_entry.options.get(
-                        ATTR_API_ENDPOINT, DEFAULT_API_ENDPOINT
-                    )
-                    == DEFAULT_API_ENDPOINT
+                    and user_input[ATTR_API_ENDPOINT] != current_api_endpoint
+                    and current_api_endpoint == DEFAULT_API_ENDPOINT
                 ):
+                    service: TelegramNotificationService = (
+                        self.config_entry.runtime_data
+                    )
                     is_logged_out = await service.bot.log_out()
                     if not is_logged_out:
                         errors["base"] = "bot_logout_failed"

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -178,11 +178,19 @@ class OptionsFlowHandler(OptionsFlowWithReload):
                 )
                 await bot.get_me()
 
-                # validation ok, logout existing bot
+                # validation ok
+                # logout existing bot only if the API endpoint is changed from the default to a custom value
                 service: TelegramNotificationService = self.config_entry.runtime_data
-                is_logged_out = await service.bot.log_out()
-                if not is_logged_out:
-                    errors["base"] = "bot_logout_failed"
+                if (
+                    user_input[ATTR_API_ENDPOINT] != DEFAULT_API_ENDPOINT
+                    and self.config_entry.options.get(
+                        ATTR_API_ENDPOINT, DEFAULT_API_ENDPOINT
+                    )
+                    == DEFAULT_API_ENDPOINT
+                ):
+                    is_logged_out = await service.bot.log_out()
+                    if not is_logged_out:
+                        errors["base"] = "bot_logout_failed"
             except TelegramError as err:
                 errors["base"] = "telegram_error"
                 description_placeholders[ERROR_MESSAGE] = str(err)
@@ -193,7 +201,7 @@ class OptionsFlowHandler(OptionsFlowWithReload):
                     data_schema=self.add_suggested_values_to_schema(
                         OPTIONS_SCHEMA, user_input
                     ),
-                    errors={"base": "telegram_error"},
+                    errors=errors,
                     description_placeholders=description_placeholders,
                 )
 

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -193,6 +193,12 @@ class OptionsFlowHandler(OptionsFlowWithReload):
                         self.config_entry.runtime_data
                     )
                     is_logged_out = await service.bot.log_out()
+                    _LOGGER.info(
+                        "[%s %s] Logged out: %s",
+                        service.bot.username,
+                        service.bot.id,
+                        is_logged_out,
+                    )
                     if not is_logged_out:
                         errors["base"] = "bot_logout_failed"
             except TelegramError as err:

--- a/homeassistant/components/telegram_bot/const.py
+++ b/homeassistant/components/telegram_bot/const.py
@@ -24,7 +24,7 @@ BOT_NAME = "telegram_bot"
 ERROR_FIELD = "error_field"
 ERROR_MESSAGE = "error_message"
 
-DEFAULT_API_ENDPOINT = "https://api.telegram.org/bot"
+DEFAULT_API_ENDPOINT = "https://api.telegram.org"
 DEFAULT_TRUSTED_NETWORKS = [ip_network("149.154.160.0/20"), ip_network("91.108.4.0/22")]
 
 SERVICE_SEND_CHAT_ACTION = "send_chat_action"

--- a/homeassistant/components/telegram_bot/const.py
+++ b/homeassistant/components/telegram_bot/const.py
@@ -13,6 +13,7 @@ SUBENTRY_TYPE_ALLOWED_CHAT_IDS = "allowed_chat_ids"
 CONF_ALLOWED_CHAT_IDS = "allowed_chat_ids"
 CONF_CONFIG_ENTRY_ID = "config_entry_id"
 
+CONF_API_ENDPOINT = "api_endpoint"
 CONF_PROXY_URL = "proxy_url"
 CONF_TRUSTED_NETWORKS = "trusted_networks"
 
@@ -75,7 +76,6 @@ CHAT_ACTION_FIND_LOCATION = "find_location"
 CHAT_ACTION_RECORD_VIDEO_NOTE = "record_video_note"
 CHAT_ACTION_UPLOAD_VIDEO_NOTE = "upload_video_note"
 
-ATTR_API_ENDPOINT = "api_endpoint"
 ATTR_ARGS = "args"
 ATTR_AUTHENTICATION = "authentication"
 ATTR_CALLBACK_QUERY = "callback_query"

--- a/homeassistant/components/telegram_bot/const.py
+++ b/homeassistant/components/telegram_bot/const.py
@@ -23,6 +23,7 @@ BOT_NAME = "telegram_bot"
 ERROR_FIELD = "error_field"
 ERROR_MESSAGE = "error_message"
 
+DEFAULT_API_ENDPOINT = "https://api.telegram.org/bot"
 DEFAULT_TRUSTED_NETWORKS = [ip_network("149.154.160.0/20"), ip_network("91.108.4.0/22")]
 
 SERVICE_SEND_CHAT_ACTION = "send_chat_action"
@@ -74,6 +75,7 @@ CHAT_ACTION_FIND_LOCATION = "find_location"
 CHAT_ACTION_RECORD_VIDEO_NOTE = "record_video_note"
 CHAT_ACTION_UPLOAD_VIDEO_NOTE = "upload_video_note"
 
+ATTR_API_ENDPOINT = "api_endpoint"
 ATTR_ARGS = "args"
 ATTR_AUTHENTICATION = "authentication"
 ATTR_CALLBACK_QUERY = "callback_query"

--- a/homeassistant/components/telegram_bot/diagnostics.py
+++ b/homeassistant/components/telegram_bot/diagnostics.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_API_KEY, CONF_URL
 from homeassistant.core import HomeAssistant
 
 from . import TelegramBotConfigEntry
-from .const import ATTR_API_ENDPOINT, CONF_CHAT_ID, DEFAULT_API_ENDPOINT
+from .const import CONF_API_ENDPOINT, CONF_CHAT_ID, DEFAULT_API_ENDPOINT
 
 TO_REDACT = [CONF_API_KEY, CONF_CHAT_ID]
 
@@ -26,14 +26,13 @@ async def async_get_config_entry_diagnostics(
         url = URL(config_entry.data[CONF_URL])
         data[CONF_URL] = url.with_host(REDACTED).human_repr()
 
-    options = async_redact_data(config_entry.options, TO_REDACT)
-    api_endpoint = config_entry.options.get(ATTR_API_ENDPOINT)
+    api_endpoint = config_entry.data.get(CONF_API_ENDPOINT)
     if api_endpoint and api_endpoint != DEFAULT_API_ENDPOINT:
-        url = URL(config_entry.options[ATTR_API_ENDPOINT])
-        options[ATTR_API_ENDPOINT] = url.with_host(REDACTED).human_repr()
+        url = URL(config_entry.data[CONF_API_ENDPOINT])
+        data[CONF_API_ENDPOINT] = url.with_host(REDACTED).human_repr()
 
     return {
         "data": data,
-        "options": options,
+        "options": async_redact_data(config_entry.options, TO_REDACT),
         "subentries_count": len(config_entry.subentries.values()),
     }

--- a/homeassistant/components/telegram_bot/diagnostics.py
+++ b/homeassistant/components/telegram_bot/diagnostics.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_API_KEY, CONF_URL
 from homeassistant.core import HomeAssistant
 
 from . import TelegramBotConfigEntry
-from .const import CONF_CHAT_ID
+from .const import ATTR_API_ENDPOINT, CONF_CHAT_ID, DEFAULT_API_ENDPOINT
 
 TO_REDACT = [CONF_API_KEY, CONF_CHAT_ID]
 
@@ -26,8 +26,14 @@ async def async_get_config_entry_diagnostics(
         url = URL(config_entry.data[CONF_URL])
         data[CONF_URL] = url.with_host(REDACTED).human_repr()
 
+    options = async_redact_data(config_entry.options, TO_REDACT)
+    api_endpoint = config_entry.options.get(ATTR_API_ENDPOINT)
+    if api_endpoint and api_endpoint != DEFAULT_API_ENDPOINT:
+        url = URL(config_entry.options[ATTR_API_ENDPOINT])
+        options[ATTR_API_ENDPOINT] = url.with_host(REDACTED).human_repr()
+
     return {
         "data": data,
-        "options": async_redact_data(config_entry.options, TO_REDACT),
+        "options": options,
         "subentries_count": len(config_entry.subentries.values()),
     }

--- a/homeassistant/components/telegram_bot/helpers.py
+++ b/homeassistant/components/telegram_bot/helpers.py
@@ -8,3 +8,8 @@ from .const import SIGNAL_UPDATE_EVENT
 def signal(bot: Bot) -> str:
     """Define signal name."""
     return f"{SIGNAL_UPDATE_EVENT}_{bot.id}"
+
+
+def get_base_url(bot: Bot) -> str:
+    """Return the base URL for the bot."""
+    return bot.base_url.replace(bot.token, "")

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -82,7 +82,12 @@ class PollBot(BaseTelegramBot):
                 error_callback=lambda error: error_callback(self.bot, error, None)
             )
         await self.application.start()
-        _LOGGER.info("[%s %s] Started polling", self.bot.username, self.bot.id)
+        _LOGGER.info(
+            "[%s %s] Started polling at %s",
+            self.bot.username,
+            self.bot.id,
+            self.bot.base_url,
+        )
 
     async def stop_polling(self) -> None:
         """Stop the polling task."""

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -9,6 +9,7 @@ from telegram.ext import ApplicationBuilder, CallbackContext, TypeHandler
 from homeassistant.core import HomeAssistant
 
 from .bot import BaseTelegramBot, TelegramBotConfigEntry
+from .helpers import get_base_url
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,7 +87,7 @@ class PollBot(BaseTelegramBot):
             "[%s %s] Started polling at %s",
             self.bot.username,
             self.bot.id,
-            self.bot.base_url,
+            get_base_url(self.bot),
         )
 
     async def stop_polling(self) -> None:

--- a/homeassistant/components/telegram_bot/strings.json
+++ b/homeassistant/components/telegram_bot/strings.json
@@ -6,6 +6,7 @@
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
+      "bot_logout_failed": "Failed to logout Telegram bot. Please try again later.",
       "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]",
       "invalid_proxy_url": "{proxy_url_error}",
       "invalid_trusted_networks": "Invalid trusted network: {error_message}",
@@ -34,9 +35,11 @@
         "sections": {
           "advanced_settings": {
             "data": {
+              "api_endpoint": "[%key:component::telegram_bot::config::step::user::sections::advanced_settings::data::api_endpoint%]",
               "proxy_url": "[%key:component::telegram_bot::config::step::user::sections::advanced_settings::data::proxy_url%]"
             },
             "data_description": {
+              "api_endpoint": "[%key:component::telegram_bot::config::step::user::sections::advanced_settings::data_description::api_endpoint%]",
               "proxy_url": "[%key:component::telegram_bot::config::step::user::sections::advanced_settings::data_description::proxy_url%]"
             },
             "name": "[%key:component::telegram_bot::config::step::user::sections::advanced_settings::name%]"
@@ -57,9 +60,11 @@
         "sections": {
           "advanced_settings": {
             "data": {
+              "api_endpoint": "API endpoint",
               "proxy_url": "Proxy URL"
             },
             "data_description": {
+              "api_endpoint": "Telegram bot API server endpoint.\nThe bot will be **locked out for 10 minutes** if you switch back to the default.\nDefault: `{default_api_endpoint}`.",
               "proxy_url": "Proxy URL if working behind one, optionally including username and password.\n({socks_url})"
             },
             "name": "Advanced settings"
@@ -223,10 +228,6 @@
     }
   },
   "options": {
-    "error": {
-      "bot_logout_failed": "Failed to logout Telegram bot. Please try again later.",
-      "telegram_error": "[%key:component::telegram_bot::config::error::telegram_error%]"
-    },
     "step": {
       "init": {
         "data": {

--- a/homeassistant/components/telegram_bot/strings.json
+++ b/homeassistant/components/telegram_bot/strings.json
@@ -234,7 +234,7 @@
           "parse_mode": "Parse mode"
         },
         "data_description": {
-          "api_endpoint": "Telegram bot API server endpoint.\nDefault: `{default_api_endpoint}`.",
+          "api_endpoint": "Telegram bot API server endpoint.\nThe bot will be **locked out for 10 minutes** if you switch back to the default.\nDefault: `{default_api_endpoint}`.",
           "parse_mode": "Default parse mode for messages if not explicit in message data."
         },
         "title": "Configure Telegram bot"

--- a/homeassistant/components/telegram_bot/strings.json
+++ b/homeassistant/components/telegram_bot/strings.json
@@ -223,12 +223,18 @@
     }
   },
   "options": {
+    "error": {
+      "bot_logout_failed": "Failed to logout Telegram bot. Please try again later.",
+      "telegram_error": "[%key:component::telegram_bot::config::error::telegram_error%]"
+    },
     "step": {
       "init": {
         "data": {
+          "api_endpoint": "API endpoint",
           "parse_mode": "Parse mode"
         },
         "data_description": {
+          "api_endpoint": "Telegram bot API server endpoint.\nDefault: `{default_api_endpoint}`.",
           "parse_mode": "Default parse mode for messages if not explicit in message data."
         },
         "title": "Configure Telegram bot"

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.network import get_url
 
 from .bot import BaseTelegramBot, TelegramBotConfigEntry
 from .const import CONF_TRUSTED_NETWORKS
+from .helpers import get_base_url
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +44,10 @@ async def async_setup_platform(
     if not webhook_registered:
         raise ConfigEntryNotReady("Failed to register webhook with Telegram")
     _LOGGER.info(
-        "[%s %s] Webhook registered with %s", bot.username, bot.id, bot.base_url
+        "[%s %s] Webhook registered with %s",
+        bot.username,
+        bot.id,
+        get_base_url(bot),
     )
 
     hass.http.register_view(

--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -23,6 +23,7 @@ from homeassistant.components.telegram_bot.const import (
     CONF_API_ENDPOINT,
     CONF_CHAT_ID,
     CONF_TRUSTED_NETWORKS,
+    DEFAULT_API_ENDPOINT,
     DOMAIN,
     PARSER_MD,
     PLATFORM_BROADCAST,
@@ -45,6 +46,7 @@ def mock_polling_config_entry() -> MockConfigEntry:
         data={
             CONF_PLATFORM: PLATFORM_POLLING,
             CONF_API_KEY: "mock api key",
+            CONF_API_ENDPOINT: DEFAULT_API_ENDPOINT,
         },
         options={ATTR_PARSER: PARSER_MD},
         subentries_data=[
@@ -61,6 +63,7 @@ def mock_polling_config_entry() -> MockConfigEntry:
                 title="mock chat 2",
             ),
         ],
+        minor_version=2,
     )
 
 
@@ -255,6 +258,7 @@ def mock_broadcast_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         data={
             CONF_PLATFORM: PLATFORM_BROADCAST,
+            CONF_API_ENDPOINT: DEFAULT_API_ENDPOINT,
             CONF_API_KEY: "mock api key",
         },
         options={ATTR_PARSER: PARSER_MD},
@@ -272,6 +276,7 @@ def mock_broadcast_config_entry() -> MockConfigEntry:
                 title="mock chat 2",
             ),
         ],
+        minor_version=2,
     )
 
 
@@ -297,6 +302,7 @@ def mock_webhooks_config_entry() -> MockConfigEntry:
                 title="mock chat",
             )
         ],
+        minor_version=2,
     )
 
 

--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -18,9 +18,9 @@ from telegram import (
 from telegram.constants import ChatType
 
 from homeassistant.components.telegram_bot.const import (
-    ATTR_API_ENDPOINT,
     ATTR_PARSER,
     CONF_ALLOWED_CHAT_IDS,
+    CONF_API_ENDPOINT,
     CONF_CHAT_ID,
     CONF_TRUSTED_NETWORKS,
     DOMAIN,
@@ -285,9 +285,10 @@ def mock_webhooks_config_entry() -> MockConfigEntry:
             CONF_PLATFORM: PLATFORM_WEBHOOKS,
             CONF_API_KEY: "mock api key",
             CONF_URL: "https://test",
+            CONF_API_ENDPOINT: "http://mock/bot",
             CONF_TRUSTED_NETWORKS: ["127.0.0.1"],
         },
-        options={ATTR_API_ENDPOINT: "http://mock/bot", ATTR_PARSER: PARSER_MD},
+        options={ATTR_PARSER: PARSER_MD},
         subentries_data=[
             ConfigSubentryData(
                 unique_id="12345678",

--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -133,6 +133,7 @@ def mock_external_calls() -> Generator[None]:
         patch.object(BotMock, "send_animation", return_value=message),
         patch.object(BotMock, "send_location", return_value=message),
         patch.object(BotMock, "send_poll", return_value=message),
+        patch.object(BotMock, "log_out", return_value=True),
         patch("telegram.ext.Updater._bootstrap"),
     ):
         yield

--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -18,6 +18,7 @@ from telegram import (
 from telegram.constants import ChatType
 
 from homeassistant.components.telegram_bot.const import (
+    ATTR_API_ENDPOINT,
     ATTR_PARSER,
     CONF_ALLOWED_CHAT_IDS,
     CONF_CHAT_ID,
@@ -286,7 +287,7 @@ def mock_webhooks_config_entry() -> MockConfigEntry:
             CONF_URL: "https://test",
             CONF_TRUSTED_NETWORKS: ["127.0.0.1"],
         },
-        options={ATTR_PARSER: PARSER_MD},
+        options={ATTR_API_ENDPOINT: "http://mock/bot", ATTR_PARSER: PARSER_MD},
         subentries_data=[
             ConfigSubentryData(
                 unique_id="12345678",

--- a/tests/components/telegram_bot/snapshots/test_diagnostics.ambr
+++ b/tests/components/telegram_bot/snapshots/test_diagnostics.ambr
@@ -2,6 +2,7 @@
 # name: test_diagnostics
   dict({
     'data': dict({
+      'api_endpoint': 'http://**redacted**/bot',
       'api_key': '**REDACTED**',
       'platform': 'webhooks',
       'trusted_networks': list([
@@ -10,7 +11,6 @@
       'url': 'https://**redacted**/',
     }),
     'options': dict({
-      'api_endpoint': 'http://**redacted**/bot',
       'parse_mode': 'markdown',
     }),
     'subentries_count': 1,

--- a/tests/components/telegram_bot/snapshots/test_diagnostics.ambr
+++ b/tests/components/telegram_bot/snapshots/test_diagnostics.ambr
@@ -10,6 +10,7 @@
       'url': 'https://**redacted**/',
     }),
     'options': dict({
+      'api_endpoint': 'http://**redacted**/bot',
       'parse_mode': 'markdown',
     }),
     'subentries_count': 1,

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -6,6 +6,7 @@ from telegram import AcceptedGiftTypes, ChatFullInfo, User
 from telegram.constants import AccentColor
 from telegram.error import BadRequest, InvalidToken, NetworkError
 
+from homeassistant.components.telegram_bot.config_flow import DESCRIPTION_PLACEHOLDERS
 from homeassistant.components.telegram_bot.const import (
     ATTR_PARSER,
     CONF_API_ENDPOINT,
@@ -25,7 +26,7 @@ from homeassistant.const import CONF_API_KEY, CONF_PLATFORM, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, pytest
 
 
 async def test_options_flow(
@@ -203,10 +204,30 @@ async def test_reconfigure_flow_webhooks(
     ]
 
 
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error", "expected_description_placeholders"),
+    [
+        # test case 1: logout fails with network error, then succeeds
+        pytest.param(
+            [NetworkError("mock network error"), True],
+            "telegram_error",
+            {**DESCRIPTION_PLACEHOLDERS, "error_message": "mock network error"},
+        ),
+        # test case 2: logout fails with unsuccessful response, then succeeds
+        pytest.param(
+            [False, True],
+            "bot_logout_failed",
+            DESCRIPTION_PLACEHOLDERS,
+        ),
+    ],
+)
 async def test_reconfigure_flow_logout_failed(
     hass: HomeAssistant,
     mock_broadcast_config_entry: MockConfigEntry,
     mock_external_calls: None,
+    side_effect: list,
+    expected_error: str,
+    expected_description_placeholders: dict[str, str],
 ) -> None:
     """Test reconfigure flow for with change in API endpoint and logout failed."""
 
@@ -219,48 +240,44 @@ async def test_reconfigure_flow_logout_failed(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
 
-    # test logout error
-
     with patch(
         "homeassistant.components.telegram_bot.bot.Bot.log_out",
-        AsyncMock(side_effect=NetworkError("mock network error")),
+        AsyncMock(side_effect=side_effect),
     ):
+        # first logout attempt fails
+
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_PLATFORM: PLATFORM_BROADCAST,
                 SECTION_ADVANCED_SETTINGS: {
-                    CONF_API_ENDPOINT: "http://mock/bot",
+                    CONF_API_ENDPOINT: "http://mock1",
                 },
             },
         )
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
-    assert result["step_id"] == "reconfigure"
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "telegram_error"}
-    assert result["description_placeholders"]["error_message"] == "mock network error"
+        assert result["step_id"] == "reconfigure"
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {"base": expected_error}
+        assert result["description_placeholders"] == expected_description_placeholders
 
-    # test unsuccessful logout
+        # second logout attempt success
 
-    with patch(
-        "homeassistant.components.telegram_bot.bot.Bot.log_out",
-        AsyncMock(return_value=False),
-    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_PLATFORM: PLATFORM_BROADCAST,
                 SECTION_ADVANCED_SETTINGS: {
-                    CONF_API_ENDPOINT: "http://mock/bot",
+                    CONF_API_ENDPOINT: "http://mock2",
                 },
             },
         )
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
-    assert result["step_id"] == "reconfigure"
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "bot_logout_failed"}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_broadcast_config_entry.data[CONF_API_ENDPOINT] == "http://mock2"
 
 
 async def test_create_entry(hass: HomeAssistant) -> None:
@@ -536,7 +553,9 @@ async def test_duplicate_entry(hass: HomeAssistant) -> None:
     data = {
         CONF_PLATFORM: PLATFORM_BROADCAST,
         CONF_API_KEY: "mock api key",
-        SECTION_ADVANCED_SETTINGS: {},
+        SECTION_ADVANCED_SETTINGS: {
+            CONF_API_ENDPOINT: "http://mock_api_endpoint",
+        },
     }
 
     with patch(

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -131,6 +131,7 @@ async def test_reconfigure_flow_webhooks(
         {
             CONF_PLATFORM: PLATFORM_WEBHOOKS,
             SECTION_ADVANCED_SETTINGS: {
+                CONF_API_ENDPOINT: "http://mock_api_endpoint",
                 CONF_PROXY_URL: "https://test",
             },
         },
@@ -193,6 +194,10 @@ async def test_reconfigure_flow_webhooks(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert mock_broadcast_config_entry.data[CONF_URL] == "https://reconfigure"
+    assert (
+        mock_broadcast_config_entry.data[CONF_API_ENDPOINT]
+        == "http://mock_api_endpoint"
+    )
     assert mock_broadcast_config_entry.data[CONF_TRUSTED_NETWORKS] == [
         "149.154.160.0/20"
     ]

--- a/tests/components/telegram_bot/test_init.py
+++ b/tests/components/telegram_bot/test_init.py
@@ -1,0 +1,45 @@
+"""Init tests for the Telegram Bot integration."""
+
+from homeassistant.components.telegram_bot.const import (
+    ATTR_PARSER,
+    CONF_API_ENDPOINT,
+    DEFAULT_API_ENDPOINT,
+    DOMAIN,
+    PARSER_MD,
+    PLATFORM_BROADCAST,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_API_KEY, CONF_PLATFORM
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_migrate_entry(
+    hass: HomeAssistant,
+    mock_external_calls: None,
+) -> None:
+    """Test migrate config entry from 1.1 to 1.2."""
+
+    mock_config_entry = MockConfigEntry(
+        unique_id="mock api key",
+        domain=DOMAIN,
+        data={
+            CONF_PLATFORM: PLATFORM_BROADCAST,
+            CONF_API_KEY: "mock api key",
+        },
+        options={ATTR_PARSER: PARSER_MD},
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.version == 1
+    assert mock_config_entry.minor_version == 2
+    assert mock_config_entry.data == {
+        CONF_PLATFORM: PLATFORM_BROADCAST,
+        CONF_API_KEY: "mock api key",
+        CONF_API_ENDPOINT: DEFAULT_API_ENDPOINT,
+    }

--- a/tests/components/telegram_bot/test_init.py
+++ b/tests/components/telegram_bot/test_init.py
@@ -15,7 +15,31 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-async def test_migrate_entry(
+async def test_migration_error(
+    hass: HomeAssistant,
+    mock_external_calls: None,
+) -> None:
+    """Test migrate config entry from 1.1 to 1.2."""
+
+    mock_config_entry = MockConfigEntry(
+        unique_id="mock api key",
+        domain=DOMAIN,
+        data={
+            CONF_PLATFORM: PLATFORM_BROADCAST,
+            CONF_API_KEY: "mock api key",
+        },
+        options={ATTR_PARSER: PARSER_MD},
+        version=99,
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.MIGRATION_ERROR
+
+
+async def test_migrate_entry_from_1_1(
     hass: HomeAssistant,
     mock_external_calls: None,
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Background:
Currently, all API requests are configured to use the official Telegram API server: `https://api.telegram.org/bot`.
There is a official self-hosted Telegram API server at: https://github.com/tdlib/telegram-bot-api
This PR adds a new field in the config/reconfigure flow to allow the user to use their self-hosted (or third party) Telegram API server.

Related:
- Discussion: https://github.com/orgs/home-assistant/discussions/2633
- Forum feature request: https://community.home-assistant.io/t/add-ability-to-configure-local-telegram-bot-api-server/370142

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43257
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
