### PR TITLE
Append ID to flood monitoring station name in EAFM

### DIFF
--- a/homeassistant/components/eafm/config_flow.py
+++ b/homeassistant/components/eafm/config_flow.py
@@ -41,13 +41,20 @@ class UKFloodsFlowHandler(ConfigFlow, domain=DOMAIN):
         self.stations = {}
         for station in stations:
             label = station["label"]
+            rloId = station["RLOIid"]
 
             # API annoyingly sometimes returns a list and some times returns a string
             # E.g. L3121 has a label of ['Scurf Dyke', 'Scurf Dyke Dyke Level']
             if isinstance(label, list):
                 label = label[-1]
 
-            self.stations[label] = station["stationReference"]
+            # Similar for RLOIid
+            # E.g. 0018 has an RLOIid of ['10427', '9154']
+            if isinstance(rloId, list):
+                rloId = rloId[-1]
+
+            fullName = label + " - " + rloId
+            self.stations[fullName] = station["stationReference"]
 
         if not self.stations:
             return self.async_abort(reason="no_stations")

--- a/tests/components/eafm/test_config_flow.py
+++ b/tests/components/eafm/test_config_flow.py
@@ -26,7 +26,7 @@ async def test_flow_no_discovered_stations(
 async def test_flow_invalid_station(hass: HomeAssistant, mock_get_stations) -> None:
     """Test config flow errors on invalid station."""
     mock_get_stations.return_value = [
-        {"label": "My station", "stationReference": "L12345"}
+        {"label": "My station", "stationReference": "L12345", "RLOIid": "R12345"}
     ]
 
     result = await hass.config_entries.flow.async_init(
@@ -45,10 +45,10 @@ async def test_flow_works(
 ) -> None:
     """Test config flow discovers no station."""
     mock_get_stations.return_value = [
-        {"label": "My station", "stationReference": "L12345"}
+        {"label": "My station", "stationReference": "L12345", "RLOIid": "R12345"}
     ]
     mock_get_station.return_value = [
-        {"label": "My station", "stationReference": "L12345"}
+        {"label": "My station", "stationReference": "L12345", "RLOIid": "R12345"}
     ]
 
     result = await hass.config_entries.flow.async_init(
@@ -58,11 +58,11 @@ async def test_flow_works(
 
     with patch("homeassistant.components.eafm.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={"station": "My station"}
+            result["flow_id"], user_input={"station": "My station - R12345"}
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "My station"
+    assert result["title"] == "My station - R12345"
     assert result["data"] == {
         "station": "L12345",
     }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Append ID to flood monitoring stations to stop the removal of stations that have the same label even though they are separate.
Stations affected by this were:
```
Abingdon
Bathpool Outfall
Blyth
Boroughbridge
Buxton
Cae Howel
Currymoor Pumping Station
Eling
Farnham
Fishlake
Flint Mill
Hexham
Honiton
Houghton
Howe Bridge
Huish Episcopi Pumping Station
Little Bridge
Longbridge
Low Moor
Midelney
Moreton
Newnham Bridge
Nun Appleton Fleet Pumping Station
Oldbury
Redbourn
Redbridge
Rodbourne
Sandhurst
Scurf Dyke
Sheepbridge
St Ives
Tenbury
Walton
West Sedgemoor Pumping Station
Whetstone
York Foss Barrier
```

I have confirmed this is not a breaking change by adding a service, making the change and then confirming the existing service continues to function. Only newly added services are affected just by updating the name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
[Link to documentation PR](https://github.com/home-assistant/home-assistant.io/pull/43301)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
