### PR TITLE
Cleanup deprecated dhcp alias

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Callable
 from datetime import timedelta
 from fnmatch import translate
-from functools import lru_cache, partial
+from functools import lru_cache
 from ipaddress import IPv4Address
 import itertools
 import logging
@@ -50,12 +50,6 @@ from homeassistant.helpers import (
     device_registry as dr,
     discovery_flow,
 )
-from homeassistant.helpers.deprecation import (
-    DeprecatedConstant,
-    all_with_deprecated_constants,
-    check_if_deprecated_constant,
-    dir_with_deprecated_constants,
-)
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
 from homeassistant.helpers.discovery_flow import DiscoveryKey
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -78,13 +72,6 @@ SCAN_INTERVAL = timedelta(minutes=60)
 
 
 _LOGGER = logging.getLogger(__name__)
-
-
-_DEPRECATED_DhcpServiceInfo = DeprecatedConstant(
-    _DhcpServiceInfo,
-    "homeassistant.helpers.service_info.dhcp.DhcpServiceInfo",
-    "2026.2",
-)
 
 
 def async_index_integration_matchers(
@@ -503,11 +490,3 @@ def _memorized_fnmatch(name: str, pattern: str) -> bool:
     since the devices will not change frequently
     """
     return bool(_compile_fnmatch(pattern).match(name))
-
-
-# These can be removed if no deprecated constant are in this module anymore
-__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
-__dir__ = partial(
-    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
-)
-__all__ = all_with_deprecated_constants(globals())

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -45,7 +45,6 @@ from tests.common import (
     MockConfigEntry,
     MockModule,
     async_fire_time_changed,
-    import_and_test_deprecated_constant,
     mock_integration,
 )
 
@@ -240,7 +239,7 @@ async def test_dhcp_match_hostname_and_macaddress(hass: HomeAssistant) -> None:
         "discovery_key": DiscoveryKey(domain="dhcp", key="b8b7f16db533", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="connect",
         macaddress="b8b7f16db533",
@@ -269,7 +268,7 @@ async def test_dhcp_renewal_match_hostname_and_macaddress(hass: HomeAssistant) -
         "discovery_key": DiscoveryKey(domain="dhcp", key="50147903852c", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.1.120",
         hostname="irobot-ae9ec12dd3b04885bcbfa36afb01e1cc",
         macaddress="50147903852c",
@@ -319,7 +318,7 @@ async def test_registered_devices(
         "discovery_key": DiscoveryKey(domain="dhcp", key="50147903852c", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.1.120",
         hostname="irobot-ae9ec12dd3b04885bcbfa36afb01e1cc",
         macaddress="50147903852c",
@@ -346,7 +345,7 @@ async def test_dhcp_match_hostname(hass: HomeAssistant) -> None:
         "discovery_key": DiscoveryKey(domain="dhcp", key="b8b7f16db533", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="connect",
         macaddress="b8b7f16db533",
@@ -373,7 +372,7 @@ async def test_dhcp_match_macaddress(hass: HomeAssistant) -> None:
         "discovery_key": DiscoveryKey(domain="dhcp", key="b8b7f16db533", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="connect",
         macaddress="b8b7f16db533",
@@ -403,7 +402,7 @@ async def test_dhcp_multiple_match_only_one_flow(hass: HomeAssistant) -> None:
         "discovery_key": DiscoveryKey(domain="dhcp", key="b8b7f16db533", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="connect",
         macaddress="b8b7f16db533",
@@ -430,7 +429,7 @@ async def test_dhcp_match_macaddress_without_hostname(hass: HomeAssistant) -> No
         "discovery_key": DiscoveryKey(domain="dhcp", key="606bbd59e4b4", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.107.151",
         hostname="",
         macaddress="606bbd59e4b4",
@@ -793,7 +792,7 @@ async def test_device_tracker_hostname_and_macaddress_exists_before_start(
         "discovery_key": DiscoveryKey(domain="dhcp", key="b8b7f16db533", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="connect",
         macaddress="b8b7f16db533",
@@ -828,7 +827,7 @@ async def test_device_tracker_registered(hass: HomeAssistant) -> None:
         "discovery_key": DiscoveryKey(domain="dhcp", key="b8b7f16db533", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="connect",
         macaddress="b8b7f16db533",
@@ -902,7 +901,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start(
         "discovery_key": DiscoveryKey(domain="dhcp", key="b8b7f16db533", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="connect",
         macaddress="b8b7f16db533",
@@ -1100,7 +1099,7 @@ async def test_aiodiscover_finds_new_hosts(hass: HomeAssistant) -> None:
         "discovery_key": DiscoveryKey(domain="dhcp", key="b8b7f16db533", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="connect",
         macaddress="b8b7f16db533",
@@ -1160,7 +1159,7 @@ async def test_aiodiscover_does_not_call_again_on_shorter_hostname(
         "discovery_key": DiscoveryKey(domain="dhcp", key="b8b7f16db533", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="irobot-abc",
         macaddress="b8b7f16db533",
@@ -1170,7 +1169,7 @@ async def test_aiodiscover_does_not_call_again_on_shorter_hostname(
         "discovery_key": DiscoveryKey(domain="dhcp", key="b8b7f16db533", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[1][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[1][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="irobot-abcdef",
         macaddress="b8b7f16db533",
@@ -1226,7 +1225,7 @@ async def test_aiodiscover_finds_new_hosts_after_interval(hass: HomeAssistant) -
         "discovery_key": DiscoveryKey(domain="dhcp", key="b8b7f16db533", version=1),
         "source": config_entries.SOURCE_DHCP,
     }
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="connect",
         macaddress="b8b7f16db533",
@@ -1316,7 +1315,7 @@ async def test_dhcp_rediscover(
     assert len(mock_init.mock_calls) == 1
     assert mock_init.mock_calls[0][1][0] == "mock-domain"
     assert mock_init.mock_calls[0][2]["context"] == expected_context
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="connect",
         macaddress="b8b7f16db533",
@@ -1405,7 +1404,7 @@ async def test_dhcp_rediscover_no_match(
     assert len(mock_init.mock_calls) == 1
     assert mock_init.mock_calls[0][1][0] == "mock-domain"
     assert mock_init.mock_calls[0][2]["context"] == expected_context
-    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+    assert mock_init.mock_calls[0][2]["data"] == DhcpServiceInfo(
         ip="192.168.210.56",
         hostname="connect",
         macaddress="b8b7f16db533",
@@ -1416,30 +1415,3 @@ async def test_dhcp_rediscover_no_match(
         await hass.async_block_till_done()
 
         assert len(mock_init.mock_calls) == 0
-
-
-@pytest.mark.parametrize(
-    ("constant_name", "replacement_name", "replacement"),
-    [
-        (
-            "DhcpServiceInfo",
-            "homeassistant.helpers.service_info.dhcp.DhcpServiceInfo",
-            DhcpServiceInfo,
-        ),
-    ],
-)
-def test_deprecated_constants(
-    caplog: pytest.LogCaptureFixture,
-    constant_name: str,
-    replacement_name: str,
-    replacement: Any,
-) -> None:
-    """Test deprecated automation constants."""
-    import_and_test_deprecated_constant(
-        caplog,
-        dhcp,
-        constant_name,
-        replacement_name,
-        replacement,
-        "2026.2",
-    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developpers only: `DhcpServiceInfo` is no longer available from ‎`homeassistant.components.dhcp`, and should be imported from `homeassistant.helpers.service_info.dhcp`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
