### PR TITLE
Cleanup deprecated YAML import from datadog

### DIFF
--- a/homeassistant/components/datadog/__init__.py
+++ b/homeassistant/components/datadog/__init__.py
@@ -3,9 +3,8 @@
 import logging
 
 from datadog import DogStatsd, initialize
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
@@ -16,53 +15,15 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, state as state_helper
-from homeassistant.helpers.typing import ConfigType
 
 from . import config_flow as config_flow
-from .const import (
-    CONF_RATE,
-    DEFAULT_HOST,
-    DEFAULT_PORT,
-    DEFAULT_PREFIX,
-    DEFAULT_RATE,
-    DOMAIN,
-)
+from .const import CONF_RATE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 type DatadogConfigEntry = ConfigEntry[DogStatsd]
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_HOST, default=DEFAULT_HOST): cv.string,
-                vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-                vol.Optional(CONF_PREFIX, default=DEFAULT_PREFIX): cv.string,
-                vol.Optional(CONF_RATE, default=DEFAULT_RATE): vol.All(
-                    vol.Coerce(int), vol.Range(min=1)
-                ),
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Datadog integration from YAML, initiating config flow import."""
-    if DOMAIN not in config:
-        return True
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config[DOMAIN],
-        )
-    )
-
-    return True
+CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: DatadogConfigEntry) -> bool:

--- a/homeassistant/components/datadog/strings.json
+++ b/homeassistant/components/datadog/strings.json
@@ -25,12 +25,6 @@
       }
     }
   },
-  "issues": {
-    "deprecated_yaml_import_connection_error": {
-      "description": "There was an error connecting to the Datadog Agent when trying to import the YAML configuration.\n\nEnsure the YAML configuration is correct and restart Home Assistant to try again or remove the {domain} configuration from your `configuration.yaml` file and continue to [set up the integration]({url}) manually.",
-      "title": "{domain} YAML configuration import failed"
-    }
-  },
   "options": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",

--- a/tests/components/datadog/common.py
+++ b/tests/components/datadog/common.py
@@ -14,14 +14,6 @@ MOCK_OPTIONS = {
 
 MOCK_CONFIG = {**MOCK_DATA, **MOCK_OPTIONS}
 
-MOCK_YAML_INVALID = {
-    "host": "127.0.0.1",
-    "port": 65535,
-    "prefix": "failtest",
-    "rate": 1,
-}
-
-
 CONNECTION_TEST_METRIC = "connection_test"
 
 

--- a/tests/components/datadog/test_config_flow.py
+++ b/tests/components/datadog/test_config_flow.py
@@ -2,13 +2,12 @@
 
 from unittest.mock import MagicMock, patch
 
-from homeassistant.components import datadog
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.components.datadog import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-import homeassistant.helpers.issue_registry as ir
 
-from .common import MOCK_CONFIG, MOCK_DATA, MOCK_OPTIONS, MOCK_YAML_INVALID
+from .common import MOCK_CONFIG, MOCK_DATA, MOCK_OPTIONS
 
 from tests.common import MockConfigEntry
 
@@ -22,7 +21,7 @@ async def test_user_flow_success(hass: HomeAssistant) -> None:
         mock_dogstatsd.return_value = mock_instance
 
         result = await hass.config_entries.flow.async_init(
-            datadog.DOMAIN, context={"source": SOURCE_USER}
+            DOMAIN, context={"source": SOURCE_USER}
         )
         assert result["type"] is FlowResultType.FORM
 
@@ -42,7 +41,7 @@ async def test_user_flow_retry_after_connection_fail(hass: HomeAssistant) -> Non
         side_effect=OSError("Connection failed"),
     ):
         result = await hass.config_entries.flow.async_init(
-            datadog.DOMAIN, context={"source": SOURCE_USER}
+            DOMAIN, context={"source": SOURCE_USER}
         )
 
         result2 = await hass.config_entries.flow.async_configure(
@@ -67,14 +66,14 @@ async def test_user_flow_abort_already_configured_service(
 ) -> None:
     """Abort user-initiated config flow if the same host/port is already configured."""
     existing_entry = MockConfigEntry(
-        domain=datadog.DOMAIN,
+        domain=DOMAIN,
         data=MOCK_DATA,
         options=MOCK_OPTIONS,
     )
     existing_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        datadog.DOMAIN,
+        DOMAIN,
         context={"source": SOURCE_USER},
     )
 
@@ -93,7 +92,7 @@ async def test_user_flow_abort_already_configured_service(
 async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:
     """Test that the options flow shows an error when connection fails."""
     mock_entry = MockConfigEntry(
-        domain=datadog.DOMAIN,
+        domain=DOMAIN,
         data=MOCK_DATA,
         options=MOCK_OPTIONS,
     )
@@ -123,67 +122,10 @@ async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:
         assert result3["data"] == MOCK_OPTIONS
 
 
-async def test_import_flow(
-    hass: HomeAssistant, issue_registry: ir.IssueRegistry
-) -> None:
-    """Test import triggers config flow and is accepted."""
-    with (
-        patch(
-            "homeassistant.components.datadog.config_flow.DogStatsd"
-        ) as mock_dogstatsd,
-    ):
-        mock_instance = MagicMock()
-        mock_dogstatsd.return_value = mock_instance
-
-        result = await hass.config_entries.flow.async_init(
-            datadog.DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=MOCK_CONFIG,
-        )
-
-        assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["data"] == MOCK_DATA
-        assert result["options"] == MOCK_OPTIONS
-
-        await hass.async_block_till_done()
-
-        # Deprecation issue should be created
-        issue = issue_registry.async_get_issue(
-            HOMEASSISTANT_DOMAIN, "deprecated_yaml_datadog"
-        )
-        assert issue is not None
-        assert issue.translation_key == "deprecated_yaml"
-        assert issue.severity == ir.IssueSeverity.WARNING
-
-
-async def test_import_connection_error(
-    hass: HomeAssistant, issue_registry: ir.IssueRegistry
-) -> None:
-    """Test import triggers connection error issue."""
-    with patch(
-        "homeassistant.components.datadog.config_flow.DogStatsd",
-        side_effect=OSError("connection refused"),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            datadog.DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=MOCK_YAML_INVALID,
-        )
-        assert result["type"] == "abort"
-        assert result["reason"] == "cannot_connect"
-
-        issue = issue_registry.async_get_issue(
-            datadog.DOMAIN, "deprecated_yaml_import_connection_error"
-        )
-        assert issue is not None
-        assert issue.translation_key == "deprecated_yaml_import_connection_error"
-        assert issue.severity == ir.IssueSeverity.WARNING
-
-
 async def test_options_flow(hass: HomeAssistant) -> None:
     """Test updating options after setup."""
     mock_entry = MockConfigEntry(
-        domain=datadog.DOMAIN,
+        domain=DOMAIN,
         data=MOCK_DATA,
         options=MOCK_OPTIONS,
     )
@@ -234,24 +176,3 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"] == new_options
         mock_instance.increment.assert_called_once_with("connection_test")
-
-
-async def test_import_flow_abort_already_configured_service(
-    hass: HomeAssistant,
-) -> None:
-    """Abort import if the same host/port is already configured."""
-    existing_entry = MockConfigEntry(
-        domain=datadog.DOMAIN,
-        data=MOCK_DATA,
-        options=MOCK_OPTIONS,
-    )
-    existing_entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        datadog.DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data=MOCK_CONFIG,
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"

--- a/tests/components/datadog/test_config_flow.py
+++ b/tests/components/datadog/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from homeassistant.components.datadog import DOMAIN
+from homeassistant.components.datadog.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType

--- a/tests/components/datadog/test_init.py
+++ b/tests/components/datadog/test_init.py
@@ -3,8 +3,13 @@
 from unittest import mock
 from unittest.mock import patch
 
-from homeassistant.components import datadog
-from homeassistant.components.datadog import async_setup_entry
+from homeassistant.components.datadog.const import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    DEFAULT_PREFIX,
+    DEFAULT_RATE,
+    DOMAIN,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_LOGBOOK_ENTRY, STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
@@ -17,7 +22,7 @@ from tests.common import EVENT_STATE_CHANGED, MockConfigEntry
 async def test_invalid_config(hass: HomeAssistant) -> None:
     """Test invalid configuration."""
     entry = MockConfigEntry(
-        domain=datadog.DOMAIN,
+        domain=DOMAIN,
         data={"host1": "host1"},
     )
     entry.add_to_hass(hass)
@@ -30,7 +35,7 @@ async def test_datadog_setup_full(hass: HomeAssistant) -> None:
         patch("homeassistant.components.datadog.DogStatsd") as mock_dogstatsd,
     ):
         entry = MockConfigEntry(
-            domain=datadog.DOMAIN,
+            domain=DOMAIN,
             data={
                 "host": "host",
                 "port": 123,
@@ -56,7 +61,7 @@ async def test_datadog_setup_defaults(hass: HomeAssistant) -> None:
         patch("homeassistant.components.datadog.DogStatsd") as mock_dogstatsd,
     ):
         entry = MockConfigEntry(
-            domain=datadog.DOMAIN,
+            domain=DOMAIN,
             data=MOCK_DATA,
             options=MOCK_OPTIONS,
         )
@@ -79,14 +84,14 @@ async def test_logbook_entry(hass: HomeAssistant) -> None:
     ):
         mock_statsd = mock_statsd_class.return_value
         entry = MockConfigEntry(
-            domain=datadog.DOMAIN,
+            domain=DOMAIN,
             data={
-                "host": datadog.DEFAULT_HOST,
-                "port": datadog.DEFAULT_PORT,
+                "host": DEFAULT_HOST,
+                "port": DEFAULT_PORT,
             },
             options={
-                "rate": datadog.DEFAULT_RATE,
-                "prefix": datadog.DEFAULT_PREFIX,
+                "rate": DEFAULT_RATE,
+                "prefix": DEFAULT_PREFIX,
             },
         )
         entry.add_to_hass(hass)
@@ -119,12 +124,12 @@ async def test_state_changed(hass: HomeAssistant) -> None:
     ):
         mock_statsd = mock_statsd_class.return_value
         entry = MockConfigEntry(
-            domain=datadog.DOMAIN,
+            domain=DOMAIN,
             data={
                 "host": "host",
-                "port": datadog.DEFAULT_PORT,
+                "port": DEFAULT_PORT,
             },
-            options={"prefix": "ha", "rate": datadog.DEFAULT_RATE},
+            options={"prefix": "ha", "rate": DEFAULT_RATE},
         )
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
@@ -176,7 +181,7 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         patch("homeassistant.components.datadog.initialize"),
     ):
         entry = MockConfigEntry(
-            domain=datadog.DOMAIN,
+            domain=DOMAIN,
             data=MOCK_DATA,
             options=MOCK_OPTIONS,
         )
@@ -203,13 +208,13 @@ async def test_state_changed_skips_unknown(hass: HomeAssistant) -> None:
         ) as mock_dogstatsd,
     ):
         entry = MockConfigEntry(
-            domain=datadog.DOMAIN,
+            domain=DOMAIN,
             data=MOCK_DATA,
             options=MOCK_OPTIONS,
         )
         entry.add_to_hass(hass)
 
-        await async_setup_entry(hass, entry)
+        await hass.config_entries.async_setup(entry.entry_id)
 
         # Test None state
         hass.bus.async_fire(EVENT_STATE_CHANGED, {"new_state": None})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Support for YAML configuration of datadog has been removed.
Please use a config entry.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, follow-up to #148104

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
