### PR TITLE
Fix parse_mode for Telegram bot actions

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -91,6 +91,10 @@ from .const import (
     CONF_CONFIG_ENTRY_ID,
     DEFAULT_API_ENDPOINT,
     DOMAIN,
+    PARSER_HTML,
+    PARSER_MD,
+    PARSER_MD2,
+    PARSER_PLAIN_TEXT,
     PLATFORM_BROADCAST,
     PLATFORM_POLLING,
     PLATFORM_WEBHOOKS,
@@ -119,11 +123,16 @@ _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
+ATTR_PARSER_SCHEMA = vol.All(
+    cv.string,
+    vol.In([PARSER_HTML, PARSER_MD, PARSER_MD2, PARSER_PLAIN_TEXT]),
+)
+
 BASE_SERVICE_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_CONFIG_ENTRY_ID): cv.string,
         vol.Optional(ATTR_TARGET): vol.All(cv.ensure_list, [vol.Coerce(int)]),
-        vol.Optional(ATTR_PARSER): cv.string,
+        vol.Optional(ATTR_PARSER): ATTR_PARSER_SCHEMA,
         vol.Optional(ATTR_DISABLE_NOTIF): cv.boolean,
         vol.Optional(ATTR_DISABLE_WEB_PREV): cv.boolean,
         vol.Optional(ATTR_RESIZE_KEYBOARD): cv.boolean,
@@ -236,7 +245,7 @@ SERVICE_SCHEMA_EDIT_MESSAGE = vol.All(
                 cv.positive_int, vol.All(cv.string, "last")
             ),
             vol.Required(ATTR_CHAT_ID): vol.Coerce(int),
-            vol.Optional(ATTR_PARSER): cv.string,
+            vol.Optional(ATTR_PARSER): ATTR_PARSER_SCHEMA,
             vol.Optional(ATTR_KEYBOARD_INLINE): cv.ensure_list,
             vol.Optional(ATTR_DISABLE_WEB_PREV): cv.boolean,
         }
@@ -253,6 +262,7 @@ SERVICE_SCHEMA_EDIT_MESSAGE_MEDIA = vol.All(
             ),
             vol.Required(ATTR_CHAT_ID): vol.Coerce(int),
             vol.Optional(ATTR_CAPTION): cv.string,
+            vol.Optional(ATTR_PARSER): ATTR_PARSER_SCHEMA,
             vol.Required(ATTR_MEDIA_TYPE): vol.In(
                 (
                     str(InputMediaType.ANIMATION),
@@ -279,6 +289,7 @@ SERVICE_SCHEMA_EDIT_CAPTION = vol.Schema(
         vol.Required(ATTR_MESSAGEID): vol.Any(
             cv.positive_int, vol.All(cv.string, "last")
         ),
+        vol.Optional(ATTR_PARSER): ATTR_PARSER_SCHEMA,
         vol.Required(ATTR_CHAT_ID): vol.Coerce(int),
         vol.Required(ATTR_CAPTION): cv.string,
         vol.Optional(ATTR_KEYBOARD_INLINE): cv.ensure_list,

--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -674,6 +674,8 @@ class TelegramNotificationService:
             "Error editing message media",
             params[ATTR_MESSAGE_TAG],
             media=media,
+            caption=kwargs.get(ATTR_CAPTION),
+            parse_mode=params[ATTR_PARSER],
             chat_id=chat_id,
             message_id=message_id,
             inline_message_id=inline_message_id,

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -66,6 +66,8 @@ from homeassistant.components.telegram_bot.const import (
     CONF_CONFIG_ENTRY_ID,
     DOMAIN,
     PARSER_HTML,
+    PARSER_MD,
+    PARSER_MD2,
     PARSER_PLAIN_TEXT,
     PLATFORM_BROADCAST,
     SECTION_ADVANCED_SETTINGS,
@@ -1152,7 +1154,7 @@ async def test_edit_message_media(
                 ATTR_MESSAGEID: 12345,
                 ATTR_CHAT_ID: 123456,
                 ATTR_KEYBOARD_INLINE: "/mock",
-                ATTR_PARSER: PARSER_PLAIN_TEXT,
+                ATTR_PARSER: PARSER_MD,
             },
             blocking=True,
         )
@@ -1161,6 +1163,7 @@ async def test_edit_message_media(
     mock.assert_called_once()
     assert mock.call_args[1]["media"].__class__.__name__ == expected_media_class
     assert mock.call_args[1]["media"].caption == "mock caption"
+    assert mock.call_args[1]["parse_mode"] == PARSER_MD
     assert mock.call_args[1]["chat_id"] == 123456
     assert mock.call_args[1]["message_id"] == 12345
     assert mock.call_args[1]["reply_markup"] == InlineKeyboardMarkup(
@@ -1195,7 +1198,16 @@ async def test_edit_message(
         )
 
     await hass.async_block_till_done()
-    mock.assert_called_once()
+    mock.assert_called_once_with(
+        "mock message",
+        chat_id=123456,
+        message_id=12345,
+        inline_message_id=None,
+        parse_mode=None,
+        disable_web_page_preview=None,
+        reply_markup=None,
+        read_timeout=None,
+    )
 
     with patch(
         "homeassistant.components.telegram_bot.bot.Bot.edit_message_caption",
@@ -1208,13 +1220,21 @@ async def test_edit_message(
                 ATTR_CAPTION: "mock caption",
                 ATTR_CHAT_ID: 123456,
                 ATTR_MESSAGEID: 12345,
-                ATTR_PARSER: PARSER_PLAIN_TEXT,
+                ATTR_PARSER: PARSER_MD2,
             },
             blocking=True,
         )
 
     await hass.async_block_till_done()
-    mock.assert_called_once()
+    mock.assert_called_once_with(
+        chat_id=123456,
+        message_id=12345,
+        inline_message_id=None,
+        caption="mock caption",
+        reply_markup=None,
+        read_timeout=None,
+        parse_mode=PARSER_MD2,
+    )
 
     with patch(
         "homeassistant.components.telegram_bot.bot.Bot.edit_message_reply_markup",

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -18,7 +18,7 @@ from telegram import (
     Message,
     Update,
 )
-from telegram.constants import ChatType, InputMediaType, ParseMode
+from telegram.constants import ChatType, InputMediaType
 from telegram.error import (
     InvalidToken,
     NetworkError,
@@ -65,6 +65,7 @@ from homeassistant.components.telegram_bot.const import (
     CHAT_ACTION_TYPING,
     CONF_CONFIG_ENTRY_ID,
     DOMAIN,
+    PARSER_HTML,
     PARSER_PLAIN_TEXT,
     PLATFORM_BROADCAST,
     SECTION_ADVANCED_SETTINGS,
@@ -139,7 +140,7 @@ async def test_polling_platform_init(
             {
                 ATTR_KEYBOARD: ["/command1, /command2", "/command3"],
                 ATTR_MESSAGE: "test_message",
-                ATTR_PARSER: ParseMode.HTML,
+                ATTR_PARSER: PARSER_HTML,
                 ATTR_DISABLE_NOTIF: True,
                 ATTR_DISABLE_WEB_PREV: True,
                 ATTR_MESSAGE_TAG: "mock_tag",
@@ -1151,6 +1152,7 @@ async def test_edit_message_media(
                 ATTR_MESSAGEID: 12345,
                 ATTR_CHAT_ID: 123456,
                 ATTR_KEYBOARD_INLINE: "/mock",
+                ATTR_PARSER: PARSER_PLAIN_TEXT,
             },
             blocking=True,
         )
@@ -1183,7 +1185,12 @@ async def test_edit_message(
         await hass.services.async_call(
             DOMAIN,
             SERVICE_EDIT_MESSAGE,
-            {ATTR_MESSAGE: "mock message", ATTR_CHAT_ID: 123456, ATTR_MESSAGEID: 12345},
+            {
+                ATTR_MESSAGE: "mock message",
+                ATTR_CHAT_ID: 123456,
+                ATTR_MESSAGEID: 12345,
+                ATTR_PARSER: PARSER_PLAIN_TEXT,
+            },
             blocking=True,
         )
 
@@ -1197,7 +1204,12 @@ async def test_edit_message(
         await hass.services.async_call(
             DOMAIN,
             SERVICE_EDIT_CAPTION,
-            {ATTR_CAPTION: "mock caption", ATTR_CHAT_ID: 123456, ATTR_MESSAGEID: 12345},
+            {
+                ATTR_CAPTION: "mock caption",
+                ATTR_CHAT_ID: 123456,
+                ATTR_MESSAGEID: 12345,
+                ATTR_PARSER: PARSER_PLAIN_TEXT,
+            },
             blocking=True,
         )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Background:**
In 2026.1, there was a breaking change where `ALLOW_EXTRA` was removed from the schema of Telegram bot actions.
That change was part code quality improvement for the integration.
However, the removal of `ALLOW_EXTRA` also unintentionally dropped the `parse_mode` parameter for some actions.

**Changes**
This PR adds the `parse_mode` parameter for actions which support it.
Also added validation for the parameter.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/161979
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
