### PR TITLE
Cleanup deprecated ssdp aliases

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -8,30 +8,7 @@ from typing import Any
 
 from homeassistant.core import HassJob, HomeAssistant
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.deprecation import (
-    DeprecatedConstant,
-    all_with_deprecated_constants,
-    check_if_deprecated_constant,
-    dir_with_deprecated_constants,
-)
-from homeassistant.helpers.service_info.ssdp import (
-    ATTR_NT as _ATTR_NT,
-    ATTR_ST as _ATTR_ST,
-    ATTR_UPNP_DEVICE_TYPE as _ATTR_UPNP_DEVICE_TYPE,
-    ATTR_UPNP_FRIENDLY_NAME as _ATTR_UPNP_FRIENDLY_NAME,
-    ATTR_UPNP_MANUFACTURER as _ATTR_UPNP_MANUFACTURER,
-    ATTR_UPNP_MANUFACTURER_URL as _ATTR_UPNP_MANUFACTURER_URL,
-    ATTR_UPNP_MODEL_DESCRIPTION as _ATTR_UPNP_MODEL_DESCRIPTION,
-    ATTR_UPNP_MODEL_NAME as _ATTR_UPNP_MODEL_NAME,
-    ATTR_UPNP_MODEL_NUMBER as _ATTR_UPNP_MODEL_NUMBER,
-    ATTR_UPNP_MODEL_URL as _ATTR_UPNP_MODEL_URL,
-    ATTR_UPNP_PRESENTATION_URL as _ATTR_UPNP_PRESENTATION_URL,
-    ATTR_UPNP_SERIAL as _ATTR_UPNP_SERIAL,
-    ATTR_UPNP_SERVICE_LIST as _ATTR_UPNP_SERVICE_LIST,
-    ATTR_UPNP_UDN as _ATTR_UPNP_UDN,
-    ATTR_UPNP_UPC as _ATTR_UPNP_UPC,
-    SsdpServiceInfo as _SsdpServiceInfo,
-)
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo as _SsdpServiceInfo
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_ssdp, bind_hass
 from homeassistant.util.logging import catch_log_exception
@@ -56,92 +33,11 @@ ATTR_SSDP_EXT = "ssdp_ext"
 ATTR_SSDP_SERVER = "ssdp_server"
 ATTR_SSDP_BOOTID = "BOOTID.UPNP.ORG"
 ATTR_SSDP_NEXTBOOTID = "NEXTBOOTID.UPNP.ORG"
-# Attributes for accessing info from retrieved UPnP device description
-_DEPRECATED_ATTR_ST = DeprecatedConstant(
-    _ATTR_ST,
-    "homeassistant.helpers.service_info.ssdp.ATTR_ST",
-    "2026.2",
-)
-_DEPRECATED_ATTR_NT = DeprecatedConstant(
-    _ATTR_NT,
-    "homeassistant.helpers.service_info.ssdp.ATTR_NT",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_DEVICE_TYPE = DeprecatedConstant(
-    _ATTR_UPNP_DEVICE_TYPE,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_DEVICE_TYPE",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_FRIENDLY_NAME = DeprecatedConstant(
-    _ATTR_UPNP_FRIENDLY_NAME,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_FRIENDLY_NAME",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_MANUFACTURER = DeprecatedConstant(
-    _ATTR_UPNP_MANUFACTURER,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MANUFACTURER",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_MANUFACTURER_URL = DeprecatedConstant(
-    _ATTR_UPNP_MANUFACTURER_URL,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MANUFACTURER_URL",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_MODEL_DESCRIPTION = DeprecatedConstant(
-    _ATTR_UPNP_MODEL_DESCRIPTION,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MODEL_DESCRIPTION",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_MODEL_NAME = DeprecatedConstant(
-    _ATTR_UPNP_MODEL_NAME,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MODEL_NAME",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_MODEL_NUMBER = DeprecatedConstant(
-    _ATTR_UPNP_MODEL_NUMBER,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MODEL_NUMBER",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_MODEL_URL = DeprecatedConstant(
-    _ATTR_UPNP_MODEL_URL,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MODEL_URL",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_SERIAL = DeprecatedConstant(
-    _ATTR_UPNP_SERIAL,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_SERIAL",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_SERVICE_LIST = DeprecatedConstant(
-    _ATTR_UPNP_SERVICE_LIST,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_SERVICE_LIST",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_UDN = DeprecatedConstant(
-    _ATTR_UPNP_UDN,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_UDN",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_UPC = DeprecatedConstant(
-    _ATTR_UPNP_UPC,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_UPC",
-    "2026.2",
-)
-_DEPRECATED_ATTR_UPNP_PRESENTATION_URL = DeprecatedConstant(
-    _ATTR_UPNP_PRESENTATION_URL,
-    "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_PRESENTATION_URL",
-    "2026.2",
-)
+
 # Attributes for accessing info added by Home Assistant
 ATTR_HA_MATCHING_DOMAINS = "x_homeassistant_matching_domains"
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
-
-_DEPRECATED_SsdpServiceInfo = DeprecatedConstant(
-    _SsdpServiceInfo,
-    "homeassistant.helpers.service_info.ssdp.SsdpServiceInfo",
-    "2026.2",
-)
 
 
 def _format_err(name: str, *args: Any) -> str:
@@ -217,11 +113,3 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     websocket_api.async_setup(hass)
 
     return True
-
-
-# These can be removed if no deprecated constant are in this module anymore
-__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
-__dir__ = partial(
-    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
-)
-__all__ = all_with_deprecated_constants(globals())

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -1,7 +1,6 @@
 """Test the SSDP integration."""
 
 from ipaddress import IPv4Address
-from typing import Any
 from unittest.mock import ANY, AsyncMock, patch
 
 from async_upnp_client.server import UpnpServer
@@ -19,21 +18,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.discovery_flow import DiscoveryKey
 from homeassistant.helpers.service_info.ssdp import (
-    ATTR_NT,
-    ATTR_ST,
     ATTR_UPNP_DEVICE_TYPE,
-    ATTR_UPNP_FRIENDLY_NAME,
     ATTR_UPNP_MANUFACTURER,
-    ATTR_UPNP_MANUFACTURER_URL,
-    ATTR_UPNP_MODEL_DESCRIPTION,
-    ATTR_UPNP_MODEL_NAME,
-    ATTR_UPNP_MODEL_NUMBER,
-    ATTR_UPNP_MODEL_URL,
-    ATTR_UPNP_PRESENTATION_URL,
-    ATTR_UPNP_SERIAL,
-    ATTR_UPNP_SERVICE_LIST,
     ATTR_UPNP_UDN,
-    ATTR_UPNP_UPC,
     SsdpServiceInfo,
 )
 from homeassistant.util import dt as dt_util
@@ -44,7 +31,6 @@ from tests.common import (
     MockConfigEntry,
     MockModule,
     async_fire_time_changed,
-    import_and_test_deprecated_constant,
     mock_integration,
 )
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -1100,105 +1086,3 @@ async def test_ssdp_rediscover_no_match(
     await hass.async_block_till_done()
 
     assert len(mock_flow_init.mock_calls) == 1
-
-
-@pytest.mark.parametrize(
-    ("constant_name", "replacement_name", "replacement"),
-    [
-        (
-            "SsdpServiceInfo",
-            "homeassistant.helpers.service_info.ssdp.SsdpServiceInfo",
-            SsdpServiceInfo,
-        ),
-        (
-            "ATTR_ST",
-            "homeassistant.helpers.service_info.ssdp.ATTR_ST",
-            ATTR_ST,
-        ),
-        (
-            "ATTR_NT",
-            "homeassistant.helpers.service_info.ssdp.ATTR_NT",
-            ATTR_NT,
-        ),
-        (
-            "ATTR_UPNP_DEVICE_TYPE",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_DEVICE_TYPE",
-            ATTR_UPNP_DEVICE_TYPE,
-        ),
-        (
-            "ATTR_UPNP_FRIENDLY_NAME",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_FRIENDLY_NAME",
-            ATTR_UPNP_FRIENDLY_NAME,
-        ),
-        (
-            "ATTR_UPNP_MANUFACTURER",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MANUFACTURER",
-            ATTR_UPNP_MANUFACTURER,
-        ),
-        (
-            "ATTR_UPNP_MANUFACTURER_URL",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MANUFACTURER_URL",
-            ATTR_UPNP_MANUFACTURER_URL,
-        ),
-        (
-            "ATTR_UPNP_MODEL_DESCRIPTION",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MODEL_DESCRIPTION",
-            ATTR_UPNP_MODEL_DESCRIPTION,
-        ),
-        (
-            "ATTR_UPNP_MODEL_NAME",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MODEL_NAME",
-            ATTR_UPNP_MODEL_NAME,
-        ),
-        (
-            "ATTR_UPNP_MODEL_NUMBER",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MODEL_NUMBER",
-            ATTR_UPNP_MODEL_NUMBER,
-        ),
-        (
-            "ATTR_UPNP_MODEL_URL",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_MODEL_URL",
-            ATTR_UPNP_MODEL_URL,
-        ),
-        (
-            "ATTR_UPNP_SERIAL",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_SERIAL",
-            ATTR_UPNP_SERIAL,
-        ),
-        (
-            "ATTR_UPNP_SERVICE_LIST",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_SERVICE_LIST",
-            ATTR_UPNP_SERVICE_LIST,
-        ),
-        (
-            "ATTR_UPNP_UDN",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_UDN",
-            ATTR_UPNP_UDN,
-        ),
-        (
-            "ATTR_UPNP_UPC",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_UPC",
-            ATTR_UPNP_UPC,
-        ),
-        (
-            "ATTR_UPNP_PRESENTATION_URL",
-            "homeassistant.helpers.service_info.ssdp.ATTR_UPNP_PRESENTATION_URL",
-            ATTR_UPNP_PRESENTATION_URL,
-        ),
-    ],
-)
-def test_deprecated_constants(
-    caplog: pytest.LogCaptureFixture,
-    constant_name: str,
-    replacement_name: str,
-    replacement: Any,
-) -> None:
-    """Test deprecated automation constants."""
-    import_and_test_deprecated_constant(
-        caplog,
-        ssdp,
-        constant_name,
-        replacement_name,
-        replacement,
-        "2026.2",
-    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developpers only: `SsdpServiceInfo` and associated attributes are no longer available from ‎`homeassistant.components.ssdp`, and should be imported from `homeassistant.helpers.service_info.ssdp`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
