### PR TITLE
Cleanup deprecated get access in Lovelace data

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -21,7 +21,6 @@ from homeassistant.helpers import (
     config_validation as cv,
     issue_registry as ir,
 )
-from homeassistant.helpers.frame import report_usage
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.translation import async_get_translations
@@ -108,34 +107,6 @@ class LovelaceData:
     dashboards: dict[str | None, dashboard.LovelaceConfig]
     resources: resources.ResourceYAMLCollection | resources.ResourceStorageCollection
     yaml_dashboards: dict[str | None, ConfigType]
-
-    def __getitem__(self, name: str) -> Any:
-        """Enable method for compatibility reason.
-
-        Following migration from an untyped dict to a dataclass in
-        https://github.com/home-assistant/core/pull/136313
-        """
-        report_usage(
-            f"accessed lovelace_data['{name}'] instead of lovelace_data.{name}",
-            breaks_in_ha_version="2026.2",
-            exclude_integrations={DOMAIN},
-        )
-        return getattr(self, name)
-
-    def get(self, name: str, default: Any = None) -> Any:
-        """Enable method for compatibility reason.
-
-        Following migration from an untyped dict to a dataclass in
-        https://github.com/home-assistant/core/pull/136313
-        """
-        report_usage(
-            f"accessed lovelace_data.get('{name}') instead of lovelace_data.{name}",
-            breaks_in_ha_version="2026.2",
-            exclude_integrations={DOMAIN},
-        )
-        if hasattr(self, name):
-            return getattr(self, name)
-        return default
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import frame
 from homeassistant.setup import async_setup_component
 
 from tests.typing import WebSocketGenerator
@@ -97,38 +96,3 @@ async def test_create_dashboards_when_not_onboarded(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {"strategy": {"type": "map"}}
-
-
-@pytest.mark.parametrize("integration_frame_path", ["custom_components/my_integration"])
-@pytest.mark.usefixtures("mock_integration_frame")
-async def test_hass_data_compatibility(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test compatibility for external access.
-
-    See:
-    https://github.com/hacs/integration/blob/4a820e8b1b066bc54a1c9c61102038af6c030603
-    /custom_components/hacs/repositories/plugin.py#L173
-    """
-    expected_prefix = (
-        "Detected that custom integration 'my_integration' accessed lovelace_data"
-    )
-
-    assert await async_setup_component(hass, "lovelace", {})
-
-    assert (lovelace_data := hass.data.get("lovelace")) is not None
-
-    # Direct access to resources is fine
-    assert lovelace_data.resources is not None
-    assert expected_prefix not in caplog.text
-
-    # Dict compatibility logs warning
-    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
-        assert lovelace_data["resources"] is not None
-    assert f"{expected_prefix}['resources']" in caplog.text
-
-    # Dict get compatibility logs warning
-    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
-        assert lovelace_data.get("resources") is not None
-    assert f"{expected_prefix}.get('resources')" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developpers only: accessing LovelaceData via dictionnary keys is no longer possible. Please use the dataclass property instead

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
