### PR TITLE
Add set_dp_value service to Tuya integration

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -11,14 +11,22 @@ from tuya_sharing import (
     SharingDeviceListener,
     SharingTokenListener,
 )
+import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers import device_registry as dr
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.const import CONF_DEVICE_ID
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    HomeAssistantError,
+    ServiceValidationError,
+)
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import (
+    CONF_DP_CODE,
+    CONF_DP_VALUE,
     CONF_ENDPOINT,
     CONF_TERMINAL_ID,
     CONF_TOKEN_INFO,
@@ -26,6 +34,7 @@ from .const import (
     DOMAIN,
     LOGGER,
     PLATFORMS,
+    SERVICE_SET_DP_VALUE,
     TUYA_CLIENT_ID,
     TUYA_DISCOVERY_NEW,
     TUYA_HA_SIGNAL_UPDATE_ENTITY,
@@ -111,7 +120,141 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
     # If the device does not register any entities, the device does not need to subscribe
     # So the subscription is here
     await hass.async_add_executor_job(manager.refresh_mq)
+
+    # Register services if not already registered
+    _async_setup_services(hass)
+
     return True
+
+
+# Service schema for set_dp_value
+SERVICE_SET_DP_VALUE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): cv.string,
+        vol.Required(CONF_DP_CODE): cv.string,
+        vol.Required(CONF_DP_VALUE): vol.Any(
+            bool,
+            vol.Coerce(int),
+            vol.Coerce(float),
+            cv.string,
+        ),
+    }
+)
+
+
+@callback
+def _get_tuya_device_id(
+    hass: HomeAssistant, device_id: str
+) -> tuple[Manager, str] | None:
+    """Get Tuya device ID from HA device ID or Tuya device ID.
+
+    Returns tuple of (manager, tuya_device_id) if found, None otherwise.
+    """
+    device_registry = dr.async_get(hass)
+
+    # First, check if device_id is a HA device registry ID
+    if device_entry := device_registry.async_get(device_id):
+        # Extract Tuya device ID from identifiers
+        for identifier in device_entry.identifiers:
+            if identifier[0] == DOMAIN:
+                tuya_device_id = identifier[1]
+                # Find the manager for this device
+                for entry in hass.config_entries.async_entries(DOMAIN):
+                    if entry.state is not ConfigEntryState.LOADED:
+                        continue
+                    manager: Manager = entry.runtime_data.manager
+                    if tuya_device_id in manager.device_map:
+                        return (manager, tuya_device_id)
+
+    # If not found, assume device_id is a Tuya device ID
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.state is not ConfigEntryState.LOADED:
+            continue
+        manager = entry.runtime_data.manager
+        if device_id in manager.device_map:
+            return (manager, device_id)
+
+    return None
+
+
+@callback
+def _async_setup_services(hass: HomeAssistant) -> None:
+    """Set up Tuya services."""
+    if hass.services.has_service(DOMAIN, SERVICE_SET_DP_VALUE):
+        return
+
+    async def async_set_dp_value(call: ServiceCall) -> None:
+        """Set a DP value on a Tuya device."""
+        device_id = call.data[CONF_DEVICE_ID]
+        dp_code = call.data[CONF_DP_CODE]
+        dp_value = call.data[CONF_DP_VALUE]
+
+        # Find the device (supports both HA device ID and Tuya device ID)
+        result = _get_tuya_device_id(hass, device_id)
+        if result is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={"device_id": device_id},
+            )
+
+        manager, tuya_device_id = result
+        device = manager.device_map[tuya_device_id]
+
+        # Check if device is online
+        if not device.online:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="device_offline",
+                translation_placeholders={"device_name": device.name},
+            )
+
+        # Validate DP code exists in device functions
+        if not device.function or dp_code not in device.function:
+            available_codes = list(device.function.keys()) if device.function else []
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_dp_code",
+                translation_placeholders={
+                    "dp_code": dp_code,
+                    "device_name": device.name,
+                    "available_codes": ", ".join(available_codes[:10])
+                    + ("..." if len(available_codes) > 10 else "")
+                    if available_codes
+                    else "none",
+                },
+            )
+
+        LOGGER.debug(
+            "Sending DP command to device %s (%s): %s=%s",
+            device.name,
+            tuya_device_id,
+            dp_code,
+            dp_value,
+        )
+
+        try:
+            await hass.async_add_executor_job(
+                manager.send_commands,
+                tuya_device_id,
+                [{"code": dp_code, "value": dp_value}],
+            )
+        except Exception as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="send_command_failed",
+                translation_placeholders={
+                    "device_name": device.name,
+                    "error": str(err),
+                },
+            ) from err
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_DP_VALUE,
+        async_set_dp_value,
+        schema=SERVICE_SET_DP_VALUE_SCHEMA,
+    )
 
 
 async def cleanup_device_registry(hass: HomeAssistant, device_manager: Manager) -> None:
@@ -131,6 +274,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> boo
         if tuya.manager.mq is not None:
             tuya.manager.mq.stop()
         tuya.manager.remove_device_listener(tuya.listener)
+
+    # Unregister services if this is the last loaded entry
+    if not hass.config_entries.async_loaded_entries(DOMAIN):
+        hass.services.async_remove(DOMAIN, SERVICE_SET_DP_VALUE)
+
     return unload_ok
 
 

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -42,6 +42,13 @@ TUYA_SCHEMA = "haauthorize"
 TUYA_DISCOVERY_NEW = "tuya_discovery_new"
 TUYA_HA_SIGNAL_UPDATE_ENTITY = "tuya_entry_update"
 
+# Service names
+SERVICE_SET_DP_VALUE = "set_dp_value"
+
+# Service field names
+CONF_DP_CODE = "dp_code"
+CONF_DP_VALUE = "dp_value"
+
 TUYA_RESPONSE_CODE = "code"
 TUYA_RESPONSE_MSG = "msg"
 TUYA_RESPONSE_QR_CODE = "qrcode"

--- a/homeassistant/components/tuya/icons.json
+++ b/homeassistant/components/tuya/icons.json
@@ -381,5 +381,10 @@
         "default": "mdi:watermark"
       }
     }
+  },
+  "services": {
+    "set_dp_value": {
+      "service": "mdi:tune"
+    }
   }
 }

--- a/homeassistant/components/tuya/services.yaml
+++ b/homeassistant/components/tuya/services.yaml
@@ -1,0 +1,18 @@
+# Describes the format for available Tuya services
+set_dp_value:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: tuya
+    dp_code:
+      required: true
+      example: "switch_1"
+      selector:
+        text:
+    dp_value:
+      required: true
+      example: "true"
+      selector:
+        object:

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -1096,12 +1096,44 @@
   "exceptions": {
     "action_dpcode_not_found": {
       "message": "Unable to process action as the device does not provide a corresponding function code (expected one of {expected} in {available})."
+    },
+    "device_not_found": {
+      "message": "Device with ID {device_id} not found in any loaded Tuya config entry."
+    },
+    "device_offline": {
+      "message": "Device {device_name} is offline and cannot receive commands."
+    },
+    "invalid_dp_code": {
+      "message": "DP code \"{dp_code}\" is not a valid function for {device_name}. Available codes: {available_codes}"
+    },
+    "send_command_failed": {
+      "message": "Failed to send command to {device_name}: {error}"
     }
   },
   "issues": {
     "deprecated_entity_new_valve": {
       "description": "The Tuya entity `{entity}` is deprecated, replaced by a new valve entity.\nPlease update your dashboards, automations and scripts, disable `{entity}` and reload the integration/restart Home Assistant to fix this issue.",
       "title": "{name} is deprecated"
+    }
+  },
+  "services": {
+    "set_dp_value": {
+      "description": "Set a data point value on a Tuya device. Use this to control device features not exposed as entities.",
+      "fields": {
+        "device_id": {
+          "description": "The Tuya device to control",
+          "name": "Device"
+        },
+        "dp_code": {
+          "description": "The data point code to control (e.g., switch_1, vibe_light_scene)",
+          "name": "DP code"
+        },
+        "dp_value": {
+          "description": "The value to set (boolean, integer, string, or base64 for Raw type)",
+          "name": "Value"
+        }
+      },
+      "name": "Set DP value"
     }
   }
 }

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pytest
 from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya.const import DOMAIN
+from homeassistant.components.tuya.const import (
+    CONF_DP_CODE,
+    CONF_DP_VALUE,
+    DOMAIN,
+    SERVICE_SET_DP_VALUE,
+)
 from homeassistant.components.tuya.diagnostics import _REDACTED_DPCODES
+from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import DEVICE_MOCKS, initialize_entry
@@ -74,3 +84,209 @@ async def test_fixtures_valid(hass: HomeAssistant) -> None:
                         f"Please mark `data['status']['{key}']` as `**REDACTED**`"
                         f" in {device_code}.json"
                     )
+
+
+@pytest.mark.parametrize("mock_device_code", ["cz_0fHWRe8ULjtmnBNd"])
+async def test_service_set_dp_value(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the set_dp_value service."""
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    # Verify service is registered
+    assert hass.services.has_service(DOMAIN, SERVICE_SET_DP_VALUE)
+
+    # Get device registry entry
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_device.id)}
+    )
+    assert device_entry is not None
+
+    # Test with HA device ID
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_DP_VALUE,
+        {
+            CONF_DEVICE_ID: device_entry.id,
+            CONF_DP_CODE: "switch_1",
+            CONF_DP_VALUE: True,
+        },
+        blocking=True,
+    )
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [{"code": "switch_1", "value": True}],
+    )
+
+    # Reset mock
+    mock_manager.send_commands.reset_mock()
+
+    # Test with Tuya device ID directly
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_DP_VALUE,
+        {
+            CONF_DEVICE_ID: mock_device.id,
+            CONF_DP_CODE: "switch_1",
+            CONF_DP_VALUE: False,
+        },
+        blocking=True,
+    )
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [{"code": "switch_1", "value": False}],
+    )
+
+
+@pytest.mark.parametrize("mock_device_code", ["cz_0fHWRe8ULjtmnBNd"])
+async def test_service_set_dp_value_device_not_found(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test the set_dp_value service with invalid device ID."""
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_DP_VALUE,
+            {
+                CONF_DEVICE_ID: "invalid_device_id",
+                CONF_DP_CODE: "switch_1",
+                CONF_DP_VALUE: True,
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "device_not_found"
+
+
+@pytest.mark.parametrize("mock_device_code", ["cz_0fHWRe8ULjtmnBNd"])
+async def test_service_set_dp_value_device_offline(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test the set_dp_value service with offline device."""
+    mock_device.online = False
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_DP_VALUE,
+            {
+                CONF_DEVICE_ID: mock_device.id,
+                CONF_DP_CODE: "switch_1",
+                CONF_DP_VALUE: True,
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "device_offline"
+
+
+@pytest.mark.parametrize("mock_device_code", ["cz_0fHWRe8ULjtmnBNd"])
+async def test_service_set_dp_value_invalid_dp_code(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test the set_dp_value service with invalid DP code."""
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_DP_VALUE,
+            {
+                CONF_DEVICE_ID: mock_device.id,
+                CONF_DP_CODE: "invalid_dp_code",
+                CONF_DP_VALUE: True,
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "invalid_dp_code"
+
+
+@pytest.mark.parametrize("mock_device_code", ["cz_0fHWRe8ULjtmnBNd"])
+async def test_service_set_dp_value_empty_function(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test the set_dp_value service with device that has no functions."""
+    mock_device.function = {}
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_DP_VALUE,
+            {
+                CONF_DEVICE_ID: mock_device.id,
+                CONF_DP_CODE: "switch_1",
+                CONF_DP_VALUE: True,
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "invalid_dp_code"
+
+
+@pytest.mark.parametrize("mock_device_code", ["cz_0fHWRe8ULjtmnBNd"])
+async def test_service_set_dp_value_send_command_failed(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test the set_dp_value service when send_commands fails."""
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    mock_manager.send_commands.side_effect = Exception("Connection failed")
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_DP_VALUE,
+            {
+                CONF_DEVICE_ID: mock_device.id,
+                CONF_DP_CODE: "switch_1",
+                CONF_DP_VALUE: True,
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "send_command_failed"
+
+
+@pytest.mark.parametrize("mock_device_code", ["cz_0fHWRe8ULjtmnBNd"])
+async def test_service_unregistered_on_last_entry_unload(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test that service is unregistered when last config entry is unloaded."""
+    mock_manager.device_map = {mock_device.id: mock_device}
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.tuya.Manager", return_value=mock_manager):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Service should be registered
+    assert hass.services.has_service(DOMAIN, SERVICE_SET_DP_VALUE)
+
+    # Unload the entry
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Service should be unregistered
+    assert not hass.services.has_service(DOMAIN, SERVICE_SET_DP_VALUE)


### PR DESCRIPTION
 ## Proposed change

  Add a new `tuya.set_dp_value` service that allows users to control Tuya devices by setting arbitrary data point (DP) values directly. This enables control of device features that are not exposed as Home Assistant entities, giving users more flexible device control.

  Many Tuya devices have functions that are not mapped to HA entities by the integration. This service allows advanced users to send commands to any DP code supported by their device, unlocking the full potential of their Tuya devices.

  **Features:**
  - Supports both HA device registry ID and Tuya device ID
  - Supports multiple value types: boolean, integer, float, string
  - Validates device online status before sending commands
  - Validates DP code exists in device functions
  - Provides clear error messages for all failure cases

  ## Type of change

  - [x] New feature (which adds functionality to an existing integration)

  ## Checklist

  - [x] I understand the code I am submitting and can explain how it works.
  - [x] The code change is tested and works locally.
  - [x] Local tests pass.
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] I have followed the [perfect PR recommendations][perfect-pr]
  - [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
  - [x] Tests have been added to verify that the new code works.