### PR TITLE
Fix AsyncIteratorReader blocking after stream exhaustion

### DIFF
--- a/homeassistant/util/async_iterator.py
+++ b/homeassistant/util/async_iterator.py
@@ -28,6 +28,7 @@ class AsyncIteratorReader:
     ) -> None:
         """Initialize the wrapper."""
         self._aborted = False
+        self._exhausted = False
         self._loop = loop
         self._stream = stream
         self._buffer: bytes | None = None
@@ -51,6 +52,8 @@ class AsyncIteratorReader:
         """
         result = bytearray()
         while n < 0 or len(result) < n:
+            if self._exhausted:
+                break
             if not self._buffer:
                 self._next_future = asyncio.run_coroutine_threadsafe(
                     self._next(), self._loop
@@ -65,6 +68,7 @@ class AsyncIteratorReader:
                 self._pos = 0
             if not self._buffer:
                 # The stream is exhausted
+                self._exhausted = True
                 break
             chunk = self._buffer[self._pos : self._pos + n]
             result.extend(chunk)


### PR DESCRIPTION
## Proposed change

Track exhaustion state in `AsyncIteratorReader` so that `read()` returns `b""` immediately after the stream is done, instead of calling `_next()` again and blocking forever on the empty queue.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #160395

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr