### PR TITLE
Cleanup deprecated zeroconf aliases

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from functools import partial
 from ipaddress import IPv4Address, IPv6Address
 import logging
 import sys
@@ -21,17 +20,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, instance_id
-from homeassistant.helpers.deprecation import (
-    DeprecatedConstant,
-    all_with_deprecated_constants,
-    check_if_deprecated_constant,
-    dir_with_deprecated_constants,
-)
 from homeassistant.helpers.network import NoURLAvailableError, get_url
-from homeassistant.helpers.service_info.zeroconf import (
-    ATTR_PROPERTIES_ID as _ATTR_PROPERTIES_ID,
-    ZeroconfServiceInfo as _ZeroconfServiceInfo,
-)
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_homekit, async_get_zeroconf, bind_hass
 from homeassistant.setup import async_when_setup_or_start
@@ -62,13 +51,6 @@ MAX_PROPERTY_VALUE_LEN = 230
 # Dns label max length
 MAX_NAME_LEN = 63
 
-# Attributes for ZeroconfServiceInfo[ATTR_PROPERTIES]
-_DEPRECATED_ATTR_PROPERTIES_ID = DeprecatedConstant(
-    _ATTR_PROPERTIES_ID,
-    "homeassistant.helpers.service_info.zeroconf.ATTR_PROPERTIES_ID",
-    "2026.2",
-)
-
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
@@ -83,12 +65,6 @@ CONFIG_SCHEMA = vol.Schema(
         )
     },
     extra=vol.ALLOW_EXTRA,
-)
-
-_DEPRECATED_ZeroconfServiceInfo = DeprecatedConstant(
-    _ZeroconfServiceInfo,
-    "homeassistant.helpers.service_info.zeroconf.ZeroconfServiceInfo",
-    "2026.2",
 )
 
 
@@ -311,11 +287,3 @@ async def _async_get_local_service_info(hass: HomeAssistant) -> AsyncServiceInfo
         port=hass.http.server_port,
         properties=params,
     )
-
-
-# These can be removed if no deprecated constant are in this module anymore
-__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
-__dir__ = partial(
-    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
-)
-__all__ = all_with_deprecated_constants(globals())

--- a/tests/components/iometer/test_config_flow.py
+++ b/tests/components/iometer/test_config_flow.py
@@ -6,19 +6,19 @@ from unittest.mock import AsyncMock
 from iometer import IOmeterConnectionError, IOmeterNoReadingsError, IOmeterNoStatusError
 import pytest
 
-from homeassistant.components import zeroconf
 from homeassistant.components.iometer.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
 IP_ADDRESS = "10.0.0.2"
 IOMETER_DEVICE_ID = "658c2b34-2017-45f2-a12b-731235f8bb97"
 
-ZEROCONF_DISCOVERY = zeroconf.ZeroconfServiceInfo(
+ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
     ip_address=ip_address(IP_ADDRESS),
     ip_addresses=[ip_address(IP_ADDRESS)],
     hostname="IOmeter-EC63E8.local.",

--- a/tests/components/vegehub/test_config_flow.py
+++ b/tests/components/vegehub/test_config_flow.py
@@ -20,12 +20,13 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .conftest import TEST_HOSTNAME, TEST_IP, TEST_SIMPLE_MAC
 
 from tests.common import MockConfigEntry
 
-DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+DISCOVERY_INFO = ZeroconfServiceInfo(
     ip_address=ip_address(TEST_IP),
     ip_addresses=[ip_address(TEST_IP)],
     port=80,
@@ -360,7 +361,7 @@ async def test_zeroconf_flow_update_ip_hostname(
     # Use the same discovery info, but change the IP and hostname
     new_ip = "192.168.0.99"
     new_hostname = "new_hostname"
-    new_discovery_info = zeroconf.ZeroconfServiceInfo(
+    new_discovery_info = ZeroconfServiceInfo(
         ip_address=ip_address(new_ip),
         ip_addresses=[ip_address(new_ip)],
         port=DISCOVERY_INFO.port,

--- a/tests/components/vegehub/test_config_flow.py
+++ b/tests/components/vegehub/test_config_flow.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.vegehub.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import (
@@ -20,7 +19,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 
 from .conftest import TEST_HOSTNAME, TEST_IP, TEST_SIMPLE_MAC
 
@@ -34,7 +36,7 @@ DISCOVERY_INFO = ZeroconfServiceInfo(
     type="mock_type",
     name="myVege",
     properties={
-        zeroconf.ATTR_PROPERTIES_ID: TEST_HOSTNAME,
+        ATTR_PROPERTIES_ID: TEST_HOSTNAME,
         "version": "5.1.1",
     },
 )

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -25,18 +25,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.generated import zeroconf as zc_gen
 from homeassistant.helpers.discovery_flow import DiscoveryKey
-from homeassistant.helpers.service_info.zeroconf import (
-    ATTR_PROPERTIES_ID,
-    ZeroconfServiceInfo,
-)
 from homeassistant.setup import ATTR_COMPONENT, async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    MockModule,
-    import_and_test_deprecated_constant,
-    mock_integration,
-)
+from tests.common import MockConfigEntry, MockModule, mock_integration
 
 NON_UTF8_VALUE = b"ABCDEF\x8a"
 NON_ASCII_KEY = b"non-ascii-key\x8a"
@@ -1695,35 +1686,3 @@ async def test_zeroconf_rediscover_no_match(
 
         assert len(mock_service_browser.mock_calls) == 1
         assert len(mock_config_flow.mock_calls) == 1
-
-
-@pytest.mark.parametrize(
-    ("constant_name", "replacement_name", "replacement"),
-    [
-        (
-            "ATTR_PROPERTIES_ID",
-            "homeassistant.helpers.service_info.zeroconf.ATTR_PROPERTIES_ID",
-            ATTR_PROPERTIES_ID,
-        ),
-        (
-            "ZeroconfServiceInfo",
-            "homeassistant.helpers.service_info.zeroconf.ZeroconfServiceInfo",
-            ZeroconfServiceInfo,
-        ),
-    ],
-)
-def test_deprecated_constants(
-    caplog: pytest.LogCaptureFixture,
-    constant_name: str,
-    replacement_name: str,
-    replacement: Any,
-) -> None:
-    """Test deprecated automation constants."""
-    import_and_test_deprecated_constant(
-        caplog,
-        zeroconf,
-        constant_name,
-        replacement_name,
-        replacement,
-        "2026.2",
-    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developpers only: `ZeroconfServiceInfo` and associated attributes are no longer available from ‎`homeassistant.components.zeroconf`, and should be imported from `homeassistant.helpers.service_info.zeroconf`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
