### PR TITLE
Fix HmIP-RGBW monochrome mode FEATURE_NOT_SUPPORTED error

### DIFF
--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -139,12 +139,28 @@ class HomematicipLight(HomematicipGenericEntity, LightEntity):
 class HomematicipLightHS(HomematicipGenericEntity, LightEntity):
     """Representation of the HomematicIP light with HS color mode."""
 
-    _attr_color_mode = ColorMode.HS
-    _attr_supported_color_modes = {ColorMode.HS}
-
     def __init__(self, hap: HomematicipHAP, device: Device, channel_index: int) -> None:
         """Initialize the light entity."""
         super().__init__(hap, device, channel=channel_index, is_multi_channel=True)
+
+    def _supports_color(self) -> bool:
+        """Return true if device supports hue/saturation color control."""
+        channel = self.get_channel_or_raise()
+        return channel.hue is not None and channel.saturationLevel is not None
+
+    @property
+    def color_mode(self) -> ColorMode:
+        """Return the color mode of the light."""
+        if self._supports_color():
+            return ColorMode.HS
+        return ColorMode.BRIGHTNESS
+
+    @property
+    def supported_color_modes(self) -> set[ColorMode]:
+        """Return the supported color modes."""
+        if self._supports_color():
+            return {ColorMode.HS}
+        return {ColorMode.BRIGHTNESS}
 
     @property
     def is_on(self) -> bool:
@@ -172,18 +188,26 @@ class HomematicipLightHS(HomematicipGenericEntity, LightEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         channel = self.get_channel_or_raise()
-        hs_color = kwargs.get(ATTR_HS_COLOR, (0.0, 0.0))
-        hue = hs_color[0] % 360.0
-        saturation = hs_color[1] / 100.0
         dim_level = round(kwargs.get(ATTR_BRIGHTNESS, 255) / 255.0, 2)
-
-        if ATTR_HS_COLOR not in kwargs:
-            hue = channel.hue
-            saturation = channel.saturationLevel
 
         if ATTR_BRIGHTNESS not in kwargs:
             # If no brightness is set, use the current brightness
             dim_level = channel.dimLevel or 1.0
+
+        # Use dim-only method for monochrome mode (hue/saturation not supported)
+        if not self._supports_color():
+            await channel.set_dim_level_async(dim_level=dim_level)
+            return
+
+        # Full color mode with hue/saturation
+        if ATTR_HS_COLOR in kwargs:
+            hs_color = kwargs[ATTR_HS_COLOR]
+            hue = hs_color[0] % 360.0
+            saturation = hs_color[1] / 100.0
+        else:
+            hue = channel.hue
+            saturation = channel.saturationLevel
+
         await channel.set_hue_saturation_dim_level_async(
             hue=hue, saturation_level=saturation, dim_level=dim_level
         )

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -55,7 +55,7 @@ async def async_setup_entry(
     entities: list[HomematicipGenericEntity] = []
 
     entities.extend(
-        HomematicipLightHS(hap, d, ch.index)
+        HomematicipColorLight(hap, d, ch.index)
         for d in hap.home.devices
         for ch in d.functionalChannels
         if ch.functionalChannelType == FunctionalChannelType.UNIVERSAL_LIGHT_CHANNEL
@@ -136,8 +136,8 @@ class HomematicipLight(HomematicipGenericEntity, LightEntity):
         await self._device.turn_off_async()
 
 
-class HomematicipLightHS(HomematicipGenericEntity, LightEntity):
-    """Representation of the HomematicIP light with HS color mode."""
+class HomematicipColorLight(HomematicipGenericEntity, LightEntity):
+    """Representation of the HomematicIP color light."""
 
     def __init__(self, hap: HomematicipHAP, device: Device, channel_index: int) -> None:
         """Initialize the light entity."""

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -694,15 +694,11 @@ async def test_hmip_light_hs_monochrome(
     )
 
     # Simulate monochrome mode by setting hue and saturationLevel to None
-    await async_manipulate_test_data(
-        hass, hmip_device, "hue", None, channel=1
-    )
+    await async_manipulate_test_data(hass, hmip_device, "hue", None, channel=1)
     await async_manipulate_test_data(
         hass, hmip_device, "saturationLevel", None, channel=1
     )
-    await async_manipulate_test_data(
-        hass, hmip_device, "dimLevel", 0.5, channel=1
-    )
+    await async_manipulate_test_data(hass, hmip_device, "dimLevel", 0.5, channel=1)
 
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_ON
@@ -719,10 +715,7 @@ async def test_hmip_light_hs_monochrome(
         blocking=True,
     )
     assert len(hmip_device.functionalChannels[1].mock_calls) == service_call_counter + 1
-    assert (
-        hmip_device.functionalChannels[1].mock_calls[-1][0]
-        == "set_dim_level_async"
-    )
+    assert hmip_device.functionalChannels[1].mock_calls[-1][0] == "set_dim_level_async"
     assert hmip_device.functionalChannels[1].mock_calls[-1][2] == {
         "dim_level": 0.78,
     }

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -678,6 +678,56 @@ async def test_hmip_light_hs(
     }
 
 
+async def test_hmip_light_hs_monochrome(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
+    """Test HomematicipLight with monochrome mode (no hue/saturation support)."""
+    entity_id = "light.rgbw_controller_channel1"
+    entity_name = "RGBW Controller Channel1"
+    device_model = "HmIP-RGBW"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["RGBW Controller"]
+    )
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, mock_hap, entity_id, entity_name, device_model
+    )
+
+    # Simulate monochrome mode by setting hue and saturationLevel to None
+    await async_manipulate_test_data(
+        hass, hmip_device, "hue", None, channel=1
+    )
+    await async_manipulate_test_data(
+        hass, hmip_device, "saturationLevel", None, channel=1
+    )
+    await async_manipulate_test_data(
+        hass, hmip_device, "dimLevel", 0.5, channel=1
+    )
+
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == STATE_ON
+    assert ha_state.attributes[ATTR_COLOR_MODE] == ColorMode.BRIGHTNESS
+    assert ha_state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.BRIGHTNESS]
+
+    service_call_counter = len(hmip_device.functionalChannels[1].mock_calls)
+
+    # Test turning on in monochrome mode - should use set_dim_level_async
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": entity_id, ATTR_BRIGHTNESS: 200},
+        blocking=True,
+    )
+    assert len(hmip_device.functionalChannels[1].mock_calls) == service_call_counter + 1
+    assert (
+        hmip_device.functionalChannels[1].mock_calls[-1][0]
+        == "set_dim_level_async"
+    )
+    assert hmip_device.functionalChannels[1].mock_calls[-1][2] == {
+        "dim_level": 0.78,
+    }
+
+
 async def test_hmip_wired_push_button_led(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:


### PR DESCRIPTION
## Proposed change

Fix HmIP-RGBW LED controller error when used in monochrome mode (single white channels).

The HmIP-RGBW supports 4 operating modes (monochrome, tunable white, RGB, RGBW). In monochrome mode, `hue` and `saturationLevel` are `None`, but the integration was calling `set_hue_saturation_dim_level_async` with these `None` values, causing a 400 `FEATURE_NOT_SUPPORTED` error from the API.

This fix detects monochrome mode and uses `set_dim_level_async` instead, and dynamically sets `color_mode` based on device capabilities.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #154634, fixes #159778
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr