### PR TITLE
Add subscribe preview feature helper to labs

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 
 from homeassistant.components import labs, websocket_api
 from homeassistant.components.blueprint import CONF_USE_BLUEPRINT
-from homeassistant.components.labs import async_listen as async_labs_listen
+from homeassistant.components.labs import async_subscribe_preview_feature
 from homeassistant.const import (
     ATTR_AREA_ID,
     ATTR_ENTITY_ID,
@@ -387,13 +387,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
 
     @callback
-    def new_triggers_conditions_listener() -> None:
+    def new_triggers_conditions_listener(
+        _event_data: labs.EventLabsUpdatedData,
+    ) -> None:
         """Handle new_triggers_conditions flag change."""
         hass.async_create_task(
             reload_helper.execute_service(ServiceCall(hass, DOMAIN, SERVICE_RELOAD))
         )
 
-    async_labs_listen(
+    async_subscribe_preview_feature(
         hass,
         DOMAIN,
         NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG,

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -386,14 +386,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         schema=vol.Schema({vol.Optional(CONF_ID): str}),
     )
 
-    @callback
-    def new_triggers_conditions_listener(
+    async def new_triggers_conditions_listener(
         _event_data: labs.EventLabsUpdatedData,
     ) -> None:
         """Handle new_triggers_conditions flag change."""
-        hass.async_create_task(
-            reload_helper.execute_service(ServiceCall(hass, DOMAIN, SERVICE_RELOAD))
-        )
+        await reload_helper.execute_service(ServiceCall(hass, DOMAIN, SERVICE_RELOAD))
 
     async_subscribe_preview_feature(
         hass,

--- a/homeassistant/components/labs/__init__.py
+++ b/homeassistant/components/labs/__init__.py
@@ -21,6 +21,7 @@ from .const import DOMAIN, LABS_DATA, STORAGE_KEY, STORAGE_VERSION
 from .helpers import (
     async_is_preview_feature_enabled,
     async_listen,
+    async_subscribe_preview_feature,
     async_update_preview_feature,
 )
 from .models import (
@@ -41,6 +42,7 @@ __all__ = [
     "EventLabsUpdatedData",
     "async_is_preview_feature_enabled",
     "async_listen",
+    "async_subscribe_preview_feature",
     "async_update_preview_feature",
 ]
 

--- a/homeassistant/components/labs/helpers.py
+++ b/homeassistant/components/labs/helpers.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Coroutine
 from typing import Any
 
 from homeassistant.const import EVENT_LABS_UPDATED
-from homeassistant.core import Event, HassJob, HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 
 from .const import LABS_DATA
 from .models import EventLabsUpdatedData
@@ -38,7 +38,7 @@ def async_subscribe_preview_feature(
     hass: HomeAssistant,
     domain: str,
     preview_feature: str,
-    listener: Callable[[EventLabsUpdatedData], Coroutine[Any, Any, None] | None],
+    listener: Callable[[EventLabsUpdatedData], Coroutine[Any, Any, None]],
 ) -> Callable[[], None]:
     """Listen for changes to a specific preview feature.
 
@@ -46,8 +46,8 @@ def async_subscribe_preview_feature(
         hass: HomeAssistant instance
         domain: Integration domain
         preview_feature: Preview feature name
-        listener: Callback or coroutine function to invoke when the preview
-            feature is toggled. Receives the event data as argument.
+        listener: Coroutine function to invoke when the preview feature
+            is toggled. Receives the event data as argument. Runs eagerly.
 
     Returns:
         Callable to unsubscribe from the listener
@@ -61,12 +61,9 @@ def async_subscribe_preview_feature(
             and event_data["preview_feature"] == preview_feature
         )
 
-    job = HassJob(listener, f"labs preview feature {domain}.{preview_feature}")
-
-    @callback
-    def _handler(event: Event[EventLabsUpdatedData]) -> None:
+    async def _handler(event: Event[EventLabsUpdatedData]) -> None:
         """Handle labs feature update event."""
-        hass.async_run_hass_job(job, event.data)
+        await listener(event.data)
 
     return hass.bus.async_listen(
         EVENT_LABS_UPDATED, _handler, event_filter=_async_event_filter
@@ -92,8 +89,7 @@ def async_listen(
         Callable to unsubscribe from the listener
     """
 
-    @callback
-    def _listener(_event_data: EventLabsUpdatedData) -> None:
+    async def _listener(_event_data: EventLabsUpdatedData) -> None:
         listener()
 
     return async_subscribe_preview_feature(hass, domain, preview_feature, _listener)

--- a/homeassistant/components/labs/websocket_api.py
+++ b/homeassistant/components/labs/websocket_api.py
@@ -133,8 +133,7 @@ def websocket_subscribe_feature(
 
     preview_feature = labs_data.preview_features[preview_feature_id]
 
-    @callback
-    def send_event(event_data: EventLabsUpdatedData) -> None:
+    async def send_event(event_data: EventLabsUpdatedData) -> None:
         """Send feature state to client."""
         connection.send_message(
             websocket_api.event_message(

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -13,7 +13,10 @@ import voluptuous as vol
 
 from homeassistant.components import automation, websocket_api
 from homeassistant.components.blueprint import CONF_USE_BLUEPRINT
-from homeassistant.components.labs import async_listen as async_labs_listen
+from homeassistant.components.labs import (
+    EventLabsUpdatedData,
+    async_subscribe_preview_feature,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_MODE,
@@ -283,13 +286,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
 
     @callback
-    def new_triggers_conditions_listener() -> None:
+    def new_triggers_conditions_listener(_event_data: EventLabsUpdatedData) -> None:
         """Handle new_triggers_conditions flag change."""
         hass.async_create_task(
             reload_service(ServiceCall(hass, DOMAIN, SERVICE_RELOAD))
         )
 
-    async_labs_listen(
+    async_subscribe_preview_feature(
         hass,
         automation.DOMAIN,
         automation.NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG,

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -285,12 +285,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         DOMAIN, SERVICE_TOGGLE, toggle_service, schema=SCRIPT_TURN_ONOFF_SCHEMA
     )
 
-    @callback
-    def new_triggers_conditions_listener(_event_data: EventLabsUpdatedData) -> None:
+    async def new_triggers_conditions_listener(
+        _event_data: EventLabsUpdatedData,
+    ) -> None:
         """Handle new_triggers_conditions flag change."""
-        hass.async_create_task(
-            reload_service(ServiceCall(hass, DOMAIN, SERVICE_RELOAD))
-        )
+        await reload_service(ServiceCall(hass, DOMAIN, SERVICE_RELOAD))
 
     async_subscribe_preview_feature(
         hass,

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -174,13 +174,15 @@ async def async_setup(hass: HomeAssistant) -> None:
     hass.data[CONDITIONS] = {}
 
     @callback
-    def new_triggers_conditions_listener() -> None:
+    def new_triggers_conditions_listener(
+        _event_data: labs.EventLabsUpdatedData,
+    ) -> None:
         """Handle new_triggers_conditions flag change."""
         # Invalidate the cache
         hass.data[CONDITION_DESCRIPTION_CACHE] = {}
         hass.data[CONDITION_DISABLED_CONDITIONS] = set()
 
-    labs.async_listen(
+    labs.async_subscribe_preview_feature(
         hass,
         automation.DOMAIN,
         automation.NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG,

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -173,8 +173,7 @@ async def async_setup(hass: HomeAssistant) -> None:
     hass.data[CONDITION_PLATFORM_SUBSCRIPTIONS] = []
     hass.data[CONDITIONS] = {}
 
-    @callback
-    def new_triggers_conditions_listener(
+    async def new_triggers_conditions_listener(
         _event_data: labs.EventLabsUpdatedData,
     ) -> None:
         """Handle new_triggers_conditions flag change."""

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -150,13 +150,15 @@ async def async_setup(hass: HomeAssistant) -> None:
     hass.data[TRIGGERS] = {}
 
     @callback
-    def new_triggers_conditions_listener() -> None:
+    def new_triggers_conditions_listener(
+        _event_data: labs.EventLabsUpdatedData,
+    ) -> None:
         """Handle new_triggers_conditions flag change."""
         # Invalidate the cache
         hass.data[TRIGGER_DESCRIPTION_CACHE] = {}
         hass.data[TRIGGER_DISABLED_TRIGGERS] = set()
 
-    labs.async_listen(
+    labs.async_subscribe_preview_feature(
         hass,
         automation.DOMAIN,
         automation.NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG,

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -149,8 +149,7 @@ async def async_setup(hass: HomeAssistant) -> None:
     hass.data[TRIGGER_PLATFORM_SUBSCRIPTIONS] = []
     hass.data[TRIGGERS] = {}
 
-    @callback
-    def new_triggers_conditions_listener(
+    async def new_triggers_conditions_listener(
         _event_data: labs.EventLabsUpdatedData,
     ) -> None:
         """Handle new_triggers_conditions flag change."""

--- a/tests/components/labs/test_init.py
+++ b/tests/components/labs/test_init.py
@@ -9,8 +9,10 @@ import pytest
 
 from homeassistant.components.labs import (
     EVENT_LABS_UPDATED,
+    EventLabsUpdatedData,
     async_is_preview_feature_enabled,
     async_listen,
+    async_subscribe_preview_feature,
     async_update_preview_feature,
 )
 from homeassistant.components.labs.const import DOMAIN, LABS_DATA
@@ -439,6 +441,149 @@ async def test_async_listen_helper(hass: HomeAssistant) -> None:
 
     # Verify listener was not called after unsubscribe
     assert len(listener_calls) == 1
+
+
+async def test_async_subscribe_preview_feature_helper(hass: HomeAssistant) -> None:
+    """Test async_subscribe_preview_feature with sync and async listeners."""
+    # Load kitchen_sink integration
+    hass.config.components.add("kitchen_sink")
+
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    # Test with sync listener
+    sync_calls: list[EventLabsUpdatedData] = []
+
+    def sync_listener(event_data: EventLabsUpdatedData) -> None:
+        """Test sync listener callback."""
+        sync_calls.append(event_data)
+
+    unsub = async_subscribe_preview_feature(
+        hass,
+        domain="kitchen_sink",
+        preview_feature="special_repair",
+        listener=sync_listener,
+    )
+
+    # Fire event for the subscribed feature
+    hass.bus.async_fire(
+        EVENT_LABS_UPDATED,
+        {
+            "domain": "kitchen_sink",
+            "preview_feature": "special_repair",
+            "enabled": True,
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Verify sync listener was called with correct event data
+    assert len(sync_calls) == 1
+    assert sync_calls[0]["enabled"] is True
+
+    # Fire event for a different feature - should not trigger listener
+    hass.bus.async_fire(
+        EVENT_LABS_UPDATED,
+        {
+            "domain": "kitchen_sink",
+            "preview_feature": "other_feature",
+            "enabled": True,
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Verify listener was not called again
+    assert len(sync_calls) == 1
+
+    # Fire event for a different domain - should not trigger listener
+    hass.bus.async_fire(
+        EVENT_LABS_UPDATED,
+        {
+            "domain": "other_domain",
+            "preview_feature": "special_repair",
+            "enabled": True,
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Verify listener was not called again
+    assert len(sync_calls) == 1
+
+    # Fire event with enabled=False
+    hass.bus.async_fire(
+        EVENT_LABS_UPDATED,
+        {
+            "domain": "kitchen_sink",
+            "preview_feature": "special_repair",
+            "enabled": False,
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Verify listener was called with enabled=False
+    assert len(sync_calls) == 2
+    assert sync_calls[1]["enabled"] is False
+
+    # Test unsubscribe
+    unsub()
+
+    # Fire event again - should not trigger listener after unsubscribe
+    hass.bus.async_fire(
+        EVENT_LABS_UPDATED,
+        {
+            "domain": "kitchen_sink",
+            "preview_feature": "special_repair",
+            "enabled": True,
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Verify listener was not called after unsubscribe
+    assert len(sync_calls) == 2
+
+    # Test with async listener
+    async_calls: list[EventLabsUpdatedData] = []
+
+    async def async_listener(event_data: EventLabsUpdatedData) -> None:
+        """Test async listener callback."""
+        async_calls.append(event_data)
+
+    unsub = async_subscribe_preview_feature(
+        hass,
+        domain="kitchen_sink",
+        preview_feature="special_repair",
+        listener=async_listener,
+    )
+
+    # Fire event for the subscribed feature
+    hass.bus.async_fire(
+        EVENT_LABS_UPDATED,
+        {
+            "domain": "kitchen_sink",
+            "preview_feature": "special_repair",
+            "enabled": True,
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Verify async listener was called with correct event data
+    assert len(async_calls) == 1
+    assert async_calls[0]["enabled"] is True
+
+    # Test unsubscribe for async listener
+    unsub()
+
+    hass.bus.async_fire(
+        EVENT_LABS_UPDATED,
+        {
+            "domain": "kitchen_sink",
+            "preview_feature": "special_repair",
+            "enabled": False,
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Verify async listener was not called after unsubscribe
+    assert len(async_calls) == 1
 
 
 async def test_async_update_preview_feature(

--- a/tests/components/labs/test_init.py
+++ b/tests/components/labs/test_init.py
@@ -444,25 +444,23 @@ async def test_async_listen_helper(hass: HomeAssistant) -> None:
 
 
 async def test_async_subscribe_preview_feature_helper(hass: HomeAssistant) -> None:
-    """Test async_subscribe_preview_feature with sync and async listeners."""
-    # Load kitchen_sink integration
+    """Test async_subscribe_preview_feature helper."""
     hass.config.components.add("kitchen_sink")
 
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
-    # Test with sync listener
-    sync_calls: list[EventLabsUpdatedData] = []
+    calls: list[EventLabsUpdatedData] = []
 
-    def sync_listener(event_data: EventLabsUpdatedData) -> None:
-        """Test sync listener callback."""
-        sync_calls.append(event_data)
+    async def listener(event_data: EventLabsUpdatedData) -> None:
+        """Test listener callback."""
+        calls.append(event_data)
 
     unsub = async_subscribe_preview_feature(
         hass,
         domain="kitchen_sink",
         preview_feature="special_repair",
-        listener=sync_listener,
+        listener=listener,
     )
 
     # Fire event for the subscribed feature
@@ -476,9 +474,8 @@ async def test_async_subscribe_preview_feature_helper(hass: HomeAssistant) -> No
     )
     await hass.async_block_till_done()
 
-    # Verify sync listener was called with correct event data
-    assert len(sync_calls) == 1
-    assert sync_calls[0]["enabled"] is True
+    assert len(calls) == 1
+    assert calls[0]["enabled"] is True
 
     # Fire event for a different feature - should not trigger listener
     hass.bus.async_fire(
@@ -491,8 +488,7 @@ async def test_async_subscribe_preview_feature_helper(hass: HomeAssistant) -> No
     )
     await hass.async_block_till_done()
 
-    # Verify listener was not called again
-    assert len(sync_calls) == 1
+    assert len(calls) == 1
 
     # Fire event for a different domain - should not trigger listener
     hass.bus.async_fire(
@@ -505,8 +501,7 @@ async def test_async_subscribe_preview_feature_helper(hass: HomeAssistant) -> No
     )
     await hass.async_block_till_done()
 
-    # Verify listener was not called again
-    assert len(sync_calls) == 1
+    assert len(calls) == 1
 
     # Fire event with enabled=False
     hass.bus.async_fire(
@@ -519,14 +514,12 @@ async def test_async_subscribe_preview_feature_helper(hass: HomeAssistant) -> No
     )
     await hass.async_block_till_done()
 
-    # Verify listener was called with enabled=False
-    assert len(sync_calls) == 2
-    assert sync_calls[1]["enabled"] is False
+    assert len(calls) == 2
+    assert calls[1]["enabled"] is False
 
     # Test unsubscribe
     unsub()
 
-    # Fire event again - should not trigger listener after unsubscribe
     hass.bus.async_fire(
         EVENT_LABS_UPDATED,
         {
@@ -537,53 +530,7 @@ async def test_async_subscribe_preview_feature_helper(hass: HomeAssistant) -> No
     )
     await hass.async_block_till_done()
 
-    # Verify listener was not called after unsubscribe
-    assert len(sync_calls) == 2
-
-    # Test with async listener
-    async_calls: list[EventLabsUpdatedData] = []
-
-    async def async_listener(event_data: EventLabsUpdatedData) -> None:
-        """Test async listener callback."""
-        async_calls.append(event_data)
-
-    unsub = async_subscribe_preview_feature(
-        hass,
-        domain="kitchen_sink",
-        preview_feature="special_repair",
-        listener=async_listener,
-    )
-
-    # Fire event for the subscribed feature
-    hass.bus.async_fire(
-        EVENT_LABS_UPDATED,
-        {
-            "domain": "kitchen_sink",
-            "preview_feature": "special_repair",
-            "enabled": True,
-        },
-    )
-    await hass.async_block_till_done()
-
-    # Verify async listener was called with correct event data
-    assert len(async_calls) == 1
-    assert async_calls[0]["enabled"] is True
-
-    # Test unsubscribe for async listener
-    unsub()
-
-    hass.bus.async_fire(
-        EVENT_LABS_UPDATED,
-        {
-            "domain": "kitchen_sink",
-            "preview_feature": "special_repair",
-            "enabled": False,
-        },
-    )
-    await hass.async_block_till_done()
-
-    # Verify async listener was not called after unsubscribe
-    assert len(async_calls) == 1
+    assert len(calls) == 2
 
 
 async def test_async_update_preview_feature(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add subscribe preview feature helper to labs.

Compared to already existing `async_listen` the new `async_subscribe_preview_feature`:
- Allows async listeners.
- Passes through preview feature data as a function argument.
- Has a name, that is more in line with other labs helpers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2955
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
