### PR TITLE
Add time_delta option to waze_travel_time

### DIFF
--- a/homeassistant/components/waze_travel_time/__init__.py
+++ b/homeassistant/components/waze_travel_time/__init__.py
@@ -1,6 +1,7 @@
 """The waze_travel_time component."""
 
 import asyncio
+from datetime import timedelta
 import logging
 
 from pywaze.route_calculator import WazeRouteCalculator
@@ -18,6 +19,8 @@ from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.location import find_coordinates
 from homeassistant.helpers.selector import (
     BooleanSelector,
+    DurationSelector,
+    DurationSelectorConfig,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
@@ -35,9 +38,11 @@ from .const import (
     CONF_INCL_FILTER,
     CONF_ORIGIN,
     CONF_REALTIME,
+    CONF_TIME_DELTA,
     CONF_UNITS,
     CONF_VEHICLE_TYPE,
     DEFAULT_FILTER,
+    DEFAULT_TIME_DELTA,
     DEFAULT_VEHICLE_TYPE,
     DOMAIN,
     METRIC_UNITS,
@@ -95,6 +100,9 @@ SERVICE_GET_TRAVEL_TIMES_SCHEMA = vol.Schema(
                 multiple=True,
             ),
         ),
+        vol.Optional(CONF_TIME_DELTA): DurationSelector(
+            DurationSelectorConfig(allow_negative=True, enable_second=False)
+        ),
     }
 )
 
@@ -130,6 +138,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         origin = origin_coordinates or service.data[CONF_ORIGIN]
         destination = destination_coordinates or service.data[CONF_DESTINATION]
 
+        time_delta = int(
+            timedelta(
+                **service.data.get(CONF_TIME_DELTA, DEFAULT_TIME_DELTA)
+            ).total_seconds()
+            / 60
+        )
+
         response = await async_get_travel_times(
             client=client,
             origin=origin,
@@ -142,6 +157,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             units=service.data[CONF_UNITS],
             incl_filters=service.data.get(CONF_INCL_FILTER, DEFAULT_FILTER),
             excl_filters=service.data.get(CONF_EXCL_FILTER, DEFAULT_FILTER),
+            time_delta=time_delta,
         )
         return {"routes": [vars(route) for route in response]}
 
@@ -184,4 +200,22 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             config_entry.version,
             config_entry.minor_version,
         )
+
+    if config_entry.version == 2 and config_entry.minor_version == 1:
+        _LOGGER.debug(
+            "Migrating from version %s.%s",
+            config_entry.version,
+            config_entry.minor_version,
+        )
+        options = dict(config_entry.options)
+        options[CONF_TIME_DELTA] = DEFAULT_TIME_DELTA
+        hass.config_entries.async_update_entry(
+            config_entry, options=options, minor_version=2
+        )
+        _LOGGER.debug(
+            "Migration to version %s.%s successful",
+            config_entry.version,
+            config_entry.minor_version,
+        )
+
     return True

--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -17,6 +17,8 @@ from homeassistant.const import CONF_NAME, CONF_REGION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.selector import (
     BooleanSelector,
+    DurationSelector,
+    DurationSelectorConfig,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
@@ -35,11 +37,13 @@ from .const import (
     CONF_INCL_FILTER,
     CONF_ORIGIN,
     CONF_REALTIME,
+    CONF_TIME_DELTA,
     CONF_UNITS,
     CONF_VEHICLE_TYPE,
     DEFAULT_FILTER,
     DEFAULT_NAME,
     DEFAULT_OPTIONS,
+    DEFAULT_TIME_DELTA,
     DOMAIN,
     IMPERIAL_UNITS,
     REGIONS,
@@ -82,6 +86,12 @@ OPTIONS_SCHEMA = vol.Schema(
         vol.Optional(CONF_AVOID_TOLL_ROADS): BooleanSelector(),
         vol.Optional(CONF_AVOID_SUBSCRIPTION_ROADS): BooleanSelector(),
         vol.Optional(CONF_AVOID_FERRIES): BooleanSelector(),
+        vol.Optional(CONF_TIME_DELTA): DurationSelector(
+            DurationSelectorConfig(
+                allow_negative=True,
+                enable_second=False,
+            )
+        ),
     }
 )
 
@@ -102,11 +112,14 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def default_options(hass: HomeAssistant) -> dict[str, str | bool | list[str]]:
+def default_options(
+    hass: HomeAssistant,
+) -> dict[str, str | bool | list[str] | dict[str, int]]:
     """Get the default options."""
     defaults = DEFAULT_OPTIONS.copy()
     if hass.config.units is US_CUSTOMARY_SYSTEM:
         defaults[CONF_UNITS] = IMPERIAL_UNITS
+    defaults[CONF_TIME_DELTA] = DEFAULT_TIME_DELTA
     return defaults
 
 
@@ -120,6 +133,8 @@ class WazeOptionsFlow(OptionsFlow):
                 user_input[CONF_INCL_FILTER] = DEFAULT_FILTER
             if user_input.get(CONF_EXCL_FILTER) is None:
                 user_input[CONF_EXCL_FILTER] = DEFAULT_FILTER
+            if user_input.get(CONF_TIME_DELTA) is None:
+                user_input[CONF_TIME_DELTA] = DEFAULT_TIME_DELTA
             return self.async_create_entry(
                 title="",
                 data=user_input,
@@ -137,6 +152,7 @@ class WazeConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Waze Travel Time."""
 
     VERSION = 2
+    MINOR_VERSION = 2
 
     @staticmethod
     @callback

--- a/homeassistant/components/waze_travel_time/const.py
+++ b/homeassistant/components/waze_travel_time/const.py
@@ -15,8 +15,10 @@ CONF_VEHICLE_TYPE = "vehicle_type"
 CONF_AVOID_TOLL_ROADS = "avoid_toll_roads"
 CONF_AVOID_SUBSCRIPTION_ROADS = "avoid_subscription_roads"
 CONF_AVOID_FERRIES = "avoid_ferries"
+CONF_TIME_DELTA = "time_delta"
 
 DEFAULT_NAME = "Waze Travel Time"
+DEFAULT_TIME_DELTA = {"minutes": 0}
 DEFAULT_REALTIME = True
 DEFAULT_VEHICLE_TYPE = "car"
 DEFAULT_AVOID_TOLL_ROADS = False
@@ -31,7 +33,7 @@ UNITS = [METRIC_UNITS, IMPERIAL_UNITS]
 REGIONS = ["us", "na", "eu", "il", "au"]
 VEHICLE_TYPES = ["car", "taxi", "motorcycle"]
 
-DEFAULT_OPTIONS: dict[str, str | bool | list[str]] = {
+DEFAULT_OPTIONS: dict[str, str | bool | list[str] | dict[str, int]] = {
     CONF_REALTIME: DEFAULT_REALTIME,
     CONF_VEHICLE_TYPE: DEFAULT_VEHICLE_TYPE,
     CONF_UNITS: METRIC_UNITS,
@@ -40,4 +42,5 @@ DEFAULT_OPTIONS: dict[str, str | bool | list[str]] = {
     CONF_AVOID_TOLL_ROADS: DEFAULT_AVOID_TOLL_ROADS,
     CONF_INCL_FILTER: DEFAULT_FILTER,
     CONF_EXCL_FILTER: DEFAULT_FILTER,
+    CONF_TIME_DELTA: DEFAULT_TIME_DELTA,
 }

--- a/homeassistant/components/waze_travel_time/coordinator.py
+++ b/homeassistant/components/waze_travel_time/coordinator.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_INCL_FILTER,
     CONF_ORIGIN,
     CONF_REALTIME,
+    CONF_TIME_DELTA,
     CONF_UNITS,
     CONF_VEHICLE_TYPE,
     DOMAIN,
@@ -51,6 +52,7 @@ async def async_get_travel_times(
     units: Literal["metric", "imperial"] = "metric",
     incl_filters: Collection[str] | None = None,
     excl_filters: Collection[str] | None = None,
+    time_delta: int = 0,
 ) -> list[CalcRoutesResponse]:
     """Get all available routes."""
 
@@ -74,6 +76,7 @@ async def async_get_travel_times(
             avoid_ferries=avoid_ferries,
             real_time=realtime,
             alternatives=3,
+            time_delta=time_delta,
         )
 
         if len(routes) < 1:
@@ -204,6 +207,11 @@ class WazeTravelTimeCoordinator(DataUpdateCoordinator[WazeTravelTimeData]):
                 CONF_AVOID_SUBSCRIPTION_ROADS
             ]
             avoid_ferries = self.config_entry.options[CONF_AVOID_FERRIES]
+            time_delta = int(
+                timedelta(**self.config_entry.options[CONF_TIME_DELTA]).total_seconds()
+                / 60
+            )
+
             routes = await async_get_travel_times(
                 self.client,
                 origin_coordinates,
@@ -216,6 +224,7 @@ class WazeTravelTimeCoordinator(DataUpdateCoordinator[WazeTravelTimeData]):
                 self.config_entry.options[CONF_UNITS],
                 incl_filter,
                 excl_filter,
+                time_delta,
             )
             if len(routes) < 1:
                 travel_data = WazeTravelTimeData(

--- a/homeassistant/components/waze_travel_time/services.yaml
+++ b/homeassistant/components/waze_travel_time/services.yaml
@@ -65,3 +65,7 @@ get_travel_times:
       selector:
         text:
           multiple: true
+    time_delta:
+      required: false
+      selector:
+        duration:

--- a/homeassistant/components/waze_travel_time/strings.json
+++ b/homeassistant/components/waze_travel_time/strings.json
@@ -29,6 +29,7 @@
           "excl_filter": "Exact street name which must NOT be part of the selected route",
           "incl_filter": "Exact street name which must be part of the selected route",
           "realtime": "Realtime travel time?",
+          "time_delta": "Time delta",
           "units": "Units",
           "vehicle_type": "Vehicle type"
         },
@@ -99,6 +100,10 @@
         "region": {
           "description": "The region. Controls which Waze server is used.",
           "name": "[%key:component::waze_travel_time::config::step::user::data::region%]"
+        },
+        "time_delta": {
+          "description": "Time offset from now to calculate the route for. Positive values are in the future, negative values are in the past.",
+          "name": "Time delta"
         },
         "units": {
           "description": "Which unit system to use.",

--- a/tests/components/waze_travel_time/test_config_flow.py
+++ b/tests/components/waze_travel_time/test_config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.components.waze_travel_time.const import (
     CONF_INCL_FILTER,
     CONF_ORIGIN,
     CONF_REALTIME,
+    CONF_TIME_DELTA,
     CONF_UNITS,
     CONF_VEHICLE_TYPE,
     DEFAULT_NAME,
@@ -120,6 +121,7 @@ async def test_options(hass: HomeAssistant) -> None:
             CONF_EXCL_FILTER: ["ExcludeThis"],
             CONF_INCL_FILTER: ["IncludeThis"],
             CONF_REALTIME: False,
+            CONF_TIME_DELTA: {"hours": 1, "minutes": 30},
             CONF_UNITS: IMPERIAL_UNITS,
             CONF_VEHICLE_TYPE: "taxi",
         },
@@ -133,6 +135,7 @@ async def test_options(hass: HomeAssistant) -> None:
         CONF_EXCL_FILTER: ["ExcludeThis"],
         CONF_INCL_FILTER: ["IncludeThis"],
         CONF_REALTIME: False,
+        CONF_TIME_DELTA: {"hours": 1, "minutes": 30},
         CONF_UNITS: IMPERIAL_UNITS,
         CONF_VEHICLE_TYPE: "taxi",
     }
@@ -144,6 +147,7 @@ async def test_options(hass: HomeAssistant) -> None:
         CONF_EXCL_FILTER: ["ExcludeThis"],
         CONF_INCL_FILTER: ["IncludeThis"],
         CONF_REALTIME: False,
+        CONF_TIME_DELTA: {"hours": 1, "minutes": 30},
         CONF_UNITS: IMPERIAL_UNITS,
         CONF_VEHICLE_TYPE: "taxi",
     }
@@ -243,6 +247,7 @@ async def test_reset_filters(hass: HomeAssistant) -> None:
         CONF_EXCL_FILTER: [""],
         CONF_INCL_FILTER: [""],
         CONF_REALTIME: False,
+        CONF_TIME_DELTA: {"minutes": 0},
         CONF_UNITS: IMPERIAL_UNITS,
         CONF_VEHICLE_TYPE: "taxi",
     }

--- a/tests/components/waze_travel_time/test_init.py
+++ b/tests/components/waze_travel_time/test_init.py
@@ -9,6 +9,7 @@ from homeassistant.components.waze_travel_time.const import (
     CONF_EXCL_FILTER,
     CONF_INCL_FILTER,
     CONF_REALTIME,
+    CONF_TIME_DELTA,
     CONF_UNITS,
     CONF_VEHICLE_TYPE,
     DEFAULT_AVOID_FERRIES,
@@ -17,6 +18,7 @@ from homeassistant.components.waze_travel_time.const import (
     DEFAULT_FILTER,
     DEFAULT_OPTIONS,
     DEFAULT_REALTIME,
+    DEFAULT_TIME_DELTA,
     DEFAULT_VEHICLE_TYPE,
     DOMAIN,
     METRIC_UNITS,
@@ -33,8 +35,20 @@ from tests.common import MockConfigEntry
     ("data", "options"),
     [(MOCK_CONFIG, DEFAULT_OPTIONS)],
 )
+@pytest.mark.parametrize(
+    ("time_delta", "expected_time_delta"),
+    [
+        pytest.param({"hours": 1, "minutes": 30}, 90, id="positive"),
+        pytest.param({"hours": -1, "minutes": -30}, -90, id="negative"),
+    ],
+)
 @pytest.mark.usefixtures("mock_update", "mock_config")
-async def test_service_get_travel_times(hass: HomeAssistant) -> None:
+async def test_service_get_travel_times(
+    hass: HomeAssistant,
+    mock_update,
+    time_delta: dict[str, int],
+    expected_time_delta: int,
+) -> None:
     """Test service get_travel_times."""
     response_data = await hass.services.async_call(
         "waze_travel_time",
@@ -46,6 +60,7 @@ async def test_service_get_travel_times(hass: HomeAssistant) -> None:
             "region": "us",
             "units": "imperial",
             "incl_filter": ["IncludeThis"],
+            "time_delta": time_delta,
         },
         blocking=True,
         return_response=True,
@@ -60,6 +75,7 @@ async def test_service_get_travel_times(hass: HomeAssistant) -> None:
             },
         ]
     }
+    assert mock_update.call_args_list[-1].kwargs["time_delta"] == expected_time_delta
 
 
 @pytest.mark.parametrize(
@@ -91,7 +107,7 @@ async def test_service_get_travel_times_empty_response(
 
 @pytest.mark.usefixtures("mock_update")
 async def test_migrate_entry_v1_v2(hass: HomeAssistant) -> None:
-    """Test successful migration of entry data."""
+    """Test successful migration of entry data from v1 to v2.2."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
         version=1,
@@ -114,8 +130,10 @@ async def test_migrate_entry_v1_v2(hass: HomeAssistant) -> None:
 
     assert updated_entry.state is ConfigEntryState.LOADED
     assert updated_entry.version == 2
+    assert updated_entry.minor_version == 2
     assert updated_entry.options[CONF_INCL_FILTER] == DEFAULT_FILTER
     assert updated_entry.options[CONF_EXCL_FILTER] == DEFAULT_FILTER
+    assert updated_entry.options[CONF_TIME_DELTA] == DEFAULT_TIME_DELTA
 
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -141,5 +159,39 @@ async def test_migrate_entry_v1_v2(hass: HomeAssistant) -> None:
 
     assert updated_entry.state is ConfigEntryState.LOADED
     assert updated_entry.version == 2
+    assert updated_entry.minor_version == 2
     assert updated_entry.options[CONF_INCL_FILTER] == ["IncludeThis"]
     assert updated_entry.options[CONF_EXCL_FILTER] == ["ExcludeThis"]
+    assert updated_entry.options[CONF_TIME_DELTA] == DEFAULT_TIME_DELTA
+
+
+@pytest.mark.usefixtures("mock_update")
+async def test_migrate_entry_v2_1_to_v2_2(hass: HomeAssistant) -> None:
+    """Test successful migration of entry from version 2.1 to 2.2."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        minor_version=1,
+        data=MOCK_CONFIG,
+        options={
+            CONF_REALTIME: DEFAULT_REALTIME,
+            CONF_VEHICLE_TYPE: DEFAULT_VEHICLE_TYPE,
+            CONF_UNITS: METRIC_UNITS,
+            CONF_AVOID_FERRIES: DEFAULT_AVOID_FERRIES,
+            CONF_AVOID_SUBSCRIPTION_ROADS: DEFAULT_AVOID_SUBSCRIPTION_ROADS,
+            CONF_AVOID_TOLL_ROADS: DEFAULT_AVOID_TOLL_ROADS,
+            CONF_INCL_FILTER: DEFAULT_FILTER,
+            CONF_EXCL_FILTER: DEFAULT_FILTER,
+        },
+    )
+
+    mock_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    updated_entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
+
+    assert updated_entry.state is ConfigEntryState.LOADED
+    assert updated_entry.version == 2
+    assert updated_entry.minor_version == 2
+    assert updated_entry.options[CONF_TIME_DELTA] == DEFAULT_TIME_DELTA

--- a/tests/components/waze_travel_time/test_sensor.py
+++ b/tests/components/waze_travel_time/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.waze_travel_time.const import (
     CONF_EXCL_FILTER,
     CONF_INCL_FILTER,
     CONF_REALTIME,
+    CONF_TIME_DELTA,
     CONF_UNITS,
     CONF_VEHICLE_TYPE,
     DEFAULT_OPTIONS,
@@ -78,6 +79,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
                 CONF_AVOID_FERRIES: True,
                 CONF_INCL_FILTER: [""],
                 CONF_EXCL_FILTER: [""],
+                CONF_TIME_DELTA: {"minutes": 0},
             },
         )
     ],
@@ -104,6 +106,7 @@ async def test_imperial(hass: HomeAssistant) -> None:
                 CONF_AVOID_FERRIES: True,
                 CONF_INCL_FILTER: ["IncludeThis"],
                 CONF_EXCL_FILTER: [""],
+                CONF_TIME_DELTA: {"minutes": 0},
             },
         )
     ],
@@ -128,6 +131,7 @@ async def test_incl_filter(hass: HomeAssistant) -> None:
                 CONF_AVOID_FERRIES: True,
                 CONF_INCL_FILTER: [""],
                 CONF_EXCL_FILTER: ["ExcludeThis"],
+                CONF_TIME_DELTA: {"minutes": 0},
             },
         )
     ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the `time_delta` option as requested in https://github.com/orgs/home-assistant/discussions/1234 to retrieve travel times in the past and in the future from the Waze API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
