### PR TITLE
Add HDFury reconfiguration

### DIFF
--- a/homeassistant/components/hdfury/quality_scale.yaml
+++ b/homeassistant/components/hdfury/quality_scale.yaml
@@ -62,7 +62,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices:
     status: exempt

--- a/homeassistant/components/hdfury/strings.json
+++ b/homeassistant/components/hdfury/strings.json
@@ -2,7 +2,9 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "incorrect_device": "The configured device is not the same found on this IP address.",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
@@ -11,6 +13,15 @@
     "step": {
       "discovery_confirm": {
         "description": "Do you want to set up {host}?"
+      },
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "[%key:component::hdfury::config::step::user::data_description::host%]"
+        },
+        "description": "Update configuration for {title}."
       },
       "user": {
         "data": {

--- a/tests/components/hdfury/conftest.py
+++ b/tests/components/hdfury/conftest.py
@@ -62,7 +62,6 @@ def mock_hdfury_client() -> Generator[AsyncMock]:
 
         # Coordinator client
         coord_client = mock_coord_client.return_value
-        coord_client._cf_client = cf_client
         coord_client.get_board = cf_client.get_board
         coord_client.get_info = AsyncMock(
             return_value={

--- a/tests/components/hdfury/conftest.py
+++ b/tests/components/hdfury/conftest.py
@@ -62,6 +62,7 @@ def mock_hdfury_client() -> Generator[AsyncMock]:
 
         # Coordinator client
         coord_client = mock_coord_client.return_value
+        coord_client._cf_client = cf_client
         coord_client.get_board = cf_client.get_board
         coord_client.get_info = AsyncMock(
             return_value={

--- a/tests/components/hdfury/test_config_flow.py
+++ b/tests/components/hdfury/test_config_flow.py
@@ -243,15 +243,13 @@ async def test_reconfigure_flow_abort_incorrect_device(
     assert result["errors"] == {}
 
     # Simulate different serial number, as if user entered wrong IP
-    mock_hdfury_client._cf_client.get_board = AsyncMock(
-        return_value={
-            "hostname": "VRROOM-21",
-            "ipaddress": "192.168.1.124",
-            "serial": "000987654321",
-            "pcbv": "3",
-            "version": "FW: 0.61",
-        }
-    )
+    mock_hdfury_client.get_board.return_value = {
+        "hostname": "VRROOM-21",
+        "ipaddress": "192.168.1.124",
+        "serial": "000987654321",
+        "pcbv": "3",
+        "version": "FW: 0.61",
+    }
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {

--- a/tests/components/hdfury/test_config_flow.py
+++ b/tests/components/hdfury/test_config_flow.py
@@ -193,7 +193,6 @@ async def test_reconfigure_flow(
             CONF_HOST: "192.168.1.124",
         },
     )
-    await hass.async_block_till_done()
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
 
@@ -223,7 +222,6 @@ async def test_reconfigure_flow_no_change(
             CONF_HOST: "192.168.1.123",
         },
     )
-    await hass.async_block_till_done()
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
 
@@ -300,7 +298,6 @@ async def test_reconfigure_flow_cannot_connect(
             CONF_HOST: "192.168.1.124",
         },
     )
-    await hass.async_block_till_done()
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
 

--- a/tests/components/hdfury/test_config_flow.py
+++ b/tests/components/hdfury/test_config_flow.py
@@ -170,3 +170,140 @@ async def test_zeroconf_flow_abort_duplicate(
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_reconfigure_flow(
+    hass: HomeAssistant,
+    mock_hdfury_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguration."""
+    mock_config_entry.add_to_hass(hass)
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {}
+
+    # Original entry
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.123"
+    assert mock_config_entry.unique_id == "000123456789"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.124",
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    # Changed entry
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.124"
+    assert mock_config_entry.unique_id == "000123456789"
+
+
+async def test_reconfigure_flow_no_change(
+    hass: HomeAssistant,
+    mock_hdfury_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguration without changing values."""
+    mock_config_entry.add_to_hass(hass)
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {}
+
+    # Original entry
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.123"
+    assert mock_config_entry.unique_id == "000123456789"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.123",
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    # Changed entry
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.123"
+    assert mock_config_entry.unique_id == "000123456789"
+
+
+async def test_reconfigure_flow_abort_incorrect_device(
+    hass: HomeAssistant,
+    mock_hdfury_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test ip of other device with different serial."""
+    mock_config_entry.add_to_hass(hass)
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {}
+
+    # Simulate different serial number, as if user entered wrong IP
+    mock_hdfury_client._cf_client.get_board = AsyncMock(
+        return_value={
+            "hostname": "VRROOM-21",
+            "ipaddress": "192.168.1.124",
+            "serial": "000987654321",
+            "pcbv": "3",
+            "version": "FW: 0.61",
+        }
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.124",
+        },
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "incorrect_device"
+
+    # Entry should still be original entry
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.123"
+    assert mock_config_entry.unique_id == "000123456789"
+
+
+async def test_reconfigure_flow_cannot_connect(
+    hass: HomeAssistant,
+    mock_hdfury_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguration fails with cannot connect."""
+    mock_config_entry.add_to_hass(hass)
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {}
+
+    # Simulate a connection error by raising a HDFuryError
+    mock_hdfury_client.get_board.side_effect = HDFuryError()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.124",
+        },
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["data_schema"]({}) == {CONF_HOST: "192.168.1.123"}
+
+    # Attempt with valid IP should work
+    mock_hdfury_client.get_board.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.124",
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    # Changed entry
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.124"
+    assert mock_config_entry.unique_id == "000123456789"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the reconfiguration flow to the HDFury integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
