### PR TITLE
Add drying mode switch to vesync

### DIFF
--- a/homeassistant/components/vesync/strings.json
+++ b/homeassistant/components/vesync/strings.json
@@ -149,8 +149,8 @@
       "display": {
         "name": "Display"
       },
-      "dry_mode": {
-        "name": "Dry mode"
+      "drying_mode_power_off": {
+        "name": "Drying mode power off"
       }
     }
   },

--- a/homeassistant/components/vesync/strings.json
+++ b/homeassistant/components/vesync/strings.json
@@ -150,7 +150,7 @@
         "name": "Display"
       },
       "drying_mode_power_off": {
-        "name": "Drying mode power off"
+        "name": "Enable drying mode while power is off"
       }
     }
   },

--- a/homeassistant/components/vesync/strings.json
+++ b/homeassistant/components/vesync/strings.json
@@ -148,6 +148,9 @@
       },
       "display": {
         "name": "Display"
+      },
+      "dry_mode": {
+        "name": "Dry mode"
       }
     }
   },

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -19,7 +19,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .common import is_outlet, is_purifier, is_wall_switch, rgetattr
+from .common import is_humidifier, is_outlet, is_wall_switch, rgetattr
 from .const import VS_DEVICES, VS_DISCOVERY
 from .coordinator import VesyncConfigEntry, VeSyncDataCoordinator
 from .entity import VeSyncBaseEntity
@@ -122,7 +122,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[VeSyncSwitchEntityDescription, ...]] = (
         key="dry_mode",
         is_on=lambda device: device.state.drying_mode_state == DeviceStatus.ON,
         exists_fn=(
-            lambda device: is_purifier(device)
+            lambda device: is_humidifier(device)
             and rgetattr(device, "state.dry_mode") is not None
         ),
         translation_key="dry_mode",

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -14,6 +14,7 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -61,8 +62,10 @@ def _toggle_auto_stop(device: VeSyncBaseDevice, *args) -> Awaitable[bool]:
             raise HomeAssistantError("Device does not support toggling automatic stop.")
 
 
-def _toggle_drying_mode(device: VeSyncBaseDevice, *args) -> Awaitable[bool]:
-    """Toggle drying mode on purifier devices."""
+def _toggle_drying_mode_on_power_off(
+    device: VeSyncBaseDevice, *args
+) -> Awaitable[bool]:
+    """Toggle auto drying mode on purifier devices."""
     match device:
         case VeSyncHumidifier() as sw if hasattr(sw, "toggle_drying_mode"):
             return sw.toggle_drying_mode(*args)
@@ -119,15 +122,15 @@ SENSOR_DESCRIPTIONS: Final[tuple[VeSyncSwitchEntityDescription, ...]] = (
         off_fn=lambda device: _toggle_auto_stop(device, False),
     ),
     VeSyncSwitchEntityDescription(
-        key="dry_mode",
-        is_on=lambda device: device.state.drying_mode_state == DeviceStatus.ON,
+        key="drying_mode_power_off",
+        is_on=lambda device: device.state.drying_mode_auto_switch == DeviceStatus.ON,
         exists_fn=(
-            lambda device: is_humidifier(device)
-            and rgetattr(device, "state.dry_mode") is not None
+            lambda device: is_humidifier(device) and "drying_mode" in device.features
         ),
-        translation_key="dry_mode",
-        on_fn=lambda device: _toggle_drying_mode(device, True),
-        off_fn=lambda device: _toggle_drying_mode(device, False),
+        translation_key="drying_mode_power_off",
+        on_fn=lambda device: _toggle_drying_mode_on_power_off(device, True),
+        off_fn=lambda device: _toggle_drying_mode_on_power_off(device, False),
+        entity_category=EntityCategory.CONFIG,
     ),
 )
 

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Final
 
 from pyvesync.base_devices import VeSyncBaseDevice, VeSyncHumidifier
+from pyvesync.const import DeviceStatus
 from pyvesync.device_container import DeviceContainer
 
 from homeassistant.components.switch import (
@@ -18,7 +19,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .common import is_outlet, is_wall_switch, rgetattr
+from .common import is_outlet, is_purifier, is_wall_switch, rgetattr
 from .const import VS_DEVICES, VS_DISCOVERY
 from .coordinator import VesyncConfigEntry, VeSyncDataCoordinator
 from .entity import VeSyncBaseEntity
@@ -58,6 +59,15 @@ def _toggle_auto_stop(device: VeSyncBaseDevice, *args) -> Awaitable[bool]:
             return sw.toggle_automatic_stop(*args)
         case _:
             raise HomeAssistantError("Device does not support toggling automatic stop.")
+
+
+def _toggle_drying_mode(device: VeSyncBaseDevice, *args) -> Awaitable[bool]:
+    """Toggle drying mode on purifier devices."""
+    match device:
+        case VeSyncHumidifier() as sw if hasattr(sw, "toggle_drying_mode"):
+            return sw.toggle_drying_mode(*args)
+        case _:
+            raise HomeAssistantError("Device does not support toggling drying mode.")
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -107,6 +117,17 @@ SENSOR_DESCRIPTIONS: Final[tuple[VeSyncSwitchEntityDescription, ...]] = (
         translation_key="auto_off_config",
         on_fn=lambda device: _toggle_auto_stop(device, True),
         off_fn=lambda device: _toggle_auto_stop(device, False),
+    ),
+    VeSyncSwitchEntityDescription(
+        key="dry_mode",
+        is_on=lambda device: device.state.drying_mode_state == DeviceStatus.ON,
+        exists_fn=(
+            lambda device: is_purifier(device)
+            and rgetattr(device, "state.dry_mode") is not None
+        ),
+        translation_key="dry_mode",
+        on_fn=lambda device: _toggle_drying_mode(device, True),
+        off_fn=lambda device: _toggle_drying_mode(device, False),
     ),
 )
 

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -63,12 +63,12 @@ def _toggle_auto_stop(device: VeSyncBaseDevice, *args) -> Awaitable[bool]:
 
 
 def _toggle_drying_mode_on_power_off(
-    device: VeSyncBaseDevice, *args
+    device: VeSyncBaseDevice, target: bool
 ) -> Awaitable[bool]:
     """Toggle auto drying mode on purifier devices."""
     match device:
         case VeSyncHumidifier() as sw if hasattr(sw, "toggle_drying_mode"):
-            return sw.toggle_drying_mode(*args)
+            return sw.toggle_drying_mode(target)
         case _:
             raise HomeAssistantError("Device does not support toggling drying mode.")
 

--- a/tests/components/vesync/snapshots/test_switch.ambr
+++ b/tests/components/vesync/snapshots/test_switch.ambr
@@ -892,6 +892,40 @@
       'unique_id': '6000s-auto_off_config',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': <EntityCategory.CONFIG: 'config'>,
+      'entity_id': 'switch.humidifier_6000s_drying_mode_power_off',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'object_id_base': 'Drying mode power off',
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Drying mode power off',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': 'drying_mode_power_off',
+      'unique_id': '6000s-drying_mode_power_off',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
 # name: test_switch_state[Humidifier 6000s][switch.humidifier_6000s_auto_off]
@@ -931,6 +965,19 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_switch_state[Humidifier 6000s][switch.humidifier_6000s_drying_mode_power_off]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Humidifier 6000s Drying mode power off',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.humidifier_6000s_drying_mode_power_off',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---
 # name: test_switch_state[Humidifier 600S][devices]

--- a/tests/components/vesync/snapshots/test_switch.ambr
+++ b/tests/components/vesync/snapshots/test_switch.ambr
@@ -904,7 +904,7 @@
       'disabled_by': None,
       'domain': 'switch',
       'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.humidifier_6000s_drying_mode_power_off',
+      'entity_id': 'switch.humidifier_6000s_enable_drying_mode_while_power_is_off',
       'has_entity_name': True,
       'hidden_by': None,
       'icon': None,
@@ -912,12 +912,12 @@
       'labels': set({
       }),
       'name': None,
-      'object_id_base': 'Drying mode power off',
+      'object_id_base': 'Enable drying mode while power is off',
       'options': dict({
       }),
       'original_device_class': None,
       'original_icon': None,
-      'original_name': 'Drying mode power off',
+      'original_name': 'Enable drying mode while power is off',
       'platform': 'vesync',
       'previous_unique_id': None,
       'suggested_object_id': None,
@@ -967,13 +967,13 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_state[Humidifier 6000s][switch.humidifier_6000s_drying_mode_power_off]
+# name: test_switch_state[Humidifier 6000s][switch.humidifier_6000s_enable_drying_mode_while_power_is_off]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Humidifier 6000s Drying mode power off',
+      'friendly_name': 'Humidifier 6000s Enable drying mode while power is off',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.humidifier_6000s_drying_mode_power_off',
+    'entity_id': 'switch.humidifier_6000s_enable_drying_mode_while_power_is_off',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some humidifiers have a pad that can be dried.   A configuration exists to auto turn this drying on when powered off.  This configures that value. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  https://github.com/home-assistant/core/issues/160040#issuecomment-3708188901
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
