### PR TITLE
Mark datetime sensors as unknown when parsing fails

### DIFF
--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -545,6 +545,7 @@ class APCUPSdSensor(APCUPSdEntity, SensorEntity):
             # The date could be "N/A" for certain fields (e.g., XOFFBATT), so when parsing fails,
             # we should simply mark it as unknown.
             except (dateutil.parser.ParserError, OverflowError):
+                _LOGGER.debug('Failed to parse date for %s: "%s"', key, data)
                 self._attr_native_value = None
             return
 

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -540,7 +540,12 @@ class APCUPSdSensor(APCUPSdEntity, SensorEntity):
         data = self.coordinator.data[key]
 
         if self.entity_description.device_class == SensorDeviceClass.TIMESTAMP:
-            self._attr_native_value = dateutil.parser.parse(data)
+            try:
+                self._attr_native_value = dateutil.parser.parse(data)
+            # The date could be "N/A" for certain fields (e.g., XOFFBATT), so when parsing fails,
+            # we should simply mark it as unknown.
+            except (dateutil.parser.ParserError, OverflowError):
+                self._attr_native_value = None
             return
 
         self._attr_native_value, inferred_unit = infer_unit(data)

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -540,12 +540,16 @@ class APCUPSdSensor(APCUPSdEntity, SensorEntity):
         data = self.coordinator.data[key]
 
         if self.entity_description.device_class == SensorDeviceClass.TIMESTAMP:
+            # The date could be "N/A" for certain fields (e.g., XOFFBATT), indicating there is no value yet.
+            if data == "N/A":
+                self._attr_native_value = None
+                return
+
             try:
                 self._attr_native_value = dateutil.parser.parse(data)
-            # The date could be "N/A" for certain fields (e.g., XOFFBATT), so when parsing fails,
-            # we should simply mark it as unknown.
             except (dateutil.parser.ParserError, OverflowError):
-                _LOGGER.debug('Failed to parse date for %s: "%s"', key, data)
+                # If parsing fails we should mark it as unknown, with a log for further debugging.
+                _LOGGER.warning('Failed to parse date for %s: "%s"', key, data)
                 self._attr_native_value = None
             return
 

--- a/tests/components/apcupsd/test_sensor.py
+++ b/tests/components/apcupsd/test_sensor.py
@@ -150,6 +150,12 @@ async def test_manual_update_entity(
             MOCK_MINIMAL_STATUS | {"XOFFBATT": "1970-01-01 00:00:00 +0000"},
             id="xoffbatt_na",
         ),
+        pytest.param(
+            MOCK_MINIMAL_STATUS | {"XOFFBATT": "invalid-time-string"},
+            "sensor.apc_ups_transfer_from_battery",
+            MOCK_MINIMAL_STATUS | {"XOFFBATT": "1970-01-01 00:00:00 +0000"},
+            id="xoffbatt_invalid_time_string",
+        ),
     ],
     indirect=["mock_request_status"],
 )

--- a/tests/components/apcupsd/test_sensor.py
+++ b/tests/components/apcupsd/test_sensor.py
@@ -3,7 +3,6 @@
 from datetime import timedelta
 from unittest.mock import AsyncMock
 
-import dateutil.parser
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -135,42 +134,57 @@ async def test_manual_update_entity(
     assert state.state == "15.0"
 
 
-@pytest.mark.parametrize("mock_request_status", [MOCK_MINIMAL_STATUS], indirect=True)
+@pytest.mark.parametrize(
+    ("mock_request_status", "entity_id", "unknown_status"),
+    [
+        pytest.param(
+            MOCK_MINIMAL_STATUS | {"LASTSTEST": "1970-01-01 00:00:00 +0000"},
+            "sensor.apc_ups_last_self_test",
+            MOCK_MINIMAL_STATUS,
+            id="last_self_test_missing",
+        ),
+        pytest.param(
+            MOCK_MINIMAL_STATUS | {"XOFFBATT": "1970-01-01 00:00:00 +0000"},
+            "sensor.apc_ups_transfer_from_battery",
+            MOCK_MINIMAL_STATUS | {"XOFFBATT": "N/A"},
+            id="xoffbatt_na",
+        ),
+    ],
+    indirect=["mock_request_status"],
+)
 async def test_sensor_unknown(
     hass: HomeAssistant,
     mock_request_status: AsyncMock,
+    entity_id: str,
+    unknown_status: dict[str, str],
 ) -> None:
     """Test if our integration can properly mark certain sensors as unknown when it becomes so."""
-    ups_mode_id = "sensor.apc_ups_mode"
-    last_self_test_id = "sensor.apc_ups_last_self_test"
+    base_status = mock_request_status.return_value
 
-    assert hass.states.get(ups_mode_id).state == MOCK_MINIMAL_STATUS["UPSMODE"]
-    # Last self test sensor should be added even if our status does not report it initially (it is
-    # a sensor that appears only after a periodical or manual self test is performed).
-    assert hass.states.get(last_self_test_id) is not None
-    assert hass.states.get(last_self_test_id).state == STATE_UNKNOWN
+    # The state should be known initially.
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state != STATE_UNKNOWN
 
-    # Simulate an event (a self test) such that "LASTSTEST" field is being reported, the state of
-    # the sensor should be properly updated with the corresponding value.
-    last_self_test_value = "1970-01-01 00:00:00 +0000"
-    mock_request_status.return_value = MOCK_MINIMAL_STATUS | {
-        "LASTSTEST": last_self_test_value
-    }
+    # Update to a payload that should make the entity unknown.
+    mock_request_status.return_value = unknown_status
     future = utcnow() + timedelta(minutes=2)
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()
-    assert (
-        hass.states.get(last_self_test_id).state
-        == dateutil.parser.parse(last_self_test_value).isoformat()
-    )
 
-    # Simulate another event (e.g., daemon restart) such that "LASTSTEST" is no longer reported.
-    mock_request_status.return_value = MOCK_MINIMAL_STATUS
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    # Revert back to the initial status, and the state should now be known again.
+    mock_request_status.return_value = base_status
     future = utcnow() + timedelta(minutes=2)
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()
-    # The state should become unknown again.
-    assert hass.states.get(last_self_test_id).state == STATE_UNKNOWN
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state != STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(("entity_key", "issue_key"), DEPRECATED_SENSORS.items())

--- a/tests/components/apcupsd/test_sensor.py
+++ b/tests/components/apcupsd/test_sensor.py
@@ -135,18 +135,19 @@ async def test_manual_update_entity(
 
 
 @pytest.mark.parametrize(
-    ("mock_request_status", "entity_id", "unknown_status"),
+    ("mock_request_status", "entity_id", "known_status"),
     [
         pytest.param(
-            MOCK_MINIMAL_STATUS | {"LASTSTEST": "1970-01-01 00:00:00 +0000"},
-            "sensor.apc_ups_last_self_test",
+            # Even though the "LASTSTEST" field is not available, we should still create the entity.
             MOCK_MINIMAL_STATUS,
+            "sensor.apc_ups_last_self_test",
+            MOCK_MINIMAL_STATUS | {"LASTSTEST": "1970-01-01 00:00:00 +0000"},
             id="last_self_test_missing",
         ),
         pytest.param(
-            MOCK_MINIMAL_STATUS | {"XOFFBATT": "1970-01-01 00:00:00 +0000"},
-            "sensor.apc_ups_transfer_from_battery",
             MOCK_MINIMAL_STATUS | {"XOFFBATT": "N/A"},
+            "sensor.apc_ups_transfer_from_battery",
+            MOCK_MINIMAL_STATUS | {"XOFFBATT": "1970-01-01 00:00:00 +0000"},
             id="xoffbatt_na",
         ),
     ],
@@ -156,27 +157,27 @@ async def test_sensor_unknown(
     hass: HomeAssistant,
     mock_request_status: AsyncMock,
     entity_id: str,
-    unknown_status: dict[str, str],
+    known_status: dict[str, str],
 ) -> None:
-    """Test if our integration can properly mark certain sensors as unknown when it becomes so."""
+    """Test if our integration can properly mark certain sensors as known/unknown when it becomes so."""
     base_status = mock_request_status.return_value
 
-    # The state should be known initially.
+    # The state should be unknown initially.
     state = hass.states.get(entity_id)
     assert state
-    assert state.state != STATE_UNKNOWN
+    assert state.state == STATE_UNKNOWN
 
-    # Update to a payload that should make the entity unknown.
-    mock_request_status.return_value = unknown_status
+    # Update to a payload that should make the entity known.
+    mock_request_status.return_value = known_status
     future = utcnow() + timedelta(minutes=2)
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_UNKNOWN
+    assert state.state != STATE_UNKNOWN
 
-    # Revert back to the initial status, and the state should now be known again.
+    # Revert back to the initial status, and the state should now be unknown again.
     mock_request_status.return_value = base_status
     future = utcnow() + timedelta(minutes=2)
     async_fire_time_changed(hass, future)
@@ -184,7 +185,7 @@ async def test_sensor_unknown(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state != STATE_UNKNOWN
+    assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(("entity_key", "issue_key"), DEPRECATED_SENSORS.items())


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We got user reports in #161925 that the datetime sensors could report literal "N/A" from apcups daemon, which would make date parsing fail. This PR makes our logic robust by marking the sensor as unknown when parsing fails.

We also refactored the `test_sensor_unknown` to be a parameterized test and added this case to prevent future regressions.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #161925
- This PR is related to issue: #161925
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ x The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
