### PR TITLE
Fix mired warning in template light

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -16,6 +16,8 @@ from homeassistant.components.light import (
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
     ATTR_TRANSITION,
+    DEFAULT_MAX_KELVIN,
+    DEFAULT_MIN_KELVIN,
     DOMAIN as LIGHT_DOMAIN,
     ENTITY_ID_FORMAT,
     PLATFORM_SCHEMA as LIGHT_PLATFORM_SCHEMA,
@@ -265,6 +267,8 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
 
     _entity_id_format = ENTITY_ID_FORMAT
     _optimistic_entity = True
+    _attr_max_color_temp_kelvin = DEFAULT_MAX_KELVIN
+    _attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
 
     # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
     # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
@@ -464,9 +468,9 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
         ):
             kelvin = kwargs[ATTR_COLOR_TEMP_KELVIN]
             common_params[ATTR_COLOR_TEMP_KELVIN] = kelvin
-            common_params[ATTR_COLOR_TEMP] = (
-                color_util.color_temperature_kelvin_to_mired(kelvin)
-            )
+            # common_params[ATTR_COLOR_TEMP] = (
+            #    color_util.color_temperature_kelvin_to_mired(kelvin)
+            # )
 
             return (script, common_params)
 
@@ -856,7 +860,7 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
 
         try:
             if render in (None, "None", ""):
-                self._attr_min_color_temp_kelvin = None
+                self._attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
                 return
 
             self._attr_min_color_temp_kelvin = (
@@ -867,14 +871,14 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
                 "Template must supply an integer temperature within the range for"
                 " this light, or 'None'"
             )
-            self._attr_min_color_temp_kelvin = None
+            self._attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
 
     @callback
     def _update_min_mireds(self, render):
         """Update the min mireds from the template."""
         try:
             if render in (None, "None", ""):
-                self._attr_max_color_temp_kelvin = None
+                self._attr_max_color_temp_kelvin = DEFAULT_MAX_KELVIN
                 return
 
             self._attr_max_color_temp_kelvin = (
@@ -885,7 +889,7 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
                 "Template must supply an integer temperature within the range for"
                 " this light, or 'None'"
             )
-            self._attr_max_color_temp_kelvin = None
+            self._attr_max_color_temp_kelvin = DEFAULT_MAX_KELVIN
 
     @callback
     def _update_supports_transition(self, render):

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -468,9 +468,9 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
         ):
             kelvin = kwargs[ATTR_COLOR_TEMP_KELVIN]
             common_params[ATTR_COLOR_TEMP_KELVIN] = kelvin
-            # common_params[ATTR_COLOR_TEMP] = (
-            #    color_util.color_temperature_kelvin_to_mired(kelvin)
-            # )
+            common_params[ATTR_COLOR_TEMP] = (
+                color_util.color_temperature_kelvin_to_mired(kelvin)
+            )
 
             return (script, common_params)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The defaults need to be set explicitly, as the light platform falls back to deprecated mired if min/max kelvin is set to `None`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #158032
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
