### PR TITLE
Add Device Type to Vesync Test Fixtures

### DIFF
--- a/tests/components/vesync/conftest.py
+++ b/tests/components/vesync/conftest.py
@@ -144,6 +144,7 @@ def fan_fixture():
         cid="fan",
         device_type="fan",
         device_name="Test Fan",
+        product_type="fan",
         device_status="on",
         modes=[],
         connection_status="online",
@@ -157,6 +158,7 @@ def bulb_fixture():
     """Create a mock VeSync bulb fixture."""
     return Mock(
         VeSyncBulb,
+        product_type="bulb",
         cid="bulb",
         device_name="Test Bulb",
     )
@@ -167,6 +169,7 @@ def switch_fixture():
     """Create a mock VeSync switch fixture."""
     return Mock(
         VeSyncSwitch,
+        product_type="switch",
         is_dimmable=Mock(return_value=False),
     )
 
@@ -176,6 +179,7 @@ def dimmable_switch_fixture():
     """Create a mock VeSync switch fixture."""
     return Mock(
         VeSyncSwitch,
+        product_type="switch",
         is_dimmable=Mock(return_value=True),
     )
 
@@ -186,6 +190,7 @@ def outlet_fixture():
     return Mock(
         VeSyncOutlet,
         cid="outlet",
+        product_type="outlet",
         device_name="Test Outlet",
     )
 
@@ -203,6 +208,7 @@ def humidifier_fixture():
         },
         features=[HumidifierFeatures.NIGHTLIGHT],
         device_type="Classic200S",
+        product_type="humidifier",
         device_name="Humidifier 200s",
         device_status="on",
         mist_modes=["auto", "manual"],
@@ -239,6 +245,7 @@ def humidifier_300s_fixture():
         },
         features=[HumidifierFeatures.NIGHTLIGHT],
         device_type="Classic300S",
+        product_type="humidifier",
         device_name="Humidifier 300s",
         device_status="on",
         mist_modes=["auto", "manual"],

--- a/tests/components/vesync/snapshots/test_diagnostics.ambr
+++ b/tests/components/vesync/snapshots/test_diagnostics.ambr
@@ -84,7 +84,7 @@
         'mock_calls': list([
         ]),
         'pid': 'Method',
-        'product_type': 'Method',
+        'product_type': 'humidifier',
         'request_keys': 'Method',
         'reset_mock': 'Method',
         'return_value': 'Method',
@@ -514,7 +514,7 @@
     ]),
     'normal_mode': 'Method',
     'pid': 'Method',
-    'product_type': 'Method',
+    'product_type': 'fan',
     'request_keys': 'Method',
     'reset_mock': 'Method',
     'return_value': 'Method',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add device type to test fixtures to prep for future changes.   This is purely to shrink #160573. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
