### PR TITLE
Cleanup deprecated color_temp support in lifx

### DIFF
--- a/homeassistant/components/lifx/const.py
+++ b/homeassistant/components/lifx/const.py
@@ -73,6 +73,3 @@ LIFX_CEILING_PRODUCT_IDS = {176, 177, 201, 202}
 LIFX_128ZONE_CEILING_PRODUCT_IDS = {201, 202}
 
 _LOGGER = logging.getLogger(__package__)
-
-# _ATTR_COLOR_TEMP deprecated - to be removed in 2026.1
-_ATTR_COLOR_TEMP = "color_temp"

--- a/homeassistant/components/lifx/manager.py
+++ b/homeassistant/components/lifx/manager.py
@@ -33,7 +33,7 @@ from homeassistant.helpers.target import (
     async_extract_referenced_entity_ids,
 )
 
-from .const import _ATTR_COLOR_TEMP, ATTR_THEME, DOMAIN
+from .const import ATTR_THEME, DOMAIN
 from .coordinator import LIFXUpdateCoordinator
 from .util import convert_8_to_16, find_hsbk
 
@@ -135,8 +135,6 @@ LIFX_EFFECT_PULSE_SCHEMA = cv.make_entity_service_schema(
         vol.Exclusive(ATTR_COLOR_TEMP_KELVIN, COLOR_GROUP): vol.All(
             vol.Coerce(int), vol.Range(min=1500, max=9000)
         ),
-        # _ATTR_COLOR_TEMP deprecated - to be removed in 2026.1
-        vol.Exclusive(_ATTR_COLOR_TEMP, COLOR_GROUP): cv.positive_int,
         ATTR_PERIOD: vol.All(vol.Coerce(float), vol.Range(min=0.05)),
         ATTR_CYCLES: vol.All(vol.Coerce(float), vol.Range(min=1)),
         ATTR_MODE: vol.In(PULSE_MODES),

--- a/homeassistant/components/lifx/util.py
+++ b/homeassistant/components/lifx/util.py
@@ -26,7 +26,6 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.util import color as color_util
 
 from .const import (
-    _ATTR_COLOR_TEMP,
     _LOGGER,
     DEFAULT_ATTEMPTS,
     DOMAIN,
@@ -114,17 +113,6 @@ def find_hsbk(hass: HomeAssistant, **kwargs: Any) -> list[float | int | None] | 
         hue = int(hue / 360 * 65535)
         saturation = int(saturation / 100 * 65535)
         kelvin = 3500
-
-    if ATTR_COLOR_TEMP_KELVIN not in kwargs and _ATTR_COLOR_TEMP in kwargs:
-        # added in 2025.1, can be removed in 2026.1
-        _LOGGER.warning(
-            "The 'color_temp' parameter is deprecated. Please use 'color_temp_kelvin' for"
-            " all service calls"
-        )
-        kelvin = color_util.color_temperature_mired_to_kelvin(
-            kwargs.pop(_ATTR_COLOR_TEMP)
-        )
-        saturation = 0
 
     if ATTR_COLOR_TEMP_KELVIN in kwargs:
         kelvin = kwargs.pop(ATTR_COLOR_TEMP_KELVIN)

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -9,7 +9,7 @@ import pytest
 
 from homeassistant.components import lifx
 from homeassistant.components.lifx import DOMAIN
-from homeassistant.components.lifx.const import _ATTR_COLOR_TEMP, ATTR_POWER
+from homeassistant.components.lifx.const import ATTR_POWER
 from homeassistant.components.lifx.light import ATTR_INFRARED, ATTR_ZONES
 from homeassistant.components.lifx.manager import (
     ATTR_CLOUD_SATURATION_MAX,
@@ -1898,15 +1898,6 @@ async def test_lifx_set_state_kelvin(hass: HomeAssistant) -> None:
         blocking=True,
     )
     assert bulb.set_color.calls[0][0][0] == [32000, 0, 25700, 2700]
-    bulb.set_color.reset_mock()
-
-    await hass.services.async_call(
-        DOMAIN,
-        "set_state",
-        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 255, _ATTR_COLOR_TEMP: 400},
-        blocking=True,
-    )
-    assert bulb.set_color.calls[0][0][0] == [32000, 0, 65535, 2500]
     bulb.set_color.reset_mock()
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Passing `color_temp` parameter to the `lifx.effect_pulse` action is no longer allowed. Please use `color_temp_kelvin` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
