### PR TITLE
Filter out invalid trackers in fressnapf_tracker

### DIFF
--- a/homeassistant/components/fressnapf_tracker/__init__.py
+++ b/homeassistant/components/fressnapf_tracker/__init__.py
@@ -55,6 +55,7 @@ async def _tracker_is_valid(hass: HomeAssistant, device: Device) -> bool:
             hass,
             DOMAIN,
             f"invalid_fressnapf_tracker_{device.serialnumber}",
+            issue_domain=DOMAIN,
             learn_more_url="https://www.home-assistant.io/integrations/fressnapf_tracker/",
             is_fixable=False,
             severity=IssueSeverity.WARNING,

--- a/homeassistant/components/fressnapf_tracker/__init__.py
+++ b/homeassistant/components/fressnapf_tracker/__init__.py
@@ -1,11 +1,21 @@
 """The Fressnapf Tracker integration."""
 
-from fressnapftracker import AuthClient, FressnapfTrackerAuthenticationError
+import logging
+
+from fressnapftracker import (
+    ApiClient,
+    AuthClient,
+    Device,
+    FressnapfTrackerAuthenticationError,
+    FressnapfTrackerError,
+    FressnapfTrackerInvalidTrackerResponseError,
+)
 
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import CONF_USER_ID, DOMAIN
 from .coordinator import (
@@ -20,6 +30,43 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SWITCH,
 ]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _tracker_is_valid(hass: HomeAssistant, device: Device) -> bool:
+    """Test if the tracker returns valid data.
+
+    Malformed data might indicate the tracker is broken or hasn't been properly registered with the app.
+    """
+    client = ApiClient(
+        serial_number=device.serialnumber,
+        device_token=device.token,
+        client=get_async_client(hass),
+    )
+    try:
+        await client.get_tracker()
+    except FressnapfTrackerInvalidTrackerResponseError:
+        _LOGGER.warning(
+            "Tracker with serialnumber %s is invalid. Consider removing it via the App",
+            device.serialnumber,
+        )
+        async_create_issue(
+            hass,
+            DOMAIN,
+            f"invalid_fressnapf_tracker_{device.serialnumber}",
+            learn_more_url="https://www.home-assistant.io/integrations/fressnapf_tracker/",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="invalid_fressnapf_tracker",
+            translation_placeholders={
+                "tracker_id": device.serialnumber,
+            },
+        )
+        return False
+    except FressnapfTrackerError as err:
+        raise ConfigEntryNotReady(err) from err
+    return True
 
 
 async def async_setup_entry(
@@ -40,6 +87,8 @@ async def async_setup_entry(
 
     coordinators: list[FressnapfTrackerDataUpdateCoordinator] = []
     for device in devices:
+        if not await _tracker_is_valid(hass, device):
+            continue
         coordinator = FressnapfTrackerDataUpdateCoordinator(
             hass,
             entry,

--- a/homeassistant/components/fressnapf_tracker/__init__.py
+++ b/homeassistant/components/fressnapf_tracker/__init__.py
@@ -9,6 +9,7 @@ from fressnapftracker import (
     FressnapfTrackerAuthenticationError,
     FressnapfTrackerError,
     FressnapfTrackerInvalidTrackerResponseError,
+    Tracker,
 )
 
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
@@ -34,8 +35,8 @@ PLATFORMS: list[Platform] = [
 _LOGGER = logging.getLogger(__name__)
 
 
-async def _tracker_is_valid(hass: HomeAssistant, device: Device) -> bool:
-    """Test if the tracker returns valid data.
+async def _get_valid_tracker(hass: HomeAssistant, device: Device) -> Tracker | None:
+    """Test if the tracker returns valid data and return it.
 
     Malformed data might indicate the tracker is broken or hasn't been properly registered with the app.
     """
@@ -45,7 +46,7 @@ async def _tracker_is_valid(hass: HomeAssistant, device: Device) -> bool:
         client=get_async_client(hass),
     )
     try:
-        await client.get_tracker()
+        return await client.get_tracker()
     except FressnapfTrackerInvalidTrackerResponseError:
         _LOGGER.warning(
             "Tracker with serialnumber %s is invalid. Consider removing it via the App",
@@ -64,10 +65,9 @@ async def _tracker_is_valid(hass: HomeAssistant, device: Device) -> bool:
                 "tracker_id": device.serialnumber,
             },
         )
-        return False
+        return None
     except FressnapfTrackerError as err:
         raise ConfigEntryNotReady(err) from err
-    return True
 
 
 async def async_setup_entry(
@@ -88,14 +88,15 @@ async def async_setup_entry(
 
     coordinators: list[FressnapfTrackerDataUpdateCoordinator] = []
     for device in devices:
-        if not await _tracker_is_valid(hass, device):
+        tracker = await _get_valid_tracker(hass, device)
+        if tracker is None:
             continue
         coordinator = FressnapfTrackerDataUpdateCoordinator(
             hass,
             entry,
             device,
+            initial_data=tracker,
         )
-        await coordinator.async_config_entry_first_refresh()
         coordinators.append(coordinator)
 
     entry.runtime_data = coordinators

--- a/homeassistant/components/fressnapf_tracker/coordinator.py
+++ b/homeassistant/components/fressnapf_tracker/coordinator.py
@@ -34,7 +34,7 @@ class FressnapfTrackerDataUpdateCoordinator(DataUpdateCoordinator[Tracker]):
         hass: HomeAssistant,
         config_entry: FressnapfTrackerConfigEntry,
         device: Device,
-        initial_data: Tracker | None = None,
+        initial_data: Tracker,
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -50,8 +50,7 @@ class FressnapfTrackerDataUpdateCoordinator(DataUpdateCoordinator[Tracker]):
             device_token=device.token,
             client=get_async_client(hass),
         )
-        if initial_data is not None:
-            self.data = initial_data
+        self.data = initial_data
 
     async def _async_update_data(self) -> Tracker:
         try:

--- a/homeassistant/components/fressnapf_tracker/coordinator.py
+++ b/homeassistant/components/fressnapf_tracker/coordinator.py
@@ -34,6 +34,7 @@ class FressnapfTrackerDataUpdateCoordinator(DataUpdateCoordinator[Tracker]):
         hass: HomeAssistant,
         config_entry: FressnapfTrackerConfigEntry,
         device: Device,
+        initial_data: Tracker | None = None,
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -49,6 +50,8 @@ class FressnapfTrackerDataUpdateCoordinator(DataUpdateCoordinator[Tracker]):
             device_token=device.token,
             client=get_async_client(hass),
         )
+        if initial_data is not None:
+            self.data = initial_data
 
     async def _async_update_data(self) -> Tracker:
         try:

--- a/homeassistant/components/fressnapf_tracker/strings.json
+++ b/homeassistant/components/fressnapf_tracker/strings.json
@@ -92,5 +92,11 @@
     "not_seen_recently": {
       "message": "The flashlight cannot be activated when the tracker has not moved recently."
     }
+  },
+  "issues": {
+    "invalid_fressnapf_tracker": {
+      "description": "The Fressnapf GPS tracker with the serial number `{tracker_id}` is sending invalid data. This most likely indicates the tracker is broken or hasn't been properly registered with the app. Please remove the tracker via the Fressnapf app. You can then close this issue.",
+      "title": "Invalid Fressnapf GPS tracker detected"
+    }
   }
 }

--- a/tests/components/fressnapf_tracker/conftest.py
+++ b/tests/components/fressnapf_tracker/conftest.py
@@ -35,6 +35,38 @@ MOCK_SERIAL_NUMBER = "ABC123456"
 MOCK_DEVICE_TOKEN = "mock_device_token"
 
 
+def create_mock_tracker() -> Tracker:
+    """Create a fresh mock Tracker instance."""
+    return Tracker(
+        name="Fluffy",
+        battery=85,
+        charging=False,
+        position=Position(
+            lat=52.520008,
+            lng=13.404954,
+            accuracy=10,
+            timestamp="2024-01-15T12:00:00Z",
+        ),
+        tracker_settings=TrackerSettings(
+            generation="GPS Tracker 2.0",
+            features=TrackerFeatures(
+                flash_light=True, energy_saving_mode=True, live_tracking=True
+            ),
+        ),
+        led_brightness=LedBrightness(status="ok", value=50),
+        energy_saving=EnergySaving(status="ok", value=1),
+        deep_sleep=None,
+        led_activatable=LedActivatable(
+            has_led=True,
+            seen_recently=True,
+            nonempty_battery=True,
+            not_charging=True,
+            overall=True,
+        ),
+        icon="http://res.cloudinary.com/iot-venture/image/upload/v1717594357/kyaqq7nfitrdvaoakb8s.jpg",
+    )
+
+
 @pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
@@ -102,42 +134,26 @@ def mock_auth_client(mock_device: Device) -> Generator[MagicMock]:
 
 
 @pytest.fixture
-def mock_api_client() -> Generator[MagicMock]:
-    """Mock the ApiClient."""
+def mock_api_client_init() -> Generator[MagicMock]:
+    """Mock the ApiClient used by _tracker_is_valid in __init__.py."""
     with patch(
-        "homeassistant.components.fressnapf_tracker.coordinator.ApiClient"
-    ) as mock_api_client:
-        client = mock_api_client.return_value
-        client.get_tracker = AsyncMock(
-            return_value=Tracker(
-                name="Fluffy",
-                battery=85,
-                charging=False,
-                position=Position(
-                    lat=52.520008,
-                    lng=13.404954,
-                    accuracy=10,
-                    timestamp="2024-01-15T12:00:00Z",
-                ),
-                tracker_settings=TrackerSettings(
-                    generation="GPS Tracker 2.0",
-                    features=TrackerFeatures(
-                        flash_light=True, energy_saving_mode=True, live_tracking=True
-                    ),
-                ),
-                led_brightness=LedBrightness(status="ok", value=50),
-                energy_saving=EnergySaving(status="ok", value=1),
-                deep_sleep=None,
-                led_activatable=LedActivatable(
-                    has_led=True,
-                    seen_recently=True,
-                    nonempty_battery=True,
-                    not_charging=True,
-                    overall=True,
-                ),
-                icon="http://res.cloudinary.com/iot-venture/image/upload/v1717594357/kyaqq7nfitrdvaoakb8s.jpg",
-            )
-        )
+        "homeassistant.components.fressnapf_tracker.ApiClient",
+        autospec=True,
+    ) as mock_client:
+        client = mock_client.return_value
+        client.get_tracker = AsyncMock(return_value=create_mock_tracker())
+        yield client
+
+
+@pytest.fixture
+def mock_api_client_coordinator() -> Generator[MagicMock]:
+    """Mock the ApiClient used by the coordinator."""
+    with patch(
+        "homeassistant.components.fressnapf_tracker.coordinator.ApiClient",
+        autospec=True,
+    ) as mock_client:
+        client = mock_client.return_value
+        client.get_tracker = AsyncMock(return_value=create_mock_tracker())
         client.set_led_brightness = AsyncMock(return_value=None)
         client.set_energy_saving = AsyncMock(return_value=None)
         yield client
@@ -162,7 +178,8 @@ def mock_config_entry() -> MockConfigEntry:
 async def init_integration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_api_client: MagicMock,
+    mock_api_client_init: MagicMock,
+    mock_api_client_coordinator: MagicMock,
     mock_auth_client: MagicMock,
 ) -> MockConfigEntry:
     """Set up the integration for testing."""

--- a/tests/components/fressnapf_tracker/test_config_flow.py
+++ b/tests/components/fressnapf_tracker/test_config_flow.py
@@ -216,7 +216,9 @@ async def test_user_flow_duplicate_phone_number(
         ),
     ],
 )
-@pytest.mark.usefixtures("mock_api_client", "mock_auth_client")
+@pytest.mark.usefixtures(
+    "mock_api_client_init", "mock_api_client_coordinator", "mock_auth_client"
+)
 async def test_reauth_reconfigure_flow(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -270,7 +272,7 @@ async def test_reauth_reconfigure_flow(
         ),
     ],
 )
-@pytest.mark.usefixtures("mock_api_client")
+@pytest.mark.usefixtures("mock_api_client_init", "mock_api_client_coordinator")
 async def test_reauth_reconfigure_flow_invalid_phone_number(
     hass: HomeAssistant,
     mock_auth_client: MagicMock,
@@ -333,7 +335,7 @@ async def test_reauth_reconfigure_flow_invalid_phone_number(
         ),
     ],
 )
-@pytest.mark.usefixtures("mock_api_client")
+@pytest.mark.usefixtures("mock_api_client_init", "mock_api_client_coordinator")
 async def test_reauth_reconfigure_flow_invalid_sms_code(
     hass: HomeAssistant,
     mock_auth_client: MagicMock,
@@ -393,7 +395,7 @@ async def test_reauth_reconfigure_flow_invalid_sms_code(
         ),
     ],
 )
-@pytest.mark.usefixtures("mock_api_client")
+@pytest.mark.usefixtures("mock_api_client_init", "mock_api_client_coordinator")
 async def test_reauth_reconfigure_flow_invalid_user_id(
     hass: HomeAssistant,
     mock_auth_client: MagicMock,

--- a/tests/components/fressnapf_tracker/test_device_tracker.py
+++ b/tests/components/fressnapf_tracker/test_device_tracker.py
@@ -35,17 +35,19 @@ async def test_state_entity_device_snapshots(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.usefixtures("mock_auth_client")
+@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
 async def test_device_tracker_no_position(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_tracker_no_position: Tracker,
-    mock_api_client: MagicMock,
+    mock_api_client_coordinator: MagicMock,
 ) -> None:
     """Test device tracker is unavailable when position is None."""
     mock_config_entry.add_to_hass(hass)
 
-    mock_api_client.get_tracker = AsyncMock(return_value=mock_tracker_no_position)
+    mock_api_client_coordinator.get_tracker = AsyncMock(
+        return_value=mock_tracker_no_position
+    )
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/fressnapf_tracker/test_device_tracker.py
+++ b/tests/components/fressnapf_tracker/test_device_tracker.py
@@ -35,19 +35,17 @@ async def test_state_entity_device_snapshots(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
+@pytest.mark.usefixtures("mock_auth_client")
 async def test_device_tracker_no_position(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_tracker_no_position: Tracker,
-    mock_api_client_coordinator: MagicMock,
+    mock_api_client_init: MagicMock,
 ) -> None:
     """Test device tracker is unavailable when position is None."""
     mock_config_entry.add_to_hass(hass)
 
-    mock_api_client_coordinator.get_tracker = AsyncMock(
-        return_value=mock_tracker_no_position
-    )
+    mock_api_client_init.get_tracker = AsyncMock(return_value=mock_tracker_no_position)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/fressnapf_tracker/test_init.py
+++ b/tests/components/fressnapf_tracker/test_init.py
@@ -34,9 +34,7 @@ def mock_api_client_malformed_tracker() -> Generator[MagicMock]:
         yield client
 
 
-@pytest.mark.usefixtures(
-    "mock_auth_client", "mock_api_client_init", "mock_api_client_coordinator"
-)
+@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
 async def test_setup_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -50,9 +48,7 @@ async def test_setup_entry(
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
-@pytest.mark.usefixtures(
-    "mock_auth_client", "mock_api_client_init", "mock_api_client_coordinator"
-)
+@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
 async def test_unload_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -71,26 +67,7 @@ async def test_unload_entry(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
-async def test_setup_entry_coordinator_api_error(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_api_client_coordinator: MagicMock,
-) -> None:
-    """Test setup retries when API returns error during coordinator update."""
-    mock_config_entry.add_to_hass(hass)
-
-    mock_api_client_coordinator.get_tracker = AsyncMock(
-        side_effect=FressnapfTrackerError("API Error")
-    )
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_coordinator")
+@pytest.mark.usefixtures("mock_auth_client")
 async def test_setup_entry_tracker_is_valid_api_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/fressnapf_tracker/test_light.py
+++ b/tests/components/fressnapf_tracker/test_light.py
@@ -58,15 +58,15 @@ async def test_state_entity_device_snapshots(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.usefixtures("mock_auth_client")
+@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
 async def test_not_added_when_no_led(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
-    mock_api_client: MagicMock,
+    mock_api_client_coordinator: MagicMock,
 ) -> None:
     """Test light entity is created correctly."""
-    mock_api_client.get_tracker.return_value = TRACKER_NO_LED
+    mock_api_client_coordinator.get_tracker.return_value = TRACKER_NO_LED
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -81,7 +81,7 @@ async def test_not_added_when_no_led(
 @pytest.mark.usefixtures("init_integration")
 async def test_turn_on(
     hass: HomeAssistant,
-    mock_api_client: MagicMock,
+    mock_api_client_coordinator: MagicMock,
 ) -> None:
     """Test turning the light on."""
     entity_id = "light.fluffy_flashlight"
@@ -97,13 +97,13 @@ async def test_turn_on(
         blocking=True,
     )
 
-    mock_api_client.set_led_brightness.assert_called_once_with(100)
+    mock_api_client_coordinator.set_led_brightness.assert_called_once_with(100)
 
 
 @pytest.mark.usefixtures("init_integration")
 async def test_turn_on_with_brightness(
     hass: HomeAssistant,
-    mock_api_client: MagicMock,
+    mock_api_client_coordinator: MagicMock,
 ) -> None:
     """Test turning the light on with brightness."""
     entity_id = "light.fluffy_flashlight"
@@ -116,13 +116,13 @@ async def test_turn_on_with_brightness(
     )
 
     # 128/255 * 100 = 50
-    mock_api_client.set_led_brightness.assert_called_once_with(50)
+    mock_api_client_coordinator.set_led_brightness.assert_called_once_with(50)
 
 
 @pytest.mark.usefixtures("init_integration")
 async def test_turn_off(
     hass: HomeAssistant,
-    mock_api_client: MagicMock,
+    mock_api_client_coordinator: MagicMock,
 ) -> None:
     """Test turning the light off."""
     entity_id = "light.fluffy_flashlight"
@@ -138,7 +138,7 @@ async def test_turn_off(
         blocking=True,
     )
 
-    mock_api_client.set_led_brightness.assert_called_once_with(0)
+    mock_api_client_coordinator.set_led_brightness.assert_called_once_with(0)
 
 
 @pytest.mark.parametrize(
@@ -149,16 +149,16 @@ async def test_turn_off(
         "not_charging",
     ],
 )
-@pytest.mark.usefixtures("mock_auth_client")
+@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
 async def test_turn_on_led_not_activatable(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_api_client: MagicMock,
+    mock_api_client_coordinator: MagicMock,
     activatable_parameter: str,
 ) -> None:
     """Test turning on the light when LED is not activatable raises."""
     setattr(
-        mock_api_client.get_tracker.return_value.led_activatable,
+        mock_api_client_coordinator.get_tracker.return_value.led_activatable,
         activatable_parameter,
         False,
     )
@@ -177,7 +177,7 @@ async def test_turn_on_led_not_activatable(
             blocking=True,
         )
 
-    mock_api_client.set_led_brightness.assert_not_called()
+    mock_api_client_coordinator.set_led_brightness.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -191,11 +191,11 @@ async def test_turn_on_led_not_activatable(
     ],
 )
 @pytest.mark.parametrize("service", [SERVICE_TURN_ON, SERVICE_TURN_OFF])
-@pytest.mark.usefixtures("mock_auth_client")
+@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
 async def test_turn_on_off_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_api_client: MagicMock,
+    mock_api_client_coordinator: MagicMock,
     api_exception: FressnapfTrackerError,
     expected_exception: type[HomeAssistantError],
     service: str,
@@ -208,7 +208,7 @@ async def test_turn_on_off_error(
 
     entity_id = "light.fluffy_flashlight"
 
-    mock_api_client.set_led_brightness.side_effect = api_exception
+    mock_api_client_coordinator.set_led_brightness.side_effect = api_exception
     with pytest.raises(expected_exception):
         await hass.services.async_call(
             LIGHT_DOMAIN,

--- a/tests/components/fressnapf_tracker/test_light.py
+++ b/tests/components/fressnapf_tracker/test_light.py
@@ -58,15 +58,15 @@ async def test_state_entity_device_snapshots(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
+@pytest.mark.usefixtures("mock_auth_client")
 async def test_not_added_when_no_led(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
-    mock_api_client_coordinator: MagicMock,
+    mock_api_client_init: MagicMock,
 ) -> None:
     """Test light entity is created correctly."""
-    mock_api_client_coordinator.get_tracker.return_value = TRACKER_NO_LED
+    mock_api_client_init.get_tracker.return_value = TRACKER_NO_LED
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -149,16 +149,17 @@ async def test_turn_off(
         "not_charging",
     ],
 )
-@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
+@pytest.mark.usefixtures("mock_auth_client")
 async def test_turn_on_led_not_activatable(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    mock_api_client_init: MagicMock,
     mock_api_client_coordinator: MagicMock,
     activatable_parameter: str,
 ) -> None:
     """Test turning on the light when LED is not activatable raises."""
     setattr(
-        mock_api_client_coordinator.get_tracker.return_value.led_activatable,
+        mock_api_client_init.get_tracker.return_value.led_activatable,
         activatable_parameter,
         False,
     )

--- a/tests/components/fressnapf_tracker/test_switch.py
+++ b/tests/components/fressnapf_tracker/test_switch.py
@@ -57,15 +57,15 @@ async def test_state_entity_device_snapshots(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.usefixtures("mock_auth_client")
+@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
 async def test_not_added_when_no_energy_saving_mode(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
-    mock_api_client: MagicMock,
+    mock_api_client_coordinator: MagicMock,
 ) -> None:
     """Test switch entity is created correctly."""
-    mock_api_client.get_tracker.return_value = TRACKER_NO_ENERGY_SAVING_MODE
+    mock_api_client_coordinator.get_tracker.return_value = TRACKER_NO_ENERGY_SAVING_MODE
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -80,7 +80,7 @@ async def test_not_added_when_no_energy_saving_mode(
 @pytest.mark.usefixtures("init_integration")
 async def test_turn_on(
     hass: HomeAssistant,
-    mock_api_client: MagicMock,
+    mock_api_client_coordinator: MagicMock,
 ) -> None:
     """Test turning the switch on."""
     entity_id = "switch.fluffy_sleep_mode"
@@ -96,13 +96,13 @@ async def test_turn_on(
         blocking=True,
     )
 
-    mock_api_client.set_energy_saving.assert_called_once_with(True)
+    mock_api_client_coordinator.set_energy_saving.assert_called_once_with(True)
 
 
 @pytest.mark.usefixtures("init_integration")
 async def test_turn_off(
     hass: HomeAssistant,
-    mock_api_client: MagicMock,
+    mock_api_client_coordinator: MagicMock,
 ) -> None:
     """Test turning the switch off."""
     entity_id = "switch.fluffy_sleep_mode"
@@ -118,7 +118,7 @@ async def test_turn_off(
         blocking=True,
     )
 
-    mock_api_client.set_energy_saving.assert_called_once_with(False)
+    mock_api_client_coordinator.set_energy_saving.assert_called_once_with(False)
 
 
 @pytest.mark.parametrize(
@@ -132,11 +132,11 @@ async def test_turn_off(
     ],
 )
 @pytest.mark.parametrize("service", [SERVICE_TURN_ON, SERVICE_TURN_OFF])
-@pytest.mark.usefixtures("mock_auth_client")
+@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
 async def test_turn_on_off_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_api_client: MagicMock,
+    mock_api_client_coordinator: MagicMock,
     api_exception: FressnapfTrackerError,
     expected_exception: type[HomeAssistantError],
     service: str,
@@ -149,7 +149,7 @@ async def test_turn_on_off_error(
 
     entity_id = "switch.fluffy_sleep_mode"
 
-    mock_api_client.set_energy_saving.side_effect = api_exception
+    mock_api_client_coordinator.set_energy_saving.side_effect = api_exception
     with pytest.raises(expected_exception):
         await hass.services.async_call(
             SWITCH_DOMAIN,

--- a/tests/components/fressnapf_tracker/test_switch.py
+++ b/tests/components/fressnapf_tracker/test_switch.py
@@ -57,15 +57,15 @@ async def test_state_entity_device_snapshots(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.usefixtures("mock_auth_client", "mock_api_client_init")
+@pytest.mark.usefixtures("mock_auth_client")
 async def test_not_added_when_no_energy_saving_mode(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
-    mock_api_client_coordinator: MagicMock,
+    mock_api_client_init: MagicMock,
 ) -> None:
     """Test switch entity is created correctly."""
-    mock_api_client_coordinator.get_tracker.return_value = TRACKER_NO_ENERGY_SAVING_MODE
+    mock_api_client_init.get_tracker.return_value = TRACKER_NO_ENERGY_SAVING_MODE
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A user reported that he has a tracker in his app he was unable to fully integrate. When polling the API this tracker is sending malformed data. This PR filters those trackers out and raises a repair issue instructing the user the remove the tracker via the app.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #161010
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
