### PR TITLE
Add JVC Projector switch platform

### DIFF
--- a/homeassistant/components/jvc_projector/__init__.py
+++ b/homeassistant/components/jvc_projector/__init__.py
@@ -17,7 +17,13 @@ from homeassistant.helpers.entity_registry import RegistryEntry, async_migrate_e
 
 from .coordinator import JVCConfigEntry, JvcProjectorDataUpdateCoordinator
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.REMOTE, Platform.SELECT, Platform.SENSOR]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.REMOTE,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: JVCConfigEntry) -> bool:

--- a/homeassistant/components/jvc_projector/icons.json
+++ b/homeassistant/components/jvc_projector/icons.json
@@ -53,6 +53,14 @@
           "warming": "mdi:heat-wave"
         }
       }
+    },
+    "switch": {
+      "eshift": {
+        "default": "mdi:blur-linear"
+      },
+      "low_latency_mode": {
+        "default": "mdi:gamepad-round-outline"
+      }
     }
   }
 }

--- a/homeassistant/components/jvc_projector/strings.json
+++ b/homeassistant/components/jvc_projector/strings.json
@@ -173,6 +173,14 @@
           "warming": "Warming"
         }
       }
+    },
+    "switch": {
+      "eshift": {
+        "name": "E-Shift"
+      },
+      "low_latency_mode": {
+        "name": "Low Latency Mode"
+      }
     }
   }
 }

--- a/homeassistant/components/jvc_projector/strings.json
+++ b/homeassistant/components/jvc_projector/strings.json
@@ -179,7 +179,7 @@
         "name": "E-Shift"
       },
       "low_latency_mode": {
-        "name": "Low Latency Mode"
+        "name": "Low latency mode"
       }
     }
   }

--- a/homeassistant/components/jvc_projector/switch.py
+++ b/homeassistant/components/jvc_projector/switch.py
@@ -1,0 +1,84 @@
+"""Switch platform for the jvc_projector integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+from jvcprojector import Command, command as cmd
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import JVCConfigEntry, JvcProjectorDataUpdateCoordinator
+from .entity import JvcProjectorEntity
+
+STATE_ON = "on"
+STATE_OFF = "off"
+
+
+@dataclass(frozen=True, kw_only=True)
+class JvcProjectorSwitchDescription(SwitchEntityDescription):
+    """Describes JVC Projector switch entities."""
+
+    command: type[Command]
+
+
+SWITCHES: Final[tuple[JvcProjectorSwitchDescription, ...]] = (
+    JvcProjectorSwitchDescription(
+        key="low_latency_mode",
+        command=cmd.LowLatencyMode,
+        entity_registry_enabled_default=False,
+    ),
+    JvcProjectorSwitchDescription(
+        key="eshift",
+        command=cmd.EShift,
+        entity_registry_enabled_default=False,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: JVCConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the JVC Projector switch platform from a config entry."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        JvcProjectorSwitchEntity(coordinator, description)
+        for description in SWITCHES
+        if coordinator.supports(description.command)
+    )
+
+
+class JvcProjectorSwitchEntity(JvcProjectorEntity, SwitchEntity):
+    """JVC Projector class for switch entities."""
+
+    def __init__(
+        self,
+        coordinator: JvcProjectorDataUpdateCoordinator,
+        description: JvcProjectorSwitchDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator, description.command)
+        self.command: type[Command] = description.command
+
+        self.entity_description = description
+        self._attr_translation_key = description.key
+        self._attr_unique_id = f"{self._attr_unique_id}_{description.key}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the entity is on."""
+        return self.coordinator.data.get(self.command.name) == STATE_ON
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        await self.coordinator.device.set(self.command, STATE_ON)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        await self.coordinator.device.set(self.command, STATE_OFF)

--- a/homeassistant/components/jvc_projector/switch.py
+++ b/homeassistant/components/jvc_projector/switch.py
@@ -8,14 +8,12 @@ from typing import Any, Final
 from jvcprojector import Command, command as cmd
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import JVCConfigEntry, JvcProjectorDataUpdateCoordinator
 from .entity import JvcProjectorEntity
-
-STATE_ON = "on"
-STATE_OFF = "off"
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/components/jvc_projector/conftest.py
+++ b/tests/components/jvc_projector/conftest.py
@@ -26,6 +26,7 @@ FIXTURES: dict[str, dict[type[Command], str | type[Exception]]] = {
         cmd.Source: JvcProjectorTimeoutError,
         cmd.Hdr: JvcProjectorTimeoutError,
         cmd.HdrProcessing: JvcProjectorTimeoutError,
+        cmd.EShift: JvcProjectorTimeoutError,
     },
     "on": {
         cmd.MacAddress: MOCK_MAC,
@@ -37,6 +38,7 @@ FIXTURES: dict[str, dict[type[Command], str | type[Exception]]] = {
         cmd.Source: "4k",
         cmd.Hdr: "hdr",
         cmd.HdrProcessing: "static",
+        cmd.EShift: "on",
     },
 }
 
@@ -68,6 +70,10 @@ CAPABILITIES = {
     cmd.LightTime.name: {
         "name": cmd.LightTime.name,
         "parameter": "empty",
+    },
+    cmd.EShift.name: {
+        "name": cmd.EShift.name,
+        "parameter": {"read": {"0": "off", "1": "on"}},
     },
 }
 

--- a/tests/components/jvc_projector/snapshots/test_switch.ambr
+++ b/tests/components/jvc_projector/snapshots/test_switch.ambr
@@ -1,0 +1,99 @@
+# serializer version: 1
+# name: test_entities[switch.jvc_projector_e_shift-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.jvc_projector_e_shift',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'E-Shift',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'E-Shift',
+    'platform': 'jvc_projector',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'eshift',
+    'unique_id': 'e0:da:dc:0a:12:34_eshift',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[switch.jvc_projector_e_shift-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JVC Projector E-Shift',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.jvc_projector_e_shift',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[switch.jvc_projector_low_latency_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.jvc_projector_low_latency_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Low latency mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Low latency mode',
+    'platform': 'jvc_projector',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'low_latency_mode',
+    'unique_id': 'e0:da:dc:0a:12:34_low_latency_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[switch.jvc_projector_low_latency_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JVC Projector Low latency mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.jvc_projector_low_latency_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/jvc_projector/test_switch.py
+++ b/tests/components/jvc_projector/test_switch.py
@@ -1,0 +1,62 @@
+"""Tests for JVC Projector switch platform."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from jvcprojector import command as cmd
+
+from homeassistant.components.jvc_projector.coordinator import INTERVAL_FAST
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util.dt import utcnow
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+ESHIFT_ENTITY_ID = "switch.jvc_projector_e_shift"
+LOW_LATENCY_ENTITY_ID = "switch.jvc_projector_low_latency_mode"
+
+
+async def test_switch_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_device: MagicMock,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test switch entities."""
+    entity_registry.async_update_entity(ESHIFT_ENTITY_ID, disabled_by=None)
+    await hass.config_entries.async_reload(mock_integration.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(
+        hass, utcnow() + timedelta(seconds=INTERVAL_FAST.seconds + 1)
+    )
+    await hass.async_block_till_done()
+
+    eshift = hass.states.get(ESHIFT_ENTITY_ID)
+    assert eshift
+    assert eshift.attributes.get(ATTR_FRIENDLY_NAME) == "JVC Projector E-Shift"
+    assert eshift.state == "on"
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ESHIFT_ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_device.set.assert_any_call(cmd.EShift, "off")
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ESHIFT_ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_device.set.assert_any_call(cmd.EShift, "on")

--- a/tests/components/jvc_projector/test_switch.py
+++ b/tests/components/jvc_projector/test_switch.py
@@ -1,27 +1,48 @@
 """Tests for JVC Projector switch platform."""
 
-from datetime import timedelta
-from unittest.mock import MagicMock
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from jvcprojector import command as cmd
+import pytest
+from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.jvc_projector.coordinator import INTERVAL_FAST
 from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util.dt import utcnow
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry, snapshot_platform
 
 ESHIFT_ENTITY_ID = "switch.jvc_projector_e_shift"
 LOW_LATENCY_ENTITY_ID = "switch.jvc_projector_low_latency_mode"
 
 
+@pytest.fixture(autouse=True)
+def platform() -> Generator[AsyncMock]:
+    """Fixture for platform."""
+    with patch("homeassistant.components.jvc_projector.PLATFORMS", [Platform.SWITCH]):
+        yield
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entities(
+    hass: HomeAssistant,
+    mock_device: MagicMock,
+    mock_integration: MockConfigEntry,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_switch_entities(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -29,19 +50,6 @@ async def test_switch_entities(
     mock_integration: MockConfigEntry,
 ) -> None:
     """Test switch entities."""
-    entity_registry.async_update_entity(ESHIFT_ENTITY_ID, disabled_by=None)
-    await hass.config_entries.async_reload(mock_integration.entry_id)
-    await hass.async_block_till_done()
-
-    async_fire_time_changed(
-        hass, utcnow() + timedelta(seconds=INTERVAL_FAST.seconds + 1)
-    )
-    await hass.async_block_till_done()
-
-    eshift = hass.states.get(ESHIFT_ENTITY_ID)
-    assert eshift
-    assert eshift.attributes.get(ATTR_FRIENDLY_NAME) == "JVC Projector E-Shift"
-    assert eshift.state == "on"
 
     await hass.services.async_call(
         SWITCH_DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new switch platform with two entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43328
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
