### PR TITLE
Rename drive inverter unavailable state in Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/icons.json
+++ b/homeassistant/components/teslemetry/icons.json
@@ -395,8 +395,8 @@
           "abort": "mdi:stop-circle",
           "enabled": "mdi:check-circle",
           "fault": "mdi:alert-circle",
-          "standby": "mdi:power-sleep",
-          "unavailable": "mdi:car-off"
+          "not_available": "mdi:car-off",
+          "standby": "mdi:power-sleep"
         }
       },
       "di_state_r": {
@@ -405,8 +405,8 @@
           "abort": "mdi:stop-circle",
           "enabled": "mdi:check-circle",
           "fault": "mdi:alert-circle",
-          "standby": "mdi:power-sleep",
-          "unavailable": "mdi:car-off"
+          "not_available": "mdi:car-off",
+          "standby": "mdi:power-sleep"
         }
       },
       "di_state_rel": {
@@ -415,8 +415,8 @@
           "abort": "mdi:stop-circle",
           "enabled": "mdi:check-circle",
           "fault": "mdi:alert-circle",
-          "standby": "mdi:power-sleep",
-          "unavailable": "mdi:car-off"
+          "not_available": "mdi:car-off",
+          "standby": "mdi:power-sleep"
         }
       },
       "di_state_rer": {
@@ -425,8 +425,8 @@
           "abort": "mdi:stop-circle",
           "enabled": "mdi:check-circle",
           "fault": "mdi:alert-circle",
-          "standby": "mdi:power-sleep",
-          "unavailable": "mdi:car-off"
+          "not_available": "mdi:car-off",
+          "standby": "mdi:power-sleep"
         }
       },
       "di_stator_temp_f": {

--- a/homeassistant/components/teslemetry/quality_scale.yaml
+++ b/homeassistant/components/teslemetry/quality_scale.yaml
@@ -75,11 +75,7 @@ rules:
       new TeslemetryVehicleData/TeslemetryEnergyData to runtime_data, then trigger
       entity creation via coordinator listeners in each platform.
   entity-category: done
-  entity-device-class:
-    status: todo
-    comment: |
-      DRIVE_INVERTER_STATES has "unavailable" as a state value which conflicts with HA's
-      unavailable state - shows duplicate in state trigger UI.
+  entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
   exception-translations:

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -72,7 +72,7 @@ CHARGE_STATES = {
 }
 
 DRIVE_INVERTER_STATES = {
-    "Unavailable": "unavailable",
+    "Unavailable": "not_available",
     "Standby": "standby",
     "Fault": "fault",
     "Abort": "abort",

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -7,6 +7,7 @@
     "end_time": "End time",
     "end_time_description": "The time this schedule ends, e.g. 01:05 for 1:05 AM.",
     "location_description": "The approximate location the vehicle must be at to use this schedule. Defaults to Home Assistant's configured location.",
+    "not_available": "Not available",
     "one_time": "One-time",
     "one_time_description": "If this is a one-time schedule.",
     "precondition_time": "Precondition time",
@@ -18,7 +19,6 @@
     "schedule_name_description": "The name of the schedule.",
     "start_time": "Start time",
     "start_time_description": "The time this schedule begins, e.g. 01:05 for 1:05 AM.",
-    "unavailable": "Unavailable",
     "vehicle": "Vehicle",
     "vehicle_to_remove_schedule": "Vehicle to remove schedule from.",
     "vehicle_to_schedule": "Vehicle to schedule.",
@@ -636,8 +636,8 @@
           "abort": "[%key:component::teslemetry::common::abort%]",
           "enabled": "[%key:common::state::enabled%]",
           "fault": "[%key:common::state::fault%]",
-          "standby": "[%key:common::state::standby%]",
-          "unavailable": "[%key:component::teslemetry::common::unavailable%]"
+          "not_available": "[%key:component::teslemetry::common::not_available%]",
+          "standby": "[%key:common::state::standby%]"
         }
       },
       "di_state_r": {
@@ -646,8 +646,8 @@
           "abort": "[%key:component::teslemetry::common::abort%]",
           "enabled": "[%key:common::state::enabled%]",
           "fault": "[%key:common::state::fault%]",
-          "standby": "[%key:common::state::standby%]",
-          "unavailable": "[%key:component::teslemetry::common::unavailable%]"
+          "not_available": "[%key:component::teslemetry::common::not_available%]",
+          "standby": "[%key:common::state::standby%]"
         }
       },
       "di_state_rel": {
@@ -656,8 +656,8 @@
           "abort": "[%key:component::teslemetry::common::abort%]",
           "enabled": "[%key:common::state::enabled%]",
           "fault": "[%key:common::state::fault%]",
-          "standby": "[%key:common::state::standby%]",
-          "unavailable": "[%key:component::teslemetry::common::unavailable%]"
+          "not_available": "[%key:component::teslemetry::common::not_available%]",
+          "standby": "[%key:common::state::standby%]"
         }
       },
       "di_state_rer": {
@@ -666,8 +666,8 @@
           "abort": "[%key:component::teslemetry::common::abort%]",
           "enabled": "[%key:common::state::enabled%]",
           "fault": "[%key:common::state::fault%]",
-          "standby": "[%key:common::state::standby%]",
-          "unavailable": "[%key:component::teslemetry::common::unavailable%]"
+          "not_available": "[%key:component::teslemetry::common::not_available%]",
+          "standby": "[%key:common::state::standby%]"
         }
       },
       "di_stator_temp_f": {


### PR DESCRIPTION
## Proposed change

Rename the "unavailable" state value in `DRIVE_INVERTER_STATES` to "not_available" to avoid conflict with Home Assistant's built-in unavailable state. This fixes the entity-device-class quality scale issue where duplicate entries appeared in the state trigger UI.

- Changed state mapping from "unavailable" to "not_available" in sensor.py
- Updated common key and all four drive inverter sensor state definitions in strings.json
- Updated all four drive inverter sensor icon definitions in icons.json
- Changed entity-device-class status from todo to done in quality_scale.yaml

This follows the same pattern used by other integrations like victron_ble which also use "not_available" to distinguish between device-reported unavailability and Home Assistant's entity unavailable state.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr