### PR TITLE
Complete config-entry-unloading quality check in Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -325,7 +325,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
 async def async_unload_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
     """Unload Teslemetry Config."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        # Remove stream listeners for each vehicle
         for vehicle in entry.runtime_data.vehicles:
             vehicle.remove_listener()
 

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -190,9 +190,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     manual=True,
                 )
 
-            remove_listener = stream.async_add_listener(
-                create_handle_vehicle_stream(vin, coordinator),
-                {"vin": vin},
+            entry.async_on_unload(
+                stream.async_add_listener(
+                    create_handle_vehicle_stream(vin, coordinator),
+                    {"vin": vin},
+                )
             )
             stream_vehicle = stream.get_vehicle(vin)
             poll = vehicle_metadata[vin].get("polling", False)
@@ -208,7 +210,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     vin=vin,
                     firmware=firmware,
                     device=device,
-                    remove_listener=remove_listener,
                 )
             )
 
@@ -317,6 +318,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     if stream:
+        entry.async_on_unload(stream.close)
         entry.async_create_background_task(hass, stream.listen(), "Teslemetry Stream")
 
     return True
@@ -324,14 +326,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
 
 async def async_unload_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
     """Unload Teslemetry Config."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        for vehicle in entry.runtime_data.vehicles:
-            vehicle.remove_listener()
-
-        if entry.runtime_data.stream:
-            entry.runtime_data.stream.close()
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_migrate_entry(

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -328,7 +328,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) 
         for vehicle in entry.runtime_data.vehicles:
             vehicle.remove_listener()
 
-        # Close the stream connection
         if entry.runtime_data.stream:
             entry.runtime_data.stream.close()
 

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -324,7 +324,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
 
 async def async_unload_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
     """Unload Teslemetry Config."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        # Remove stream listeners for each vehicle
+        for vehicle in entry.runtime_data.vehicles:
+            vehicle.remove_listener()
+
+        # Close the stream connection
+        if entry.runtime_data.stream:
+            entry.runtime_data.stream.close()
+
+    return unload_ok
 
 
 async def async_migrate_entry(

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
 from dataclasses import dataclass
 
 from tesla_fleet_api.const import Scope
@@ -44,7 +43,6 @@ class TeslemetryVehicleData:
     vin: str
     firmware: str
     device: DeviceInfo
-    remove_listener: Callable
     wakelock = asyncio.Lock()
 
 

--- a/homeassistant/components/teslemetry/quality_scale.yaml
+++ b/homeassistant/components/teslemetry/quality_scale.yaml
@@ -24,13 +24,7 @@ rules:
   unique-config-entry: done
   # Silver
   action-exceptions: done
-  config-entry-unloading:
-    status: todo
-    comment: |
-      async_unload_entry must clean up: (1) close TeslemetryStream websocket via
-      stream.close(), (2) call remove_listener() for each vehicle to unsubscribe
-      from stream events, (3) consider using entry.async_on_unload() during setup
-      to register cleanup callbacks automatically.
+  config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
   entity-unavailable: done


### PR DESCRIPTION
## Proposed change

This PR addresses the `config-entry-unloading` quality scale item for the Teslemetry integration.

The `async_unload_entry` function now properly cleans up resources when the config entry is unloaded:
- Calls `remove_listener()` for each vehicle to unsubscribe from TeslemetryStream events
- Closes the TeslemetryStream WebSocket connection via `stream.close()`

Previously, the function only unloaded platforms without cleaning up the stream connection and listeners, which could lead to resource leaks.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
