### PR TITLE
Add Matter lock API and user management support - Phase 1

### DIFF
--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
-from functools import wraps
-from typing import Any, Concatenate
+from typing import Any
 
 from matter_server.client.models.node import MatterNode
-from matter_server.common.errors import MatterError
 from matter_server.common.helpers.util import dataclass_to_dict
 import voluptuous as vol
 
@@ -16,14 +13,15 @@ from homeassistant.components.websocket_api import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
 
 from .adapter import MatterAdapter
-from .helpers import MissingNode, get_matter, node_from_ha_device_id
-
-ID = "id"
-TYPE = "type"
-DEVICE_ID = "device_id"
-
-
-ERROR_NODE_NOT_FOUND = "node_not_found"
+from .api_base import (
+    DEVICE_ID,
+    ID,
+    TYPE,
+    async_get_matter_adapter,
+    async_get_node,
+    async_handle_failed_command,
+)
+from .api_lock import async_register_lock_api
 
 
 @callback
@@ -38,87 +36,8 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_open_commissioning_window)
     websocket_api.async_register_command(hass, websocket_remove_matter_fabric)
     websocket_api.async_register_command(hass, websocket_interview_node)
-
-
-def async_get_node(
-    func: Callable[
-        [HomeAssistant, ActiveConnection, dict[str, Any], MatterAdapter, MatterNode],
-        Coroutine[Any, Any, None],
-    ],
-) -> Callable[
-    [HomeAssistant, ActiveConnection, dict[str, Any], MatterAdapter],
-    Coroutine[Any, Any, None],
-]:
-    """Decorate async function to get node."""
-
-    @wraps(func)
-    async def async_get_node_func(
-        hass: HomeAssistant,
-        connection: ActiveConnection,
-        msg: dict[str, Any],
-        matter: MatterAdapter,
-    ) -> None:
-        """Provide user specific data and store to function."""
-        node = node_from_ha_device_id(hass, msg[DEVICE_ID])
-        if not node:
-            raise MissingNode(
-                f"Could not resolve Matter node from device id {msg[DEVICE_ID]}"
-            )
-        await func(hass, connection, msg, matter, node)
-
-    return async_get_node_func
-
-
-def async_get_matter_adapter(
-    func: Callable[
-        [HomeAssistant, ActiveConnection, dict[str, Any], MatterAdapter],
-        Coroutine[Any, Any, None],
-    ],
-) -> Callable[
-    [HomeAssistant, ActiveConnection, dict[str, Any]], Coroutine[Any, Any, None]
-]:
-    """Decorate function to get the MatterAdapter."""
-
-    @wraps(func)
-    async def _get_matter(
-        hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
-    ) -> None:
-        """Provide the Matter client to the function."""
-        matter = get_matter(hass)
-
-        await func(hass, connection, msg, matter)
-
-    return _get_matter
-
-
-def async_handle_failed_command[**_P](
-    func: Callable[
-        Concatenate[HomeAssistant, ActiveConnection, dict[str, Any], _P],
-        Coroutine[Any, Any, None],
-    ],
-) -> Callable[
-    Concatenate[HomeAssistant, ActiveConnection, dict[str, Any], _P],
-    Coroutine[Any, Any, None],
-]:
-    """Decorate function to handle MatterError and send relevant error."""
-
-    @wraps(func)
-    async def async_handle_failed_command_func(
-        hass: HomeAssistant,
-        connection: ActiveConnection,
-        msg: dict[str, Any],
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> None:
-        """Handle MatterError within function and send relevant error."""
-        try:
-            await func(hass, connection, msg, *args, **kwargs)
-        except MatterError as err:
-            connection.send_error(msg[ID], str(err.error_code), err.args[0])
-        except MissingNode as err:
-            connection.send_error(msg[ID], ERROR_NODE_NOT_FOUND, err.args[0])
-
-    return async_handle_failed_command_func
+    # Register lock user management commands
+    async_register_lock_api(hass)
 
 
 @websocket_api.require_admin

--- a/homeassistant/components/matter/api_base.py
+++ b/homeassistant/components/matter/api_base.py
@@ -1,0 +1,103 @@
+"""Shared decorators and utilities for Matter WebSocket API."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from functools import wraps
+from typing import Any, Concatenate
+
+from matter_server.client.models.node import MatterNode
+from matter_server.common.errors import MatterError
+
+from homeassistant.components.websocket_api import ActiveConnection
+from homeassistant.core import HomeAssistant
+
+from .adapter import MatterAdapter
+from .helpers import MissingNode, get_matter, node_from_ha_device_id
+
+ID = "id"
+TYPE = "type"
+DEVICE_ID = "device_id"
+
+ERROR_NODE_NOT_FOUND = "node_not_found"
+
+
+def async_get_node(
+    func: Callable[
+        [HomeAssistant, ActiveConnection, dict[str, Any], MatterAdapter, MatterNode],
+        Coroutine[Any, Any, None],
+    ],
+) -> Callable[
+    [HomeAssistant, ActiveConnection, dict[str, Any], MatterAdapter],
+    Coroutine[Any, Any, None],
+]:
+    """Decorate async function to get node."""
+
+    @wraps(func)
+    async def async_get_node_func(
+        hass: HomeAssistant,
+        connection: ActiveConnection,
+        msg: dict[str, Any],
+        matter: MatterAdapter,
+    ) -> None:
+        """Provide user specific data and store to function."""
+        node = node_from_ha_device_id(hass, msg[DEVICE_ID])
+        if not node:
+            raise MissingNode(
+                f"Could not resolve Matter node from device id {msg[DEVICE_ID]}"
+            )
+        await func(hass, connection, msg, matter, node)
+
+    return async_get_node_func
+
+
+def async_get_matter_adapter(
+    func: Callable[
+        [HomeAssistant, ActiveConnection, dict[str, Any], MatterAdapter],
+        Coroutine[Any, Any, None],
+    ],
+) -> Callable[
+    [HomeAssistant, ActiveConnection, dict[str, Any]], Coroutine[Any, Any, None]
+]:
+    """Decorate function to get the MatterAdapter."""
+
+    @wraps(func)
+    async def _get_matter(
+        hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
+    ) -> None:
+        """Provide the Matter client to the function."""
+        matter = get_matter(hass)
+
+        await func(hass, connection, msg, matter)
+
+    return _get_matter
+
+
+def async_handle_failed_command[**_P](
+    func: Callable[
+        Concatenate[HomeAssistant, ActiveConnection, dict[str, Any], _P],
+        Coroutine[Any, Any, None],
+    ],
+) -> Callable[
+    Concatenate[HomeAssistant, ActiveConnection, dict[str, Any], _P],
+    Coroutine[Any, Any, None],
+]:
+    """Decorate function to handle MatterError and send relevant error."""
+
+    @wraps(func)
+    async def async_handle_failed_command_func(
+        hass: HomeAssistant,
+        connection: ActiveConnection,
+        msg: dict[str, Any],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> None:
+        """Handle MatterError within function and send relevant error."""
+        try:
+            await func(hass, connection, msg, *args, **kwargs)
+        except MatterError as err:
+            connection.send_error(msg[ID], str(err.error_code), err.args[0])
+        except MissingNode as err:
+            connection.send_error(msg[ID], ERROR_NODE_NOT_FOUND, err.args[0])
+
+    return async_handle_failed_command_func

--- a/homeassistant/components/matter/api_lock.py
+++ b/homeassistant/components/matter/api_lock.py
@@ -1,0 +1,768 @@
+"""WebSocket API for Matter lock user management."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from functools import wraps
+import logging
+from typing import Any, Concatenate
+
+from chip.clusters import Objects as clusters
+from matter_server.client.models.node import MatterNode
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.components.websocket_api import ActiveConnection
+from homeassistant.core import HomeAssistant, callback
+
+from .adapter import MatterAdapter
+from .api_base import (
+    DEVICE_ID,
+    ID,
+    TYPE,
+    async_get_matter_adapter,
+    async_get_node,
+    async_handle_failed_command,
+)
+from .const import (
+    ATTR_CREDENTIAL_RULE,
+    ATTR_MAX_CREDENTIALS_PER_USER,
+    ATTR_MAX_PIN_USERS,
+    ATTR_MAX_RFID_USERS,
+    ATTR_MAX_USERS,
+    ATTR_SUPPORTS_USER_MGMT,
+    ATTR_USER_INDEX,
+    ATTR_USER_NAME,
+    ATTR_USER_STATUS,
+    ATTR_USER_TYPE,
+    ATTR_USER_UNIQUE_ID,
+    CRED_TYPE_FACE,
+    CRED_TYPE_FINGERPRINT,
+    CRED_TYPE_PIN,
+    CRED_TYPE_RFID,
+    CREDENTIAL_RULE_MAP,
+    CREDENTIAL_RULE_REVERSE_MAP,
+    CREDENTIAL_TYPE_MAP,
+    ERR_LOCK_NOT_FOUND,
+    ERR_NO_AVAILABLE_SLOTS,
+    ERR_USER_ALREADY_EXISTS,
+    ERR_USER_NOT_FOUND,
+    ERR_USR_NOT_SUPPORTED,
+    USER_STATUS_MAP,
+    USER_STATUS_REVERSE_MAP,
+    USER_TYPE_MAP,
+    USER_TYPE_REVERSE_MAP,
+)
+from .helpers_lock import (
+    DoorLockFeature,
+    get_lock_endpoint_from_node,
+    lock_supports_holiday_schedules,
+    lock_supports_usr_feature,
+    lock_supports_week_day_schedules,
+    lock_supports_year_day_schedules,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LockNotFound(Exception):
+    """Exception raised when a lock endpoint is not found on a node."""
+
+
+class UsrNotSupported(Exception):
+    """Exception raised when lock does not support USR feature."""
+
+
+def async_handle_lock_errors[**_P](
+    func: Callable[
+        Concatenate[HomeAssistant, ActiveConnection, dict[str, Any], _P],
+        Coroutine[Any, Any, None],
+    ],
+) -> Callable[
+    Concatenate[HomeAssistant, ActiveConnection, dict[str, Any], _P],
+    Coroutine[Any, Any, None],
+]:
+    """Decorate function to handle lock-specific errors."""
+
+    @wraps(func)
+    async def async_handle_lock_errors_func(
+        hass: HomeAssistant,
+        connection: ActiveConnection,
+        msg: dict[str, Any],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> None:
+        """Handle lock-specific errors."""
+        try:
+            await func(hass, connection, msg, *args, **kwargs)
+        except LockNotFound:
+            connection.send_error(
+                msg[ID], ERR_LOCK_NOT_FOUND, "No lock endpoint found on this device"
+            )
+        except UsrNotSupported:
+            connection.send_error(
+                msg[ID],
+                ERR_USR_NOT_SUPPORTED,
+                "Lock does not support user/credential management",
+            )
+
+    return async_handle_lock_errors_func
+
+
+def _get_supported_credential_types(feature_map: int) -> list[str]:
+    """Get list of supported credential types from feature map."""
+    types = []
+    if feature_map & DoorLockFeature.kPinCredential:
+        types.append(CRED_TYPE_PIN)
+    if feature_map & DoorLockFeature.kRfidCredential:
+        types.append(CRED_TYPE_RFID)
+    if feature_map & DoorLockFeature.kFingerCredentials:
+        types.append(CRED_TYPE_FINGERPRINT)
+    if feature_map & DoorLockFeature.kFaceCredentials:
+        types.append(CRED_TYPE_FACE)
+    return types
+
+
+def _get_attr(obj: Any, attr: str) -> Any:
+    """Get attribute from object or dict.
+
+    Matter SDK responses can be either dataclass objects or dicts depending on
+    the SDK version and serialization context.
+    """
+    if isinstance(obj, dict):
+        return obj.get(attr)
+    return getattr(obj, attr, None)
+
+
+def _format_user_response(user_data: Any) -> dict[str, Any] | None:
+    """Format GetUser response to API response format.
+
+    Returns None if the user slot is empty (no userStatus).
+    """
+    if user_data is None:
+        return None
+
+    user_status = _get_attr(user_data, "userStatus")
+    if user_status is None:
+        return None
+
+    credentials = []
+    creds = _get_attr(user_data, "credentials")
+    if creds:
+        for cred in creds:
+            cred_type = _get_attr(cred, "credentialType")
+            cred_index = _get_attr(cred, "credentialIndex")
+            credentials.append(
+                {
+                    "type": CREDENTIAL_TYPE_MAP.get(cred_type, "unknown"),
+                    "index": cred_index,
+                }
+            )
+
+    return {
+        ATTR_USER_INDEX: _get_attr(user_data, "userIndex"),
+        ATTR_USER_NAME: _get_attr(user_data, "userName"),
+        ATTR_USER_UNIQUE_ID: _get_attr(user_data, "userUniqueID"),
+        ATTR_USER_STATUS: USER_STATUS_MAP.get(user_status, "unknown"),
+        ATTR_USER_TYPE: USER_TYPE_MAP.get(_get_attr(user_data, "userType"), "unknown"),
+        ATTR_CREDENTIAL_RULE: CREDENTIAL_RULE_MAP.get(
+            _get_attr(user_data, "credentialRule"), "unknown"
+        ),
+        "credentials": credentials,
+        "next_user_index": _get_attr(user_data, "nextUserIndex"),
+    }
+
+
+@callback
+def async_register_lock_api(hass: HomeAssistant) -> None:
+    """Register lock user management API endpoints."""
+    websocket_api.async_register_command(hass, websocket_get_lock_info)
+    websocket_api.async_register_command(hass, websocket_add_lock_user)
+    websocket_api.async_register_command(hass, websocket_update_lock_user)
+    websocket_api.async_register_command(hass, websocket_set_lock_user)
+    websocket_api.async_register_command(hass, websocket_get_lock_user)
+    websocket_api.async_register_command(hass, websocket_get_lock_users)
+    websocket_api.async_register_command(hass, websocket_clear_lock_user)
+
+
+# --- Lock information ---
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "matter/lock/get_lock_info",
+        vol.Required(DEVICE_ID): str,
+    }
+)
+@websocket_api.async_response
+@async_handle_lock_errors
+@async_handle_failed_command
+@async_get_matter_adapter
+@async_get_node
+async def websocket_get_lock_info(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    matter: MatterAdapter,
+    node: MatterNode,
+) -> None:
+    """Get lock capabilities and configuration info."""
+    lock_endpoint = get_lock_endpoint_from_node(node)
+    if lock_endpoint is None:
+        raise LockNotFound
+
+    supports_usr = lock_supports_usr_feature(lock_endpoint)
+
+    # Get feature map for credential type detection
+    feature_map = (
+        lock_endpoint.get_attribute_value(None, clusters.DoorLock.Attributes.FeatureMap)
+        or 0
+    )
+
+    result: dict[str, Any] = {
+        ATTR_SUPPORTS_USER_MGMT: supports_usr,
+        "supported_credential_types": _get_supported_credential_types(feature_map),
+    }
+
+    # Only include capacity info if USR feature is supported
+    if supports_usr:
+        result[ATTR_MAX_USERS] = lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.NumberOfTotalUsersSupported
+        )
+        result[ATTR_MAX_PIN_USERS] = lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.NumberOfPINUsersSupported
+        )
+        result[ATTR_MAX_RFID_USERS] = lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.NumberOfRFIDUsersSupported
+        )
+        result[ATTR_MAX_CREDENTIALS_PER_USER] = lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.NumberOfCredentialsSupportedPerUser
+        )
+        result["min_pin_length"] = lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.MinPINCodeLength
+        )
+        result["max_pin_length"] = lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.MaxPINCodeLength
+        )
+        result["min_rfid_length"] = lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.MinRFIDCodeLength
+        )
+        result["max_rfid_length"] = lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.MaxRFIDCodeLength
+        )
+
+    # Schedule feature support and capacity (informational)
+    result["supports_week_day_schedules"] = lock_supports_week_day_schedules(
+        lock_endpoint
+    )
+    result["supports_year_day_schedules"] = lock_supports_year_day_schedules(
+        lock_endpoint
+    )
+    result["supports_holiday_schedules"] = lock_supports_holiday_schedules(
+        lock_endpoint
+    )
+
+    result["max_week_day_schedules_per_user"] = (
+        lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.NumberOfWeekDaySchedulesSupportedPerUser
+        )
+        if result["supports_week_day_schedules"]
+        else 0
+    )
+    result["max_year_day_schedules_per_user"] = (
+        lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.NumberOfYearDaySchedulesSupportedPerUser
+        )
+        if result["supports_year_day_schedules"]
+        else 0
+    )
+    result["max_holiday_schedules"] = (
+        lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.NumberOfHolidaySchedulesSupported
+        )
+        if result["supports_holiday_schedules"]
+        else 0
+    )
+
+    connection.send_result(msg[ID], result)
+
+
+# --- User CRUD operations ---
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "matter/lock/add_user",
+        vol.Required(DEVICE_ID): str,
+        vol.Required(ATTR_USER_INDEX): vol.All(vol.Coerce(int), vol.Range(min=1)),
+        vol.Optional(ATTR_USER_NAME): vol.Any(str, None),
+        vol.Optional(ATTR_USER_UNIQUE_ID): vol.Any(vol.Coerce(int), None),
+        vol.Optional(ATTR_USER_TYPE, default="unrestricted_user"): vol.In(
+            USER_TYPE_REVERSE_MAP.keys()
+        ),
+        vol.Optional(ATTR_CREDENTIAL_RULE, default="single"): vol.In(
+            CREDENTIAL_RULE_REVERSE_MAP.keys()
+        ),
+    }
+)
+@websocket_api.async_response
+@async_handle_lock_errors
+@async_handle_failed_command
+@async_get_matter_adapter
+@async_get_node
+async def websocket_add_lock_user(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    matter: MatterAdapter,
+    node: MatterNode,
+) -> None:
+    """Add a new user to the lock at a specific index."""
+    lock_endpoint = get_lock_endpoint_from_node(node)
+    if lock_endpoint is None:
+        raise LockNotFound
+
+    if not lock_supports_usr_feature(lock_endpoint):
+        raise UsrNotSupported
+
+    # Check if user slot is already occupied
+    get_user_response = await matter.matter_client.send_device_command(
+        node_id=node.node_id,
+        endpoint_id=lock_endpoint.endpoint_id,
+        command=clusters.DoorLock.Commands.GetUser(
+            userIndex=msg[ATTR_USER_INDEX],
+        ),
+    )
+
+    if _get_attr(get_user_response, "userStatus") is not None:
+        connection.send_error(
+            msg[ID],
+            ERR_USER_ALREADY_EXISTS,
+            f"User slot {msg[ATTR_USER_INDEX]} is already occupied",
+        )
+        return
+
+    await matter.matter_client.send_device_command(
+        node_id=node.node_id,
+        endpoint_id=lock_endpoint.endpoint_id,
+        command=clusters.DoorLock.Commands.SetUser(
+            operationType=clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd,
+            userIndex=msg[ATTR_USER_INDEX],
+            userName=msg.get(ATTR_USER_NAME),
+            userUniqueID=msg.get(ATTR_USER_UNIQUE_ID),
+            userStatus=clusters.DoorLock.Enums.UserStatusEnum.kOccupiedEnabled,
+            userType=USER_TYPE_REVERSE_MAP.get(
+                msg.get(ATTR_USER_TYPE, "unrestricted_user"), 0
+            ),
+            credentialRule=CREDENTIAL_RULE_REVERSE_MAP.get(
+                msg.get(ATTR_CREDENTIAL_RULE, "single"), 0
+            ),
+        ),
+        timed_request_timeout_ms=1000,
+    )
+
+    connection.send_result(msg[ID], {ATTR_USER_INDEX: msg[ATTR_USER_INDEX]})
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "matter/lock/update_user",
+        vol.Required(DEVICE_ID): str,
+        vol.Required(ATTR_USER_INDEX): vol.All(vol.Coerce(int), vol.Range(min=1)),
+        vol.Optional(ATTR_USER_NAME): vol.Any(str, None),
+        vol.Optional(ATTR_USER_UNIQUE_ID): vol.Any(vol.Coerce(int), None),
+        vol.Optional(ATTR_USER_STATUS): vol.In(
+            ["occupied_enabled", "occupied_disabled"]
+        ),
+        vol.Optional(ATTR_USER_TYPE): vol.In(USER_TYPE_REVERSE_MAP.keys()),
+        vol.Optional(ATTR_CREDENTIAL_RULE): vol.In(CREDENTIAL_RULE_REVERSE_MAP.keys()),
+    }
+)
+@websocket_api.async_response
+@async_handle_lock_errors
+@async_handle_failed_command
+@async_get_matter_adapter
+@async_get_node
+async def websocket_update_lock_user(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    matter: MatterAdapter,
+    node: MatterNode,
+) -> None:
+    """Update an existing user on the lock."""
+    lock_endpoint = get_lock_endpoint_from_node(node)
+    if lock_endpoint is None:
+        raise LockNotFound
+
+    if not lock_supports_usr_feature(lock_endpoint):
+        raise UsrNotSupported
+
+    get_user_response = await matter.matter_client.send_device_command(
+        node_id=node.node_id,
+        endpoint_id=lock_endpoint.endpoint_id,
+        command=clusters.DoorLock.Commands.GetUser(
+            userIndex=msg[ATTR_USER_INDEX],
+        ),
+    )
+
+    if _get_attr(get_user_response, "userStatus") is None:
+        connection.send_error(
+            msg[ID],
+            ERR_USER_NOT_FOUND,
+            f"User slot {msg[ATTR_USER_INDEX]} is empty",
+        )
+        return
+
+    # Preserve existing values for fields not specified in the update
+    user_name = msg.get(ATTR_USER_NAME, _get_attr(get_user_response, "userName"))
+    user_unique_id = msg.get(
+        ATTR_USER_UNIQUE_ID, _get_attr(get_user_response, "userUniqueID")
+    )
+
+    user_status = _get_attr(get_user_response, "userStatus")
+    if ATTR_USER_STATUS in msg:
+        user_status = USER_STATUS_REVERSE_MAP.get(msg[ATTR_USER_STATUS], user_status)
+
+    user_type = _get_attr(get_user_response, "userType")
+    if ATTR_USER_TYPE in msg:
+        user_type = USER_TYPE_REVERSE_MAP.get(msg[ATTR_USER_TYPE], user_type)
+
+    credential_rule = _get_attr(get_user_response, "credentialRule")
+    if ATTR_CREDENTIAL_RULE in msg:
+        credential_rule = CREDENTIAL_RULE_REVERSE_MAP.get(
+            msg[ATTR_CREDENTIAL_RULE], credential_rule
+        )
+
+    await matter.matter_client.send_device_command(
+        node_id=node.node_id,
+        endpoint_id=lock_endpoint.endpoint_id,
+        command=clusters.DoorLock.Commands.SetUser(
+            operationType=clusters.DoorLock.Enums.DataOperationTypeEnum.kModify,
+            userIndex=msg[ATTR_USER_INDEX],
+            userName=user_name,
+            userUniqueID=user_unique_id,
+            userStatus=user_status,
+            userType=user_type,
+            credentialRule=credential_rule,
+        ),
+        timed_request_timeout_ms=1000,
+    )
+
+    connection.send_result(msg[ID], {ATTR_USER_INDEX: msg[ATTR_USER_INDEX]})
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "matter/lock/set_user",
+        vol.Required(DEVICE_ID): str,
+        vol.Optional(ATTR_USER_INDEX): vol.Any(
+            vol.All(vol.Coerce(int), vol.Range(min=1)), None
+        ),
+        vol.Optional(ATTR_USER_NAME): vol.Any(str, None),
+        vol.Optional(ATTR_USER_UNIQUE_ID): vol.Any(vol.Coerce(int), None),
+        vol.Optional(ATTR_USER_STATUS, default="occupied_enabled"): vol.In(
+            ["occupied_enabled", "occupied_disabled"]
+        ),
+        vol.Optional(ATTR_USER_TYPE, default="unrestricted_user"): vol.In(
+            USER_TYPE_REVERSE_MAP.keys()
+        ),
+        vol.Optional(ATTR_CREDENTIAL_RULE, default="single"): vol.In(
+            CREDENTIAL_RULE_REVERSE_MAP.keys()
+        ),
+    }
+)
+@websocket_api.async_response
+@async_handle_lock_errors
+@async_handle_failed_command
+@async_get_matter_adapter
+@async_get_node
+async def websocket_set_lock_user(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    matter: MatterAdapter,
+    node: MatterNode,
+) -> None:
+    """Add or update a user on the lock.
+
+    If user_index is null, finds the first available slot and creates a new user.
+    If user_index is provided, updates the existing user at that index.
+    """
+    lock_endpoint = get_lock_endpoint_from_node(node)
+    if lock_endpoint is None:
+        raise LockNotFound
+
+    if not lock_supports_usr_feature(lock_endpoint):
+        raise UsrNotSupported
+
+    user_index = msg.get(ATTR_USER_INDEX)
+
+    if user_index is None:
+        # Adding new user - find first available slot
+        max_users = (
+            lock_endpoint.get_attribute_value(
+                None, clusters.DoorLock.Attributes.NumberOfTotalUsersSupported
+            )
+            or 0
+        )
+
+        for idx in range(1, max_users + 1):
+            get_user_response = await matter.matter_client.send_device_command(
+                node_id=node.node_id,
+                endpoint_id=lock_endpoint.endpoint_id,
+                command=clusters.DoorLock.Commands.GetUser(userIndex=idx),
+            )
+            if _get_attr(get_user_response, "userStatus") is None:
+                user_index = idx
+                break
+
+        if user_index is None:
+            connection.send_error(
+                msg[ID],
+                ERR_NO_AVAILABLE_SLOTS,
+                "No available user slots on the lock",
+            )
+            return
+
+        user_status_enum = (
+            clusters.DoorLock.Enums.UserStatusEnum.kOccupiedEnabled
+            if msg.get(ATTR_USER_STATUS) == "occupied_enabled"
+            else clusters.DoorLock.Enums.UserStatusEnum.kOccupiedDisabled
+        )
+
+        await matter.matter_client.send_device_command(
+            node_id=node.node_id,
+            endpoint_id=lock_endpoint.endpoint_id,
+            command=clusters.DoorLock.Commands.SetUser(
+                operationType=clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd,
+                userIndex=user_index,
+                userName=msg.get(ATTR_USER_NAME),
+                userUniqueID=msg.get(ATTR_USER_UNIQUE_ID),
+                userStatus=user_status_enum,
+                userType=USER_TYPE_REVERSE_MAP.get(
+                    msg.get(ATTR_USER_TYPE, "unrestricted_user"), 0
+                ),
+                credentialRule=CREDENTIAL_RULE_REVERSE_MAP.get(
+                    msg.get(ATTR_CREDENTIAL_RULE, "single"), 0
+                ),
+            ),
+            timed_request_timeout_ms=1000,
+        )
+    else:
+        # Updating existing user
+        get_user_response = await matter.matter_client.send_device_command(
+            node_id=node.node_id,
+            endpoint_id=lock_endpoint.endpoint_id,
+            command=clusters.DoorLock.Commands.GetUser(userIndex=user_index),
+        )
+
+        if _get_attr(get_user_response, "userStatus") is None:
+            connection.send_error(
+                msg[ID],
+                ERR_USER_NOT_FOUND,
+                f"User slot {user_index} is empty",
+            )
+            return
+
+        user_name = msg.get(ATTR_USER_NAME, _get_attr(get_user_response, "userName"))
+        user_unique_id = msg.get(
+            ATTR_USER_UNIQUE_ID, _get_attr(get_user_response, "userUniqueID")
+        )
+
+        user_status = _get_attr(get_user_response, "userStatus")
+        if ATTR_USER_STATUS in msg:
+            user_status = USER_STATUS_REVERSE_MAP.get(
+                msg[ATTR_USER_STATUS], user_status
+            )
+
+        user_type = _get_attr(get_user_response, "userType")
+        if ATTR_USER_TYPE in msg:
+            user_type = USER_TYPE_REVERSE_MAP.get(msg[ATTR_USER_TYPE], user_type)
+
+        credential_rule = _get_attr(get_user_response, "credentialRule")
+        if ATTR_CREDENTIAL_RULE in msg:
+            credential_rule = CREDENTIAL_RULE_REVERSE_MAP.get(
+                msg[ATTR_CREDENTIAL_RULE], credential_rule
+            )
+
+        await matter.matter_client.send_device_command(
+            node_id=node.node_id,
+            endpoint_id=lock_endpoint.endpoint_id,
+            command=clusters.DoorLock.Commands.SetUser(
+                operationType=clusters.DoorLock.Enums.DataOperationTypeEnum.kModify,
+                userIndex=user_index,
+                userName=user_name,
+                userUniqueID=user_unique_id,
+                userStatus=user_status,
+                userType=user_type,
+                credentialRule=credential_rule,
+            ),
+            timed_request_timeout_ms=1000,
+        )
+
+    connection.send_result(msg[ID], {ATTR_USER_INDEX: user_index})
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "matter/lock/get_user",
+        vol.Required(DEVICE_ID): str,
+        vol.Required(ATTR_USER_INDEX): vol.All(vol.Coerce(int), vol.Range(min=1)),
+    }
+)
+@websocket_api.async_response
+@async_handle_lock_errors
+@async_handle_failed_command
+@async_get_matter_adapter
+@async_get_node
+async def websocket_get_lock_user(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    matter: MatterAdapter,
+    node: MatterNode,
+) -> None:
+    """Get a single user from the lock."""
+    lock_endpoint = get_lock_endpoint_from_node(node)
+    if lock_endpoint is None:
+        raise LockNotFound
+
+    if not lock_supports_usr_feature(lock_endpoint):
+        raise UsrNotSupported
+
+    get_user_response = await matter.matter_client.send_device_command(
+        node_id=node.node_id,
+        endpoint_id=lock_endpoint.endpoint_id,
+        command=clusters.DoorLock.Commands.GetUser(
+            userIndex=msg[ATTR_USER_INDEX],
+        ),
+    )
+
+    result = _format_user_response(get_user_response)
+    if result is None:
+        connection.send_error(
+            msg[ID],
+            ERR_USER_NOT_FOUND,
+            f"User slot {msg[ATTR_USER_INDEX]} is empty",
+        )
+        return
+
+    connection.send_result(msg[ID], result)
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "matter/lock/get_users",
+        vol.Required(DEVICE_ID): str,
+    }
+)
+@websocket_api.async_response
+@async_handle_lock_errors
+@async_handle_failed_command
+@async_get_matter_adapter
+@async_get_node
+async def websocket_get_lock_users(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    matter: MatterAdapter,
+    node: MatterNode,
+) -> None:
+    """Get all users from the lock."""
+    lock_endpoint = get_lock_endpoint_from_node(node)
+    if lock_endpoint is None:
+        raise LockNotFound
+
+    if not lock_supports_usr_feature(lock_endpoint):
+        raise UsrNotSupported
+
+    max_users = (
+        lock_endpoint.get_attribute_value(
+            None, clusters.DoorLock.Attributes.NumberOfTotalUsersSupported
+        )
+        or 0
+    )
+
+    users: list[dict[str, Any]] = []
+    current_index = 1
+
+    # Iterate through users using next_user_index for efficiency
+    while current_index is not None and current_index <= max_users:
+        get_user_response = await matter.matter_client.send_device_command(
+            node_id=node.node_id,
+            endpoint_id=lock_endpoint.endpoint_id,
+            command=clusters.DoorLock.Commands.GetUser(
+                userIndex=current_index,
+            ),
+        )
+
+        user_data = _format_user_response(get_user_response)
+        if user_data is not None:
+            users.append(user_data)
+
+        # Move to next user index
+        next_index = _get_attr(get_user_response, "nextUserIndex")
+        if next_index is None or next_index <= current_index:
+            break
+        current_index = next_index
+
+    connection.send_result(
+        msg[ID],
+        {
+            "total_users": len(users),
+            "max_users": max_users,
+            "users": users,
+        },
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "matter/lock/clear_user",
+        vol.Required(DEVICE_ID): str,
+        vol.Required(ATTR_USER_INDEX): vol.All(
+            vol.Coerce(int), vol.Any(vol.Range(min=1), 0xFFFE)
+        ),
+    }
+)
+@websocket_api.async_response
+@async_handle_lock_errors
+@async_handle_failed_command
+@async_get_matter_adapter
+@async_get_node
+async def websocket_clear_lock_user(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    matter: MatterAdapter,
+    node: MatterNode,
+) -> None:
+    """Clear a user from the lock.
+
+    Use index 0xFFFE to clear all users.
+    """
+    lock_endpoint = get_lock_endpoint_from_node(node)
+    if lock_endpoint is None:
+        raise LockNotFound
+
+    if not lock_supports_usr_feature(lock_endpoint):
+        raise UsrNotSupported
+
+    await matter.matter_client.send_device_command(
+        node_id=node.node_id,
+        endpoint_id=lock_endpoint.endpoint_id,
+        command=clusters.DoorLock.Commands.ClearUser(
+            userIndex=msg[ATTR_USER_INDEX],
+        ),
+        timed_request_timeout_ms=1000,
+    )
+
+    connection.send_result(msg[ID])

--- a/homeassistant/components/matter/const.py
+++ b/homeassistant/components/matter/const.py
@@ -15,3 +15,105 @@ ID_TYPE_DEVICE_ID = "deviceid"
 ID_TYPE_SERIAL = "serial"
 
 FEATUREMAP_ATTRIBUTE_ID = 65532
+
+# --- Lock domain constants ---
+
+# Event names
+EVENT_LOCK_OPERATION = f"{DOMAIN}_lock_operation"
+EVENT_LOCK_DISPOSABLE_USER_DELETED = f"{DOMAIN}_lock_disposable_user_deleted"
+
+# Shared field keys (used across lock.py and api_lock.py)
+ATTR_USER_INDEX = "user_index"
+ATTR_USER_NAME = "user_name"
+ATTR_USER_UNIQUE_ID = "user_unique_id"
+ATTR_USER_STATUS = "user_status"
+ATTR_USER_TYPE = "user_type"
+ATTR_CREDENTIAL_RULE = "credential_rule"
+ATTR_SUPPORTS_USER_MGMT = "supports_user_management"
+ATTR_MAX_USERS = "max_users"
+ATTR_MAX_PIN_USERS = "max_pin_users"
+ATTR_MAX_RFID_USERS = "max_rfid_users"
+ATTR_MAX_CREDENTIALS_PER_USER = "max_credentials_per_user"
+
+# Error codes
+ERR_LOCK_NOT_FOUND = "lock_not_found"
+ERR_USR_NOT_SUPPORTED = "usr_not_supported"
+ERR_USER_ALREADY_EXISTS = "user_already_exists"
+ERR_USER_NOT_FOUND = "user_not_found"
+ERR_NO_AVAILABLE_SLOTS = "no_available_slots"
+
+# Credential type strings
+CRED_TYPE_PIN = "pin"
+CRED_TYPE_RFID = "rfid"
+CRED_TYPE_FINGERPRINT = "fingerprint"
+CRED_TYPE_FACE = "face"
+
+# Door lock operation source mapping (Matter DoorLock OperationSourceEnum)
+DOOR_LOCK_OPERATION_SOURCE: dict[int, str] = {
+    0: "Unspecified",
+    1: "Manual",  # [Optional]
+    2: "Proprietary Remote",  # [Optional]
+    3: "Keypad",  # [Optional]
+    4: "Auto",  # [Optional]
+    5: "Button",  # [Optional]
+    6: "Schedule",  # [HDSCH]
+    7: "Remote",  # [M]
+    8: "RFID",  # [RID]
+    9: "Biometric",  # [USR]
+    10: "Aliro",  # [Aliro]
+}
+
+# Door lock operation type mapping (Matter DoorLock LockOperationTypeEnum)
+DOOR_LOCK_OPERATION_TYPE: dict[int, str] = {
+    0: "lock",
+    1: "unlock",
+    2: "non_access_user_event",
+    3: "forced_user_event",
+    4: "unlatch",
+}
+
+# User status mapping (Matter DoorLock UserStatusEnum)
+USER_STATUS_MAP: dict[int, str] = {
+    0: "available",
+    1: "occupied_enabled",
+    3: "occupied_disabled",
+}
+USER_STATUS_REVERSE_MAP: dict[str, int] = {v: k for k, v in USER_STATUS_MAP.items()}
+
+# User type mapping (Matter DoorLock UserTypeEnum)
+USER_TYPE_MAP: dict[int, str] = {
+    0: "unrestricted_user",
+    1: "year_day_schedule_user",
+    2: "week_day_schedule_user",
+    3: "programming_user",
+    4: "non_access_user",
+    5: "forced_user",
+    6: "disposable_user",
+    7: "expiring_user",
+    8: "schedule_restricted_user",
+    9: "remote_only_user",
+}
+USER_TYPE_REVERSE_MAP: dict[str, int] = {v: k for k, v in USER_TYPE_MAP.items()}
+
+# Credential type mapping (Matter DoorLock CredentialTypeEnum)
+CREDENTIAL_TYPE_MAP: dict[int, str] = {
+    0: "programming_pin",
+    1: CRED_TYPE_PIN,
+    2: CRED_TYPE_RFID,
+    3: CRED_TYPE_FINGERPRINT,
+    4: "finger_vein",
+    5: CRED_TYPE_FACE,
+    6: "aliro_credential_issuer_key",
+    7: "aliro_evictable_endpoint_key",
+    8: "aliro_non_evictable_endpoint_key",
+}
+
+# Credential rule mapping (Matter DoorLock CredentialRuleEnum)
+CREDENTIAL_RULE_MAP: dict[int, str] = {
+    0: "single",
+    1: "dual",
+    2: "tri",
+}
+CREDENTIAL_RULE_REVERSE_MAP: dict[str, int] = {
+    v: k for k, v in CREDENTIAL_RULE_MAP.items()
+}

--- a/homeassistant/components/matter/helpers_lock.py
+++ b/homeassistant/components/matter/helpers_lock.py
@@ -1,0 +1,81 @@
+"""Lock-specific helpers for the Matter integration.
+
+Provides DoorLock cluster endpoint resolution and feature detection.
+These are separated from the general Matter helpers (helpers.py) to
+maintain single responsibility — general helpers handle node/device
+resolution while this module handles lock-specific concerns.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from chip.clusters import Objects as clusters
+
+from homeassistant.core import callback
+
+if TYPE_CHECKING:
+    from matter_server.client.models.node import MatterEndpoint, MatterNode
+
+# DoorLock Feature bitmap from Matter SDK
+DoorLockFeature = clusters.DoorLock.Bitmaps.Feature
+
+
+@callback
+def get_lock_endpoint_from_node(node: MatterNode) -> MatterEndpoint | None:
+    """Get the DoorLock endpoint from a node.
+
+    Returns the first endpoint that has the DoorLock cluster, or None if not found.
+    """
+    for endpoint in node.endpoints.values():
+        if endpoint.has_cluster(clusters.DoorLock):
+            return endpoint
+    return None
+
+
+def _get_feature_map(endpoint: MatterEndpoint) -> int | None:
+    """Read the DoorLock FeatureMap attribute from an endpoint."""
+    value: int | None = endpoint.get_attribute_value(
+        None, clusters.DoorLock.Attributes.FeatureMap
+    )
+    return value
+
+
+@callback
+def lock_supports_usr_feature(endpoint: MatterEndpoint) -> bool:
+    """Check if lock endpoint supports USR (User) feature.
+
+    The USR feature indicates the lock supports user and credential management
+    commands like SetUser, GetUser, SetCredential, etc.
+    """
+    feature_map = _get_feature_map(endpoint)
+    if feature_map is None:
+        return False
+    return bool(feature_map & DoorLockFeature.kUser)
+
+
+@callback
+def lock_supports_week_day_schedules(endpoint: MatterEndpoint) -> bool:
+    """Check if lock endpoint supports Week Day Schedules (WDSCH) feature."""
+    feature_map = _get_feature_map(endpoint)
+    if feature_map is None:
+        return False
+    return bool(feature_map & DoorLockFeature.kWeekDayAccessSchedules)
+
+
+@callback
+def lock_supports_year_day_schedules(endpoint: MatterEndpoint) -> bool:
+    """Check if lock endpoint supports Year Day Schedules (YDSCH) feature."""
+    feature_map = _get_feature_map(endpoint)
+    if feature_map is None:
+        return False
+    return bool(feature_map & DoorLockFeature.kYearDayAccessSchedules)
+
+
+@callback
+def lock_supports_holiday_schedules(endpoint: MatterEndpoint) -> bool:
+    """Check if lock endpoint supports Holiday Schedules (HDSCH) feature."""
+    feature_map = _get_feature_map(endpoint)
+    if feature_map is None:
+        return False
+    return bool(feature_map & DoorLockFeature.kHolidaySchedules)

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -15,32 +15,35 @@ from homeassistant.components.lock import (
     LockEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_CODE, Platform
+from homeassistant.const import ATTR_CODE, ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import LOGGER
+from .const import (
+    ATTR_MAX_CREDENTIALS_PER_USER,
+    ATTR_MAX_PIN_USERS,
+    ATTR_MAX_RFID_USERS,
+    ATTR_MAX_USERS,
+    ATTR_SUPPORTS_USER_MGMT,
+    ATTR_USER_INDEX,
+    ATTR_USER_NAME,
+    DOOR_LOCK_OPERATION_SOURCE,
+    DOOR_LOCK_OPERATION_TYPE,
+    EVENT_LOCK_DISPOSABLE_USER_DELETED,
+    EVENT_LOCK_OPERATION,
+    LOGGER,
+)
 from .entity import MatterEntity, MatterEntityDescription
 from .helpers import get_matter
+from .helpers_lock import DoorLockFeature
 from .models import MatterDiscoverySchema
 
-DOOR_LOCK_OPERATION_SOURCE = {
-    # mapping from operation source id's to textual representation
-    0: "Unspecified",
-    1: "Manual",  # [Optional]
-    2: "Proprietary Remote",  # [Optional]
-    3: "Keypad",  # [Optional]
-    4: "Auto",  # [Optional]
-    5: "Button",  # [Optional]
-    6: "Schedule",  # [HDSCH]
-    7: "Remote",  # [M]
-    8: "RFID",  # [RID]
-    9: "Biometric",  # [USR]
-    10: "Aliro",  # [Aliro]
-}
 
-
-DoorLockFeature = clusters.DoorLock.Bitmaps.Feature
+def _get_attr(obj: Any, attr: str) -> Any:
+    """Get attribute from object or dict."""
+    if isinstance(obj, dict):
+        return obj.get(attr)
+    return getattr(obj, attr, None)
 
 
 async def async_setup_entry(
@@ -104,12 +107,110 @@ class MatterLock(MatterEntity, LockEntity):
             case (
                 clusters.DoorLock.Events.LockOperation.event_id
             ):  # Lock cluster event 2
-                # update the changed_by attribute to indicate lock operation source
                 operation_source: int = node_event_data.get("operationSource", -1)
-                self._attr_changed_by = DOOR_LOCK_OPERATION_SOURCE.get(
-                    operation_source, "Unknown"
+                operation_type: int = node_event_data.get("lockOperationType", -1)
+                user_index = node_event_data.get("userIndex")
+
+                # Fire event and handle user lookup asynchronously
+                self.hass.async_create_task(
+                    self._handle_lock_operation(
+                        operation_source, operation_type, user_index
+                    )
                 )
-                self.async_write_ha_state()
+
+    async def _handle_lock_operation(
+        self, operation_source: int, operation_type: int, user_index: int | None
+    ) -> None:
+        """Handle lock operation event - look up user and fire event."""
+        source_name = DOOR_LOCK_OPERATION_SOURCE.get(operation_source, "Unknown")
+        operation_name = DOOR_LOCK_OPERATION_TYPE.get(operation_type, "unknown")
+        user_name: str | None = None
+
+        # Look up user name if we have a user index
+        if user_index is not None:
+            try:
+                get_user_response = await self.matter_client.send_device_command(
+                    node_id=self._endpoint.node.node_id,
+                    endpoint_id=self._endpoint.endpoint_id,
+                    command=clusters.DoorLock.Commands.GetUser(userIndex=user_index),
+                )
+                user_name = _get_attr(get_user_response, "userName")
+                user_type = _get_attr(get_user_response, "userType")
+                user_status = _get_attr(get_user_response, "userStatus")
+
+                # Clean up disposable users after use
+                # UserType 6 = disposable_user, UserStatus 3 = occupied_disabled
+                if user_type == 6 and user_status == 3:
+                    await self._cleanup_disposable_user(user_index, user_name)
+            except Exception:  # noqa: BLE001
+                LOGGER.debug(
+                    "Failed to get user info for index %s on %s",
+                    user_index,
+                    self.entity_id,
+                    exc_info=True,
+                )
+
+        # Update changed_by with user name if available, otherwise source
+        if user_name:
+            self._attr_changed_by = f"{user_name} ({source_name})"
+        else:
+            self._attr_changed_by = source_name
+        self.async_write_ha_state()
+
+        # Fire event with all details
+        event_data = {
+            ATTR_ENTITY_ID: self.entity_id,
+            "operation": operation_name,
+            "source": source_name,
+            ATTR_USER_INDEX: user_index,
+            ATTR_USER_NAME: user_name,
+        }
+        self.hass.bus.async_fire(EVENT_LOCK_OPERATION, event_data)
+        LOGGER.debug("Fired %s event: %s", EVENT_LOCK_OPERATION, event_data)
+
+    async def _cleanup_disposable_user(
+        self, user_index: int, user_name: str | None = None
+    ) -> None:
+        """Clean up a disposable user after use.
+
+        Disposable users (one-time codes) should be deleted after use.
+        Some locks disable them (status=3) instead of deleting them,
+        so we clean them up automatically.
+        """
+        try:
+            LOGGER.debug(
+                "Cleaning up disabled disposable user '%s' at index %s for %s",
+                user_name or "unknown",
+                user_index,
+                self.entity_id,
+            )
+            await self.matter_client.send_device_command(
+                node_id=self._endpoint.node.node_id,
+                endpoint_id=self._endpoint.endpoint_id,
+                command=clusters.DoorLock.Commands.ClearUser(userIndex=user_index),
+                timed_request_timeout_ms=1000,
+            )
+            LOGGER.info(
+                "Deleted disposable user '%s' at index %s after one-time use for %s",
+                user_name or "unknown",
+                user_index,
+                self.entity_id,
+            )
+            self.hass.bus.async_fire(
+                EVENT_LOCK_DISPOSABLE_USER_DELETED,
+                {
+                    ATTR_ENTITY_ID: self.entity_id,
+                    ATTR_USER_INDEX: user_index,
+                    ATTR_USER_NAME: user_name,
+                },
+            )
+        except Exception:  # noqa: BLE001
+            LOGGER.debug(
+                "Failed to cleanup disposable user at index %s for %s",
+                user_index,
+                self.entity_id,
+                exc_info=True,
+            )
 
     @property
     def code_format(self) -> str | None:
@@ -255,6 +356,32 @@ class MatterLock(MatterEntity, LockEntity):
         if bool(feature_map & DoorLockFeature.kUnbolt):
             supported_features |= LockEntityFeature.OPEN
         self._attr_supported_features = supported_features
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return entity specific state attributes for lock capabilities."""
+        supports_usr = bool((self._feature_map or 0) & DoorLockFeature.kUser)
+
+        attrs: dict[str, Any] = {
+            ATTR_SUPPORTS_USER_MGMT: supports_usr,
+        }
+
+        # Only include capacity info if USR feature is supported
+        if supports_usr:
+            attrs[ATTR_MAX_USERS] = self.get_matter_attribute_value(
+                clusters.DoorLock.Attributes.NumberOfTotalUsersSupported
+            )
+            attrs[ATTR_MAX_PIN_USERS] = self.get_matter_attribute_value(
+                clusters.DoorLock.Attributes.NumberOfPINUsersSupported
+            )
+            attrs[ATTR_MAX_RFID_USERS] = self.get_matter_attribute_value(
+                clusters.DoorLock.Attributes.NumberOfRFIDUsersSupported
+            )
+            attrs[ATTR_MAX_CREDENTIALS_PER_USER] = self.get_matter_attribute_value(
+                clusters.DoorLock.Attributes.NumberOfCredentialsSupportedPerUser
+            )
+
+        return attrs
 
 
 DISCOVERY_SCHEMAS = [

--- a/tests/components/matter/test_api_lock.py
+++ b/tests/components/matter/test_api_lock.py
@@ -1,0 +1,827 @@
+"""Test the Matter lock user management WebSocket API."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from chip.clusters import Objects as clusters
+from matter_server.client.models.node import MatterNode
+import pytest
+
+from homeassistant.components.matter.api_base import DEVICE_ID, ID, TYPE
+from homeassistant.components.matter.const import (
+    ATTR_CREDENTIAL_RULE,
+    ATTR_MAX_CREDENTIALS_PER_USER,
+    ATTR_MAX_PIN_USERS,
+    ATTR_MAX_RFID_USERS,
+    ATTR_MAX_USERS,
+    ATTR_SUPPORTS_USER_MGMT,
+    ATTR_USER_INDEX,
+    ATTR_USER_NAME,
+    ATTR_USER_STATUS,
+    ATTR_USER_TYPE,
+    ATTR_USER_UNIQUE_ID,
+    CRED_TYPE_PIN,
+    CRED_TYPE_RFID,
+    DOMAIN,
+    ERR_LOCK_NOT_FOUND,
+    ERR_NO_AVAILABLE_SLOTS,
+    ERR_USER_ALREADY_EXISTS,
+    ERR_USER_NOT_FOUND,
+    ERR_USR_NOT_SUPPORTED,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.typing import WebSocketGenerator
+
+# The door_lock fixture has node_id=1, compressed_fabric_id=1234
+# Device identifier: deviceid_{fabric_id_hex}-{node_id_hex}-MatterNodeDevice
+DOOR_LOCK_DEVICE_ID = (
+    DOMAIN,
+    "deviceid_00000000000004D2-0000000000000001-MatterNodeDevice",
+)
+
+# Feature map bits
+_FEATURE_USR = 256  # kUser (bit 8)
+_FEATURE_PIN = 1  # kPinCredential (bit 0)
+_FEATURE_RFID = 2  # kRfidCredential (bit 1)
+_FEATURE_USR_PIN_RFID = _FEATURE_USR | _FEATURE_PIN | _FEATURE_RFID  # 259
+
+
+# --- Helper to get device registry ID ---
+
+
+def _get_device_id(device_registry: dr.DeviceRegistry) -> str:
+    """Get the HA device registry ID for the door lock fixture."""
+    entry = device_registry.async_get_device(identifiers={DOOR_LOCK_DEVICE_ID})
+    assert entry is not None
+    return entry.id
+
+
+# --- Lock info ---
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_get_lock_info(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test get_lock_info returns capabilities and capacity."""
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/get_lock_info",
+            DEVICE_ID: _get_device_id(device_registry),
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    result = msg["result"]
+    assert result[ATTR_SUPPORTS_USER_MGMT] is True
+    assert CRED_TYPE_PIN in result["supported_credential_types"]
+    assert CRED_TYPE_RFID in result["supported_credential_types"]
+    # From the door_lock fixture attribute values
+    assert result[ATTR_MAX_USERS] == 10
+    assert result[ATTR_MAX_PIN_USERS] == 10
+    assert result[ATTR_MAX_RFID_USERS] == 10
+    assert result[ATTR_MAX_CREDENTIALS_PER_USER] == 5
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_get_lock_info_no_usr(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test get_lock_info when USR feature is not supported."""
+    # Default door_lock fixture has featuremap=0
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/get_lock_info",
+            DEVICE_ID: _get_device_id(device_registry),
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    result = msg["result"]
+    assert result[ATTR_SUPPORTS_USER_MGMT] is False
+    # Capacity keys should not be present when USR is not supported
+    assert ATTR_MAX_USERS not in result
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["onoff_light"])
+async def test_get_lock_info_no_lock(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test get_lock_info on a non-lock device returns error."""
+    ws_client = await hass_ws_client(hass)
+
+    entry = device_registry.async_get_device(identifiers={DOOR_LOCK_DEVICE_ID})
+    assert entry is not None
+
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/get_lock_info",
+            DEVICE_ID: entry.id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_LOCK_NOT_FOUND
+
+
+# --- Add user ---
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_add_lock_user(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test adding a new user to the lock."""
+    # GetUser returns empty slot, then SetUser succeeds
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            {"userStatus": None},  # GetUser: slot empty
+            None,  # SetUser: success
+        ]
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/add_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 1,
+            ATTR_USER_NAME: "Alice",
+            ATTR_USER_UNIQUE_ID: 12345,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"][ATTR_USER_INDEX] == 1
+
+    # Verify two commands were sent (GetUser + SetUser)
+    assert matter_client.send_device_command.call_count == 2
+
+    # Verify SetUser was called with correct parameters
+    set_user_call = matter_client.send_device_command.call_args_list[1]
+    cmd = set_user_call.kwargs.get("command") or set_user_call[1].get("command")
+    assert cmd.userIndex == 1
+    assert cmd.userName == "Alice"
+    assert cmd.userUniqueID == 12345
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_add_lock_user_already_exists(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test adding a user to an occupied slot returns error."""
+    # GetUser returns occupied slot
+    matter_client.send_device_command = AsyncMock(
+        return_value={"userStatus": 1, "userName": "Existing"}
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/add_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 1,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_USER_ALREADY_EXISTS
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_add_lock_user_usr_not_supported(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test adding a user to a lock without USR feature returns error."""
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/add_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 1,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_USR_NOT_SUPPORTED
+
+
+# --- Update user ---
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_update_lock_user(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test updating an existing user on the lock."""
+    # GetUser returns existing user, then SetUser succeeds
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            {
+                "userIndex": 1,
+                "userName": "Alice",
+                "userUniqueID": 100,
+                "userStatus": 1,
+                "userType": 0,
+                "credentialRule": 0,
+            },
+            None,  # SetUser: success
+        ]
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/update_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 1,
+            ATTR_USER_NAME: "Bob",
+            ATTR_USER_TYPE: "week_day_schedule_user",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"][ATTR_USER_INDEX] == 1
+    assert matter_client.send_device_command.call_count == 2
+
+    # Verify SetUser was called with updated name but preserved other fields
+    set_user_call = matter_client.send_device_command.call_args_list[1]
+    cmd = set_user_call.kwargs.get("command") or set_user_call[1].get("command")
+    assert cmd.userName == "Bob"
+    assert cmd.userUniqueID == 100  # preserved from GetUser
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_update_lock_user_not_found(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test updating a user in an empty slot returns error."""
+    matter_client.send_device_command = AsyncMock(return_value={"userStatus": None})
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/update_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 5,
+            ATTR_USER_NAME: "Ghost",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_USER_NOT_FOUND
+
+
+# --- Set user (add or update) ---
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_set_lock_user_auto_slot(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test set_user auto-finds first available slot when user_index is omitted."""
+    # First slot occupied, second slot empty, then SetUser succeeds
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            {"userStatus": 1},  # GetUser(1): occupied
+            {"userStatus": None},  # GetUser(2): empty
+            None,  # SetUser: success
+        ]
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/set_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_NAME: "NewUser",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    # Should have been assigned index 2 (first empty slot)
+    assert msg["result"][ATTR_USER_INDEX] == 2
+    assert matter_client.send_device_command.call_count == 3
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_set_lock_user_no_available_slots(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test set_user returns error when all user slots are occupied."""
+    # All 10 slots occupied (door_lock fixture has NumberOfTotalUsersSupported=10)
+    matter_client.send_device_command = AsyncMock(return_value={"userStatus": 1})
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/set_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_NAME: "NoRoom",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NO_AVAILABLE_SLOTS
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_set_lock_user_with_index_updates_existing(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test set_user with user_index modifies an existing user."""
+    # GetUser returns existing user, then SetUser succeeds
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            {
+                "userIndex": 3,
+                "userName": "Old",
+                "userUniqueID": None,
+                "userStatus": 1,
+                "userType": 0,
+                "credentialRule": 0,
+            },
+            None,  # SetUser: success
+        ]
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/set_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 3,
+            ATTR_USER_NAME: "Updated",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"][ATTR_USER_INDEX] == 3
+    assert matter_client.send_device_command.call_count == 2
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_set_lock_user_with_index_not_found(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test set_user with user_index on empty slot returns error."""
+    matter_client.send_device_command = AsyncMock(return_value={"userStatus": None})
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/set_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 7,
+            ATTR_USER_NAME: "Missing",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_USER_NOT_FOUND
+
+
+# --- Get user ---
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_get_lock_user(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test getting a single user from the lock."""
+    matter_client.send_device_command = AsyncMock(
+        return_value={
+            "userIndex": 1,
+            "userName": "Alice",
+            "userUniqueID": 42,
+            "userStatus": 1,
+            "userType": 0,
+            "credentialRule": 0,
+            "credentials": [
+                {"credentialType": 1, "credentialIndex": 1},
+            ],
+            "nextUserIndex": 2,
+        }
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/get_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 1,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    result = msg["result"]
+    assert result[ATTR_USER_INDEX] == 1
+    assert result[ATTR_USER_NAME] == "Alice"
+    assert result[ATTR_USER_UNIQUE_ID] == 42
+    assert result[ATTR_USER_STATUS] == "occupied_enabled"
+    assert result[ATTR_USER_TYPE] == "unrestricted_user"
+    assert result[ATTR_CREDENTIAL_RULE] == "single"
+    assert len(result["credentials"]) == 1
+    assert result["credentials"][0]["type"] == CRED_TYPE_PIN
+    assert result["credentials"][0]["index"] == 1
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_get_lock_user_not_found(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test getting a user from an empty slot returns error."""
+    matter_client.send_device_command = AsyncMock(return_value={"userStatus": None})
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/get_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 99,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_USER_NOT_FOUND
+
+
+# --- Get all users ---
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_get_lock_users(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test getting all users from the lock."""
+    # Return two users: index 1 (occupied, nextUserIndex=3), index 3 (occupied, no next)
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            {
+                "userIndex": 1,
+                "userName": "Alice",
+                "userUniqueID": None,
+                "userStatus": 1,
+                "userType": 0,
+                "credentialRule": 0,
+                "credentials": None,
+                "nextUserIndex": 3,
+            },
+            {
+                "userIndex": 3,
+                "userName": "Bob",
+                "userUniqueID": None,
+                "userStatus": 1,
+                "userType": 0,
+                "credentialRule": 0,
+                "credentials": None,
+                "nextUserIndex": None,
+            },
+        ]
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/get_users",
+            DEVICE_ID: _get_device_id(device_registry),
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    result = msg["result"]
+    assert result["total_users"] == 2
+    assert result[ATTR_MAX_USERS] == 10
+    assert len(result["users"]) == 2
+    assert result["users"][0][ATTR_USER_NAME] == "Alice"
+    assert result["users"][1][ATTR_USER_NAME] == "Bob"
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_get_lock_users_empty(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test getting users from a lock with no users."""
+    # First slot is empty and has no next index
+    matter_client.send_device_command = AsyncMock(
+        return_value={
+            "userStatus": None,
+            "nextUserIndex": None,
+        }
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/get_users",
+            DEVICE_ID: _get_device_id(device_registry),
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    result = msg["result"]
+    assert result["total_users"] == 0
+    assert result["users"] == []
+
+
+# --- Clear user ---
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_clear_lock_user(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test clearing a user from the lock."""
+    matter_client.send_device_command = AsyncMock(return_value=None)
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/clear_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 2,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+
+    # Verify ClearUser command was sent
+    matter_client.send_device_command.assert_called_once()
+    call_kwargs = matter_client.send_device_command.call_args.kwargs
+    assert call_kwargs["node_id"] == matter_node.node_id
+    assert call_kwargs["endpoint_id"] == 1
+    assert isinstance(call_kwargs["command"], clusters.DoorLock.Commands.ClearUser)
+    assert call_kwargs["command"].userIndex == 2
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_clear_all_lock_users(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test clearing all users with the special 0xFFFE index."""
+    matter_client.send_device_command = AsyncMock(return_value=None)
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/clear_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 0xFFFE,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    call_kwargs = matter_client.send_device_command.call_args.kwargs
+    assert call_kwargs["command"].userIndex == 0xFFFE
+
+
+# --- USR not supported (shared error path) ---
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_get_user_usr_not_supported(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test get_user on a lock without USR feature returns error."""
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/get_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 1,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_USR_NOT_SUPPORTED
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_get_users_usr_not_supported(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test get_users on a lock without USR feature returns error."""
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/get_users",
+            DEVICE_ID: _get_device_id(device_registry),
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_USR_NOT_SUPPORTED
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_clear_user_usr_not_supported(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test clear_user on a lock without USR feature returns error."""
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/clear_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 1,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_USR_NOT_SUPPORTED
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_set_user_usr_not_supported(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test set_user on a lock without USR feature returns error."""
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/set_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_NAME: "Test",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_USR_NOT_SUPPORTED
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_update_user_usr_not_supported(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test update_user on a lock without USR feature returns error."""
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "matter/lock/update_user",
+            DEVICE_ID: _get_device_id(device_registry),
+            ATTR_USER_INDEX: 1,
+            ATTR_USER_NAME: "Test",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_USR_NOT_SUPPORTED

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -1,6 +1,6 @@
 """Test Matter locks."""
 
-from unittest.mock import MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call
 
 from chip.clusters import Objects as clusters
 from matter_server.client.models.node import MatterNode
@@ -9,7 +9,18 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.lock import ATTR_CHANGED_BY, LockEntityFeature, LockState
-from homeassistant.const import ATTR_CODE, STATE_UNKNOWN, Platform
+from homeassistant.components.matter.const import (
+    ATTR_MAX_CREDENTIALS_PER_USER,
+    ATTR_MAX_PIN_USERS,
+    ATTR_MAX_RFID_USERS,
+    ATTR_MAX_USERS,
+    ATTR_SUPPORTS_USER_MGMT,
+    ATTR_USER_INDEX,
+    ATTR_USER_NAME,
+    EVENT_LOCK_DISPOSABLE_USER_DELETED,
+    EVENT_LOCK_OPERATION,
+)
+from homeassistant.const import ATTR_CODE, ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
@@ -19,6 +30,8 @@ from .common import (
     snapshot_matter_entities,
     trigger_subscription_callback,
 )
+
+from tests.common import async_capture_events
 
 
 @pytest.mark.usefixtures("matter_devices")
@@ -261,3 +274,319 @@ async def test_lock_with_unbolt(
     state = hass.states.get("lock.mock_door_lock_with_unbolt")
     assert state
     assert state.state == LockState.OPEN
+
+
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_lock_operation_event_with_user_lookup(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test lock operation event resolves user name from device."""
+    events = async_capture_events(hass, EVENT_LOCK_OPERATION)
+
+    # Mock GetUser response for the user lookup triggered by LockOperation event
+    matter_client.send_device_command = AsyncMock(
+        return_value={
+            "userName": "Alice",
+            "userType": 0,
+            "userStatus": 1,
+        }
+    )
+
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=257,
+            event_id=2,
+            event_number=0,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data={
+                "operationSource": 7,
+                "lockOperationType": 1,
+                "userIndex": 1,
+            },
+        ),
+    )
+
+    state = hass.states.get("lock.mock_door_lock")
+    assert state
+    assert state.attributes[ATTR_CHANGED_BY] == "Alice (Remote)"
+
+    # Verify the GetUser command was sent
+    matter_client.send_device_command.assert_called_once_with(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.GetUser(userIndex=1),
+    )
+
+    # Verify the fired event data
+    assert len(events) == 1
+    event_data = events[0].data
+    assert event_data[ATTR_ENTITY_ID] == "lock.mock_door_lock"
+    assert event_data["operation"] == "unlock"
+    assert event_data["source"] == "Remote"
+    assert event_data[ATTR_USER_INDEX] == 1
+    assert event_data[ATTR_USER_NAME] == "Alice"
+
+
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_lock_operation_event_user_lookup_failure(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test lock operation event handles user lookup failure gracefully."""
+    events = async_capture_events(hass, EVENT_LOCK_OPERATION)
+
+    # Mock GetUser to raise an exception
+    matter_client.send_device_command = AsyncMock(
+        side_effect=Exception("Device communication error")
+    )
+
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=257,
+            event_id=2,
+            event_number=0,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data={
+                "operationSource": 3,
+                "lockOperationType": 0,
+                "userIndex": 5,
+            },
+        ),
+    )
+
+    # Should still update changed_by with source only (no user name)
+    state = hass.states.get("lock.mock_door_lock")
+    assert state
+    assert state.attributes[ATTR_CHANGED_BY] == "Keypad"
+
+    # Event should still fire
+    assert len(events) == 1
+    assert events[0].data[ATTR_USER_NAME] is None
+    assert events[0].data[ATTR_USER_INDEX] == 5
+
+
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_lock_operation_event_no_user_index(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test lock operation event without a user index."""
+    events = async_capture_events(hass, EVENT_LOCK_OPERATION)
+
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=257,
+            event_id=2,
+            event_number=0,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data={"operationSource": 4, "lockOperationType": 0},
+        ),
+    )
+
+    state = hass.states.get("lock.mock_door_lock")
+    assert state
+    assert state.attributes[ATTR_CHANGED_BY] == "Auto"
+
+    assert len(events) == 1
+    assert events[0].data[ATTR_USER_INDEX] is None
+    assert events[0].data[ATTR_USER_NAME] is None
+
+
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_disposable_user_cleanup(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test disposable user is cleaned up after one-time use."""
+    events = async_capture_events(hass, EVENT_LOCK_DISPOSABLE_USER_DELETED)
+
+    # Mock GetUser returning a disposable user (type=6) in disabled state (status=3)
+    # Then mock ClearUser succeeding (returns None)
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            {
+                "userName": "OneTimeCode",
+                "userType": 6,
+                "userStatus": 3,
+            },
+            None,  # ClearUser response
+        ]
+    )
+
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=257,
+            event_id=2,
+            event_number=0,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data={
+                "operationSource": 3,
+                "lockOperationType": 1,
+                "userIndex": 2,
+            },
+        ),
+    )
+
+    # Verify ClearUser was called for the disposable user
+    assert matter_client.send_device_command.call_count == 2
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.ClearUser(userIndex=2),
+        timed_request_timeout_ms=1000,
+    )
+
+    # Verify the deletion event was fired
+    assert len(events) == 1
+    assert events[0].data[ATTR_ENTITY_ID] == "lock.mock_door_lock"
+    assert events[0].data[ATTR_USER_INDEX] == 2
+    assert events[0].data[ATTR_USER_NAME] == "OneTimeCode"
+
+
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_disposable_user_cleanup_failure(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test disposable user cleanup handles failure gracefully."""
+    events = async_capture_events(hass, EVENT_LOCK_DISPOSABLE_USER_DELETED)
+
+    # Mock GetUser returning disposable user, then ClearUser failing
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            {
+                "userName": "FailCode",
+                "userType": 6,
+                "userStatus": 3,
+            },
+            Exception("Clear failed"),
+        ]
+    )
+
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=257,
+            event_id=2,
+            event_number=0,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data={
+                "operationSource": 3,
+                "lockOperationType": 1,
+                "userIndex": 3,
+            },
+        ),
+    )
+
+    # Cleanup failed, so no deletion event should be fired
+    assert len(events) == 0
+
+    # changed_by should still be updated from the user lookup
+    state = hass.states.get("lock.mock_door_lock")
+    assert state
+    assert state.attributes[ATTR_CHANGED_BY] == "FailCode (Keypad)"
+
+
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_extra_state_attributes_without_usr(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test extra state attributes when USR feature is not supported."""
+    # Default door_lock fixture has featuremap=0, no USR support
+    state = hass.states.get("lock.mock_door_lock")
+    assert state
+    assert state.attributes[ATTR_SUPPORTS_USER_MGMT] is False
+    assert ATTR_MAX_USERS not in state.attributes
+    assert ATTR_MAX_PIN_USERS not in state.attributes
+    assert ATTR_MAX_RFID_USERS not in state.attributes
+    assert ATTR_MAX_CREDENTIALS_PER_USER not in state.attributes
+
+
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        {
+            # Enable USR feature (bit 8 = 256) + PIN (bit 0 = 1)
+            "1/257/65532": 257,
+        }
+    ],
+)
+async def test_extra_state_attributes_with_usr(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test extra state attributes when USR feature is supported."""
+    state = hass.states.get("lock.mock_door_lock")
+    assert state
+    assert state.attributes[ATTR_SUPPORTS_USER_MGMT] is True
+    # Verify capacity attributes are present (from fixture values)
+    assert state.attributes[ATTR_MAX_USERS] == 10
+    assert state.attributes[ATTR_MAX_PIN_USERS] == 10
+    assert state.attributes[ATTR_MAX_RFID_USERS] == 10
+    assert state.attributes[ATTR_MAX_CREDENTIALS_PER_USER] == 5
+
+
+@pytest.mark.parametrize("node_fixture", ["door_lock"])
+async def test_extra_state_attributes_dynamic_featuremap(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test extra state attributes update when featuremap changes dynamically."""
+    # Initially no USR support
+    state = hass.states.get("lock.mock_door_lock")
+    assert state
+    assert state.attributes[ATTR_SUPPORTS_USER_MGMT] is False
+
+    # Enable USR feature dynamically
+    set_node_attribute(matter_node, 1, 257, 65532, 256)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get("lock.mock_door_lock")
+    assert state
+    assert state.attributes[ATTR_SUPPORTS_USER_MGMT] is True
+    assert ATTR_MAX_USERS in state.attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
## Summary

- Add Matter lock user management: WebSocket API, lock operation events with user lookup, disposable user auto-cleanup, and lock capability state attributes
- Consolidate all shared lock string literals into `const.py` as typed constants, eliminating cross-file duplication between `lock.py` and `api_lock.py`
- Add 31 new tests (8 entity-level, 23 WebSocket API) covering all happy paths and error paths

## Architecture

```mermaid
graph TD
    subgraph "WebSocket API Layer"
        API["api.py<br/><i>async_register_api()</i>"]
        BASE["api_base.py <b>(new)</b><br/><i>shared decorators</i><br/>async_get_node<br/>async_get_matter_adapter<br/>async_handle_failed_command"]
        LOCK_API["api_lock.py <b>(new)</b><br/><i>7 websocket endpoints</i>"]
    end

    subgraph "Entity Layer"
        LOCK["lock.py<br/><i>MatterLock entity</i><br/>events · changed_by · attrs"]
    end

    subgraph "Shared"
        CONST["const.py<br/><i>EVENT_ · ATTR_ · ERR_</i><br/><i>CRED_TYPE_ · enum maps</i>"]
        HELPERS["helpers_lock.py <b>(new)</b><br/><i>feature detection</i><br/>get_lock_endpoint_from_node<br/>lock_supports_usr_feature"]
    end

    API -->|"registers"| LOCK_API
    LOCK_API --> BASE
    LOCK_API --> CONST
    LOCK_API --> HELPERS
    LOCK --> CONST
    LOCK --> HELPERS

    style CONST fill:#e1f5fe
    style BASE fill:#f3e5f5
    style LOCK_API fill:#f3e5f5
    style HELPERS fill:#f3e5f5
```

## WebSocket API endpoints

All endpoints require admin access and operate on a `device_id` resolved to a Matter node.

```mermaid
graph LR
    subgraph "matter/lock/*"
        INFO["get_lock_info"]
        ADD["add_user"]
        UPDATE["update_user"]
        SET["set_user"]
        GET1["get_user"]
        GETALL["get_users"]
        CLEAR["clear_user"]
    end

    INFO -->|"returns"| CAP["capabilities<br/>credential types<br/>user capacity"]
    ADD -->|"checks slot empty<br/>then SetUser kAdd"| DEV[("Lock Device")]
    UPDATE -->|"preserves existing<br/>fields, SetUser kModify"| DEV
    SET -->|"auto-finds slot<br/>or modifies existing"| DEV
    GET1 -->|"GetUser then format"| DEV
    GETALL -->|"iterates via<br/>nextUserIndex"| DEV
    CLEAR -->|"ClearUser<br/>or 0xFFFE for all"| DEV
```

## Lock entity enhancements (`lock.py`)

```mermaid
sequenceDiagram
    participant Device as Matter Lock
    participant Entity as MatterLock Entity
    participant Bus as HA Event Bus

    Device->>Entity: NODE_EVENT (LockOperation, event_id=2)
    Entity->>Device: GetUser(userIndex)
    Device-->>Entity: userName, userType, userStatus

    alt Normal user
        Entity->>Entity: changed_by = "Alice (Remote)"
        Entity->>Bus: EVENT_LOCK_OPERATION
    end

    alt Disposable user (type=6, status=3)
        Entity->>Entity: changed_by = "OneTimeCode (Keypad)"
        Entity->>Device: ClearUser(userIndex)
        Entity->>Bus: EVENT_LOCK_OPERATION
        Entity->>Bus: EVENT_LOCK_DISPOSABLE_USER_DELETED
    end

    alt GetUser fails
        Entity->>Entity: changed_by = "Keypad" (source only)
        Entity->>Bus: EVENT_LOCK_OPERATION
    end
```

**Extra state attributes** exposed on the lock entity:

| Attribute | Condition | Source |
| --- | --- | --- |
| `supports_user_management` | Always | `DoorLockFeature.kUser` bit in featuremap |
| `max_users` | USR feature set | `NumberOfTotalUsersSupported` |
| `max_pin_users` | USR feature set | `NumberOfPINUsersSupported` |
| `max_rfid_users` | USR feature set | `NumberOfRFIDUsersSupported` |
| `max_credentials_per_user` | USR feature set | `NumberOfCredentialsSupportedPerUser` |

## Constants consolidation (`const.py`)

All cross-file shared strings are now typed constants with conventional prefixes:

| Prefix | Count | Purpose |
| --- | --- | --- |
| `EVENT_` | 2 | Bus event names (`matter_lock_operation`, `matter_lock_disposable_user_deleted`) |
| `ATTR_` | 11 | Field keys shared between entity attrs, event data, and API request/response dicts |
| `ERR_` | 5 | WebSocket error codes |
| `CRED_TYPE_` | 4 | Credential type strings used in feature detection and map values |
| Enum maps | 8 | `DOOR_LOCK_OPERATION_SOURCE/TYPE`, `USER_STATUS_MAP`, `USER_TYPE_MAP`, `CREDENTIAL_TYPE_MAP`, `CREDENTIAL_RULE_MAP`, + reverse maps |


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
