### PR TITLE
Deprecate unknown fan mode in coolmaster

### DIFF
--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -70,6 +70,10 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
 
     _attr_name = None
 
+    # TODO(2026.7.0): When support for unknown fan speeds is removed, delete this variable.
+    # Holds unknown fan speeds we have already warned about.
+    warned_unknown_fan_speeds: set[str] = set()
+
     def __init__(
         self,
         coordinator: CoolmasterDataUpdateCoordinator,
@@ -129,11 +133,13 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
         fan_speed_lower = self._unit.fan_speed.lower()
         if fan_speed_lower not in CM_TO_HA_FAN:
             # TODO(2026.7.0): Stop supporting unknown fan speeds.
-            _LOGGER.warning(
-                "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: %s. "
-                "Support for unknown fan speeds will be removed in 2026.7.0",
-                fan_speed_lower,
-            )
+            if fan_speed_lower not in CoolmasterClimate.warned_unknown_fan_speeds:
+                CoolmasterClimate.warned_unknown_fan_speeds.add(fan_speed_lower)
+                _LOGGER.warning(
+                    "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: %s. "
+                    "Support for unknown fan speeds will be removed in 2026.7.0",
+                    fan_speed_lower,
+                )
             return fan_speed_lower
 
         return CM_TO_HA_FAN[fan_speed_lower]

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -129,14 +129,14 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
     def fan_mode(self):
         """Return the fan setting."""
 
-        # Normalize to lowercase for lookup, and pass unknown values through.
+        # Normalize to lowercase for lookup, and pass unknown lowercase values through.
         fan_speed_lower = self._unit.fan_speed.lower()
         if fan_speed_lower not in CM_TO_HA_FAN:
             # TODO(2026.7.0): Stop supporting unknown fan speeds.
             if fan_speed_lower not in CoolmasterClimate.warned_unknown_fan_speeds:
                 CoolmasterClimate.warned_unknown_fan_speeds.add(fan_speed_lower)
                 _LOGGER.warning(
-                    "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: %s. "
+                    "Detected unknown fan speed value from HVAC unit: %s. "
                     "Support for unknown fan speeds will be removed in 2026.7.0",
                     fan_speed_lower,
                 )

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -19,10 +19,9 @@ from homeassistant.components.climate import (
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CONF_SUPPORTED_MODES, DOMAIN
+from .const import CONF_SUPPORTED_MODES
 from .coordinator import CoolmasterConfigEntry, CoolmasterDataUpdateCoordinator
 from .entity import CoolmasterEntity
 
@@ -60,7 +59,7 @@ async def async_setup_entry(
     supported_modes: list[str] = config_entry.data[CONF_SUPPORTED_MODES]
     async_add_entities(
         CoolmasterClimate(
-            hass, coordinator, unit_id, [HVACMode(mode) for mode in supported_modes]
+            coordinator, unit_id, [HVACMode(mode) for mode in supported_modes]
         )
         for unit_id in coordinator.data
     )
@@ -73,7 +72,6 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         coordinator: CoolmasterDataUpdateCoordinator,
         unit_id: str,
         supported_modes: list[HVACMode],
@@ -82,7 +80,6 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
         super().__init__(coordinator, unit_id)
         self._attr_hvac_modes = supported_modes
         self._attr_unique_id = unit_id
-        self._hass = hass
 
     @property
     def supported_features(self) -> ClimateEntityFeature:
@@ -132,18 +129,10 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
         fan_speed_lower = self._unit.fan_speed.lower()
         if fan_speed_lower not in CM_TO_HA_FAN:
             # TODO(2026.7.0): Stop supporting unknown fan speeds.
-            ir.async_create_issue(
-                self._hass,
-                DOMAIN,
-                "unknown_fan_speed",
-                is_fixable=False,
-                breaks_in_ha_version="2026.7.0",
-                severity=ir.IssueSeverity.WARNING,
-                translation_key="unknown_fan_speed",
-                translation_placeholders={
-                    "fan_speed": self._unit.fan_speed,
-                    "issues_url": "https://github.com/home-assistant/core/issues",
-                },
+            _LOGGER.warning(
+                "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: %s. "
+                "Support for unknown fan speeds will be removed in 2026.7.0",
+                fan_speed_lower,
             )
             return fan_speed_lower
 

--- a/homeassistant/components/coolmaster/strings.json
+++ b/homeassistant/components/coolmaster/strings.json
@@ -41,5 +41,11 @@
         "name": "Error code"
       }
     }
+  },
+  "issues": {
+    "unknown_fan_speed": {
+      "description": "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: {fan_speed}. Support for unknown fan speeds will be removed in 2026.7.0.\n\nPlease report this fan speed on our [GitHub issue tracker]({issues_url})",
+      "title": "CoolMaster integration detected unknown fan speed"
+    }
   }
 }

--- a/homeassistant/components/coolmaster/strings.json
+++ b/homeassistant/components/coolmaster/strings.json
@@ -41,11 +41,5 @@
         "name": "Error code"
       }
     }
-  },
-  "issues": {
-    "unknown_fan_speed": {
-      "description": "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: {fan_speed}. Support for unknown fan speeds will be removed in 2026.7.0.\n\nPlease report this fan speed on our [GitHub issue tracker]({issues_url})",
-      "title": "CoolMaster integration detected unknown fan speed"
-    }
   }
 }

--- a/tests/components/coolmaster/conftest.py
+++ b/tests/components/coolmaster/conftest.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.climate import HVACMode
+from homeassistant.components.coolmaster.climate import CoolmasterClimate
 from homeassistant.components.coolmaster.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
@@ -267,3 +268,14 @@ async def config_entry_with_empty_status(hass: HomeAssistant) -> MockConfigEntry
     await hass.async_block_till_done()
 
     return config_entry
+
+
+@pytest.fixture(autouse=True)
+def reset_warned_fan_speeds():
+    """Reset the warned unknown fan speeds set before each test."""
+    # TODO(2026.7.0): When support for unknown fan speeds is removed, delete this fixture.
+    # This is necessary because `warned_unknown_fan_speeds` is a class variable and would persist
+    # across tests otherwise.
+    CoolmasterClimate.warned_unknown_fan_speeds.clear()
+    yield
+    CoolmasterClimate.warned_unknown_fan_speeds.clear()

--- a/tests/components/coolmaster/conftest.py
+++ b/tests/components/coolmaster/conftest.py
@@ -199,7 +199,9 @@ class CoolMasterNetEmptyStatusMock:
 
 
 @pytest.fixture
-async def load_int(hass: HomeAssistant) -> MockConfigEntry:
+async def load_int(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> MockConfigEntry:
     """Set up the Coolmaster integration in Home Assistant."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import issue_registry as ir
 
 
 async def test_climate_state(
@@ -131,13 +132,19 @@ async def test_climate_hvac_modes(
 async def test_climate_fan_mode(
     hass: HomeAssistant,
     load_int: ConfigEntry,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test the Coolmaster climate fan mode."""
     assert hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODE] == FAN_LOW
     assert hass.states.get("climate.l1_101").attributes[ATTR_FAN_MODE] == FAN_HIGH
     assert hass.states.get("climate.l1_102").attributes[ATTR_FAN_MODE] == "vlow"
     assert hass.states.get("climate.l1_103").attributes[ATTR_FAN_MODE] == FAN_MEDIUM
-    assert hass.states.get("climate.l1_104").attributes[ATTR_FAN_MODE] == "ULTRA"
+    assert hass.states.get("climate.l1_104").attributes[ATTR_FAN_MODE] == "ultra"
+
+    # TODO(2026.7.0): When support for unknown fan speeds is removed, delete this check.
+    assert set(issue_registry.issues) == {
+        ("coolmaster", "unknown_fan_speed"),
+    }
 
 
 async def test_climate_fan_modes(

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -175,13 +175,12 @@ async def test_climate_unknown_fan_mode_warning(
     end_record_count = len(caplog.records)
 
     for record in caplog.records[start_record_count:end_record_count]:
-        if (
+        assert not (
             "Detected unknown fan speed value from HVAC unit: ultra. "
             "Support for unknown fan speeds will be removed in 2026.7.0"
             in record.getMessage()
             and record.levelname == "WARNING"
-        ):
-            pytest.fail("Duplicate warning logged for unknown fan speed 'ultra'")
+        )
 
 
 async def test_climate_fan_modes(

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -36,7 +36,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import issue_registry as ir
 
 
 async def test_climate_state(
@@ -132,7 +131,6 @@ async def test_climate_hvac_modes(
 async def test_climate_fan_mode(
     hass: HomeAssistant,
     load_int: ConfigEntry,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test the Coolmaster climate fan mode."""
     assert hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODE] == FAN_LOW
@@ -141,10 +139,21 @@ async def test_climate_fan_mode(
     assert hass.states.get("climate.l1_103").attributes[ATTR_FAN_MODE] == FAN_MEDIUM
     assert hass.states.get("climate.l1_104").attributes[ATTR_FAN_MODE] == "ultra"
 
-    # TODO(2026.7.0): When support for unknown fan speeds is removed, delete this check.
-    assert set(issue_registry.issues) == {
-        ("coolmaster", "unknown_fan_speed"),
-    }
+
+async def test_climate_unknown_fan_mode_warning(
+    load_int: ConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the Coolmaster climate unknown fan mode warning."""
+    # TODO(2026.7.0): When support for unknown fan speeds is removed, delete this test.
+    setup_logs = caplog.get_records(when="setup")
+    assert any(
+        "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: ultra. "
+        "Support for unknown fan speeds will be removed in 2026.7.0"
+        in rec.getMessage()
+        and rec.levelname == "WARNING"
+        for rec in setup_logs
+    )
 
 
 async def test_climate_fan_modes(

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -151,14 +151,14 @@ async def test_climate_unknown_fan_mode_warning(
 
     # Assert that both unknown fan speeds logged a warning.
     assert any(
-        "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: ultra. "
+        "Detected unknown fan speed value from HVAC unit: ultra. "
         "Support for unknown fan speeds will be removed in 2026.7.0"
         in rec.getMessage()
         and rec.levelname == "WARNING"
         for rec in setup_logs
     )
     assert any(
-        "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: vlow. "
+        "Detected unknown fan speed value from HVAC unit: vlow. "
         "Support for unknown fan speeds will be removed in 2026.7.0"
         in rec.getMessage()
         and rec.levelname == "WARNING"
@@ -176,7 +176,7 @@ async def test_climate_unknown_fan_mode_warning(
 
     for record in caplog.records[start_record_count:end_record_count]:
         if (
-            "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: ultra. "
+            "Detected unknown fan speed value from HVAC unit: ultra. "
             "Support for unknown fan speeds will be removed in 2026.7.0"
             in record.getMessage()
             and record.levelname == "WARNING"

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -141,12 +141,15 @@ async def test_climate_fan_mode(
 
 
 async def test_climate_unknown_fan_mode_warning(
+    hass: HomeAssistant,
     load_int: ConfigEntry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the Coolmaster climate unknown fan mode warning."""
     # TODO(2026.7.0): When support for unknown fan speeds is removed, delete this test.
     setup_logs = caplog.get_records(when="setup")
+
+    # Assert that both unknown fan speeds logged a warning.
     assert any(
         "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: ultra. "
         "Support for unknown fan speeds will be removed in 2026.7.0"
@@ -154,6 +157,31 @@ async def test_climate_unknown_fan_mode_warning(
         and rec.levelname == "WARNING"
         for rec in setup_logs
     )
+    assert any(
+        "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: vlow. "
+        "Support for unknown fan speeds will be removed in 2026.7.0"
+        in rec.getMessage()
+        and rec.levelname == "WARNING"
+        for rec in setup_logs
+    )
+
+    start_record_count = len(caplog.records)
+    # Get the entity from the climate component
+    climate_component = hass.data[CLIMATE_DOMAIN]
+    entity = climate_component.get_entity("climate.l1_104")
+
+    # Access the fan_mode property again to ensure no duplicate warnings are logged
+    assert entity.fan_mode == "ultra"
+    end_record_count = len(caplog.records)
+
+    for record in caplog.records[start_record_count:end_record_count]:
+        if (
+            "The CoolMaster integration has detected an unknown fan speed value from your HVAC unit: ultra. "
+            "Support for unknown fan speeds will be removed in 2026.7.0"
+            in record.getMessage()
+            and record.levelname == "WARNING"
+        ):
+            pytest.fail("Duplicate warning logged for unknown fan speed 'ultra'")
 
 
 async def test_climate_fan_modes(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR address a comment in my previous PR (#160825) - https://github.com/home-assistant/core/pull/160825#discussion_r2729063197 by logging a warning (once per unknown fan speed) when a coolmaster unit is initialized with a fan speed the integration doesn't know about. The integration also notes that support for unknown fan speeds will be deprecated in 2026.7.0.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #160818 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
