### PR TITLE
Allow lovelace path for dashboard in yaml and fix yaml dashboard migration

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -61,7 +61,7 @@ def _validate_url_slug(value: Any) -> str:
     """Validate value is a valid url slug."""
     if value is None:
         raise vol.Invalid("Slug should not be None")
-    if "-" not in value:
+    if value != DOMAIN and "-" not in value:
         raise vol.Invalid("Url path needs to contain a hyphen (-)")
     str_value = str(value)
     slg = slugify(str_value, separator="-")

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -200,9 +200,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     # For YAML mode, add the default "lovelace" dashboard if not already defined
     # This migrates the legacy yaml mode to a proper yaml dashboard entry
     if mode == MODE_YAML and DOMAIN not in yaml_dashboards:
+        translations = await async_get_translations(
+            hass, hass.config.language, "dashboard", {onboarding.DOMAIN}
+        )
+        title = translations.get(
+            "component.onboarding.dashboard.overview.title", "Overview"
+        )
         yaml_dashboards = {
             DOMAIN: {
-                CONF_TITLE: "overview",
+                CONF_TITLE: title,
                 CONF_ICON: DEFAULT_ICON,
                 CONF_SHOW_IN_SIDEBAR: True,
                 CONF_REQUIRE_ADMIN: False,

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -33,6 +33,7 @@ from .const import (  # noqa: F401
     CONF_ALLOW_SINGLE_WORD,
     CONF_ICON,
     CONF_REQUIRE_ADMIN,
+    CONF_RESOURCE_MODE,
     CONF_SHOW_IN_SIDEBAR,
     CONF_TITLE,
     CONF_URL_PATH,
@@ -87,6 +88,9 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_MODE, default=MODE_STORAGE): vol.All(
                     vol.Lower, vol.In([MODE_YAML, MODE_STORAGE])
                 ),
+                vol.Optional(CONF_RESOURCE_MODE): vol.All(
+                    vol.Lower, vol.In([MODE_YAML, MODE_STORAGE])
+                ),
                 vol.Optional(CONF_DASHBOARDS): cv.schema_with_slug_keys(
                     YAML_DASHBOARD_SCHEMA,
                     slug_validator=_validate_url_slug,
@@ -103,7 +107,8 @@ CONFIG_SCHEMA = vol.Schema(
 class LovelaceData:
     """Dataclass to store information in hass.data."""
 
-    mode: str
+    mode: str  # Kept for backward compatibility
+    resource_mode: str  # The actual mode used for resources (yaml or storage)
     dashboards: dict[str | None, dashboard.LovelaceConfig]
     resources: resources.ResourceYAMLCollection | resources.ResourceStorageCollection
     yaml_dashboards: dict[str | None, ConfigType]
@@ -114,19 +119,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     mode = config[DOMAIN][CONF_MODE]
     yaml_resources = config[DOMAIN].get(CONF_RESOURCES)
 
-    # Deprecated - Remove in 2026.8
-    # For YAML mode, register the default panel in yaml mode (temporary until user migrates)
-    # Use legacy_lovelace so the frontend knows to load this panel differently
-    if mode == MODE_YAML:
-        frontend.async_register_built_in_panel(
-            hass,
-            DOMAIN,
-            config={"mode": mode, "legacy_lovelace": True},
-            sidebar_title="overview",
-            sidebar_icon="mdi:view-dashboard",
-            sidebar_default_visible=False,
-        )
-        _async_create_yaml_mode_repair(hass)
+    # resource_mode controls how resources are loaded (yaml vs storage)
+    # Falls back to mode for backward compatibility
+    resource_mode = config[DOMAIN].get(CONF_RESOURCE_MODE, mode)
 
     async def reload_resources_service_handler(service_call: ServiceCall) -> None:
         """Reload yaml resources."""
@@ -150,12 +145,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         )
         hass.data[LOVELACE_DATA].resources = resource_collection
 
-    default_config: dashboard.LovelaceConfig
     resource_collection: (
         resources.ResourceYAMLCollection | resources.ResourceStorageCollection
     )
-    if mode == MODE_YAML:
-        default_config = dashboard.LovelaceYAML(hass, None, None)
+    default_config = dashboard.LovelaceStorage(hass, None)
+
+    # Load resources based on resource_mode
+    if resource_mode == MODE_YAML:
         resource_collection = await create_yaml_resource_col(hass, yaml_resources)
 
         async_register_admin_service(
@@ -178,8 +174,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
 
     else:
-        default_config = dashboard.LovelaceStorage(hass, None)
-
         if yaml_resources is not None:
             _LOGGER.warning(
                 "Lovelace is running in storage mode. Define resources via user"
@@ -202,12 +196,31 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass, websocket.websocket_lovelace_delete_config
     )
 
+    yaml_dashboards = config[DOMAIN].get(CONF_DASHBOARDS, {})
+
+    # For YAML mode, add the default "lovelace" dashboard if not already defined
+    # This migrates the legacy yaml mode to a proper yaml dashboard entry
+    if mode == MODE_YAML and DOMAIN not in yaml_dashboards:
+        yaml_dashboards = {
+            DOMAIN: {
+                CONF_TITLE: "Home",
+                CONF_ICON: DEFAULT_ICON,
+                CONF_SHOW_IN_SIDEBAR: True,
+                CONF_REQUIRE_ADMIN: False,
+                CONF_MODE: MODE_YAML,
+                CONF_FILENAME: LOVELACE_CONFIG_FILE,
+            },
+            **yaml_dashboards,
+        }
+        _async_create_yaml_mode_repair(hass)
+
     hass.data[LOVELACE_DATA] = LovelaceData(
-        mode=mode,
+        mode=MODE_STORAGE,  # Kept for backward compatibility
+        resource_mode=resource_mode,  # The actual mode used for resources
         # We store a dictionary mapping url_path: config. None is the default.
         dashboards={None: default_config},
         resources=resource_collection,
-        yaml_dashboards=config[DOMAIN].get(CONF_DASHBOARDS, {}),
+        yaml_dashboards=yaml_dashboards,
     )
 
     if hass.config.recovery_mode:
@@ -451,7 +464,7 @@ async def _async_migrate_default_config(
 # Deprecated - Remove in 2026.8
 @callback
 def _async_create_yaml_mode_repair(hass: HomeAssistant) -> None:
-    """Create repair issue for YAML mode migration."""
+    """Create repair issue for YAML mode deprecation."""
     ir.async_create_issue(
         hass,
         DOMAIN,

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -85,6 +85,7 @@ CONFIG_SCHEMA = vol.Schema(
     {
         vol.Optional(DOMAIN, default={}): vol.Schema(
             {
+                # Deprecated - Remove in 2026.8
                 vol.Optional(CONF_MODE, default=MODE_STORAGE): vol.All(
                     vol.Lower, vol.In([MODE_YAML, MODE_STORAGE])
                 ),
@@ -119,7 +120,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     yaml_resources = config[DOMAIN].get(CONF_RESOURCES)
 
     # resource_mode controls how resources are loaded (yaml vs storage)
-    # Falls back to mode for backward compatibility
+    # Deprecated - Remove mode fallback in 2026.8
     resource_mode = config[DOMAIN].get(CONF_RESOURCE_MODE, mode)
 
     async def reload_resources_service_handler(service_call: ServiceCall) -> None:
@@ -197,6 +198,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     yaml_dashboards = config[DOMAIN].get(CONF_DASHBOARDS, {})
 
+    # Deprecated - Remove in 2026.8
     # For YAML mode, add the default "lovelace" dashboard if not already defined
     # This migrates the legacy yaml mode to a proper yaml dashboard entry
     if mode == MODE_YAML and DOMAIN not in yaml_dashboards:

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -61,7 +61,7 @@ def _validate_url_slug(value: Any) -> str:
     """Validate value is a valid url slug."""
     if value is None:
         raise vol.Invalid("Slug should not be None")
-    if value != DOMAIN and "-" not in value:
+    if value != "lovelace" and "-" not in value:
         raise vol.Invalid("Url path needs to contain a hyphen (-)")
     str_value = str(value)
     slg = slugify(str_value, separator="-")

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -116,6 +116,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     # Deprecated - Remove in 2026.8
     # For YAML mode, register the default panel in yaml mode (temporary until user migrates)
+    # Use legacy_lovelace so the frontend knows to load this panel differently
     if mode == MODE_YAML:
         frontend.async_register_built_in_panel(
             hass,

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -203,7 +203,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if mode == MODE_YAML and DOMAIN not in yaml_dashboards:
         yaml_dashboards = {
             DOMAIN: {
-                CONF_TITLE: "Home",
+                CONF_TITLE: "overview",
                 CONF_ICON: DEFAULT_ICON,
                 CONF_SHOW_IN_SIDEBAR: True,
                 CONF_REQUIRE_ADMIN: False,

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -120,7 +120,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         frontend.async_register_built_in_panel(
             hass,
             DOMAIN,
-            config={"mode": mode},
+            config={"mode": mode, "legacy_lovelace": True},
             sidebar_title="overview",
             sidebar_icon="mdi:view-dashboard",
             sidebar_default_visible=False,

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -107,8 +107,7 @@ CONFIG_SCHEMA = vol.Schema(
 class LovelaceData:
     """Dataclass to store information in hass.data."""
 
-    mode: str  # Kept for backward compatibility
-    resource_mode: str  # The actual mode used for resources (yaml or storage)
+    resource_mode: str  # The mode used for resources (yaml or storage)
     dashboards: dict[str | None, dashboard.LovelaceConfig]
     resources: resources.ResourceYAMLCollection | resources.ResourceStorageCollection
     yaml_dashboards: dict[str | None, ConfigType]
@@ -215,8 +214,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _async_create_yaml_mode_repair(hass)
 
     hass.data[LOVELACE_DATA] = LovelaceData(
-        mode=MODE_STORAGE,  # Kept for backward compatibility
-        resource_mode=resource_mode,  # The actual mode used for resources
+        resource_mode=resource_mode,
         # We store a dictionary mapping url_path: config. None is the default.
         dashboards={None: default_config},
         resources=resource_collection,

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -190,6 +190,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             RESOURCE_UPDATE_FIELDS,
         ).async_setup(hass)
 
+    websocket_api.async_register_command(hass, websocket.websocket_lovelace_info)
     websocket_api.async_register_command(hass, websocket.websocket_lovelace_config)
     websocket_api.async_register_command(hass, websocket.websocket_lovelace_save_config)
     websocket_api.async_register_command(

--- a/homeassistant/components/lovelace/cast.py
+++ b/homeassistant/components/lovelace/cast.py
@@ -158,7 +158,15 @@ async def _get_dashboard_info(
     """Load a dashboard and return info on views."""
     if url_path == DEFAULT_DASHBOARD:
         url_path = None
-    dashboard = hass.data[LOVELACE_DATA].dashboards.get(url_path)
+
+    # When url_path is None, prefer "lovelace" dashboard if it exists (for YAML mode)
+    # Otherwise fall back to dashboards[None] (storage mode default)
+    if url_path is None:
+        dashboard = hass.data[LOVELACE_DATA].dashboards.get(DOMAIN) or hass.data[
+            LOVELACE_DATA
+        ].dashboards.get(None)
+    else:
+        dashboard = hass.data[LOVELACE_DATA].dashboards.get(url_path)
 
     if dashboard is None:
         raise ValueError("Invalid dashboard specified")

--- a/homeassistant/components/lovelace/const.py
+++ b/homeassistant/components/lovelace/const.py
@@ -57,6 +57,7 @@ RESOURCE_UPDATE_FIELDS: VolDictType = {
 SERVICE_RELOAD_RESOURCES = "reload_resources"
 RESOURCE_RELOAD_SERVICE_SCHEMA = vol.Schema({})
 
+CONF_RESOURCE_MODE = "resource_mode"
 CONF_TITLE = "title"
 CONF_REQUIRE_ADMIN = "require_admin"
 CONF_SHOW_IN_SIDEBAR = "show_in_sidebar"

--- a/homeassistant/components/lovelace/strings.json
+++ b/homeassistant/components/lovelace/strings.json
@@ -6,7 +6,7 @@
   },
   "issues": {
     "yaml_mode_deprecated": {
-      "description": "The `mode` option in `lovelace:` configuration is deprecated and will be removed in Home Assistant 2026.8.\n\nTo migrate:\n\n1. Remove `mode: yaml` from `lovelace:` in your `configuration.yaml`\n2. Rename `{config_file}` to a new filename (e.g., `my-dashboard.yaml`)\n3. Add a dashboard entry in your `configuration.yaml`:\n\n```yaml\nlovelace:\n  resource_mode: yaml  # Use this to load resources from YAML\n  dashboards:\n    lovelace:\n      mode: yaml\n      filename: my-dashboard.yaml\n      title: Overview\n      icon: mdi:view-dashboard\n      show_in_sidebar: true\n```\n\n4. Restart Home Assistant",
+      "description": "The `mode` option in `lovelace:` configuration is deprecated and will be removed in Home Assistant 2026.8.\n\nTo migrate:\n\n1. Remove `mode: yaml` from `lovelace:` in your `configuration.yaml`\n2. If you have `resources:` declared in your lovelace configuration, add `resource_mode: yaml` to keep loading resources from YAML\n3. Add a dashboard entry in your `configuration.yaml`:\n\n   ```yaml\n   lovelace:\n     resource_mode: yaml  # Add this if you have resources declared\n     dashboards:\n       lovelace:\n         mode: yaml\n         filename: {config_file}\n         title: Overview\n         icon: mdi:view-dashboard\n         show_in_sidebar: true\n   ```\n\n4. Restart Home Assistant",
       "title": "Lovelace YAML mode deprecated"
     }
   },

--- a/homeassistant/components/lovelace/strings.json
+++ b/homeassistant/components/lovelace/strings.json
@@ -6,8 +6,8 @@
   },
   "issues": {
     "yaml_mode_deprecated": {
-      "description": "Starting with Home Assistant 2026.8, the default Lovelace dashboard will no longer support YAML mode. To migrate:\n\n1. Remove `mode: yaml` from `lovelace:` in your `configuration.yaml`\n2. Rename `{config_file}` to a new filename (e.g., `my-dashboard.yaml`)\n3. Add a dashboard entry in your `configuration.yaml`:\n\n```yaml\nlovelace:\n  dashboards:\n    lovelace:\n      mode: yaml\n      filename: my-dashboard.yaml\n      title: Overview\n      icon: mdi:view-dashboard\n      show_in_sidebar: true\n```\n\n4. Restart Home Assistant",
-      "title": "Lovelace YAML mode migration required"
+      "description": "The `mode` option in `lovelace:` configuration is deprecated and will be removed in Home Assistant 2026.8.\n\nTo migrate:\n\n1. Remove `mode: yaml` from `lovelace:` in your `configuration.yaml`\n2. Rename `{config_file}` to a new filename (e.g., `my-dashboard.yaml`)\n3. Add a dashboard entry in your `configuration.yaml`:\n\n```yaml\nlovelace:\n  resource_mode: yaml  # Use this to load resources from YAML\n  dashboards:\n    lovelace:\n      mode: yaml\n      filename: my-dashboard.yaml\n      title: Overview\n      icon: mdi:view-dashboard\n      show_in_sidebar: true\n```\n\n4. Restart Home Assistant",
+      "title": "Lovelace YAML mode deprecated"
     }
   },
   "services": {

--- a/homeassistant/components/lovelace/system_health.py
+++ b/homeassistant/components/lovelace/system_health.py
@@ -42,9 +42,7 @@ async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
             else:
                 health_info[key] = dashboard[key]
 
-    if hass.data[LOVELACE_DATA].mode == MODE_YAML:
-        health_info[CONF_MODE] = MODE_YAML
-    elif MODE_STORAGE in modes:
+    if MODE_STORAGE in modes:
         health_info[CONF_MODE] = MODE_STORAGE
     elif MODE_YAML in modes:
         health_info[CONF_MODE] = MODE_YAML

--- a/homeassistant/components/lovelace/websocket.py
+++ b/homeassistant/components/lovelace/websocket.py
@@ -14,7 +14,13 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.json import json_fragment
 
-from .const import CONF_URL_PATH, DOMAIN, LOVELACE_DATA, ConfigNotFound
+from .const import (
+    CONF_RESOURCE_MODE,
+    CONF_URL_PATH,
+    DOMAIN,
+    LOVELACE_DATA,
+    ConfigNotFound,
+)
 from .dashboard import LovelaceConfig
 
 if TYPE_CHECKING:
@@ -106,6 +112,20 @@ async def websocket_lovelace_resources_impl(
         resources.loaded = True
 
     connection.send_result(msg["id"], resources.async_items())
+
+
+@websocket_api.websocket_command({"type": "lovelace/info"})
+@websocket_api.async_response
+async def websocket_lovelace_info(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Send Lovelace UI info over WebSocket connection."""
+    connection.send_result(
+        msg["id"],
+        {CONF_RESOURCE_MODE: hass.data[LOVELACE_DATA].resource_mode},
+    )
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/lovelace/websocket.py
+++ b/homeassistant/components/lovelace/websocket.py
@@ -14,7 +14,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.json import json_fragment
 
-from .const import CONF_URL_PATH, LOVELACE_DATA, ConfigNotFound
+from .const import CONF_URL_PATH, DOMAIN, LOVELACE_DATA, ConfigNotFound
 from .dashboard import LovelaceConfig
 
 if TYPE_CHECKING:
@@ -38,7 +38,15 @@ def _handle_errors[_R](
         msg: dict[str, Any],
     ) -> None:
         url_path = msg.get(CONF_URL_PATH)
-        config = hass.data[LOVELACE_DATA].dashboards.get(url_path)
+
+        # When url_path is None, prefer "lovelace" dashboard if it exists (for YAML mode)
+        # Otherwise fall back to dashboards[None] (storage mode default)
+        if url_path is None:
+            config = hass.data[LOVELACE_DATA].dashboards.get(DOMAIN) or hass.data[
+                LOVELACE_DATA
+            ].dashboards.get(None)
+        else:
+            config = hass.data[LOVELACE_DATA].dashboards.get(url_path)
 
         if config is None:
             connection.send_error(

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -803,3 +803,47 @@ async def test_lovelace_no_migration_no_default_panel_set(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"]["value"] is None
+
+
+async def test_lovelace_info_default(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test lovelace/info returns default resource_mode."""
+    assert await async_setup_component(hass, "lovelace", {})
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 5, "type": "lovelace/info"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {"resource_mode": "storage"}
+
+
+async def test_lovelace_info_yaml_resource_mode(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test lovelace/info returns yaml resource_mode."""
+    assert await async_setup_component(
+        hass, "lovelace", {"lovelace": {"resource_mode": "yaml"}}
+    )
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 5, "type": "lovelace/info"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {"resource_mode": "yaml"}
+
+
+async def test_lovelace_info_yaml_mode_fallback(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test lovelace/info returns yaml resource_mode when mode is yaml."""
+    assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "yaml"}})
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 5, "type": "lovelace/info"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {"resource_mode": "yaml"}

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -277,7 +277,10 @@ async def test_lovelace_from_yaml(
 ) -> None:
     """Test we load lovelace config from yaml."""
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
-    assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {"mode": "yaml"}
+    assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {
+        "mode": "yaml",
+        "legacy_lovelace": True,
+    }
 
     client = await hass_ws_client(hass)
 
@@ -369,7 +372,10 @@ async def test_lovelace_from_yaml_creates_repair_issue(
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
 
     # Panel should still be registered for backwards compatibility
-    assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {"mode": "yaml"}
+    assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {
+        "mode": "yaml",
+        "legacy_lovelace": True,
+    }
 
     # Repair issue should be created
     issue_registry = ir.async_get(hass)

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -277,10 +277,7 @@ async def test_lovelace_from_yaml(
 ) -> None:
     """Test we load lovelace config from yaml."""
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
-    assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {
-        "mode": "yaml",
-        "legacy_lovelace": True,
-    }
+    assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {"mode": "yaml"}
 
     client = await hass_ws_client(hass)
 
@@ -371,11 +368,8 @@ async def test_lovelace_from_yaml_creates_repair_issue(
     """Test YAML mode creates a repair issue."""
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
 
-    # Panel should still be registered for backwards compatibility
-    assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {
-        "mode": "yaml",
-        "legacy_lovelace": True,
-    }
+    # Panel should be registered as a YAML dashboard
+    assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {"mode": "yaml"}
 
     # Repair issue should be created
     issue_registry = ir.async_get(hass)

--- a/tests/components/lovelace/test_system_health.py
+++ b/tests/components/lovelace/test_system_health.py
@@ -62,7 +62,8 @@ async def test_system_health_info_yaml(hass: HomeAssistant) -> None:
         return_value={"views": [{"cards": []}]},
     ):
         info = await get_system_health_info(hass, "lovelace")
-    assert info == {"dashboards": 1, "mode": "yaml", "resources": 0, "views": 1}
+    # 2 dashboards: default storage (None) + yaml "lovelace" dashboard
+    assert info == {"dashboards": 2, "mode": "yaml", "resources": 0, "views": 1}
 
 
 async def test_system_health_info_yaml_not_found(hass: HomeAssistant) -> None:
@@ -71,8 +72,9 @@ async def test_system_health_info_yaml_not_found(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
     await hass.async_block_till_done()
     info = await get_system_health_info(hass, "lovelace")
+    # 2 dashboards: default storage (None) + yaml "lovelace" dashboard
     assert info == {
-        "dashboards": 1,
+        "dashboards": 2,
         "mode": "yaml",
         "error": f"{hass.config.path('ui-lovelace.yaml')} not found",
         "resources": 0,


### PR DESCRIPTION
## Proposed change

Following #158265.

- Clean up top level `mode` key
- Introduce a new key : `resource_mode` to replace `mode` so it's clear that it's only for resources.
- Update repairs, the file rename is not needed.
- Add new endpoint lovelace/info to get resource mode for the front-end

<img width="617" height="669" alt="CleanShot 2026-01-29 at 11 16 12" src="https://github.com/user-attachments/assets/209047c0-6e8d-4947-9443-84d6164bb755" />

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/161819
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
