### PR TITLE
Fix Control4 HVAC state-to-action mapping

### DIFF
--- a/homeassistant/components/control4/climate.py
+++ b/homeassistant/components/control4/climate.py
@@ -58,12 +58,13 @@ C4_TO_HA_HVAC_MODE = {
 
 HA_TO_C4_HVAC_MODE = {v: k for k, v in C4_TO_HA_HVAC_MODE.items()}
 
-# Map Control4 HVAC state to Home Assistant HVAC action
+# Map the five known Control4 HVAC states to Home Assistant HVAC actions
 C4_TO_HA_HVAC_ACTION = {
-    "heating": HVACAction.HEATING,
-    "cooling": HVACAction.COOLING,
-    "idle": HVACAction.IDLE,
     "off": HVACAction.OFF,
+    "heat": HVACAction.HEATING,
+    "cool": HVACAction.COOLING,
+    "dry": HVACAction.DRYING,
+    "fan": HVACAction.FAN,
 }
 
 
@@ -236,7 +237,10 @@ class Control4Climate(Control4Entity, ClimateEntity):
         if c4_state is None:
             return None
         # Convert state to lowercase for mapping
-        return C4_TO_HA_HVAC_ACTION.get(str(c4_state).lower())
+        action = C4_TO_HA_HVAC_ACTION.get(str(c4_state).lower())
+        if action is None:
+            _LOGGER.debug("Unknown HVAC state received from Control4: %s", c4_state)
+        return action
 
     @property
     def target_temperature(self) -> float | None:

--- a/tests/components/control4/conftest.py
+++ b/tests/components/control4/conftest.py
@@ -121,7 +121,7 @@ def mock_climate_variables() -> dict:
     """Mock climate variable data for default thermostat state."""
     return {
         123: {
-            "HVAC_STATE": "idle",
+            "HVAC_STATE": "Off",
             "HVAC_MODE": "Heat",
             "TEMPERATURE_F": 72.5,
             "HUMIDITY": 45,

--- a/tests/components/control4/snapshots/test_climate.ambr
+++ b/tests/components/control4/snapshots/test_climate.ambr
@@ -50,7 +50,7 @@
       'current_humidity': 45,
       'current_temperature': 72,
       'friendly_name': 'Test Controller Residential Thermostat V2',
-      'hvac_action': <HVACAction.IDLE: 'idle'>,
+      'hvac_action': <HVACAction.OFF: 'off'>,
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,


### PR DESCRIPTION
## Proposed change
The Control4 HVAC_STATE variable reports "Off", "Heat", "Cool", "Dry", and "Fan" — not the lowercase "heating", "cooling", "idle" values the mapping previously expected. Update C4_TO_HA_HVAC_ACTION to match the actual Control4 states and log unknown values at debug level.

Update tests to use realistic Control4-cased state values and add parametrized coverage for all five HVAC action mappings.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
