### PR TITLE
Bump ZHA to 0.0.88

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==0.0.87", "serialx==0.6.2"],
+  "requirements": ["zha==0.0.88", "serialx==0.6.2"],
   "usb": [
     {
       "description": "*2652*",

--- a/homeassistant/components/zha/websocket_api.py
+++ b/homeassistant/components/zha/websocket_api.py
@@ -854,7 +854,7 @@ async def websocket_read_zigbee_cluster_attributes(
     cluster_id: int = msg[ATTR_CLUSTER_ID]
     cluster_type: str = msg[ATTR_CLUSTER_TYPE]
     attribute: int = msg[ATTR_ATTRIBUTE]
-    manufacturer: int | None = msg.get(ATTR_MANUFACTURER)
+    manufacturer: int | ZigpyUndefinedType = msg.get(ATTR_MANUFACTURER, ZIGPY_UNDEFINED)
     zha_device = zha_gateway.get_device(ieee)
     success = {}
     failure = {}

--- a/homeassistant/components/zha/websocket_api.py
+++ b/homeassistant/components/zha/websocket_api.py
@@ -53,6 +53,10 @@ import zigpy.backups
 from zigpy.config import CONF_DEVICE
 from zigpy.config.validators import cv_boolean
 from zigpy.types.named import EUI64, KeyData
+from zigpy.typing import (
+    UNDEFINED as ZIGPY_UNDEFINED,
+    UndefinedType as ZigpyUndefinedType,
+)
 from zigpy.zcl.clusters.security import IasAce
 import zigpy.zdo.types as zdo_types
 
@@ -1326,7 +1330,9 @@ def async_load_api(hass: HomeAssistant) -> None:
         cluster_type: str = service.data[ATTR_CLUSTER_TYPE]
         attribute: int | str = service.data[ATTR_ATTRIBUTE]
         value: int | bool | str = service.data[ATTR_VALUE]
-        manufacturer: int | None = service.data.get(ATTR_MANUFACTURER)
+        manufacturer: int | ZigpyUndefinedType = service.data.get(
+            ATTR_MANUFACTURER, ZIGPY_UNDEFINED
+        )
         zha_device = zha_gateway.get_device(ieee)
         response = None
         if zha_device is not None:
@@ -1380,7 +1386,9 @@ def async_load_api(hass: HomeAssistant) -> None:
         command_type: str = service.data[ATTR_COMMAND_TYPE]
         args: list | None = service.data.get(ATTR_ARGS)
         params: dict | None = service.data.get(ATTR_PARAMS)
-        manufacturer: int | None = service.data.get(ATTR_MANUFACTURER)
+        manufacturer: int | ZigpyUndefinedType = service.data.get(
+            ATTR_MANUFACTURER, ZIGPY_UNDEFINED
+        )
         zha_device = zha_gateway.get_device(ieee)
         if zha_device is not None:
             if cluster_id >= MFG_CLUSTER_ID_START and manufacturer is None:
@@ -1435,7 +1443,9 @@ def async_load_api(hass: HomeAssistant) -> None:
         cluster_id: int = service.data[ATTR_CLUSTER_ID]
         command: int = service.data[ATTR_COMMAND]
         args: list = service.data[ATTR_ARGS]
-        manufacturer: int | None = service.data.get(ATTR_MANUFACTURER)
+        manufacturer: int | ZigpyUndefinedType = service.data.get(
+            ATTR_MANUFACTURER, ZIGPY_UNDEFINED
+        )
         group = zha_gateway.get_group(group_id)
         if cluster_id >= MFG_CLUSTER_ID_START and manufacturer is None:
             _LOGGER.error("Missing manufacturer attribute for cluster: %d", cluster_id)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3299,7 +3299,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.87
+zha==0.0.88
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2766,7 +2766,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.87
+zha==0.0.88
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.68.0

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -7,6 +7,7 @@ import pytest
 from zha.application.platforms.fan.const import PRESET_MODE_ON
 from zigpy.device import Device
 from zigpy.profiles import zha
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters import general, hvac
 
 from homeassistant.components.fan import (
@@ -113,28 +114,28 @@ async def test_fan(
     cluster.write_attributes.reset_mock()
     await async_turn_on(hass, entity_id)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 2}, manufacturer=None)
+        call({"fan_mode": 2}, manufacturer=UNDEFINED)
     ]
 
     # turn off from HA
     cluster.write_attributes.reset_mock()
     await async_turn_off(hass, entity_id)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 0}, manufacturer=None)
+        call({"fan_mode": 0}, manufacturer=UNDEFINED)
     ]
 
     # change speed from HA
     cluster.write_attributes.reset_mock()
     await async_set_percentage(hass, entity_id, percentage=100)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 3}, manufacturer=None)
+        call({"fan_mode": 3}, manufacturer=UNDEFINED)
     ]
 
     # change preset_mode from HA
     cluster.write_attributes.reset_mock()
     await async_set_preset_mode(hass, entity_id, preset_mode=PRESET_MODE_ON)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 4}, manufacturer=None)
+        call({"fan_mode": 4}, manufacturer=UNDEFINED)
     ]
 
     # set invalid preset_mode from HA

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -6,6 +6,7 @@ from unittest.mock import call, patch
 import pytest
 from zigpy.device import Device
 from zigpy.profiles import zha
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters import general
 import zigpy.zcl.foundation as zcl_f
 
@@ -122,7 +123,7 @@ async def test_number(
             blocking=True,
         )
         assert cluster.write_attributes.mock_calls == [
-            call({"present_value": 30.0}, manufacturer=None)
+            call({"present_value": 30.0}, manufacturer=UNDEFINED)
         ]
         cluster.PLUGGED_ATTR_READS["present_value"] = 30.0
 

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -6,6 +6,7 @@ from unittest.mock import call, patch
 import pytest
 from zigpy.device import Device
 from zigpy.profiles import zha
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters import general
 import zigpy.zcl.foundation as zcl_f
 
@@ -143,5 +144,5 @@ async def test_switch(
     )
     assert len(cluster.read_attributes.mock_calls) == 1
     assert cluster.read_attributes.call_args == call(
-        ["on_off"], allow_cache=False, only_cache=False, manufacturer=None
+        ["on_off"], allow_cache=False, only_cache=False, manufacturer=UNDEFINED
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump ZHA to [0.0.88](https://github.com/zigpy/zha/releases/tag/0.0.88).

This is bundled bugfix release of underlying zigpy libraries that addresses a regression with quirks and fixes a warning logged by a radio library.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #161812
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
