### PR TITLE
Add services using "apps" instead of "addons" to hassio integration

### DIFF
--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -17,6 +17,8 @@ DOMAIN = "hassio"
 
 ATTR_ADDON = "addon"
 ATTR_ADDONS = "addons"
+ATTR_APP = "app"
+ATTR_APPS = "apps"
 ATTR_ADMIN = "admin"
 ATTR_COMPRESSED = "compressed"
 ATTR_CONFIG = "config"

--- a/homeassistant/components/hassio/icons.json
+++ b/homeassistant/components/hassio/icons.json
@@ -22,6 +22,18 @@
     "addon_stop": {
       "service": "mdi:stop"
     },
+    "app_restart": {
+      "service": "mdi:restart"
+    },
+    "app_start": {
+      "service": "mdi:play"
+    },
+    "app_stdin": {
+      "service": "mdi:console"
+    },
+    "app_stop": {
+      "service": "mdi:stop"
+    },
     "backup_full": {
       "service": "mdi:content-save"
     },

--- a/homeassistant/components/hassio/services.yaml
+++ b/homeassistant/components/hassio/services.yaml
@@ -30,6 +30,42 @@ addon_stop:
       selector:
         addon:
 
+app_start:
+  fields:
+    app:
+      required: true
+      example: core_ssh
+      selector:
+        app:
+
+app_restart:
+  fields:
+    app:
+      required: true
+      example: core_ssh
+      selector:
+        app:
+
+app_stdin:
+  fields:
+    app:
+      required: true
+      example: core_ssh
+      selector:
+        app:
+    input:
+      required: true
+      selector:
+        object:
+
+app_stop:
+  fields:
+    app:
+      required: true
+      example: core_ssh
+      selector:
+        app:
+
 host_reboot:
 host_shutdown:
 backup_full:
@@ -64,6 +100,10 @@ backup_partial:
       default: false
       selector:
         boolean:
+    apps:
+      example: ["core_ssh", "core_samba", "core_mosquitto"]
+      selector:
+        object:
     addons:
       example: ["core_ssh", "core_samba", "core_mosquitto"]
       selector:
@@ -111,6 +151,10 @@ restore_partial:
         boolean:
     folders:
       example: ["homeassistant", "share"]
+      selector:
+        object:
+    apps:
+      example: ["core_ssh", "core_samba", "core_mosquitto"]
       selector:
         object:
     addons:

--- a/homeassistant/components/hassio/strings.json
+++ b/homeassistant/components/hassio/strings.json
@@ -336,6 +336,50 @@
       },
       "name": "Stop add-on"
     },
+    "app_restart": {
+      "description": "Restarts a Home Assistant app.",
+      "fields": {
+        "app": {
+          "description": "The app to restart.",
+          "name": "[%key:component::hassio::services::app_start::fields::app::name%]"
+        }
+      },
+      "name": "Restart app"
+    },
+    "app_start": {
+      "description": "Starts a Home Assistant app.",
+      "fields": {
+        "app": {
+          "description": "The app to start.",
+          "name": "App"
+        }
+      },
+      "name": "Start app"
+    },
+    "app_stdin": {
+      "description": "Writes data to the Home Assistant app's standard input.",
+      "fields": {
+        "app": {
+          "description": "The app to write to.",
+          "name": "[%key:component::hassio::services::app_start::fields::app::name%]"
+        },
+        "input": {
+          "description": "The data to write.",
+          "name": "Input"
+        }
+      },
+      "name": "Write data to app stdin"
+    },
+    "app_stop": {
+      "description": "Stops a Home Assistant app.",
+      "fields": {
+        "app": {
+          "description": "The app to stop.",
+          "name": "[%key:component::hassio::services::app_start::fields::app::name%]"
+        }
+      },
+      "name": "Stop app"
+    },
     "backup_full": {
       "description": "Creates a full backup.",
       "fields": {
@@ -366,8 +410,12 @@
       "description": "Creates a partial backup.",
       "fields": {
         "addons": {
-          "description": "List of add-ons to include in the backup. Use the name slug of each add-on.",
-          "name": "Add-ons"
+          "description": "List of apps (formerly add-ons) to include in the backup. Use the slug of each app. Deprecated: use apps instead.",
+          "name": "Add-ons (deprecated)"
+        },
+        "apps": {
+          "description": "List of apps to include in the backup. Use the slug of each app.",
+          "name": "Apps"
         },
         "compressed": {
           "description": "[%key:component::hassio::services::backup_full::fields::compressed::description%]",
@@ -426,8 +474,12 @@
       "description": "Restores from a partial backup.",
       "fields": {
         "addons": {
-          "description": "List of add-ons to restore from the backup. Use the name slug of each add-on.",
+          "description": "List of apps (formerly add-ons) to restore from the backup. Use the slug of each app. Deprecated: use apps instead.",
           "name": "[%key:component::hassio::services::backup_partial::fields::addons::name%]"
+        },
+        "apps": {
+          "description": "List of apps to restore from the backup. Use the slug of each app.",
+          "name": "[%key:component::hassio::services::backup_partial::fields::apps::name%]"
         },
         "folders": {
           "description": "List of directories to restore from the backup.",

--- a/homeassistant/components/hassio/strings.json
+++ b/homeassistant/components/hassio/strings.json
@@ -357,7 +357,7 @@
       "name": "Start app"
     },
     "app_stdin": {
-      "description": "Writes data to the Home Assistant app's standard input.",
+      "description": "Writes data to the standard input of a Home Assistant app.",
       "fields": {
         "app": {
           "description": "The app to write to.",
@@ -410,8 +410,8 @@
       "description": "Creates a partial backup.",
       "fields": {
         "addons": {
-          "description": "List of apps (formerly add-ons) to include in the backup. Use the slug of each app. Deprecated: use apps instead.",
-          "name": "Add-ons (deprecated)"
+          "description": "List of apps (formerly add-ons) to include in the backup. Use the slug of each app. Legacy option - use apps instead.",
+          "name": "Add-ons (legacy)"
         },
         "apps": {
           "description": "List of apps to include in the backup. Use the slug of each app.",
@@ -474,7 +474,7 @@
       "description": "Restores from a partial backup.",
       "fields": {
         "addons": {
-          "description": "List of apps (formerly add-ons) to restore from the backup. Use the slug of each app. Deprecated: use apps instead.",
+          "description": "List of apps (formerly add-ons) to restore from the backup. Use the slug of each app. Legacy option - use apps instead.",
           "name": "[%key:component::hassio::services::backup_partial::fields::addons::name%]"
         },
         "apps": {

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -698,14 +698,24 @@ async def test_invalid_service_calls(
 
 
 @pytest.mark.parametrize(
-    "service",
-    ["backup_partial", "restore_partial"],
+    ("service", "service_data"),
+    [
+        (
+            "backup_partial",
+            {"apps": ["test"], "addons": ["test"]},
+        ),
+        (
+            "restore_partial",
+            {"apps": ["test"], "addons": ["test"], "slug": "test"},
+        ),
+    ],
 )
 @pytest.mark.usefixtures("addon_installed")
 async def test_service_calls_apps_addons_exclusive(
     hass: HomeAssistant,
     supervisor_is_connected: AsyncMock,
     service: str,
+    service_data: dict[str, Any],
 ) -> None:
     """Test that apps and addons parameters are mutually exclusive."""
     supervisor_is_connected.side_effect = SupervisorError

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -723,13 +723,6 @@ async def test_service_calls_apps_addons_exclusive(
         assert await async_setup_component(hass, "hassio", {})
         await hass.async_block_till_done()
 
-    service_data: dict[str, Any] = {
-        "apps": ["test"],
-        "addons": ["test"],
-    }
-    if service == "restore_partial":
-        service_data["slug"] = "test"
-
     with pytest.raises(
         Invalid, match="two or more values in the same group of exclusion"
     ):

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -490,10 +490,17 @@ async def test_warn_when_cannot_connect(
 async def test_service_register(hass: HomeAssistant) -> None:
     """Check if service will be setup."""
     assert await async_setup_component(hass, "hassio", {})
+    # New app services
+    assert hass.services.has_service("hassio", "app_start")
+    assert hass.services.has_service("hassio", "app_stop")
+    assert hass.services.has_service("hassio", "app_restart")
+    assert hass.services.has_service("hassio", "app_stdin")
+    # Legacy addon services (deprecated)
     assert hass.services.has_service("hassio", "addon_start")
     assert hass.services.has_service("hassio", "addon_stop")
     assert hass.services.has_service("hassio", "addon_restart")
     assert hass.services.has_service("hassio", "addon_stdin")
+    # Other services
     assert hass.services.has_service("hassio", "host_shutdown")
     assert hass.services.has_service("hassio", "host_reboot")
     assert hass.services.has_service("hassio", "host_reboot")
@@ -503,14 +510,18 @@ async def test_service_register(hass: HomeAssistant) -> None:
     assert hass.services.has_service("hassio", "restore_partial")
 
 
+@pytest.mark.parametrize(
+    "app_or_addon",
+    ["app", "addon"],
+)
 @pytest.mark.freeze_time("2021-11-13 11:48:00")
 async def test_service_calls(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    caplog: pytest.LogCaptureFixture,
     supervisor_client: AsyncMock,
     addon_installed: AsyncMock,
     supervisor_is_connected: AsyncMock,
+    app_or_addon: str,
 ) -> None:
     """Call service and check the API calls behind that."""
     supervisor_is_connected.side_effect = SupervisorError
@@ -534,11 +545,17 @@ async def test_service_calls(
         "http://127.0.0.1/backups/test/restore/partial", json={"result": "ok"}
     )
 
-    await hass.services.async_call("hassio", "addon_start", {"addon": "test"})
-    await hass.services.async_call("hassio", "addon_stop", {"addon": "test"})
-    await hass.services.async_call("hassio", "addon_restart", {"addon": "test"})
     await hass.services.async_call(
-        "hassio", "addon_stdin", {"addon": "test", "input": "test"}
+        "hassio", f"{app_or_addon}_start", {app_or_addon: "test"}
+    )
+    await hass.services.async_call(
+        "hassio", f"{app_or_addon}_stop", {app_or_addon: "test"}
+    )
+    await hass.services.async_call(
+        "hassio", f"{app_or_addon}_restart", {app_or_addon: "test"}
+    )
+    await hass.services.async_call(
+        "hassio", f"{app_or_addon}_stdin", {app_or_addon: "test", "input": "test"}
     )
     await hass.async_block_till_done()
 
@@ -557,7 +574,7 @@ async def test_service_calls(
         "backup_partial",
         {
             "homeassistant": True,
-            "addons": ["test"],
+            "apps": ["test"],
             "folders": ["ssl"],
             "password": "123456",
         },
@@ -565,6 +582,7 @@ async def test_service_calls(
     await hass.async_block_till_done()
 
     assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 28
+    # API receives "addons" even when we pass "apps"
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "2021-11-13 03:48:00",
         "homeassistant": True,
@@ -582,7 +600,7 @@ async def test_service_calls(
         {
             "slug": "test",
             "homeassistant": False,
-            "addons": ["test"],
+            "apps": ["test"],
             "folders": ["ssl"],
             "password": "123456",
         },
@@ -590,6 +608,7 @@ async def test_service_calls(
     await hass.async_block_till_done()
 
     assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 30
+    # API receives "addons" even when we pass "apps"
     assert aioclient_mock.mock_calls[-1][2] == {
         "addons": ["test"],
         "folders": ["ssl"],
@@ -650,10 +669,15 @@ async def test_service_calls(
     }
 
 
+@pytest.mark.parametrize(
+    "app_or_addon",
+    ["app", "addon"],
+)
 async def test_invalid_service_calls(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     supervisor_is_connected: AsyncMock,
+    app_or_addon: str,
 ) -> None:
     """Call service with invalid input and check that it raises."""
     supervisor_is_connected.side_effect = SupervisorError
@@ -663,18 +687,25 @@ async def test_invalid_service_calls(
 
     with pytest.raises(Invalid):
         await hass.services.async_call(
-            "hassio", "addon_start", {"addon": "does_not_exist"}
+            "hassio", f"{app_or_addon}_start", {app_or_addon: "does_not_exist"}
         )
     with pytest.raises(Invalid):
         await hass.services.async_call(
-            "hassio", "addon_stdin", {"addon": "does_not_exist", "input": "test"}
+            "hassio",
+            f"{app_or_addon}_stdin",
+            {app_or_addon: "does_not_exist", "input": "test"},
         )
 
 
+@pytest.mark.parametrize(
+    "app_or_addon",
+    ["app", "addon"],
+)
 async def test_addon_service_call_with_complex_slug(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     supervisor_is_connected: AsyncMock,
+    app_or_addon: str,
 ) -> None:
     """Addon slugs can have ., - and _, confirm that passes validation."""
     supervisor_mock_data = {
@@ -705,7 +736,9 @@ async def test_addon_service_call_with_complex_slug(
         assert await async_setup_component(hass, "hassio", {})
         await hass.async_block_till_done()
 
-    await hass.services.async_call("hassio", "addon_start", {"addon": "test.a_1-2"})
+    await hass.services.async_call(
+        "hassio", f"{app_or_addon}_start", {app_or_addon: "test.a_1-2"}
+    )
 
 
 @pytest.mark.usefixtures("hassio_env")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Following the addons to apps rename, services for controlling the apps were still using "addons" in service names and payloads. This PR adds new service actions that stick to the new naming.

Old actions are still preserved without any deprecation period or warnings at this point. To make translations compatible, help texts were not updated, with the exception of "addons" parameter in the backup_partial/restore_partion actions, to explain the coexistence of both "addons" and "apps" attributes when using the visual editor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43275
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
