### PR TITLE
Switch to product_type instead of is_instance for vesync

### DIFF
--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -1,6 +1,7 @@
 """Common utilities for VeSync Component."""
 
 import logging
+from typing import TypeGuard
 
 from pyvesync.base_devices import VeSyncHumidifier
 from pyvesync.base_devices.fan_base import VeSyncFanBase
@@ -8,6 +9,7 @@ from pyvesync.base_devices.fryer_base import VeSyncFryer
 from pyvesync.base_devices.outlet_base import VeSyncOutlet
 from pyvesync.base_devices.purifier_base import VeSyncPurifier
 from pyvesync.base_devices.vesyncbasedevice import VeSyncBaseDevice
+from pyvesync.const import ProductTypes
 from pyvesync.devices.vesyncswitch import VeSyncWallSwitch
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,37 +37,39 @@ def rgetattr(obj: object, attr: str) -> object | str | None:
     return obj
 
 
-def is_humidifier(device: VeSyncBaseDevice) -> bool:
+def is_humidifier(device: VeSyncBaseDevice) -> TypeGuard[VeSyncHumidifier]:
     """Check if the device represents a humidifier."""
 
-    return isinstance(device, VeSyncHumidifier)
+    return device.product_type == ProductTypes.HUMIDIFIER
 
 
-def is_fan(device: VeSyncBaseDevice) -> bool:
+def is_fan(device: VeSyncBaseDevice) -> TypeGuard[VeSyncFanBase]:
     """Check if the device represents a fan."""
 
-    return isinstance(device, VeSyncFanBase)
+    return device.product_type == ProductTypes.FAN
 
 
-def is_outlet(device: VeSyncBaseDevice) -> bool:
+def is_outlet(device: VeSyncBaseDevice) -> TypeGuard[VeSyncOutlet]:
     """Check if the device represents an outlet."""
 
-    return isinstance(device, VeSyncOutlet)
+    return device.product_type == ProductTypes.OUTLET
 
 
-def is_wall_switch(device: VeSyncBaseDevice) -> bool:
+def is_wall_switch(device: VeSyncBaseDevice) -> TypeGuard[VeSyncWallSwitch]:
     """Check if the device represents a wall switch, note this doessn't include dimming switches."""
+    if device.product_type != ProductTypes.SWITCH:
+        return False
 
-    return isinstance(device, VeSyncWallSwitch)
+    return getattr(device, "supports_dimmable", False) is False
 
 
-def is_purifier(device: VeSyncBaseDevice) -> bool:
+def is_purifier(device: VeSyncBaseDevice) -> TypeGuard[VeSyncPurifier]:
     """Check if the device represents an air purifier."""
 
-    return isinstance(device, VeSyncPurifier)
+    return device.product_type == ProductTypes.PURIFIER
 
 
-def is_air_fryer(device: VeSyncBaseDevice) -> bool:
+def is_air_fryer(device: VeSyncBaseDevice) -> TypeGuard[VeSyncFryer]:
     """Check if the device represents an air fryer."""
 
-    return isinstance(device, VeSyncFryer)
+    return device.product_type == ProductTypes.AIR_FRYER


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Moving away from is_instance as required from the core team.    This also sets up for typing required in #160573.  Reducing the size of that PR. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
