### PR TITLE
Cleanup deprecated vacuum state constants

### DIFF
--- a/homeassistant/components/vacuum/const.py
+++ b/homeassistant/components/vacuum/const.py
@@ -3,15 +3,8 @@
 from __future__ import annotations
 
 from enum import IntFlag, StrEnum
-from functools import partial
 from typing import TYPE_CHECKING
 
-from homeassistant.helpers.deprecation import (
-    DeprecatedConstantEnum,
-    all_with_deprecated_constants,
-    check_if_deprecated_constant,
-    dir_with_deprecated_constants,
-)
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.util.hass_dict import HassKey
 
@@ -51,19 +44,3 @@ class VacuumEntityFeature(IntFlag):
     MAP = 2048
     STATE = 4096  # Must be set by vacuum platforms derived from StateVacuumEntity
     START = 8192
-
-
-# These STATE_* constants are deprecated as of Home Assistant 2025.1.
-# Please use the VacuumActivity enum instead.
-_DEPRECATED_STATE_CLEANING = DeprecatedConstantEnum(VacuumActivity.CLEANING, "2026.1")
-_DEPRECATED_STATE_DOCKED = DeprecatedConstantEnum(VacuumActivity.DOCKED, "2026.1")
-_DEPRECATED_STATE_RETURNING = DeprecatedConstantEnum(VacuumActivity.RETURNING, "2026.1")
-_DEPRECATED_STATE_ERROR = DeprecatedConstantEnum(VacuumActivity.ERROR, "2026.1")
-
-
-# These can be removed if no deprecated constant are in this module anymore
-__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
-__dir__ = partial(
-    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
-)
-__all__ = all_with_deprecated_constants(globals())

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-from enum import Enum
 import logging
-from types import ModuleType
 from typing import Any
 
 import pytest
 
-from homeassistant.components import vacuum
 from homeassistant.components.vacuum import (
     DOMAIN,
     SERVICE_CLEAN_SPOT,
@@ -31,45 +28,10 @@ from .common import async_start
 
 from tests.common import (
     MockConfigEntry,
-    MockEntity,
     MockModule,
-    help_test_all,
-    import_and_test_deprecated_constant_enum,
     mock_integration,
     setup_test_component_platform,
 )
-
-
-def _create_tuples(enum: type[Enum], constant_prefix: str) -> list[tuple[Enum, str]]:
-    return [(enum_field, constant_prefix) for enum_field in enum if enum_field]
-
-
-@pytest.mark.parametrize(
-    "module",
-    [vacuum],
-)
-def test_all(module: ModuleType) -> None:
-    """Test module.__all__ is correctly set."""
-    help_test_all(module)
-
-
-@pytest.mark.parametrize(
-    ("enum", "constant_prefix"), _create_tuples(vacuum.VacuumActivity, "STATE_")
-)
-@pytest.mark.parametrize(
-    "module",
-    [vacuum],
-)
-def test_deprecated_constants_for_state(
-    caplog: pytest.LogCaptureFixture,
-    enum: Enum,
-    constant_prefix: str,
-    module: ModuleType,
-) -> None:
-    """Test deprecated constants."""
-    import_and_test_deprecated_constant_enum(
-        caplog, module, enum, constant_prefix, "2026.1"
-    )
 
 
 @pytest.mark.parametrize(
@@ -242,181 +204,6 @@ async def test_send_command(hass: HomeAssistant, config_flow_fixture: None) -> N
     )
 
     assert "test" in strings
-
-
-async def test_vacuum_not_log_deprecated_state_warning(
-    hass: HomeAssistant,
-    mock_vacuum_entity: MockVacuum,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test correctly using activity doesn't log issue or raise repair."""
-    state = hass.states.get(mock_vacuum_entity.entity_id)
-    assert state is not None
-    assert (
-        "should implement the 'activity' property and return its state using the VacuumActivity enum"
-        not in caplog.text
-    )
-
-
-@pytest.mark.usefixtures("mock_as_custom_component")
-async def test_vacuum_log_deprecated_state_warning_using_state_prop(
-    hass: HomeAssistant,
-    config_flow_fixture: None,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test incorrectly using state property does log issue and raise repair."""
-
-    class MockLegacyVacuum(MockVacuum):
-        """Mocked vacuum entity."""
-
-        @property
-        def state(self) -> str:
-            """Return the state of the entity."""
-            return VacuumActivity.CLEANING
-
-    entity = MockLegacyVacuum(
-        name="Testing",
-        entity_id="vacuum.test",
-    )
-    config_entry = MockConfigEntry(domain="test")
-    config_entry.add_to_hass(hass)
-
-    mock_integration(
-        hass,
-        MockModule(
-            "test",
-            async_setup_entry=help_async_setup_entry_init,
-            async_unload_entry=help_async_unload_entry,
-        ),
-        built_in=False,
-    )
-    setup_test_component_platform(hass, DOMAIN, [entity], from_config_entry=True)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-
-    state = hass.states.get(entity.entity_id)
-    assert state is not None
-
-    assert (
-        "should implement the 'activity' property and return its state using the VacuumActivity enum"
-        in caplog.text
-    )
-
-
-@pytest.mark.usefixtures("mock_as_custom_component")
-async def test_vacuum_log_deprecated_state_warning_using_attr_state_attr(
-    hass: HomeAssistant,
-    config_flow_fixture: None,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test incorrectly using _attr_state attribute does log issue and raise repair."""
-
-    class MockLegacyVacuum(MockVacuum):
-        """Mocked vacuum entity."""
-
-        def start(self) -> None:
-            """Start cleaning."""
-            self._attr_state = VacuumActivity.CLEANING
-
-    entity = MockLegacyVacuum(
-        name="Testing",
-        entity_id="vacuum.test",
-    )
-    config_entry = MockConfigEntry(domain="test")
-    config_entry.add_to_hass(hass)
-
-    mock_integration(
-        hass,
-        MockModule(
-            "test",
-            async_setup_entry=help_async_setup_entry_init,
-            async_unload_entry=help_async_unload_entry,
-        ),
-        built_in=False,
-    )
-    setup_test_component_platform(hass, DOMAIN, [entity], from_config_entry=True)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-
-    state = hass.states.get(entity.entity_id)
-    assert state is not None
-
-    assert (
-        "should implement the 'activity' property and return its state using the VacuumActivity enum"
-        not in caplog.text
-    )
-
-    await async_start(hass, entity.entity_id)
-
-    assert (
-        "should implement the 'activity' property and return its state using the VacuumActivity enum"
-        in caplog.text
-    )
-    caplog.clear()
-    await async_start(hass, entity.entity_id)
-    # Test we only log once
-    assert (
-        "should implement the 'activity' property and return its state using the VacuumActivity enum"
-        not in caplog.text
-    )
-
-
-@pytest.mark.usefixtures("mock_as_custom_component")
-async def test_vacuum_deprecated_state_does_not_break_state(
-    hass: HomeAssistant,
-    config_flow_fixture: None,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test using _attr_state attribute does not break state."""
-
-    class MockLegacyVacuum(MockEntity, StateVacuumEntity):
-        """Mocked vacuum entity."""
-
-        _attr_supported_features = VacuumEntityFeature.STATE | VacuumEntityFeature.START
-
-        def __init__(self, **values: Any) -> None:
-            """Initialize a mock vacuum entity."""
-            super().__init__(**values)
-            self._attr_state = VacuumActivity.DOCKED
-
-        def start(self) -> None:
-            """Start cleaning."""
-            self._attr_state = VacuumActivity.CLEANING
-
-    entity = MockLegacyVacuum(
-        name="Testing",
-        entity_id="vacuum.test",
-    )
-    config_entry = MockConfigEntry(domain="test")
-    config_entry.add_to_hass(hass)
-
-    mock_integration(
-        hass,
-        MockModule(
-            "test",
-            async_setup_entry=help_async_setup_entry_init,
-            async_unload_entry=help_async_unload_entry,
-        ),
-        built_in=False,
-    )
-    setup_test_component_platform(hass, DOMAIN, [entity], from_config_entry=True)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-
-    state = hass.states.get(entity.entity_id)
-    assert state is not None
-    assert state.state == "docked"
-
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_START,
-        {
-            "entity_id": entity.entity_id,
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity.entity_id)
-    assert state is not None
-    assert state.state == "cleaning"
 
 
 @pytest.mark.parametrize(("is_built_in", "log_warnings"), [(True, 0), (False, 3)])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developpers only: STATE_*** constants, and the ability to set the state explicitly have been removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See breaking change above

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
