### PR TITLE
Assist satellites: Allow selective message broadcast

### DIFF
--- a/homeassistant/components/assist_satellite/intent.py
+++ b/homeassistant/components/assist_satellite/intent.py
@@ -5,7 +5,7 @@ from typing import Final
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er, intent
+from homeassistant.helpers import config_validation as cv, entity_registry as er, intent
 
 from .const import DOMAIN, AssistSatelliteEntityFeature
 
@@ -21,34 +21,71 @@ class BroadcastIntentHandler(intent.IntentHandler):
     """Broadcast a message."""
 
     intent_type = intent.INTENT_BROADCAST
-    description = "Broadcast a message through the home"
+    description = (
+        "Broadcast a message through the home to specific areas, floors, or satellites"
+    )
 
     @property
     def slot_schema(self) -> dict | None:
         """Return a slot schema."""
-        return {vol.Required("message"): str}
+        return {
+            vol.Required("message"): str,
+            vol.Optional("name"): intent.non_empty_string,
+            vol.Optional("area"): intent.non_empty_string,
+            vol.Optional("floor"): intent.non_empty_string,
+            vol.Optional("preferred_area_id"): cv.string,
+            vol.Optional("preferred_floor_id"): cv.string,
+        }
 
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Broadcast a message."""
         hass = intent_obj.hass
         ent_reg = er.async_get(hass)
+        slots = self.async_validate_slots(intent_obj.slots)
 
-        # Find all assist satellite entities that are not the one invoking the intent
-        entities: dict[str, er.RegistryEntry] = {}
-        for entity in hass.states.async_entity_ids(DOMAIN):
-            entry = ent_reg.async_get(entity)
-            if (
-                (entry is None)
-                or (
-                    # Supports announce
-                    not (
-                        entry.supported_features & AssistSatelliteEntityFeature.ANNOUNCE
-                    )
-                )
-                # Not the invoking device
-                or (intent_obj.device_id and (entry.device_id == intent_obj.device_id))
-            ):
-                # Skip satellite
+        # Extract message and optional targeting parameters
+        message = slots["message"]["value"]
+        name = slots.get("name", {}).get("value")
+        area_name = slots.get("area", {}).get("value")
+        floor_name = slots.get("floor", {}).get("value")
+
+        # Build constraints for entity matching
+        match_constraints = intent.MatchTargetsConstraints(
+            name=name,
+            area_name=area_name,
+            floor_name=floor_name,
+            domains=[DOMAIN],
+            features=AssistSatelliteEntityFeature.ANNOUNCE,
+            assistant=None,  # Don't filter by assistant - broadcast to all satellites
+            single_target=False,
+        )
+
+        # Build preferences for disambiguation
+        match_preferences = intent.MatchTargetsPreferences(
+            area_id=slots.get("preferred_area_id", {}).get("value"),
+            floor_id=slots.get("preferred_floor_id", {}).get("value"),
+        )
+
+        # Match entities based on constraints
+        match_result = intent.async_match_targets(
+            hass, match_constraints, match_preferences
+        )
+
+        # Raise error if no matches found (invalid area/floor/name)
+        if not match_result.is_match:
+            raise intent.MatchFailedError(
+                result=match_result, constraints=match_constraints
+            )
+
+        # Post-filter: exclude invoking device and excluded domains
+        filtered_states = []
+        for state in match_result.states:
+            entry = ent_reg.async_get(state.entity_id)
+            if entry is None:
+                continue
+
+            # Exclude invoking device
+            if intent_obj.device_id and (entry.device_id == intent_obj.device_id):
                 continue
 
             # Check domain of config entry against excluded domains
@@ -63,26 +100,29 @@ class BroadcastIntentHandler(intent.IntentHandler):
             ):
                 continue
 
-            entities[entity] = entry
+            filtered_states.append(state)
 
-        await hass.services.async_call(
-            DOMAIN,
-            "announce",
-            {"message": intent_obj.slots["message"]["value"]},
-            blocking=True,
-            context=intent_obj.context,
-            target={"entity_id": list(entities)},
-        )
+        # Call announce service with filtered entities
+        if filtered_states:
+            await hass.services.async_call(
+                DOMAIN,
+                "announce",
+                {"message": message},
+                blocking=True,
+                context=intent_obj.context,
+                target={"entity_id": [state.entity_id for state in filtered_states]},
+            )
 
+        # Build response
         response = intent_obj.create_response()
         response.async_set_results(
             success_results=[
                 intent.IntentResponseTarget(
                     type=intent.IntentResponseTargetType.ENTITY,
-                    id=entity,
-                    name=state.name if (state := hass.states.get(entity)) else entity,
+                    id=state.entity_id,
+                    name=state.name,
                 )
-                for entity in entities
+                for state in filtered_states
             ]
         )
         return response

--- a/tests/components/assist_satellite/test_intent.py
+++ b/tests/components/assist_satellite/test_intent.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import intent
+from homeassistant.helpers import area_registry as ar, entity_registry as er, intent
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_DOMAIN, MockAssistSatellite
@@ -136,3 +136,240 @@ async def test_broadcast_intent_excluded_domains(
             "response_type": "action_done",
             "speech": {},
         }
+
+
+async def test_broadcast_intent_to_area(
+    hass: HomeAssistant,
+    init_components: ConfigEntry,
+    entity: MockAssistSatellite,
+    entity2: MockAssistSatellite,
+    mock_tts: None,
+) -> None:
+    """Test broadcasting to a specific area."""
+    # Set up areas
+    area_reg = ar.async_get(hass)
+    kitchen_area = area_reg.async_create("Kitchen")
+    bedroom_area = area_reg.async_create("Bedroom")
+
+    # Assign entities to areas
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get("assist_satellite.test_entity")
+    ent_reg.async_update_entity(entity_entry.entity_id, area_id=kitchen_area.id)
+
+    entity2_entry = ent_reg.async_get("assist_satellite.test_entity_2")
+    ent_reg.async_update_entity(entity2_entry.entity_id, area_id=bedroom_area.id)
+
+    # Broadcast to kitchen only
+    with patch(
+        "homeassistant.components.tts.async_resolve_engine",
+        return_value="tts.cloud",
+    ):
+        result = await intent.async_handle(
+            hass,
+            "test",
+            intent.INTENT_BROADCAST,
+            {"message": {"value": "Kitchen message"}, "area": {"value": "Kitchen"}},
+        )
+
+    # Only entity in kitchen should receive broadcast
+    assert result.as_dict()["data"]["success"] == [
+        {
+            "id": "assist_satellite.test_entity",
+            "name": "Test Entity",
+            "type": intent.IntentResponseTargetType.ENTITY,
+        },
+    ]
+    assert len(entity.announcements) == 1
+    assert len(entity2.announcements) == 0
+
+
+async def test_broadcast_intent_by_name(
+    hass: HomeAssistant,
+    init_components: ConfigEntry,
+    entity: MockAssistSatellite,
+    entity2: MockAssistSatellite,
+    mock_tts: None,
+) -> None:
+    """Test broadcasting to a specific entity by name."""
+
+    with patch(
+        "homeassistant.components.tts.async_resolve_engine",
+        return_value="tts.cloud",
+    ):
+        result = await intent.async_handle(
+            hass,
+            "test",
+            intent.INTENT_BROADCAST,
+            {
+                "message": {"value": "Specific message"},
+                "name": {"value": "Test Entity 2"},
+            },
+        )
+
+    # Only entity2 should receive broadcast
+    assert result.as_dict()["data"]["success"] == [
+        {
+            "id": "assist_satellite.test_entity_2",
+            "name": "Test Entity 2",
+            "type": intent.IntentResponseTargetType.ENTITY,
+        },
+    ]
+    assert len(entity.announcements) == 0
+    assert len(entity2.announcements) == 1
+
+
+async def test_broadcast_intent_invalid_area(
+    hass: HomeAssistant,
+    init_components: ConfigEntry,
+    entity: MockAssistSatellite,
+    entity2: MockAssistSatellite,
+    mock_tts: None,
+) -> None:
+    """Test broadcasting to an invalid area raises MatchFailedError."""
+
+    with (
+        patch(
+            "homeassistant.components.tts.async_resolve_engine",
+            return_value="tts.cloud",
+        ),
+        pytest.raises(intent.MatchFailedError) as exc_info,
+    ):
+        await intent.async_handle(
+            hass,
+            "test",
+            intent.INTENT_BROADCAST,
+            {
+                "message": {"value": "Test message"},
+                "area": {"value": "NonExistentArea"},
+            },
+        )
+
+    # Verify error is about invalid area
+    assert (
+        exc_info.value.result.no_match_reason == intent.MatchFailedReason.INVALID_AREA
+    )
+
+
+async def test_broadcast_intent_area_with_invoking_device(
+    hass: HomeAssistant,
+    init_components: ConfigEntry,
+    entity: MockAssistSatellite,
+    entity2: MockAssistSatellite,
+    mock_tts: None,
+) -> None:
+    """Test that invoking device is excluded even when filtering by area."""
+    # Set up area
+    area_reg = ar.async_get(hass)
+    kitchen_area = area_reg.async_create("Kitchen")
+
+    # Assign both entities to the same area
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get("assist_satellite.test_entity")
+    ent_reg.async_update_entity(entity_entry.entity_id, area_id=kitchen_area.id)
+
+    entity2_entry = ent_reg.async_get("assist_satellite.test_entity_2")
+    ent_reg.async_update_entity(entity2_entry.entity_id, area_id=kitchen_area.id)
+
+    # Broadcast to kitchen from entity1's device
+    with patch(
+        "homeassistant.components.tts.async_resolve_engine",
+        return_value="tts.cloud",
+    ):
+        result = await intent.async_handle(
+            hass,
+            "test",
+            intent.INTENT_BROADCAST,
+            {"message": {"value": "Kitchen message"}, "area": {"value": "Kitchen"}},
+            device_id=entity.device_entry.id,
+        )
+
+    # Only entity2 should receive broadcast (entity1 is the invoking device)
+    assert result.as_dict()["data"]["success"] == [
+        {
+            "id": "assist_satellite.test_entity_2",
+            "name": "Test Entity 2",
+            "type": intent.IntentResponseTargetType.ENTITY,
+        },
+    ]
+    assert len(entity.announcements) == 0
+    assert len(entity2.announcements) == 1
+
+
+async def test_broadcast_intent_area_only_invoking_device(
+    hass: HomeAssistant,
+    init_components: ConfigEntry,
+    entity: MockAssistSatellite,
+    entity2: MockAssistSatellite,
+    mock_tts: None,
+) -> None:
+    """Test empty success when area contains only invoking device."""
+    # Set up areas
+    area_reg = ar.async_get(hass)
+    kitchen_area = area_reg.async_create("Kitchen")
+    bedroom_area = area_reg.async_create("Bedroom")
+
+    # Assign entities to different areas
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get("assist_satellite.test_entity")
+    ent_reg.async_update_entity(entity_entry.entity_id, area_id=kitchen_area.id)
+
+    entity2_entry = ent_reg.async_get("assist_satellite.test_entity_2")
+    ent_reg.async_update_entity(entity2_entry.entity_id, area_id=bedroom_area.id)
+
+    # Broadcast to kitchen from entity1's device (only device in kitchen)
+    with patch(
+        "homeassistant.components.tts.async_resolve_engine",
+        return_value="tts.cloud",
+    ):
+        result = await intent.async_handle(
+            hass,
+            "test",
+            intent.INTENT_BROADCAST,
+            {"message": {"value": "Kitchen message"}, "area": {"value": "Kitchen"}},
+            device_id=entity.device_entry.id,
+        )
+
+    # No devices should receive broadcast (only device in area is invoking device)
+    assert result.as_dict()["data"]["success"] == []
+    assert len(entity.announcements) == 0
+    assert len(entity2.announcements) == 0
+
+
+async def test_broadcast_intent_entity_without_registry_entry(
+    hass: HomeAssistant,
+    init_components: ConfigEntry,
+    entity: MockAssistSatellite,
+    entity2: MockAssistSatellite,
+    mock_tts: None,
+) -> None:
+    """Test that entities without registry entries are skipped gracefully."""
+    ent_reg = er.async_get(hass)
+    original_async_get = ent_reg.async_get
+
+    # Mock async_get to return None for entity1 (simulating missing registry entry)
+    def mock_async_get(entity_id):
+        if entity_id == "assist_satellite.test_entity":
+            return None
+        return original_async_get(entity_id)
+
+    with (
+        patch(
+            "homeassistant.components.tts.async_resolve_engine",
+            return_value="tts.cloud",
+        ),
+        patch.object(ent_reg, "async_get", side_effect=mock_async_get),
+    ):
+        result = await intent.async_handle(
+            hass, "test", intent.INTENT_BROADCAST, {"message": {"value": "Hello"}}
+        )
+
+    # Only entity2 should receive broadcast (entity1 has no registry entry)
+    assert result.as_dict()["data"]["success"] == [
+        {
+            "id": "assist_satellite.test_entity_2",
+            "name": "Test Entity 2",
+            "type": intent.IntentResponseTargetType.ENTITY,
+        },
+    ]
+    assert len(entity.announcements) == 0
+    assert len(entity2.announcements) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This patch allows to select location of the broadcast, per-area, entity or floor.

It will especially be useful in situations with many places where to broadcast. Scenario that should eventually be possible:
- announce to the first floor to get down for dinner
- announce to kids room to go shower

Implementation is based on https://github.com/home-assistant/core/blob/dev/homeassistant/components/climate/intent.py

For now this implementation works well when using a LLM (because it can properly use the tool built out of this intent) but not yet with the built-in assist intent parser. I'll work on this in a second patch.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
