### PR TITLE
Add model_id and sw_version to Teslemetry device info

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -161,7 +161,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             coordinator = TeslemetryVehicleDataCoordinator(
                 hass, entry, vehicle, product
             )
-            firmware = vehicle_metadata[vin].get("firmware", "Unknown")
+            firmware = vehicle_metadata[vin].get("firmware")
             device = DeviceInfo(
                 identifiers={(DOMAIN, vin)},
                 manufacturer="Tesla",
@@ -375,28 +375,24 @@ def async_setup_energy_device(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Set up energy device with models, versions, and listeners."""
-    # Add energy device models
+    data = energysite.info_coordinator.data
     models = set()
-    for gateway in energysite.info_coordinator.data.get("components_gateways", []):
-        if gateway.get("part_name"):
-            models.add(gateway["part_name"])
-    for battery in energysite.info_coordinator.data.get("components_batteries", []):
-        if battery.get("part_name"):
-            models.add(battery["part_name"])
+    for component in (
+        *data.get("components_gateways", []),
+        *data.get("components_batteries", []),
+    ):
+        if part_name := component.get("part_name"):
+            models.add(part_name)
     if models:
         energysite.device["model"] = ", ".join(sorted(models))
 
-    # Add software version
-    if version := energysite.info_coordinator.data.get("version"):
+    if version := data.get("version"):
         energysite.device["sw_version"] = version
 
-    # Create the energy site device regardless of it having entities
-    # This is so users with a Wall Connector but without a Powerwall can make service calls
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id, **energysite.device
     )
 
-    # Register listener to update device sw_version when it changes
     entry.async_on_unload(
         energysite.info_coordinator.async_add_listener(
             create_energy_info_listener(
@@ -418,7 +414,6 @@ async def async_setup_stream(
         f"Prefer typed for {vehicle.vin}",
     )
 
-    # Register listener to update device sw_version when streaming updates
     entry.async_on_unload(
         vehicle.stream_vehicle.listen_Version(
             create_vehicle_streaming_listener(hass, vehicle.vin)

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -161,13 +161,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             coordinator = TeslemetryVehicleDataCoordinator(
                 hass, entry, vehicle, product
             )
+            firmware = vehicle_metadata[vin].get("firmware", "Unknown")
             device = DeviceInfo(
                 identifiers={(DOMAIN, vin)},
                 manufacturer="Tesla",
                 configuration_url="https://teslemetry.com/console",
                 name=product["display_name"],
                 model=vehicle.model,
+                model_id=vin[3],
                 serial_number=vin,
+                sw_version=firmware,
             )
             current_devices.add((DOMAIN, vin))
 
@@ -185,7 +188,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 create_handle_vehicle_stream(vin, coordinator),
                 {"vin": vin},
             )
-            firmware = vehicle_metadata[vin].get("firmware", "Unknown")
             stream_vehicle = stream.get_vehicle(vin)
             poll = vehicle_metadata[vin].get("polling", False)
 
@@ -276,7 +278,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
         ),
     )
 
-    # Add energy device models
+    # Add energy device models and software version
     for energysite in energysites:
         models = set()
         for gateway in energysite.info_coordinator.data.get("components_gateways", []):
@@ -287,6 +289,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 models.add(battery["part_name"])
         if models:
             energysite.device["model"] = ", ".join(sorted(models))
+        if version := energysite.info_coordinator.data.get("version"):
+            energysite.device["sw_version"] = version
 
         # Create the energy site device regardless of it having entities
         # This is so users with a Wall Connector but without a Powerwall can still make service calls

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -41,7 +41,7 @@ from .coordinator import (
     TeslemetryEnergySiteLiveCoordinator,
     TeslemetryVehicleDataCoordinator,
 )
-from .helpers import flatten
+from .helpers import async_update_device_sw_version, flatten
 from .models import TeslemetryData, TeslemetryEnergyData, TeslemetryVehicleData
 from .services import async_setup_services
 
@@ -278,25 +278,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
         ),
     )
 
-    # Add energy device models and software version
-    for energysite in energysites:
-        models = set()
-        for gateway in energysite.info_coordinator.data.get("components_gateways", []):
-            if gateway.get("part_name"):
-                models.add(gateway["part_name"])
-        for battery in energysite.info_coordinator.data.get("components_batteries", []):
-            if battery.get("part_name"):
-                models.add(battery["part_name"])
-        if models:
-            energysite.device["model"] = ", ".join(sorted(models))
-        if version := energysite.info_coordinator.data.get("version"):
-            energysite.device["sw_version"] = version
+    # Register listeners for polling vehicle sw_version updates
+    for vehicle_data in vehicles:
+        if vehicle_data.poll:
+            entry.async_on_unload(
+                vehicle_data.coordinator.async_add_listener(
+                    create_vehicle_polling_listener(
+                        hass, vehicle_data.vin, vehicle_data.coordinator
+                    )
+                )
+            )
 
-        # Create the energy site device regardless of it having entities
-        # This is so users with a Wall Connector but without a Powerwall can still make service calls
-        device_registry.async_get_or_create(
-            config_entry_id=entry.entry_id, **energysite.device
-        )
+    # Setup energy devices with models, versions, and listeners
+    for energysite in energysites:
+        async_setup_energy_device(hass, entry, energysite, device_registry)
 
     # Remove devices that are no longer present
     for device_entry in dr.async_entries_for_config_entry(
@@ -373,6 +368,44 @@ def create_handle_vehicle_stream(vin: str, coordinator) -> Callable[[dict], None
     return handle_vehicle_stream
 
 
+def async_setup_energy_device(
+    hass: HomeAssistant,
+    entry: TeslemetryConfigEntry,
+    energysite: TeslemetryEnergyData,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Set up energy device with models, versions, and listeners."""
+    # Add energy device models
+    models = set()
+    for gateway in energysite.info_coordinator.data.get("components_gateways", []):
+        if gateway.get("part_name"):
+            models.add(gateway["part_name"])
+    for battery in energysite.info_coordinator.data.get("components_batteries", []):
+        if battery.get("part_name"):
+            models.add(battery["part_name"])
+    if models:
+        energysite.device["model"] = ", ".join(sorted(models))
+
+    # Add software version
+    if version := energysite.info_coordinator.data.get("version"):
+        energysite.device["sw_version"] = version
+
+    # Create the energy site device regardless of it having entities
+    # This is so users with a Wall Connector but without a Powerwall can make service calls
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id, **energysite.device
+    )
+
+    # Register listener to update device sw_version when it changes
+    entry.async_on_unload(
+        energysite.info_coordinator.async_add_listener(
+            create_energy_info_listener(
+                hass, energysite.id, energysite.info_coordinator
+            )
+        )
+    )
+
+
 async def async_setup_stream(
     hass: HomeAssistant, entry: TeslemetryConfigEntry, vehicle: TeslemetryVehicleData
 ):
@@ -384,3 +417,55 @@ async def async_setup_stream(
         vehicle.stream_vehicle.prefer_typed(True),
         f"Prefer typed for {vehicle.vin}",
     )
+
+    # Register listener to update device sw_version when streaming updates
+    entry.async_on_unload(
+        vehicle.stream_vehicle.listen_Version(
+            create_vehicle_streaming_listener(hass, vehicle.vin)
+        )
+    )
+
+
+def create_vehicle_streaming_listener(
+    hass: HomeAssistant, vin: str
+) -> Callable[[str | None], None]:
+    """Create a listener for vehicle streaming version updates."""
+
+    def handle_version(value: str | None) -> None:
+        """Handle version update from stream."""
+        if value is not None:
+            # Remove build from version (e.g., "2024.44.25 abc123" -> "2024.44.25")
+            sw_version = value.split(" ")[0]
+            async_update_device_sw_version(hass, vin, sw_version)
+
+    return handle_version
+
+
+def create_vehicle_polling_listener(
+    hass: HomeAssistant, vin: str, coordinator: TeslemetryVehicleDataCoordinator
+) -> Callable[[], None]:
+    """Create a listener for vehicle polling coordinator updates."""
+
+    def handle_update() -> None:
+        """Handle coordinator update."""
+        if version := coordinator.data.get("vehicle_state_car_version"):
+            # Remove build from version (e.g., "2024.44.25 abc123" -> "2024.44.25")
+            sw_version = version.split(" ")[0]
+            async_update_device_sw_version(hass, vin, sw_version)
+
+    return handle_update
+
+
+def create_energy_info_listener(
+    hass: HomeAssistant,
+    site_id: int,
+    coordinator: TeslemetryEnergySiteInfoCoordinator,
+) -> Callable[[], None]:
+    """Create a listener for energy site info coordinator updates."""
+
+    def handle_update() -> None:
+        """Handle coordinator update."""
+        if version := coordinator.data.get("version"):
+            async_update_device_sw_version(hass, str(site_id), version)
+
+    return handle_update

--- a/homeassistant/components/teslemetry/helpers.py
+++ b/homeassistant/components/teslemetry/helpers.py
@@ -4,7 +4,9 @@ from typing import Any
 
 from tesla_fleet_api.exceptions import TeslaFleetError
 
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN, LOGGER
 
@@ -68,3 +70,14 @@ async def handle_vehicle_command(command) -> Any:
         )
     # Response with result of true
     return result
+
+
+@callback
+def async_update_device_sw_version(
+    hass: HomeAssistant, identifier: str, sw_version: str
+) -> None:
+    """Update the software version in the device registry."""
+    dev_reg = dr.async_get(hass)
+    if device := dev_reg.async_get_device(identifiers={(DOMAIN, identifier)}):
+        if device.sw_version != sw_version:
+            dev_reg.async_update_device(device.id, sw_version=sw_version)

--- a/homeassistant/components/teslemetry/quality_scale.yaml
+++ b/homeassistant/components/teslemetry/quality_scale.yaml
@@ -48,11 +48,7 @@ rules:
       test fixture. Clarify _alt and _noscope fixture purposes. Test error messages in
       test_service_validation_errors.
   # Gold
-  devices:
-    status: todo
-    comment: |
-      Add model id to device info. VIN sensor may be redundant (already serial number in device).
-      Version sensor should be sw_version in device info instead.
+  devices: done
   diagnostics: done
   discovery:
     status: exempt

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -1532,10 +1532,6 @@ ENERGY_INFO_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
     ),
-    SensorEntityDescription(
-        key="version",
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
 )
 
 ENERGY_HISTORY_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = tuple(

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -1032,9 +1032,6 @@
       "vehicle_state_tpms_pressure_rr": {
         "name": "Tire pressure rear right"
       },
-      "version": {
-        "name": "Version"
-      },
       "vin": {
         "name": "[%key:component::teslemetry::common::vehicle%]",
         "state": {

--- a/tests/components/teslemetry/snapshots/test_init.ambr
+++ b/tests/components/teslemetry/snapshots/test_init.ambr
@@ -26,7 +26,7 @@
     'name_by_user': None,
     'primary_config_entry': <ANY>,
     'serial_number': '123456',
-    'sw_version': None,
+    'sw_version': '23.44.0 eb113390',
     'via_device_id': None,
   })
 # ---
@@ -52,12 +52,12 @@
     }),
     'manufacturer': 'Tesla',
     'model': 'Model 3',
-    'model_id': None,
+    'model_id': '3',
     'name': 'Test',
     'name_by_user': None,
     'primary_config_entry': <ANY>,
     'serial_number': 'LRW3F7EK4NC700000',
-    'sw_version': None,
+    'sw_version': '2026.0.0',
     'via_device_id': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -2362,68 +2362,6 @@
     'state': '40.727',
   })
 # ---
-# name: test_sensors[sensor.energy_site_version-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.energy_site_version',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Version',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Version',
-    'platform': 'teslemetry',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'version',
-    'unique_id': '123456-version',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[sensor.energy_site_version-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Energy Site Version',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.energy_site_version',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '23.44.0 eb113390',
-  })
-# ---
-# name: test_sensors[sensor.energy_site_version-statealt]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Energy Site Version',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.energy_site_version',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '23.44.0 eb113390',
-  })
-# ---
 # name: test_sensors[sensor.energy_site_vpp_backup_reserve-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
## Proposed change

Add enhanced device information to Teslemetry devices to address the `devices` quality scale rule:

- Add `model_id` to vehicle DeviceInfo using the 4th character of the VIN (S/X/3/Y/C/R/T) which identifies the Tesla model type
- Add `sw_version` to vehicle DeviceInfo using the firmware version from Teslemetry metadata
- Add `sw_version` to energy site DeviceInfo using the version field from the info coordinator data
- Remove the redundant `version` sensor from energy sites since this information is now available in device info

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr