### PR TITLE
Use chained comparison in Teslemetry update platform

### DIFF
--- a/homeassistant/components/teslemetry/quality_scale.yaml
+++ b/homeassistant/components/teslemetry/quality_scale.yaml
@@ -3,11 +3,7 @@ rules:
   action-setup: done
   appropriate-polling: done
   brands: done
-  common-modules:
-    status: todo
-    comment: |
-      Multiline lambdas should be wrapped in parentheses for readability (e.g. streaming_listener).
-      Use chained comparison: "if 1 < x < 100" instead of "if x > 1 and x < 100".
+  common-modules: done
   config-flow: done
   config-flow-test-coverage: done
   dependency-transparency: done

--- a/homeassistant/components/teslemetry/update.py
+++ b/homeassistant/components/teslemetry/update.py
@@ -234,7 +234,7 @@ class TeslemetryStreamingUpdateEntity(
     def _async_update_progress(self) -> None:
         """Update the progress of the update."""
 
-        if self._download_percentage > 1 and self._download_percentage < 100:
+        if 1 < self._download_percentage < 100:
             self._attr_in_progress = True
             self._attr_update_percentage = self._download_percentage
         elif self._install_percentage > 10:


### PR DESCRIPTION
## Summary

- Use chained comparison operator (`1 < x < 100`) instead of `x > 1 and x < 100` in `update.py` for more Pythonic style
- Mark `common-modules` quality scale rule as done

## Type of change

Code quality improvement.

Note: The lambda reformatting previously in this PR was independently handled upstream by the ruff 0.15.0 upgrade.