### PR TITLE
add device class for ammonia

### DIFF
--- a/homeassistant/components/number/const.py
+++ b/homeassistant/components/number/const.py
@@ -86,6 +86,12 @@ class NumberDeviceClass(StrEnum):
     Unit of measurement: `g/m³`, `mg/m³`
     """
 
+    AMMONIA = "ammonia"
+    """Amount of NH3.
+
+    Unit of measurement: `ppb` (parts per billion), `μg/m³`
+    """
+
     APPARENT_POWER = "apparent_power"
     """Apparent power.
 
@@ -475,6 +481,10 @@ DEVICE_CLASS_UNITS: dict[NumberDeviceClass, set[type[StrEnum] | str | None]] = {
     NumberDeviceClass.ABSOLUTE_HUMIDITY: {
         CONCENTRATION_GRAMS_PER_CUBIC_METER,
         CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+    },
+    NumberDeviceClass.AMMONIA: {
+        CONCENTRATION_PARTS_PER_BILLION,
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     },
     NumberDeviceClass.APPARENT_POWER: set(UnitOfApparentPower),
     NumberDeviceClass.AQI: {None},

--- a/homeassistant/components/number/icons.json
+++ b/homeassistant/components/number/icons.json
@@ -6,6 +6,9 @@
     "absolute_humidity": {
       "default": "mdi:water-opacity"
     },
+    "ammonia": {
+      "default": "mdi:molecule"
+    },
     "apparent_power": {
       "default": "mdi:flash"
     },

--- a/homeassistant/components/number/strings.json
+++ b/homeassistant/components/number/strings.json
@@ -33,6 +33,9 @@
     "absolute_humidity": {
       "name": "[%key:component::sensor::entity_component::absolute_humidity::name%]"
     },
+    "ammonia": {
+      "name": "[%key:component::sensor::entity_component::ammonia::name%]"
+    },
     "apparent_power": {
       "name": "[%key:component::sensor::entity_component::apparent_power::name%]"
     },

--- a/homeassistant/components/random/strings.json
+++ b/homeassistant/components/random/strings.json
@@ -82,6 +82,7 @@
     "sensor_device_class": {
       "options": {
         "absolute_humidity": "[%key:component::sensor::entity_component::absolute_humidity::name%]",
+        "ammonia": "[%key:component::sensor::entity_component::ammonia::name%]",
         "apparent_power": "[%key:component::sensor::entity_component::apparent_power::name%]",
         "aqi": "[%key:component::sensor::entity_component::aqi::name%]",
         "area": "[%key:component::sensor::entity_component::area::name%]",

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.json import json_bytes
 from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import (
+    AmmoniaConcentrationConverter,
     ApparentPowerConverter,
     AreaConverter,
     BloodGlucoseConcentrationConverter,
@@ -72,6 +73,7 @@ UPDATE_STATISTICS_METADATA_TIME_OUT = 10
 
 UNIT_SCHEMA = vol.Schema(
     {
+        vol.Optional("ammonia"): vol.In(AmmoniaConcentrationConverter.VALID_UNITS),
         vol.Optional("apparent_power"): vol.In(ApparentPowerConverter.VALID_UNITS),
         vol.Optional("area"): vol.In(AreaConverter.VALID_UNITS),
         vol.Optional("blood_glucose_concentration"): vol.In(

--- a/homeassistant/components/scrape/strings.json
+++ b/homeassistant/components/scrape/strings.json
@@ -140,6 +140,7 @@
     "device_class": {
       "options": {
         "absolute_humidity": "[%key:component::sensor::entity_component::absolute_humidity::name%]",
+        "ammonia": "[%key:component::sensor::entity_component::ammonia::name%]",
         "apparent_power": "[%key:component::sensor::entity_component::apparent_power::name%]",
         "aqi": "[%key:component::sensor::entity_component::aqi::name%]",
         "area": "[%key:component::sensor::entity_component::area::name%]",

--- a/homeassistant/components/sensor/const.py
+++ b/homeassistant/components/sensor/const.py
@@ -47,6 +47,7 @@ from homeassistant.const import (
     UnitOfVolumetricFlux,
 )
 from homeassistant.util.unit_conversion import (
+    AmmoniaConcentrationConverter,
     ApparentPowerConverter,
     AreaConverter,
     BaseUnitConverter,
@@ -121,6 +122,12 @@ class SensorDeviceClass(StrEnum):
     """Absolute humidity.
 
     Unit of measurement: `g/m³`, `mg/m³`
+    """
+
+    AMMONIA = "ammonia"
+    """Amount of NH3.
+
+    Unit of measurement: `ppb` (parts per billion), `μg/m³`
     """
 
     APPARENT_POWER = "apparent_power"
@@ -552,6 +559,7 @@ STATE_CLASSES: Final[list[str]] = [cls.value for cls in SensorStateClass]
 UNIT_CONVERTERS: dict[SensorDeviceClass | str | None, type[BaseUnitConverter]] = {
     SensorDeviceClass.APPARENT_POWER: ApparentPowerConverter,
     SensorDeviceClass.ABSOLUTE_HUMIDITY: MassVolumeConcentrationConverter,
+    SensorDeviceClass.AMMONIA: AmmoniaConcentrationConverter,
     SensorDeviceClass.AREA: AreaConverter,
     SensorDeviceClass.ATMOSPHERIC_PRESSURE: PressureConverter,
     SensorDeviceClass.BLOOD_GLUCOSE_CONCENTRATION: BloodGlucoseConcentrationConverter,
@@ -595,6 +603,10 @@ DEVICE_CLASS_UNITS: dict[SensorDeviceClass, set[type[StrEnum] | str | None]] = {
     SensorDeviceClass.ABSOLUTE_HUMIDITY: {
         CONCENTRATION_GRAMS_PER_CUBIC_METER,
         CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+    },
+    SensorDeviceClass.AMMONIA: {
+        CONCENTRATION_PARTS_PER_BILLION,
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     },
     SensorDeviceClass.APPARENT_POWER: set(UnitOfApparentPower),
     SensorDeviceClass.AQI: {None},
@@ -757,6 +769,7 @@ UNITS_PRECISION = {
 
 DEVICE_CLASS_STATE_CLASSES: dict[SensorDeviceClass, set[SensorStateClass]] = {
     SensorDeviceClass.ABSOLUTE_HUMIDITY: {SensorStateClass.MEASUREMENT},
+    SensorDeviceClass.AMMONIA: {SensorStateClass.MEASUREMENT},
     SensorDeviceClass.APPARENT_POWER: {SensorStateClass.MEASUREMENT},
     SensorDeviceClass.AQI: {SensorStateClass.MEASUREMENT},
     SensorDeviceClass.AREA: set(SensorStateClass),

--- a/homeassistant/components/sensor/device_condition.py
+++ b/homeassistant/components/sensor/device_condition.py
@@ -34,6 +34,7 @@ from . import ATTR_STATE_CLASS, DOMAIN, SensorDeviceClass
 DEVICE_CLASS_NONE = "none"
 
 CONF_IS_ABSOLUTE_HUMIDITY = "is_absolute_humidity"
+CONF_IS_AMMONIA = "is_ammonia"
 CONF_IS_APPARENT_POWER = "is_apparent_power"
 CONF_IS_AQI = "is_aqi"
 CONF_IS_AREA = "is_area"
@@ -92,6 +93,7 @@ CONF_IS_WIND_SPEED = "is_wind_speed"
 
 ENTITY_CONDITIONS = {
     SensorDeviceClass.ABSOLUTE_HUMIDITY: [{CONF_TYPE: CONF_IS_ABSOLUTE_HUMIDITY}],
+    SensorDeviceClass.AMMONIA: [{CONF_TYPE: CONF_IS_AMMONIA}],
     SensorDeviceClass.APPARENT_POWER: [{CONF_TYPE: CONF_IS_APPARENT_POWER}],
     SensorDeviceClass.AQI: [{CONF_TYPE: CONF_IS_AQI}],
     SensorDeviceClass.AREA: [{CONF_TYPE: CONF_IS_AREA}],
@@ -166,6 +168,7 @@ CONDITION_SCHEMA = vol.All(
             vol.Required(CONF_TYPE): vol.In(
                 [
                     CONF_IS_ABSOLUTE_HUMIDITY,
+                    CONF_IS_AMMONIA,
                     CONF_IS_APPARENT_POWER,
                     CONF_IS_AQI,
                     CONF_IS_AREA,

--- a/homeassistant/components/sensor/device_trigger.py
+++ b/homeassistant/components/sensor/device_trigger.py
@@ -33,6 +33,7 @@ from . import ATTR_STATE_CLASS, DOMAIN, SensorDeviceClass
 DEVICE_CLASS_NONE = "none"
 
 CONF_ABSOLUTE_HUMIDITY = "absolute_humidity"
+CONF_AMMONIA = "ammonia"
 CONF_APPARENT_POWER = "apparent_power"
 CONF_AQI = "aqi"
 CONF_AREA = "area"
@@ -91,6 +92,7 @@ CONF_WIND_SPEED = "wind_speed"
 
 ENTITY_TRIGGERS = {
     SensorDeviceClass.ABSOLUTE_HUMIDITY: [{CONF_TYPE: CONF_ABSOLUTE_HUMIDITY}],
+    SensorDeviceClass.AMMONIA: [{CONF_TYPE: CONF_AMMONIA}],
     SensorDeviceClass.APPARENT_POWER: [{CONF_TYPE: CONF_APPARENT_POWER}],
     SensorDeviceClass.AQI: [{CONF_TYPE: CONF_AQI}],
     SensorDeviceClass.AREA: [{CONF_TYPE: CONF_AREA}],
@@ -166,6 +168,7 @@ TRIGGER_SCHEMA = vol.All(
             vol.Required(CONF_TYPE): vol.In(
                 [
                     CONF_ABSOLUTE_HUMIDITY,
+                    CONF_AMMONIA,
                     CONF_APPARENT_POWER,
                     CONF_AQI,
                     CONF_AREA,

--- a/homeassistant/components/sensor/icons.json
+++ b/homeassistant/components/sensor/icons.json
@@ -6,6 +6,9 @@
     "absolute_humidity": {
       "default": "mdi:water-opacity"
     },
+    "ammonia": {
+      "default": "mdi:molecule"
+    },
     "apparent_power": {
       "default": "mdi:flash"
     },

--- a/homeassistant/components/sensor/strings.json
+++ b/homeassistant/components/sensor/strings.json
@@ -2,6 +2,7 @@
   "device_automation": {
     "condition_type": {
       "is_absolute_humidity": "Current {entity_name} absolute humidity",
+      "is_ammonia": "Current {entity_name} ammonia concentration level",
       "is_apparent_power": "Current {entity_name} apparent power",
       "is_aqi": "Current {entity_name} air quality index",
       "is_area": "Current {entity_name} area",
@@ -65,6 +66,7 @@
     },
     "trigger_type": {
       "absolute_humidity": "{entity_name} absolute humidity changes",
+      "ammonia": "{entity_name} ammonia concentration changes",
       "apparent_power": "{entity_name} apparent power changes",
       "aqi": "{entity_name} air quality index changes",
       "area": "{entity_name} area changes",
@@ -149,6 +151,9 @@
     },
     "absolute_humidity": {
       "name": "Absolute humidity"
+    },
+    "ammonia": {
+      "name": "Ammonia"
     },
     "apparent_power": {
       "name": "Apparent power"

--- a/homeassistant/components/sql/strings.json
+++ b/homeassistant/components/sql/strings.json
@@ -115,6 +115,7 @@
     "device_class": {
       "options": {
         "absolute_humidity": "[%key:component::sensor::entity_component::absolute_humidity::name%]",
+        "ammonia": "[%key:component::sensor::entity_component::ammonia::name%]",
         "apparent_power": "[%key:component::sensor::entity_component::apparent_power::name%]",
         "aqi": "[%key:component::sensor::entity_component::aqi::name%]",
         "area": "[%key:component::sensor::entity_component::area::name%]",

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -1130,6 +1130,7 @@
     "sensor_device_class": {
       "options": {
         "absolute_humidity": "[%key:component::sensor::entity_component::absolute_humidity::name%]",
+        "ammonia": "[%key:component::sensor::entity_component::ammonia::name%]",
         "apparent_power": "[%key:component::sensor::entity_component::apparent_power::name%]",
         "aqi": "[%key:component::sensor::entity_component::aqi::name%]",
         "area": "[%key:component::sensor::entity_component::area::name%]",

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -102,6 +102,7 @@ _AMBIENT_IDEAL_GAS_MOLAR_VOLUME = (  # m3⋅mol⁻¹
     _IDEAL_GAS_CONSTANT * _AMBIENT_TEMPERATURE / _AMBIENT_PRESSURE
 )
 # Molar masses in g⋅mol⁻¹
+_AMMONIA_MOLAR_MASS = 17.031
 _CARBON_MONOXIDE_MOLAR_MASS = 28.01
 _NITROGEN_DIOXIDE_MOLAR_MASS = 46.0055
 _NITROGEN_MONOXIDE_MOLAR_MASS = 30.0061
@@ -187,6 +188,22 @@ class BaseUnitConverter:
     def _are_unit_inverses(cls, from_unit: str | None, to_unit: str | None) -> bool:
         """Return true if one unit is an inverse but not the other."""
         return (from_unit in cls._UNIT_INVERSES) != (to_unit in cls._UNIT_INVERSES)
+
+
+class AmmoniaConcentrationConverter(BaseUnitConverter):
+    """Convert ammonia ratio to mass per volume."""
+
+    UNIT_CLASS = "ammonia"
+    _UNIT_CONVERSION: dict[str | None, float] = {
+        CONCENTRATION_PARTS_PER_BILLION: 1e9,
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER: (
+            _AMMONIA_MOLAR_MASS / _AMBIENT_IDEAL_GAS_MOLAR_VOLUME * 1e6
+        ),
+    }
+    VALID_UNITS = {
+        CONCENTRATION_PARTS_PER_BILLION,
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    }
 
 
 class ApparentPowerConverter(BaseUnitConverter):

--- a/tests/components/sensor/common.py
+++ b/tests/components/sensor/common.py
@@ -46,6 +46,7 @@ from tests.common import MockEntity
 
 UNITS_OF_MEASUREMENT = {
     SensorDeviceClass.ABSOLUTE_HUMIDITY: CONCENTRATION_GRAMS_PER_CUBIC_METER,
+    SensorDeviceClass.AMMONIA: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     SensorDeviceClass.APPARENT_POWER: UnitOfApparentPower.VOLT_AMPERE,
     SensorDeviceClass.AQI: None,
     SensorDeviceClass.AREA: UnitOfArea.SQUARE_METERS,

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -120,7 +120,7 @@ async def test_get_conditions(
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id
     )
-    assert len(conditions) == 57
+    assert len(conditions) == 58
     assert conditions == unordered(expected_conditions)
 
 

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -121,7 +121,7 @@ async def test_get_triggers(
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
-    assert len(triggers) == 57
+    assert len(triggers) == 58
     assert triggers == unordered(expected_triggers)
 
 

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -2218,6 +2218,7 @@ async def test_non_numeric_device_class_with_unit_of_measurement(
 @pytest.mark.parametrize(
     "device_class",
     [
+        SensorDeviceClass.AMMONIA,
         SensorDeviceClass.APPARENT_POWER,
         SensorDeviceClass.AQI,
         SensorDeviceClass.AREA,

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -40,6 +40,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import unit_conversion
 from homeassistant.util.unit_conversion import (
+    AmmoniaConcentrationConverter,
     ApparentPowerConverter,
     AreaConverter,
     BaseUnitConverter,
@@ -81,6 +82,7 @@ INVALID_SYMBOL = "bob"
 _ALL_CONVERTERS: dict[type[BaseUnitConverter], list[str | None]] = {
     converter: sorted(converter.VALID_UNITS, key=lambda x: (x is None, x))
     for converter in (
+        AmmoniaConcentrationConverter,
         AreaConverter,
         BloodGlucoseConcentrationConverter,
         MassVolumeConcentrationConverter,
@@ -115,6 +117,11 @@ _ALL_CONVERTERS: dict[type[BaseUnitConverter], list[str | None]] = {
 
 # Dict containing all converters with a corresponding unit ratio.
 _GET_UNIT_RATIO: dict[type[BaseUnitConverter], tuple[str | None, str | None, float]] = {
+    AmmoniaConcentrationConverter: (
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        CONCENTRATION_PARTS_PER_BILLION,
+        0.707999,
+    ),
     ApparentPowerConverter: (
         UnitOfApparentPower.MILLIVOLT_AMPERE,
         UnitOfApparentPower.VOLT_AMPERE,
@@ -226,6 +233,20 @@ _GET_UNIT_RATIO: dict[type[BaseUnitConverter], tuple[str | None, str | None, flo
 _CONVERTED_VALUE: dict[
     type[BaseUnitConverter], list[tuple[float, str | None, float, str | None]]
 ] = {
+    AmmoniaConcentrationConverter: [
+        (
+            1,
+            CONCENTRATION_PARTS_PER_BILLION,
+            0.707999,
+            CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        ),
+        (
+            120,
+            CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            169.491752,
+            CONCENTRATION_PARTS_PER_BILLION,
+        ),
+    ],
     ApparentPowerConverter: [
         (
             10,


### PR DESCRIPTION
## Proposed change

Adds a new device class for ammonia with units: ppb (parts per billion) and μg/m³. To be used for air quality sensors like the Apollo AIR-1.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
