### PR TITLE
Bump reolink-aio to 0.18.1

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -20,5 +20,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.18.0"]
+  "requirements": ["reolink-aio==0.18.1"]
 }

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -818,8 +818,12 @@
       "animal_type": {
         "name": "Animal type",
         "state": {
+          "bear": "Bear",
           "cat": "Cat",
-          "dog": "Dog"
+          "cow": "Cow",
+          "dog": "Dog",
+          "fox": "Fox",
+          "squirrel": "Squirrel"
         }
       },
       "battery_state": {
@@ -850,6 +854,7 @@
       "person_type": {
         "name": "Person type",
         "state": {
+          "child": "Child",
           "man": "Man",
           "woman": "Woman"
         }
@@ -870,7 +875,9 @@
           "motorcycle": "Motorcycle",
           "pickup_truck": "Pickup truck",
           "sedan": "Sedan",
-          "suv": "SUV"
+          "suv": "SUV",
+          "truck": "Truck",
+          "van": "Van"
         }
       },
       "wifi_signal": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2746,7 +2746,7 @@ renault-api==0.5.2
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.18.0
+reolink-aio==0.18.1
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2312,7 +2312,7 @@ renault-api==0.5.2
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.18.0
+reolink-aio==0.18.1
 
 # homeassistant.components.rflink
 rflink==0.0.67


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.18.1:
**Additions:**
- [Add snapshot_past method](https://github.com/starkillerOG/reolink_aio/commit/0eadd2df37639d39eee87524ae431fa6b702eeba)
  - [fix snapshot_past](https://github.com/starkillerOG/reolink_aio/commit/485b94fa217e5d77ae694b0a8509165c392cc362)
- [Add YOLO AI sub_types "child", "van", "truck", "squirrel", "fox", "bear", "cow"](https://github.com/starkillerOG/reolink_aio/commit/2d9fab2b1f7901bb8dbb482a4da1cbed8c9454d9)
- [Add ptz_callibrate Baichuan fallback](https://github.com/starkillerOG/reolink_aio/commit/281e541984a9d175cc92932a68a1f12b9eea8fd3)
- [Add PtzCtrl Baichuan fallback](https://github.com/starkillerOG/reolink_aio/commit/2349fcb58bd8113628061615f7f85aece8fc233e)
  - [Add Baichuan PTZ capability flags](https://github.com/starkillerOG/reolink_aio/commit/a4c2f79ff0bd5000eb2bda22397f12b911defb46)
  - [Baichuan capabilities ptz diagonal, ptz callibrate and ptz speed](https://github.com/starkillerOG/reolink_aio/commit/eb89e09b129f44016fafe6df31e98756db1f8bfe)
- [Add diagonal PTZ commands](https://github.com/starkillerOG/reolink_aio/commit/fbfd06a626a3a554c9e45ea0c7b6310a5d64bcdb)

**Bug fixes:**
- [circumventing reolink firmware limitation stopping siren_play by issuing a manual play first](https://github.com/starkillerOG/reolink_aio/commit/99f826574987729f9f06c6c4b9cec55e3d839ca0)
- [Implement correct decryption of payload from cmd_id 298](https://github.com/starkillerOG/reolink_aio/commit/f23c428c1d57c69431df60338685a4ded317102d)
- [Fix set_image not supported error messages](https://github.com/starkillerOG/reolink_aio/commit/dbba03054f4fbf2b548b9794414662efe6dff667)
- [When not receiving all responses, back-off by sleeping 5 seconds](https://github.com/starkillerOG/reolink_aio/commit/a28939c0aa842e4126522e7041ab89298023910d)
- [Fix PTZ position for Baichuan only cams](https://github.com/starkillerOG/reolink_aio/commit/629a81b766acd5fc09e2e1d055be69bae34f0392)

**Optimizations:**
- [Create .pre-commit-config.yaml](https://github.com/starkillerOG/reolink_aio/commit/ecda064af18e6b800c8bd74a838cb278e2856858)
- [Rename image_future to payload_future](https://github.com/starkillerOG/reolink_aio/commit/10289b708b9bf7fe71e7b9ea61e87d114ce83c8b)
- [Unify payload parsing of cmd_id 109 and 298](https://github.com/starkillerOG/reolink_aio/commit/4569a29a4e7c89398483a1decd1677c8f71ef1ce)
- [Implement generic send_payload method](https://github.com/starkillerOG/reolink_aio/commit/cede79c5e074079530bb74c9f6140f7a76d09464)
  - [Fix send_payload when channel is None](https://github.com/starkillerOG/reolink_aio/commit/49c400dd3e9ccd40d78f6f458438386587c60bc8)
  - [Fix send_payload when last message is without body](https://github.com/starkillerOG/reolink_aio/commit/48f2101241512adfa308061a96c5fea7860571ae)
  - [Correct decryption of payloads](https://github.com/starkillerOG/reolink_aio/commit/241e44a2c18de86f55385d2496b7074e609b7c31)
 - [Improve unknown yolo AI sub type warning](https://github.com/starkillerOG/reolink_aio/commit/862b23e9de11fe00e49c8d913deb52ffda00acd1)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.18.0...0.18.1

Add the relevant translations for the new AI types

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/159989 fixes https://github.com/home-assistant/core/issues/160609
- This PR is related to issue: https://github.com/home-assistant/core/issues/147721 https://github.com/starkillerOG/reolink_aio/issues/140
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
