### PR TITLE
Bump ZHA to 0.0.87

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -57,12 +57,7 @@ async def async_get_last_network_settings(
     radio_mgr = ZhaRadioManager.from_config_entry(hass, config_entry)
 
     async with radio_mgr.create_zigpy_app(connect=False) as app:
-        try:
-            settings = max(app.backups, key=lambda b: b.backup_time)
-        except ValueError:
-            settings = None
-
-    return settings
+        return app.backups.most_recent_backup()
 
 
 async def async_get_network_settings(

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -1157,6 +1157,8 @@ def convert_to_zcl_values(
             continue
         value = fields[field.name]
         if issubclass(field.type, enum.Flag) and isinstance(value, list):
+            # Zigpy internal bitmap types are int subclasses as well
+            assert issubclass(field.type, int)
             new_value = 0
 
             for flag in value:

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==0.0.84", "serialx==0.6.2"],
+  "requirements": ["zha==0.0.85", "serialx==0.6.2"],
   "usb": [
     {
       "description": "*2652*",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==0.0.85", "serialx==0.6.2"],
+  "requirements": ["zha==0.0.86", "serialx==0.6.2"],
   "usb": [
     {
       "description": "*2652*",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==0.0.86", "serialx==0.6.2"],
+  "requirements": ["zha==0.0.87", "serialx==0.6.2"],
   "usb": [
     {
       "description": "*2652*",

--- a/homeassistant/components/zha/repairs/network_settings_inconsistent.py
+++ b/homeassistant/components/zha/repairs/network_settings_inconsistent.py
@@ -12,6 +12,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.json import json_dumps
+from homeassistant.util.json import json_loads_object
 
 from ..const import DOMAIN
 from ..radio_manager import ZhaRadioManager
@@ -99,8 +101,8 @@ async def warn_on_inconsistent_network_settings(
         translation_key=ISSUE_INCONSISTENT_NETWORK_SETTINGS,
         data={
             "config_entry_id": config_entry.entry_id,
-            "old_state": old_state.as_dict(),
-            "new_state": new_state.as_dict(),
+            "old_state": json_dumps(old_state.as_dict()),
+            "new_state": json_dumps(new_state.as_dict()),
         },
     )
 
@@ -111,8 +113,8 @@ class NetworkSettingsInconsistentFlow(RepairsFlow):
     def __init__(self, hass: HomeAssistant, data: dict[str, Any]) -> None:
         """Initialize the flow."""
         self.hass = hass
-        self._old_state = NetworkBackup.from_dict(data["old_state"])
-        self._new_state = NetworkBackup.from_dict(data["new_state"])
+        self._old_state = NetworkBackup.from_dict(json_loads_object(data["old_state"]))
+        self._new_state = NetworkBackup.from_dict(json_loads_object(data["new_state"]))
 
         self._entry_id: str = data["config_entry_id"]
 

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1284,6 +1284,15 @@
       "control_status": {
         "name": "Control status"
       },
+      "dc_current": {
+        "name": "DC current"
+      },
+      "dc_power": {
+        "name": "DC power"
+      },
+      "dc_voltage": {
+        "name": "DC voltage"
+      },
       "device_run_time": {
         "name": "Device run time"
       },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3288,7 +3288,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.86
+zha==0.0.87
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3288,7 +3288,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.84
+zha==0.0.85
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3288,7 +3288,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.85
+zha==0.0.86
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2758,7 +2758,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.86
+zha==0.0.87
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.68.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2758,7 +2758,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.85
+zha==0.0.86
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.68.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2758,7 +2758,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.84
+zha==0.0.85
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.68.0

--- a/tests/components/zha/snapshots/test_diagnostics.ambr
+++ b/tests/components/zha/snapshots/test_diagnostics.ambr
@@ -185,6 +185,12 @@
                 'zcl_type': 'EUI64',
               }),
               dict({
+                'id': '0x0013',
+                'name': 'current_zone_sensitivity_level',
+                'unsupported': True,
+                'zcl_type': 'uint8',
+              }),
+              dict({
                 'id': '0x0012',
                 'name': 'num_zone_sensitivity_levels_supported',
                 'unsupported': True,
@@ -194,14 +200,14 @@
             'cluster_id': '0x0500',
             'endpoint_attribute': 'ias_zone',
           }),
+        ]),
+        'out_clusters': list([
           dict({
             'attributes': list([
             ]),
             'cluster_id': '0x0501',
             'endpoint_attribute': 'ias_ace',
           }),
-        ]),
-        'out_clusters': list([
         ]),
         'profile_id': 260,
       }),
@@ -249,15 +255,15 @@
             'class_name': 'AlarmControlPanel',
             'cluster_handlers': list([
               dict({
-                'class_name': 'IasAceClusterHandler',
+                'class_name': 'IasAceClientClusterHandler',
                 'cluster': dict({
                   'id': 1281,
                   'name': 'IAS Ancillary Control Equipment',
-                  'type': 'server',
+                  'type': 'client',
                 }),
                 'endpoint_id': 1,
-                'generic_id': 'cluster_handler_0x0501',
-                'id': '1:0x0501',
+                'generic_id': 'cluster_handler_0x0501_client',
+                'id': '1:0x0501_client',
                 'status': 'INITIALIZED',
                 'unique_id': '**REDACTED**',
                 'value_attribute': None,

--- a/tests/components/zha/test_alarm_control_panel.py
+++ b/tests/components/zha/test_alarm_control_panel.py
@@ -60,8 +60,8 @@ async def test_alarm_control_panel(
     zigpy_device = zigpy_device_mock(
         {
             1: {
-                SIG_EP_INPUT: [security.IasAce.cluster_id],
-                SIG_EP_OUTPUT: [],
+                SIG_EP_INPUT: [],
+                SIG_EP_OUTPUT: [security.IasAce.cluster_id],
                 SIG_EP_TYPE: zha.DeviceType.IAS_ANCILLARY_CONTROL,
                 SIG_EP_PROFILE: zha.PROFILE_ID,
             }
@@ -75,7 +75,7 @@ async def test_alarm_control_panel(
 
     zha_device_proxy: ZHADeviceProxy = gateway_proxy.get_device_proxy(zigpy_device.ieee)
     entity_id = find_entity_id(Platform.ALARM_CONTROL_PANEL, zha_device_proxy, hass)
-    cluster = zigpy_device.endpoints[1].ias_ace
+    cluster = zigpy_device.endpoints[1].out_clusters[security.IasAce.cluster_id]
     assert entity_id is not None
 
     assert hass.states.get(entity_id).state == AlarmControlPanelState.DISARMED

--- a/tests/components/zha/test_device_tracker.py
+++ b/tests/components/zha/test_device_tracker.py
@@ -6,7 +6,9 @@ import time
 from unittest.mock import patch
 
 import pytest
-from zha.application.registries import SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE
+from zha.application.platforms.device_tracker import (
+    SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE,
+)
 from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general

--- a/tests/components/zha/test_diagnostics.py
+++ b/tests/components/zha/test_diagnostics.py
@@ -104,8 +104,8 @@ async def test_diagnostics_for_device(
     zigpy_device = zigpy_device_mock(
         {
             1: {
-                SIG_EP_INPUT: [security.IasAce.cluster_id, security.IasZone.cluster_id],
-                SIG_EP_OUTPUT: [],
+                SIG_EP_INPUT: [security.IasZone.cluster_id],
+                SIG_EP_OUTPUT: [security.IasAce.cluster_id],
                 SIG_EP_TYPE: zha.DeviceType.IAS_ANCILLARY_CONTROL,
                 SIG_EP_PROFILE: zha.PROFILE_ID,
             }
@@ -120,19 +120,13 @@ async def test_diagnostics_for_device(
 
     zha_device_proxy: ZHADeviceProxy = gateway_proxy.get_device_proxy(zigpy_device.ieee)
 
-    # add unknown unsupported attribute with id and name
-    zha_device_proxy.device.device.endpoints[1].in_clusters[
-        security.IasAce.cluster_id
-    ].unsupported_attributes.update({0x1000, "unknown_attribute_name"})
-
     # add known unsupported attributes with id and name
-    zha_device_proxy.device.device.endpoints[1].in_clusters[
-        security.IasZone.cluster_id
-    ].unsupported_attributes.update(
-        {
-            security.IasZone.AttributeDefs.num_zone_sensitivity_levels_supported.id,
-            security.IasZone.AttributeDefs.current_zone_sensitivity_level.name,
-        }
+    zha_device_proxy.device.device.endpoints[1].ias_zone.add_unsupported_attribute(
+        security.IasZone.AttributeDefs.num_zone_sensitivity_levels_supported
+    )
+
+    zha_device_proxy.device.device.endpoints[1].ias_zone.add_unsupported_attribute(
+        security.IasZone.AttributeDefs.current_zone_sensitivity_level
     )
 
     device = device_registry.async_get_device(

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -276,7 +276,6 @@ async def test_on_with_off_color(
         dev1_cluster_on_off.commands_by_name["on"].schema,
         expect_reply=True,
         manufacturer=None,
-        tsn=None,
     )
     assert dev1_cluster_color.request.call_args == call(
         False,
@@ -286,7 +285,6 @@ async def test_on_with_off_color(
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tsn=None,
     )
 
     light1_state = hass.states.get(device_1_entity_id)
@@ -332,7 +330,6 @@ async def test_on_with_off_color(
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tsn=None,
     )
     assert dev1_cluster_color.request.call_args == call(
         False,
@@ -342,7 +339,6 @@ async def test_on_with_off_color(
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tsn=None,
     )
     assert dev1_cluster_level.request.call_args_list[1] == call(
         False,
@@ -352,7 +348,6 @@ async def test_on_with_off_color(
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tsn=None,
     )
 
     light1_state = hass.states.get(device_1_entity_id)
@@ -404,7 +399,6 @@ async def async_test_on_off_from_hass(
         cluster.commands_by_name["on"].schema,
         expect_reply=True,
         manufacturer=None,
-        tsn=None,
     )
 
     await async_test_off_from_hass(hass, cluster, entity_id)
@@ -428,7 +422,6 @@ async def async_test_off_from_hass(
         cluster.commands_by_name["off"].schema,
         expect_reply=True,
         manufacturer=None,
-        tsn=None,
     )
 
 
@@ -459,7 +452,6 @@ async def async_test_level_on_off_from_hass(
         on_off_cluster.commands_by_name["on"].schema,
         expect_reply=True,
         manufacturer=None,
-        tsn=None,
     )
     on_off_cluster.request.reset_mock()
     level_cluster.request.reset_mock()
@@ -484,7 +476,6 @@ async def async_test_level_on_off_from_hass(
         transition_time=100,
         expect_reply=True,
         manufacturer=None,
-        tsn=None,
     )
     on_off_cluster.request.reset_mock()
     level_cluster.request.reset_mock()
@@ -508,7 +499,6 @@ async def async_test_level_on_off_from_hass(
         transition_time=int(expected_default_transition),
         expect_reply=True,
         manufacturer=None,
-        tsn=None,
     )
     on_off_cluster.request.reset_mock()
     level_cluster.request.reset_mock()
@@ -558,7 +548,6 @@ async def async_test_flash_from_hass(
         effect_variant=general.Identify.EffectVariant.Default,
         expect_reply=True,
         manufacturer=None,
-        tsn=None,
     )
 
 

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -284,9 +284,6 @@ async def async_test_powerconfiguration2(
     hass: HomeAssistant, cluster: Cluster, entity_id: str
 ):
     """Test powerconfiguration/battery sensor."""
-    await send_attributes_report(hass, cluster, {33: -1})
-    assert_state(hass, entity_id, STATE_UNKNOWN, "%")
-
     await send_attributes_report(hass, cluster, {33: 255})
     assert_state(hass, entity_id, STATE_UNKNOWN, "%")
 
@@ -399,7 +396,7 @@ async def async_test_pi_heating_demand(
                 "summation_formatting": 0b1_0111_010,
                 "unit_of_measure": 0x00,
             },
-            {"instaneneous_demand", "current_summ_received"},
+            {"instantaneous_demand", "current_summ_received"},
             STATE_UNKNOWN,
         ),
         (
@@ -417,7 +414,7 @@ async def async_test_pi_heating_demand(
                 "unit_of_measure": 0x00,
                 "current_summ_received": 0,
             },
-            {"instaneneous_demand", "current_summ_delivered"},
+            {"instantaneous_demand", "current_summ_delivered"},
             "0.0",
         ),
         (

--- a/tests/components/zha/test_siren.py
+++ b/tests/components/zha/test_siren.py
@@ -114,7 +114,6 @@ async def test_siren(
                 2,
                 manufacturer=None,
                 expect_reply=True,
-                tsn=None,
             )
         ]
 
@@ -149,7 +148,6 @@ async def test_siren(
                 2,
                 manufacturer=None,
                 expect_reply=True,
-                tsn=None,
             )
         ]
 
@@ -192,7 +190,6 @@ async def test_siren(
                 2,
                 manufacturer=None,
                 expect_reply=True,
-                tsn=None,
             )
         ]
         # test that the state has changed to on

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -109,7 +109,6 @@ async def test_switch(
             cluster.commands_by_name["on"].schema,
             expect_reply=True,
             manufacturer=None,
-            tsn=None,
         )
         state = hass.states.get(entity_id)
         assert state
@@ -131,7 +130,6 @@ async def test_switch(
             cluster.commands_by_name["off"].schema,
             expect_reply=True,
             manufacturer=None,
-            tsn=None,
         )
         state = hass.states.get(entity_id)
         assert state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump ZHA to [0.0.87](https://github.com/zigpy/zha/releases/tag/0.0.87) ([0.0.85](https://github.com/zigpy/zha/releases/tag/0.0.85) contains the main changelog, 0.0.86 and 0.0.87 are just single-PR bugfix releases for typing changes and an attribute reading fix). This contains two large internal refactors:
- Automatic ZCL entity discovery has reworked and greatly simplified, in preparation for a larger rewrite in the near future.
- Better handling of manufacturer-specific ZCL attributes and commands, especially those colliding with regular ZCL attributes.

Other changes include:
- Network backups are performed after migrating channels. This prevents an unnecessary repair regarding network settings from being created after migration.
- DC electrical measurement sensors are now supported for custom device autodiscovery.
- OTA release notes now contain changelogs for all intermediate upgrades.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
