### PR TITLE
Improve test coverage for switch in Fritz

### DIFF
--- a/tests/components/fritz/conftest.py
+++ b/tests/components/fritz/conftest.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 from fritzconnection.core.processor import Service
 from fritzconnection.lib.fritzhosts import FritzHosts
+from fritzconnection.lib.fritzstatus import FritzStatus
+from fritzconnection.lib.fritztools import ArgumentNamespace
 import pytest
 
 from .const import (
@@ -12,6 +14,9 @@ from .const import (
     MOCK_HOST_ATTRIBUTES_DATA,
     MOCK_MESH_DATA,
     MOCK_MODELNAME,
+    MOCK_STATUS_AVM_DEVICE_LOG_DATA,
+    MOCK_STATUS_CONNECTION_DATA,
+    MOCK_STATUS_DEVICE_INFO_DATA,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -120,4 +125,26 @@ def fh_class_mock():
     ) as result:
         result.get_mesh_topology = MagicMock(return_value=MOCK_MESH_DATA)
         result.get_hosts_attributes = MagicMock(return_value=MOCK_HOST_ATTRIBUTES_DATA)
+        yield result
+
+
+@pytest.fixture
+def fs_class_mock():
+    """Fixture that sets up a mocked FritzStatus class."""
+    with patch(
+        "homeassistant.components.fritz.coordinator.FritzStatus",
+        new=FritzStatus,
+    ) as result:
+        result.get_default_connection_service = MagicMock(
+            return_value=MOCK_STATUS_CONNECTION_DATA
+        )
+        result.get_device_info = MagicMock(
+            return_value=ArgumentNamespace(MOCK_STATUS_DEVICE_INFO_DATA)
+        )
+        result.get_monitor_data = MagicMock(return_value={})
+        result.get_cpu_temperatures = MagicMock(return_value=[42, 38])
+        result.get_avm_device_log = MagicMock(
+            return_value=MOCK_STATUS_AVM_DEVICE_LOG_DATA
+        )
+        result.has_wan_enabled = True
         yield result

--- a/tests/components/fritz/const.py
+++ b/tests/components/fritz/const.py
@@ -1,5 +1,7 @@
 """Common stuff for Fritz!Tools tests."""
 
+from fritzconnection.lib.fritzstatus import DefaultConnectionService
+
 from homeassistant.components.fritz.const import DOMAIN
 from homeassistant.const import (
     CONF_DEVICES,
@@ -57,9 +59,17 @@ MOCK_FB_SERVICES: dict[str, dict] = {
         "GetInfo": {
             "NewSerialNumber": MOCK_MESH_MASTER_MAC,
             "NewName": "TheName",
+            "NewManufacturerName": "AVM",
+            "NewManufacturerOUI": "00040E",
             "NewModelName": MOCK_MODELNAME,
+            "NewDescription": f"{MOCK_MODELNAME} {MOCK_FIRMWARE}",
+            "NewProductClass": "AVMFB7590AX",
             "NewSoftwareVersion": MOCK_FIRMWARE,
+            "NewHardwareVersion": MOCK_MODELNAME,
+            "NewSpecVersion": "1.0",
+            "NewDeviceLog": "long string here ...",
             "NewUpTime": 2518179,
+            "NewProvisioningCode": "000.044.004.000",
         },
     },
     "Hosts1": {
@@ -147,7 +157,27 @@ MOCK_FB_SERVICES: dict[str, dict] = {
             "NewDownstreamMaxBitRate": 43430530,
             "NewExternalIPAddress": "1.2.3.4",
         },
-        "GetPortMappingNumberOfEntries": {},
+        "GetPortMappingNumberOfEntries": {
+            "NewPortMappingNumberOfEntries": 2,
+        },
+        "GetGenericPortMappingEntry": {
+            0: {
+                "NewInternalClient": "10.10.10.10",
+                "NewPortMappingDescription": "Test Port Mapping",
+                "NewInternalPort": 8080,
+                "NewExternalPort": 80,
+                "NewProtocol": "TCP",
+                "NewEnabled": True,
+            },
+            1: {
+                "NewInternalClient": "10.10.10.10",
+                "NewPortMappingDescription": "Test Port Mapping",
+                "NewInternalPort": 8081,
+                "NewExternalPort": 81,
+                "NewProtocol": "UDP",
+                "NewEnabled": True,
+            },
+        },
     },
     "WLANConfiguration1": {
         "GetInfo": {
@@ -158,11 +188,15 @@ MOCK_FB_SERVICES: dict[str, dict] = {
             "NewX_AVM-DE_PossibleBeaconTypes": "None,11i,11iandWPA3",
             "NewStandard": "ax",
             "NewBSSID": "1C:ED:6F:12:34:13",
+            "NewMACAddressControlEnabled": True,
         },
         "GetSSID": {
             "NewSSID": "MyWifi",
         },
         "GetSecurityKeys": {"NewKeyPassphrase": "1234567890"},
+        "GetBeaconAdvertisement": {
+            "NewBeaconAdvertisementEnabled": True,
+        },
     },
     "X_AVM-DE_Homeauto1": {
         "GetGenericDeviceInfos": [
@@ -937,6 +971,12 @@ MOCK_CALL_DEFLECTION_DATA = {
         }
     }
 }
+
+MOCK_STATUS_CONNECTION_DATA = DefaultConnectionService("1", "WANPPPConnection", "1")
+MOCK_STATUS_DEVICE_INFO_DATA = MOCK_FB_SERVICES["DeviceInfo1"]["GetInfo"]
+MOCK_STATUS_AVM_DEVICE_LOG_DATA = MOCK_FB_SERVICES["DeviceInfo1"]["GetInfo"][
+    "NewDeviceLog"
+]
 
 MOCK_USER_DATA = MOCK_CONFIG[DOMAIN][CONF_DEVICES][0]
 MOCK_USER_INPUT_ADVANCED = MOCK_USER_DATA

--- a/tests/components/fritz/snapshots/test_switch.ambr
+++ b/tests/components/fritz/snapshots/test_switch.ambr
@@ -1,4 +1,104 @@
 # serializer version: 1
+# name: test_switch_setup[fc_data0][switch.mock_title_port_forward_test_port_mapping-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mock Title Port forward Test Port Mapping',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:check-network',
+    'original_name': 'Mock Title Port forward Test Port Mapping',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-port_forward_test_port_mapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data0][switch.mock_title_port_forward_test_port_mapping-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Port forward Test Port Mapping',
+      'icon': 'mdi:check-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data0][switch.mock_title_port_forward_test_port_mapping_81-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping_81',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mock Title Port forward Test Port Mapping 81',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:check-network',
+    'original_name': 'Mock Title Port forward Test Port Mapping 81',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-port_forward_test_port_mapping_81',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data0][switch.mock_title_port_forward_test_port_mapping_81-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Port forward Test Port Mapping 81',
+      'icon': 'mdi:check-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping_81',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_wifi_2_4ghz-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -148,6 +248,106 @@
     'state': 'on',
   })
 # ---
+# name: test_switch_setup[fc_data1][switch.mock_title_port_forward_test_port_mapping-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mock Title Port forward Test Port Mapping',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:check-network',
+    'original_name': 'Mock Title Port forward Test Port Mapping',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-port_forward_test_port_mapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data1][switch.mock_title_port_forward_test_port_mapping-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Port forward Test Port Mapping',
+      'icon': 'mdi:check-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data1][switch.mock_title_port_forward_test_port_mapping_81-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping_81',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mock Title Port forward Test Port Mapping 81',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:check-network',
+    'original_name': 'Mock Title Port forward Test Port Mapping 81',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-port_forward_test_port_mapping_81',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data1][switch.mock_title_port_forward_test_port_mapping_81-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Port forward Test Port Mapping 81',
+      'icon': 'mdi:check-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping_81',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_wifi-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -291,6 +491,106 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.printer_internet_access',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data2][switch.mock_title_port_forward_test_port_mapping-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mock Title Port forward Test Port Mapping',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:check-network',
+    'original_name': 'Mock Title Port forward Test Port Mapping',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-port_forward_test_port_mapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data2][switch.mock_title_port_forward_test_port_mapping-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Port forward Test Port Mapping',
+      'icon': 'mdi:check-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data2][switch.mock_title_port_forward_test_port_mapping_81-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping_81',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mock Title Port forward Test Port Mapping 81',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:check-network',
+    'original_name': 'Mock Title Port forward Test Port Mapping 81',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-port_forward_test_port_mapping_81',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data2][switch.mock_title_port_forward_test_port_mapping_81-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Port forward Test Port Mapping 81',
+      'icon': 'mdi:check-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping_81',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -500,6 +800,106 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.mock_title_port_forward_test_port_mapping-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mock Title Port forward Test Port Mapping',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:check-network',
+    'original_name': 'Mock Title Port forward Test Port Mapping',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-port_forward_test_port_mapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.mock_title_port_forward_test_port_mapping-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Port forward Test Port Mapping',
+      'icon': 'mdi:check-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.mock_title_port_forward_test_port_mapping_81-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping_81',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mock Title Port forward Test Port Mapping 81',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:check-network',
+    'original_name': 'Mock Title Port forward Test Port Mapping 81',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-port_forward_test_port_mapping_81',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.mock_title_port_forward_test_port_mapping_81-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Port forward Test Port Mapping 81',
+      'icon': 'mdi:check-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_port_forward_test_port_mapping_81',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---
 # name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_mywifi-entry]

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -360,19 +360,9 @@ async def test_switch_device_no_wan_access(
             STATE_OFF,
         ),
         (
-            "switch.mock_title_wi_fi_mywifi",
-            "async_set_wlan_configuration",
-            STATE_OFF,
-        ),
-        (
             "switch.printer_internet_access",
             "async_set_allow_wan_access",
             STATE_ON,
-        ),
-        (
-            "switch.mock_title_call_deflection_0",
-            "async_set_deflection_enable",
-            STATE_OFF,
         ),
     ],
 )
@@ -402,7 +392,6 @@ async def test_switch_turn_on_off(
 
     with patch(
         f"homeassistant.components.fritz.coordinator.AvmWrapper.{wrapper_method}",
-        # return_value=return_value,
     ) as mock_set_action:
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -417,7 +406,6 @@ async def test_switch_turn_on_off(
 
     with patch(
         f"homeassistant.components.fritz.coordinator.AvmWrapper.{wrapper_method}",
-        #  return_value=return_value,
     ) as mock_set_action_2:
         await hass.services.async_call(
             SWITCH_DOMAIN,

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -2,17 +2,38 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
 
+from fritzconnection.core.exceptions import FritzActionError
+from fritzconnection.lib.fritzstatus import DefaultConnectionService
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.fritz.const import DOMAIN
-from homeassistant.const import Platform
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .const import MOCK_CALL_DEFLECTION_DATA, MOCK_FB_SERVICES, MOCK_USER_DATA
+from .conftest import FritzConnectionMock
+from .const import (
+    MOCK_CALL_DEFLECTION_DATA,
+    MOCK_FB_SERVICES,
+    MOCK_HOST_ATTRIBUTES_DATA,
+    MOCK_USER_DATA,
+)
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -194,3 +215,217 @@ async def test_switch_setup(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+async def test_switch_no_device_conn_type(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
+) -> None:
+    """Test Fritz!Tools switches when no device connection type is available."""
+
+    entity_id = "switch.mock_title_port_forward_test_port_mapping"
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    fs_class_mock.get_default_connection_service.return_value = (
+        DefaultConnectionService("", "", "")
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(entity_id) is None
+
+
+async def test_switch_empty_port_entities_list(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
+) -> None:
+    """Test Fritz!Tools switches with empty port entities."""
+
+    entity_id = "switch.mock_title_port_forward_test_port_mapping"
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.fritz.coordinator.AvmWrapper.async_get_num_port_mapping",
+        return_value=None,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(entity_id) is None
+
+
+async def test_switch_no_port_entities_list(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
+) -> None:
+    """Test Fritz!Tools switches with no port entities."""
+
+    entity_id = "switch.mock_title_port_forward_test_port_mapping"
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.fritz.coordinator.AvmWrapper.async_get_port_mapping",
+        return_value=None,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(entity_id) is None
+
+
+async def test_switch_no_profile_entities_list(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+) -> None:
+    """Test Fritz!Tools switches with no profile entities."""
+
+    entity_id = "sswitch.printer_internet_access"
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    services = deepcopy(MOCK_FB_SERVICES)
+    services.pop("X_AVM-DE_HostFilter1")
+    fc_class_mock.return_value = FritzConnectionMock(services)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(entity_id) is None
+
+
+async def test_switch_no_mesh_wifi_uplink(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+) -> None:
+    """Test Fritz!Tools switches when no mesh WiFi uplink."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    fh_class_mock.get_mesh_topology.side_effect = FritzActionError(
+        "No mesh WiFi uplink"
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+
+async def test_switch_device_no_wan_access(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+) -> None:
+    """Test Fritz!Tools switches when device has no WAN access."""
+
+    entity_id = "switch.printer_internet_access"
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    attributes = [
+        {k: v for k, v in host.items() if k != "X_AVM-DE_WANAccess"}
+        for host in MOCK_HOST_ATTRIBUTES_DATA
+    ]
+    fh_class_mock.get_hosts_attributes = MagicMock(return_value=attributes)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "wrapper_method", "state_value"),
+    [
+        (
+            "switch.mock_title_port_forward_test_port_mapping",
+            "async_add_port_mapping",
+            STATE_OFF,
+        ),
+        (
+            "switch.mock_title_wi_fi_mywifi",
+            "async_set_wlan_configuration",
+            STATE_OFF,
+        ),
+        (
+            "switch.printer_internet_access",
+            "async_set_allow_wan_access",
+            STATE_ON,
+        ),
+        (
+            "switch.mock_title_call_deflection_0",
+            "async_set_deflection_enable",
+            STATE_OFF,
+        ),
+    ],
+)
+async def test_switch_turn_on_off(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+    entity_id: str,
+    wrapper_method: str,
+    state_value: str,
+) -> None:
+    """Test Fritz!Tools switches turn on and turn off."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    fc_class_mock.return_value = FritzConnectionMock(
+        MOCK_FB_SERVICES | MOCK_CALL_DEFLECTION_DATA
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert entry.state is ConfigEntryState.LOADED
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_ON
+
+    with patch(
+        f"homeassistant.components.fritz.coordinator.AvmWrapper.{wrapper_method}",
+        # return_value=return_value,
+    ) as mock_set_action:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+        mock_set_action.assert_called_once()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_OFF
+
+    with patch(
+        f"homeassistant.components.fritz.coordinator.AvmWrapper.{wrapper_method}",
+        #  return_value=return_value,
+    ) as mock_set_action_2:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+        mock_set_action_2.assert_called_once()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == state_value


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve coverage: from 62 lines missing to only 3 ;-)
Removed lines that cannot be tested:

- `self.port_mapping` is always a dict. Anyway there is already a sanity check here: <https://github.com/home-assistant/core/blob/dev/homeassistant/components/fritz/switch.py#L87-L89>
- `self.ip_address` cannot be None because of sanity check here: <https://github.com/home-assistant/core/blob/dev/homeassistant/components/fritz/switch.py#L185>

Note:

Missing coverage is due to 2 tests still failing. Investigating.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
