### PR TITLE
Fix Shelly CoIoT repair issue

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -59,7 +59,6 @@ from .coordinator import (
 )
 from .repairs import (
     async_manage_ble_scanner_firmware_unsupported_issue,
-    async_manage_coiot_unconfigured_issue,
     async_manage_deprecated_firmware_issue,
     async_manage_open_wifi_ap_issue,
     async_manage_outbound_websocket_incorrectly_enabled_issue,
@@ -233,7 +232,6 @@ async def _async_setup_block_entry(
         await hass.config_entries.async_forward_entry_setups(
             entry, runtime_data.platforms
         )
-        await async_manage_coiot_unconfigured_issue(hass, entry)
         remove_empty_sub_devices(hass, entry)
     elif (
         sleep_period is None

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -5,12 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from aioshelly.block_device import BlockDevice
-from aioshelly.const import (
-    MODEL_OUT_PLUG_S_G3,
-    MODEL_PLUG,
-    MODEL_PLUG_S_G3,
-    RPC_GENERATIONS,
-)
+from aioshelly.const import MODEL_OUT_PLUG_S_G3, MODEL_PLUG_S_G3, RPC_GENERATIONS
 from aioshelly.exceptions import DeviceConnectionError, RpcCallError
 from aioshelly.rpc_device import RpcDevice
 from awesomeversion import AwesomeVersion
@@ -24,7 +19,6 @@ from homeassistant.helpers import issue_registry as ir
 from .const import (
     BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID,
     BLE_SCANNER_MIN_FIRMWARE,
-    COIOT_UNCONFIGURED_ISSUE_ID,
     CONF_BLE_SCANNER_MODE,
     DEPRECATED_FIRMWARE_ISSUE_ID,
     DEPRECATED_FIRMWARES,
@@ -151,50 +145,6 @@ def async_manage_outbound_websocket_incorrectly_enabled_issue(
             is_persistent=True,
             severity=ir.IssueSeverity.WARNING,
             translation_key="outbound_websocket_incorrectly_enabled",
-            translation_placeholders={
-                "device_name": device.name,
-                "ip_address": device.ip_address,
-            },
-            data={"entry_id": entry.entry_id},
-        )
-        return
-
-    ir.async_delete_issue(hass, DOMAIN, issue_id)
-
-
-async def async_manage_coiot_unconfigured_issue(
-    hass: HomeAssistant,
-    entry: ShellyConfigEntry,
-) -> None:
-    """Manage the CoIoT unconfigured issue."""
-    issue_id = COIOT_UNCONFIGURED_ISSUE_ID.format(unique=entry.unique_id)
-
-    if TYPE_CHECKING:
-        assert entry.runtime_data.block is not None
-
-    device = entry.runtime_data.block.device
-
-    if device.model == MODEL_PLUG:
-        # Shelly Plug Gen 1 does not have CoIoT settings
-        ir.async_delete_issue(hass, DOMAIN, issue_id)
-        return
-
-    coiot_config = device.settings["coiot"]
-    coiot_enabled = coiot_config.get("enabled")
-
-    coiot_peer = f"{await get_coiot_address(hass)}:{get_coiot_port(hass)}"
-    # Check if CoIoT is disabled or peer address is not correctly set
-    if not coiot_enabled or (
-        (peer_config := coiot_config.get("peer")) and peer_config != coiot_peer
-    ):
-        ir.async_create_issue(
-            hass,
-            DOMAIN,
-            issue_id,
-            is_fixable=True,
-            is_persistent=False,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key="coiot_unconfigured",
             translation_placeholders={
                 "device_name": device.name,
                 "ip_address": device.ip_address,

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -22,6 +22,7 @@ from aioshelly.const import (
     MODEL_EM3,
     MODEL_I3,
     MODEL_NAMES,
+    MODEL_PLUG,
     RPC_GENERATIONS,
 )
 from aioshelly.rpc_device import RpcDevice, WsServer
@@ -55,6 +56,7 @@ from homeassistant.util.dt import utcnow
 from .const import (
     API_WS_URL,
     BASIC_INPUTS_EVENTS_TYPES,
+    COIOT_UNCONFIGURED_ISSUE_ID,
     COMPONENT_ID_PATTERN,
     CONF_COAP_PORT,
     CONF_GEN,
@@ -67,6 +69,7 @@ from .const import (
     GEN2_RELEASE_URL,
     LOGGER,
     MAX_SCRIPT_SIZE,
+    PUSH_UPDATE_ISSUE_ID,
     ROLE_GENERIC,
     RPC_INPUTS_EVENTS_TYPES,
     SHAIR_MAX_WORK_HOURS,
@@ -1003,4 +1006,80 @@ def is_rpc_ble_scanner_supported(entry: ConfigEntry) -> bool:
     return (
         entry.runtime_data.rpc_supports_scripts
         and not entry.runtime_data.rpc_zigbee_firmware
+    )
+
+
+async def check_coiot_config(device: BlockDevice, hass: HomeAssistant) -> bool:
+    """Check if CoIoT is correctly configured."""
+    if device.model == MODEL_PLUG:
+        # Shelly Plug Gen 1 does not have CoIoT settings
+        return True
+
+    coiot_config = device.settings["coiot"]
+
+    # Check if CoIoT is disabled
+    if not coiot_config.get("enabled"):
+        return False
+
+    coiot_peer = f"{await get_coiot_address(hass)}:{get_coiot_port(hass)}"
+
+    # Check if CoIoT is address is not correctly set
+    if (peer_config := coiot_config.get("peer")) and peer_config != coiot_peer:
+        LOGGER.debug(
+            "CoIoT is unconfigured for device %s, peer_config: %s, coiot_peer: %s",
+            device.name,
+            peer_config,
+            coiot_peer,
+        )
+        return False
+
+    return True
+
+
+async def async_manage_coiot_issues_task(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """CoIoT configuration or push updates issues task."""
+    config_issue_id = COIOT_UNCONFIGURED_ISSUE_ID.format(unique=entry.unique_id)
+    push_updates_issue_id = PUSH_UPDATE_ISSUE_ID.format(unique=entry.unique_id)
+
+    if TYPE_CHECKING:
+        assert entry.runtime_data.block is not None
+
+    device = entry.runtime_data.block.device
+
+    if await check_coiot_config(device, hass):
+        # CoIoT is correctly configured, create push updates issue
+        ir.async_delete_issue(hass, DOMAIN, config_issue_id)
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            push_updates_issue_id,
+            is_fixable=False,
+            is_persistent=False,
+            severity=ir.IssueSeverity.ERROR,
+            learn_more_url="https://www.home-assistant.io/integrations/shelly/#shelly-device-configuration-generation-1",
+            translation_key="push_update_failure",
+            translation_placeholders={
+                "device_name": device.name,
+                "ip_address": device.ip_address,
+            },
+        )
+        return
+
+    # CoIoT is not correctly configured, create config issue
+    ir.async_delete_issue(hass, DOMAIN, push_updates_issue_id)
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        config_issue_id,
+        is_fixable=True,
+        is_persistent=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="coiot_unconfigured",
+        translation_placeholders={
+            "device_name": device.name,
+            "ip_address": device.ip_address,
+        },
+        data={"entry_id": entry.entry_id},
     )

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -1024,8 +1024,7 @@ async def check_coiot_config(device: BlockDevice, hass: HomeAssistant) -> bool:
     coiot_address = await get_coiot_address(hass)
     if coiot_address is None:
         LOGGER.debug(
-            "Skipping CoIoT peer check for device %s as no local address "
-            "is available",
+            "Skipping CoIoT peer check for device %s as no local address is available",
             device.name,
         )
         return True

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -1021,9 +1021,17 @@ async def check_coiot_config(device: BlockDevice, hass: HomeAssistant) -> bool:
     if not coiot_config.get("enabled"):
         return False
 
-    coiot_peer = f"{await get_coiot_address(hass)}:{get_coiot_port(hass)}"
+    coiot_address = await get_coiot_address(hass)
+    if coiot_address is None:
+        LOGGER.debug(
+            "Skipping CoIoT peer check for device %s as no local address "
+            "is available",
+            device.name,
+        )
+        return True
 
-    # Check if CoIoT is address is not correctly set
+    coiot_peer = f"{coiot_address}:{get_coiot_port(hass)}"
+    # Check if CoIoT address is not correctly set
     if (peer_config := coiot_config.get("peer")) and peer_config != coiot_peer:
         LOGGER.debug(
             "CoIoT is unconfigured for device %s, peer_config: %s, coiot_peer: %s",

--- a/tests/components/shelly/__init__.py
+++ b/tests/components/shelly/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.components.shelly.const import (
     CONF_GEN,
     CONF_SLEEP_PERIOD,
     DOMAIN,
+    MAX_PUSH_UPDATE_FAILURES,
     REST_SENSORS_UPDATE_INTERVAL,
     RPC_SENSORS_POLLING_INTERVAL,
 )
@@ -69,6 +70,15 @@ async def init_integration(
         await hass.async_block_till_done()
 
     return entry
+
+
+async def mock_block_device_push_update_failure(
+    hass: HomeAssistant, mock_block_device: Mock
+) -> None:
+    """Create updates with COAP_REPLY indicating push update failure for block device."""
+    for _ in range(MAX_PUSH_UPDATE_FAILURES):
+        mock_block_device.mock_update_reply()
+        await hass.async_block_till_done()
 
 
 def mutate_rpc_device_status(

--- a/tests/components/shelly/__init__.py
+++ b/tests/components/shelly/__init__.py
@@ -79,6 +79,7 @@ async def mock_block_device_push_update_failure(
     for _ in range(MAX_PUSH_UPDATE_FAILURES):
         mock_block_device.mock_update_reply()
         await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 def mutate_rpc_device_status(

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -39,7 +39,11 @@ MOCK_SETTINGS = {
         "num_inputs": 3,
         "num_outputs": 2,
     },
-    "coiot": {"update_period": 15},
+    "coiot": {
+        "update_period": 15,
+        "enabled": True,
+        "peer": "10.10.10.10:5683",
+    },
     "fw": "20201124-092159/v1.9.0@57ac4ad8",
     "inputs": [
         {

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -20,7 +20,6 @@ from homeassistant.components.shelly.const import (
     CONF_SLEEP_PERIOD,
     DOMAIN,
     ENTRY_RELOAD_COOLDOWN,
-    MAX_PUSH_UPDATE_FAILURES,
     RPC_RECONNECT_INTERVAL,
     UPDATE_PERIOD_MULTIPLIER,
     BLEScannerMode,
@@ -36,6 +35,7 @@ from . import (
     MOCK_MAC,
     init_integration,
     inject_rpc_device_event,
+    mock_block_device_push_update_failure,
     mock_polling_rpc_update,
     mock_rest_update,
     register_device,
@@ -332,15 +332,7 @@ async def test_block_device_push_updates_failure(
 ) -> None:
     """Test block device with push updates failure."""
     await init_integration(hass, 1)
-
-    # Updates with COAP_REPLAY type should create an issue
-    for _ in range(MAX_PUSH_UPDATE_FAILURES):
-        mock_block_device.mock_update_reply()
-        await hass.async_block_till_done()
-
-    assert issue_registry.async_get_issue(
-        domain=DOMAIN, issue_id=f"push_update_{MOCK_MAC}"
-    )
+    await mock_block_device_push_update_failure(hass, mock_block_device)
 
     # An update with COAP_PERIODIC type should clear the issue
     mock_block_device.mock_update()

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -52,7 +52,13 @@ async def test_block_config_entry_diagnostics(
             "model": MODEL_25,
             "sw_version": "some fw string",
         },
-        "device_settings": {"coiot": {"update_period": 15}},
+        "device_settings": {
+            "coiot": {
+                "update_period": 15,
+                "enabled": True,
+                "peer": "10.10.10.10:5683",
+            }
+        },
         "device_status": MOCK_STATUS_COAP,
         "last_error": "DeviceConnectionError()",
     }

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -639,14 +639,37 @@ async def test_coiot_key_missing_no_issue_created(
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
 
 
-async def test_coiot_no_hass_url(
+async def test_coiot_push_issue_when_missing_hass_url(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     mock_block_device: Mock,
     issue_registry: ir.IssueRegistry,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test no CoIoT repair issues when HA URL is not available."""
+    """Test CoIoT push update issue created when HA URL is not available."""
+    issue_id = PUSH_UPDATE_ISSUE_ID.format(unique=MOCK_MAC)
+    assert await async_setup_component(hass, "repairs", {})
+    await hass.async_block_till_done()
+    await init_integration(hass, 1)
+
+    with patch(
+        "homeassistant.components.shelly.utils.get_url",
+        side_effect=NoURLAvailableError(),
+    ):
+        await mock_block_device_push_update_failure(hass, mock_block_device)
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1
+
+
+async def test_coiot_fix_flow_no_hass_url(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_block_device: Mock,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test CoIoT repair issue when HA URL is not available."""
     monkeypatch.setitem(
         mock_block_device.settings,
         "coiot",

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -1,5 +1,6 @@
 """Test repairs handling for Shelly."""
 
+from typing import Any
 from unittest.mock import Mock, patch
 
 from aioshelly.const import MODEL_PLUG, MODEL_WALL_DISPLAY
@@ -14,6 +15,7 @@ from homeassistant.components.shelly.const import (
     DOMAIN,
     OPEN_WIFI_AP_ISSUE_ID,
     OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID,
+    PUSH_UPDATE_ISSUE_ID,
     BLEScannerMode,
     DeprecatedFirmwareInfo,
 )
@@ -22,7 +24,7 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.network import NoURLAvailableError
 from homeassistant.setup import async_setup_component
 
-from . import MOCK_MAC, init_integration
+from . import MOCK_MAC, init_integration, mock_block_device_push_update_failure
 
 from tests.components.repairs import (
     async_process_repairs_platforms,
@@ -505,23 +507,28 @@ async def test_other_fixable_issues(
     assert result["type"] == "create_entry"
 
 
-async def test_coiot_missing_or_wrong_peer_issue(
+@pytest.mark.parametrize(
+    "coiot",
+    [
+        {"enabled": False, "update_period": 15, "peer": "10.10.10.10:5683"},
+        {"enabled": True, "update_period": 15, "peer": "7.7.7.7:5683"},
+    ],
+)
+async def test_coiot_disabled_or_wrong_peer_issue(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     mock_block_device: Mock,
     issue_registry: ir.IssueRegistry,
     monkeypatch: pytest.MonkeyPatch,
+    coiot: dict[str, Any],
 ) -> None:
-    """Test repair issues handling wrong or missing CoIoT configuration."""
-    monkeypatch.setitem(
-        mock_block_device.settings,
-        "coiot",
-        {"enabled": False, "update_period": 15, "peer": "wrong.peer.address:5683"},
-    )
+    """Test repair issues handling wrong or disabled CoIoT configuration."""
+    monkeypatch.setitem(mock_block_device.settings, "coiot", coiot)
     issue_id = COIOT_UNCONFIGURED_ISSUE_ID.format(unique=MOCK_MAC)
     assert await async_setup_component(hass, "repairs", {})
     await hass.async_block_till_done()
     await init_integration(hass, 1)
+    await mock_block_device_push_update_failure(hass, mock_block_device)
 
     assert issue_registry.async_get_issue(DOMAIN, issue_id)
     assert len(issue_registry.issues) == 1
@@ -551,16 +558,17 @@ async def test_coiot_exception(
     issue_registry: ir.IssueRegistry,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test no repair issues handling up-to-date CoIoT configuration."""
+    """Test CoIoT exception handling in fix flow."""
     monkeypatch.setitem(
         mock_block_device.settings,
         "coiot",
-        {"enabled": True, "update_period": 15, "peer": "correct.peer.address:5683"},
+        {"enabled": False, "update_period": 15, "peer": "7.7.7.7:5683"},
     )
     issue_id = COIOT_UNCONFIGURED_ISSUE_ID.format(unique=MOCK_MAC)
     assert await async_setup_component(hass, "repairs", {})
     await hass.async_block_till_done()
     await init_integration(hass, 1)
+    await mock_block_device_push_update_failure(hass, mock_block_device)
 
     assert issue_registry.async_get_issue(DOMAIN, issue_id)
     assert len(issue_registry.issues) == 1
@@ -598,12 +606,7 @@ async def test_coiot_configured_no_issue_created(
     monkeypatch: pytest.MonkeyPatch,
     raw_url: str,
 ) -> None:
-    """Test no repair issues when CoIoT configuration is missing."""
-    monkeypatch.setitem(
-        mock_block_device.settings,
-        "coiot",
-        {"enabled": True, "update_period": 15, "peer": "10.10.10.10:5683"},
-    )
+    """Test no repair issues when CoIoT configuration is valid."""
     issue_id = COIOT_UNCONFIGURED_ISSUE_ID.format(unique=MOCK_MAC)
     assert await async_setup_component(hass, "repairs", {})
     with patch(
@@ -612,6 +615,7 @@ async def test_coiot_configured_no_issue_created(
     ):
         await hass.async_block_till_done()
         await init_integration(hass, 1)
+        await mock_block_device_push_update_failure(hass, mock_block_device)
 
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
 
@@ -642,16 +646,17 @@ async def test_coiot_no_hass_url(
     issue_registry: ir.IssueRegistry,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test no repair issues handling up-to-date CoIoT configuration."""
+    """Test no CoIoT repair issues when HA URL is not available."""
     monkeypatch.setitem(
         mock_block_device.settings,
         "coiot",
-        {"enabled": True, "update_period": 15, "peer": "correct.peer.address:5683"},
+        {"enabled": False, "update_period": 15, "peer": "7.7.7.7:5683"},
     )
     issue_id = COIOT_UNCONFIGURED_ISSUE_ID.format(unique=MOCK_MAC)
     assert await async_setup_component(hass, "repairs", {})
     await hass.async_block_till_done()
     await init_integration(hass, 1)
+    await mock_block_device_push_update_failure(hass, mock_block_device)
 
     assert issue_registry.async_get_issue(DOMAIN, issue_id)
     assert len(issue_registry.issues) == 1
@@ -688,11 +693,17 @@ async def test_coiot_issue_ignore(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test ignoring the CoIoT unconfigured issue."""
+    monkeypatch.setitem(
+        mock_block_device.settings,
+        "coiot",
+        {"enabled": False, "update_period": 15, "peer": "7.7.7.7:5683"},
+    )
     issue_id = COIOT_UNCONFIGURED_ISSUE_ID.format(unique=MOCK_MAC)
 
     assert await async_setup_component(hass, "repairs", {})
     await hass.async_block_till_done()
     await init_integration(hass, 1)
+    await mock_block_device_push_update_failure(hass, mock_block_device)
 
     assert issue_registry.async_get_issue(DOMAIN, issue_id)
     assert len(issue_registry.issues) == 1
@@ -714,17 +725,19 @@ async def test_coiot_issue_ignore(
     assert issue.dismissed_version
 
 
-async def test_coiot_plug_1_no_issue_created(
+async def test_plug_1_push_update_issue_created(
     hass: HomeAssistant,
     mock_block_device: Mock,
     issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test no repair issues when device is Shelly Plug 1."""
-
-    mock_block_device.model = MODEL_PLUG
-    issue_id = COIOT_UNCONFIGURED_ISSUE_ID.format(unique=MOCK_MAC)
+    """Test push update repair issue when device is Shelly Plug 1."""
+    monkeypatch.setattr(mock_block_device, "model", MODEL_PLUG)
+    issue_id = PUSH_UPDATE_ISSUE_ID.format(unique=MOCK_MAC)
     assert await async_setup_component(hass, "repairs", {})
     await hass.async_block_till_done()
-    await init_integration(hass, 1)
+    await init_integration(hass, 1, model=MODEL_PLUG)
+    await mock_block_device_push_update_failure(hass, mock_block_device)
 
-    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/pull/161914 has increased Shelly integration start up time from 2-4 seconds to 22-24 seconds on my production environment:
<img width="410" height="87" alt="image" src="https://github.com/user-attachments/assets/bb62063f-8fb8-45bb-b500-089e9778e989" />

In addition the current behavior is not user friendly if `CoIoT` is not configured correctly we create two issues, one is fixable and one is not fixable, users will be confused what to do with the non fixable issue, the non-fixable is usually first:
<img width="591" height="170" alt="image" src="https://github.com/user-attachments/assets/87a29813-8de3-4996-b4c7-02b83ee8202d" />

The two issues are related most of the time, if `CoIoT` is not configured correctly push updates does not work, if configured correctly push updates should work.
With this PR the issues behavior is changed:
- If `CoIoT` is not configured correctly offer the user to automatically fix it.
- If `CoIoT` is configured correctly push updates issue created - asking the user to read the docs , mainly to explain which port should be available and troubleshooting information.
- If in any case we assume that `CoIoT` is not configured correctly (e.g., VLANs) but push updates are working correctly do not create any issue (existing behavior create an issue for no reason).
- Any push update clear both issues (in case the `CoIoT` config was updated outside of Home Assistant).

This also fix the long start up time since it is run only upon errors and on a background task so not blocking anything, it also reduce chances for incorrect issues since the logic only run after push updates fail.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
