### PR TITLE
Use default time zone for boot time

### DIFF
--- a/homeassistant/components/systemmonitor/coordinator.py
+++ b/homeassistant/components/systemmonitor/coordinator.py
@@ -221,7 +221,9 @@ class SystemMonitorCoordinator(TimestampDataUpdateCoordinator[SensorData]):
 
         if self._initial_update:
             # Boot time only needs to refresh on first pass
-            self.boot_time = dt_util.utc_from_timestamp(self._psutil.boot_time())
+            self.boot_time = dt_util.utc_from_timestamp(
+                self._psutil.boot_time(), tz=dt_util.get_default_time_zone()
+            )
             _LOGGER.debug("boot time: %s", self.boot_time)
 
         selected_processes: list[Process] = []

--- a/tests/components/systemmonitor/snapshots/test_diagnostics.ambr
+++ b/tests/components/systemmonitor/snapshots/test_diagnostics.ambr
@@ -9,7 +9,7 @@
           'vethxyzxyz': "[snicaddr(family=<AddressFamily.AF_INET: 2>, address='172.16.10.1', netmask='255.255.255.0', broadcast='255.255.255.255', ptp=None)]",
         }),
         'battery': 'sbattery(percent=93, secsleft=16628, power_plugged=False)',
-        'boot_time': '2024-02-24 15:00:00+00:00',
+        'boot_time': '2024-02-24 07:00:00-08:00',
         'cpu_percent': '10.0',
         'disk_usage': dict({
           '/': 'sdiskusage(total=536870912000, used=322122547200, free=214748364800, percent=60.0)',
@@ -79,7 +79,7 @@
       'data': dict({
         'addresses': None,
         'battery': 'sbattery(percent=93, secsleft=16628, power_plugged=False)',
-        'boot_time': '2024-02-24 15:00:00+00:00',
+        'boot_time': '2024-02-24 07:00:00-08:00',
         'cpu_percent': '10.0',
         'disk_usage': dict({
           '/': 'sdiskusage(total=536870912000, used=322122547200, free=214748364800, percent=60.0)',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The system monitor integration's boot  time is currently incorrect. It handles the boot time as if it was in UTC; however, the boot time is actually in the system / default time zone.

See: https://psutil.readthedocs.io/en/latest/#psutil.boot_time

> Return the system boot time expressed in seconds since the epoch (seconds since January 1, 1970, at midnight UTC). The returned value is based on the system clock, which means it may be affected by changes such as manual adjustments or time synchronization (e.g. NTP).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
