### PR TITLE
Allow empty string titles in legacy notifier service

### DIFF
--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -241,7 +241,6 @@ class BaseNotificationService:
         """Handle sending notification message service calls."""
         kwargs = {}
         message: str = service.data[ATTR_MESSAGE]
-        title: str | None
         if service.data.get(ATTR_TITLE) is not None:
             kwargs[ATTR_TITLE] = service.data.get(ATTR_TITLE)
 

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -242,8 +242,8 @@ class BaseNotificationService:
         kwargs = {}
         message: str = service.data[ATTR_MESSAGE]
         title: str | None
-        if title := service.data.get(ATTR_TITLE):
-            kwargs[ATTR_TITLE] = title
+        if service.data.get(ATTR_TITLE) is not None:
+            kwargs[ATTR_TITLE] = service.data.get(ATTR_TITLE)
 
         if self.registered_targets.get(service.service) is not None:
             kwargs[ATTR_TARGET] = [self.registered_targets[service.service]]

--- a/tests/components/notify/test_legacy.py
+++ b/tests/components/notify/test_legacy.py
@@ -577,6 +577,34 @@ async def test_calling_notify_from_script_loaded_from_yaml_without_title(
     )
 
 
+async def test_calling_notify_from_script_loaded_from_yaml_with_empty_title(
+    hass: HomeAssistant, tmp_path: Path
+) -> None:
+    """Test if we can call a notify from a script."""
+    send_message_mock = await help_setup_notify(hass, tmp_path)
+    step = {
+        "service": "notify.notify",
+        "data": {
+            "data": {"push": {"sound": "US-EN-Morgan-Freeman-Roommate-Is-Arriving.wav"}}
+        },
+        "data_template": {"message": "Test 123 {{ 2 + 2 }}\n", "title": ""},
+    }
+    await async_setup_component(
+        hass, "script", {"script": {"test": {"sequence": step}}}
+    )
+    await hass.services.async_call("script", "test")
+    await hass.async_block_till_done()
+    send_message_mock.assert_called_once_with(
+        "Test 123 4",
+        {
+            "title": "",
+            "data": {
+                "push": {"sound": "US-EN-Morgan-Freeman-Roommate-Is-Arriving.wav"}
+            },
+        },
+    )
+
+
 async def test_calling_notify_from_script_loaded_from_yaml_with_title(
     hass: HomeAssistant, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

**What breaks**
Explicitly configuring a legacy notifier to send a message with `title: ''` will no longer fall back on the default title of `"Home Assistant"`

**How to make it work again**
Delete `title: ''` entirely, or replace with `title: Home Assistant`

**Why we did this**
To allow empty string titles

## Proposed change

I propose we tweak the logic that parses notification configuration and calls legacy notification services to *explicitly allow empty titles*. My motivation is integrating Home Assistant with [https://github.com/caronc/apprise](Apprise). In Apprise, notification titles are optional. For certain backends (like Discord), messages without titles look a lot better, as they can be shorter and don't have a superfluous newline.

I dug around in Git history a bit, and found the original intent was to allow `None` titles (i.e. missing title key in yaml configuration): https://github.com/home-assistant/core/pull/3100

This was followed up by some hotfix patch that introduced the current logic (almost 10 years ago!), which I believe _accidentally_ conflates `None` with `""` by using the truthiness of strings, rather than comparing to `None` directly: https://github.com/home-assistant/core/pull/3302

In this PR, I've just swapped the truthiness check for a direct comparison to `None`, exactly as we do a few lines below for `ATTR_TARGET`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
