### PR TITLE
Fix KNX fan unique_id for switch-only fans

### DIFF
--- a/homeassistant/components/knx/fan.py
+++ b/homeassistant/components/knx/fan.py
@@ -48,6 +48,7 @@ def async_migrate_yaml_uids(
     hass: HomeAssistant, platform_config: list[ConfigType]
 ) -> None:
     """Migrate entities unique_id for YAML switch-only fan entities."""
+    # issue was introduced in 2026.1 - this migration in 2026.2
     ent_reg = er.async_get(hass)
     invalid_uid = str(None)
     if (

--- a/homeassistant/components/knx/fan.py
+++ b/homeassistant/components/knx/fan.py
@@ -73,13 +73,24 @@ def async_migrate_yaml_uids(
             new_uid_base[0],  # list of group addresses - first item is sending address
         )
     )
-    _LOGGER.info(
-        "Migrating fan entity '%s' unique_id from '%s' to %s",
-        none_entity_id,
-        invalid_uid,
-        new_uid,
-    )
-    ent_reg.async_update_entity(none_entity_id, new_unique_id=str(new_uid))
+    try:
+        ent_reg.async_update_entity(none_entity_id, new_unique_id=str(new_uid))
+        _LOGGER.info(
+            "Migrating fan entity '%s' unique_id from '%s' to %s",
+            none_entity_id,
+            invalid_uid,
+            new_uid,
+        )
+    except ValueError:
+        # New unique_id already exists - remove invalid entry. User might have changed YAML
+        _LOGGER.info(
+            "Failed to migrate fan entity '%s' unique_id from '%s' to '%s'. "
+            "Removing the invalid entry",
+            none_entity_id,
+            invalid_uid,
+            new_uid,
+        )
+        ent_reg.async_remove(none_entity_id)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/knx/fan.py
+++ b/homeassistant/components/knx/fan.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 import math
 from typing import Any
 
 from propcache.api import cached_property
 from xknx.devices import Fan as XknxFan
+from xknx.telegram.address import parse_device_group_address
 
 from homeassistant import config_entries
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.const import CONF_ENTITY_CATEGORY, CONF_NAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     async_get_current_platform,
@@ -37,6 +40,46 @@ from .storage.const import (
 )
 from .storage.util import ConfigExtractor
 
+_LOGGER = logging.getLogger(__name__)
+
+
+@callback
+def async_migrate_yaml_uids(
+    hass: HomeAssistant, platform_config: list[ConfigType]
+) -> None:
+    """Migrate entities unique_id for YAML switch-only fan entities."""
+    ent_reg = er.async_get(hass)
+    invalid_uid = str(None)
+    if (
+        none_entity_id := ent_reg.async_get_entity_id(Platform.FAN, DOMAIN, invalid_uid)
+    ) is None:
+        return
+    for config in platform_config:
+        if not config.get(KNX_ADDRESS) and (
+            new_uid_base := config.get(FanSchema.CONF_SWITCH_ADDRESS)
+        ):
+            break
+    else:
+        _LOGGER.info(
+            "No YAML entry found to migrate fan entity '%s' unique_id from '%s'. Removing entry",
+            none_entity_id,
+            invalid_uid,
+        )
+        ent_reg.async_remove(none_entity_id)
+        return
+    new_uid = str(
+        parse_device_group_address(
+            new_uid_base[0],  # list of group addresses - first item is sending address
+        )
+    )
+    _LOGGER.info(
+        "Migrating fan entity '%s' unique_id from '%s' to %s",
+        none_entity_id,
+        invalid_uid,
+        new_uid,
+    )
+    ent_reg.async_update_entity(none_entity_id, new_unique_id=str(new_uid))
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -57,6 +100,7 @@ async def async_setup_entry(
 
     entities: list[_KnxFan] = []
     if yaml_platform_config := knx_module.config_yaml.get(Platform.FAN):
+        async_migrate_yaml_uids(hass, yaml_platform_config)
         entities.extend(
             KnxYamlFan(knx_module, entity_config)
             for entity_config in yaml_platform_config
@@ -177,7 +221,10 @@ class KnxYamlFan(_KnxFan, KnxYamlEntity):
         self._step_range: tuple[int, int] | None = (1, max_step) if max_step else None
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
 
-        self._attr_unique_id = str(self._device.speed.group_address)
+        if self._device.speed.group_address:
+            self._attr_unique_id = str(self._device.speed.group_address)
+        else:
+            self._attr_unique_id = str(self._device.switch.group_address)
 
 
 class KnxUiFan(_KnxFan, KnxUiEntity):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
YAML fan entities without a speed address have been created with unique_id "None". Those were introduced in 2026.1. This fix migrates the entries - as far as possible - to proper yaml unique_ids.
- If one entity was created, it will get a new unique_id
- If the yaml creating this entity was removed meanwhile, the entry is removed
- If multiple such entities would have been configured, there should not be multiple entries since the unique_id would be duplicated

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #161978
- This PR is related to issue: https://github.com/home-assistant/core/pull/159367
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
