### PR TITLE
Add support for searching media to Kodi

### DIFF
--- a/homeassistant/components/kodi/browse_media.py
+++ b/homeassistant/components/kodi/browse_media.py
@@ -371,7 +371,7 @@ async def search_items(
 ) -> list[BrowseMedia]:
     """Search the items for the query."""
 
-    media_filter_classes = query.media_filter_classes
+    media_filter_classes = query.media_filter_classes or []
     media_filter_classes_supported_for_search = [
         MediaClass.MOVIE,
         MediaClass.TV_SHOW,
@@ -379,13 +379,13 @@ async def search_items(
 
     is_internal = is_internal_request(hass)
 
-    if media_filter_classes:
-        media_filter_classes = [
-            t
-            for t in media_filter_classes
-            if t in media_filter_classes_supported_for_search
-        ]
-    else:
+    media_filter_classes = [
+        t
+        for t in media_filter_classes
+        if t in media_filter_classes_supported_for_search
+    ]
+
+    if not media_filter_classes:
         media_filter_classes = media_filter_classes_supported_for_search
 
     if query.media_content_id and media_source.is_media_source_id(

--- a/homeassistant/components/kodi/manifest.json
+++ b/homeassistant/components/kodi/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "loggers": ["jsonrpc_async", "jsonrpc_base", "jsonrpc_websocket", "pykodi"],
-  "requirements": ["pykodi==0.2.7"],
+  "requirements": ["pykodi==0.2.7", "rapidfuzz==3.14.3"],
   "zeroconf": ["_xbmc-jsonrpc-h._tcp.local."]
 }

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -20,6 +20,8 @@ from homeassistant.components.media_player import (
     MediaPlayerEntityFeature,
     MediaPlayerState,
     MediaType,
+    SearchMedia,
+    SearchMediaQuery,
     async_process_play_media_url,
 )
 from homeassistant.const import (
@@ -43,6 +45,7 @@ from .browse_media import (
     get_media_info,
     library_payload,
     media_source_content_filter,
+    search_items,
 )
 from .const import DOMAIN, EVENT_TURN_OFF, EVENT_TURN_ON
 
@@ -128,6 +131,7 @@ class KodiEntity(MediaPlayerEntity):
     _attr_translation_key = "media_player"
     _attr_supported_features = (
         MediaPlayerEntityFeature.BROWSE_MEDIA
+        | MediaPlayerEntityFeature.SEARCH_MEDIA
         | MediaPlayerEntityFeature.NEXT_TRACK
         | MediaPlayerEntityFeature.PAUSE
         | MediaPlayerEntityFeature.PLAY
@@ -824,6 +828,17 @@ class KodiEntity(MediaPlayerEntity):
                 f"Media not found: {media_content_type} / {media_content_id}"
             )
         return response
+
+    async def async_search_media(
+        self,
+        query: SearchMediaQuery,
+    ) -> SearchMedia:
+        """Search the media player."""
+
+        media = await search_items(
+            self.hass, self._kodi, query, self.get_browse_image_url
+        )
+        return SearchMedia(result=media)
 
     async def async_get_browse_image(
         self,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2755,6 +2755,9 @@ radiotherm==2.1.0
 # homeassistant.components.raincloud
 raincloudy==0.0.7
 
+# homeassistant.components.kodi
+rapidfuzz==3.14.3
+
 # homeassistant.components.rapt_ble
 rapt-ble==0.1.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2327,6 +2327,9 @@ radios==0.3.2
 # homeassistant.components.radiotherm
 radiotherm==2.1.0
 
+# homeassistant.components.kodi
+rapidfuzz==3.14.3
+
 # homeassistant.components.rapt_ble
 rapt-ble==0.1.2
 


### PR DESCRIPTION
Kodi provides a mechanism to query the available movies, TV shows etc using jsonrpc.

This change adds a logic to match them against the search query using [rapidfuzz](https://github.com/rapidfuzz/RapidFuzz).

This change only adds the support for searching movies and TV shows. I do not have music hosted in my kodi instance to test it. But the logic can be extended in the same way.

The search behaviour is as follows:
For movies, return the matching movie(s).
For TV shows, return the first unwatched episode for the matching show(s).

Sample usage:
"Play Avengers on Kodi"
"Play Brooklyn nine nine on Kodi"

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
    Add initial HassMediaSearchAndPlay support for Kodi.
    
    Kodi provides a mechanism to query the available movies, TV shows etc
    using jsonrpc.
    
    This change adds a logic to match them against the search query using
    rapidfuzz.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. (NA)
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] (NA)

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
