### PR TITLE
Remove file description dependency in onedrive

### DIFF
--- a/homeassistant/components/onedrive/__init__.py
+++ b/homeassistant/components/onedrive/__init__.py
@@ -124,8 +124,6 @@ async def _migrate_backup_files(client: OneDriveClient, backup_folder_id: str) -
         ):
             metadata = loads(metadata_json)
             del metadata["metadata_version"]
-            # Add backup_file_id to the metadata content for v2
-            metadata["backup_file_id"] = file.id
             metadata_filename = file.name.rsplit(".", 1)[0] + ".metadata.json"
             await client.upload_file(
                 backup_folder_id,

--- a/homeassistant/components/onedrive/__init__.py
+++ b/homeassistant/components/onedrive/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from html import unescape
-from json import loads
+from json import dumps, loads
 import logging
 from typing import cast
 
@@ -117,8 +117,6 @@ async def _migrate_backup_files(client: OneDriveClient, backup_folder_id: str) -
     Version 1: Backup metadata was stored in the backup file's description field.
     Version 2: Backup metadata is stored in a separate .metadata.json file.
     """
-    from json import dumps  # noqa: PLC0415
-
     files = await client.list_drive_items(backup_folder_id)
     for file in files:
         if file.description and '"metadata_version": 1' in (

--- a/homeassistant/components/onedrive/__init__.py
+++ b/homeassistant/components/onedrive/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from html import unescape
-from json import dumps, loads
+from json import loads
 import logging
 from typing import cast
 
@@ -14,7 +14,6 @@ from onedrive_personal_sdk.exceptions import (
     NotFoundError,
     OneDriveException,
 )
-from onedrive_personal_sdk.models.items import ItemUpdate
 
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
@@ -72,15 +71,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: OneDriveConfigEntry) -> 
             entry, data={**entry.data, CONF_FOLDER_ID: backup_folder.id}
         )
 
-    # write instance id to description
-    if backup_folder.description != (instance_id := await async_get_instance_id(hass)):
-        await _handle_item_operation(
-            lambda: client.update_drive_item(
-                backup_folder.id, ItemUpdate(description=instance_id)
-            ),
-            folder_name,
-        )
-
     # update in case folder was renamed manually inside OneDrive
     if backup_folder.name != entry.data[CONF_FOLDER_NAME]:
         hass.config_entries.async_update_entry(
@@ -122,7 +112,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: OneDriveConfigEntry) ->
 
 
 async def _migrate_backup_files(client: OneDriveClient, backup_folder_id: str) -> None:
-    """Migrate backup files to metadata version 2."""
+    """Migrate backup files from metadata version 1 to version 2.
+
+    Version 1: Backup metadata was stored in the backup file's description field.
+    Version 2: Backup metadata is stored in a separate .metadata.json file.
+    """
+    from json import dumps  # noqa: PLC0415
+
     files = await client.list_drive_items(backup_folder_id)
     for file in files:
         if file.description and '"metadata_version": 1' in (
@@ -130,24 +126,13 @@ async def _migrate_backup_files(client: OneDriveClient, backup_folder_id: str) -
         ):
             metadata = loads(metadata_json)
             del metadata["metadata_version"]
+            # Add backup_file_id to the metadata content for v2
+            metadata["backup_file_id"] = file.id
             metadata_filename = file.name.rsplit(".", 1)[0] + ".metadata.json"
-            metadata_file = await client.upload_file(
+            await client.upload_file(
                 backup_folder_id,
                 metadata_filename,
                 dumps(metadata),
-            )
-            metadata_description = {
-                "metadata_version": 2,
-                "backup_id": metadata["backup_id"],
-                "backup_file_id": file.id,
-            }
-            await client.update_drive_item(
-                path_or_id=metadata_file.id,
-                data=ItemUpdate(description=dumps(metadata_description)),
-            )
-            await client.update_drive_item(
-                path_or_id=file.id,
-                data=ItemUpdate(description=""),
             )
             _LOGGER.debug("Migrated backup file %s", file.name)
 

--- a/homeassistant/components/onedrive/backup.py
+++ b/homeassistant/components/onedrive/backup.py
@@ -190,6 +190,9 @@ class OneDriveBackupAgent(BackupAgent):
             )
         except OneDriveException:
             # Clean up the backup file if metadata upload fails
+            _LOGGER.debug(
+                "Uploading metadata failed, deleting backup file %s", backup_filename
+            )
             await self._client.delete_drive_item(
                 f"{self._folder_id}:/{backup_filename}:"
             )

--- a/homeassistant/components/onedrive/backup.py
+++ b/homeassistant/components/onedrive/backup.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Callable, Coroutine
 from dataclasses import dataclass
 from functools import wraps
-from html import unescape
 from json import dumps, loads
 import logging
 from time import time
@@ -18,7 +17,6 @@ from onedrive_personal_sdk.exceptions import (
     HashMismatchError,
     OneDriveException,
 )
-from onedrive_personal_sdk.models.items import ItemUpdate
 from onedrive_personal_sdk.models.upload import FileInfo
 
 from homeassistant.components.backup import (
@@ -38,8 +36,8 @@ _LOGGER = logging.getLogger(__name__)
 MAX_CHUNK_SIZE = 60 * 1024 * 1024  # largest chunk possible, must be <= 60 MiB
 TARGET_CHUNKS = 20
 TIMEOUT = ClientTimeout(connect=10, total=43200)  # 12 hours
-METADATA_VERSION = 2
 CACHE_TTL = 300
+METADATA_FILE_SUFFIX = ".metadata.json"
 
 
 async def async_get_backup_agents(
@@ -185,34 +183,20 @@ class OneDriveBackupAgent(BackupAgent):
                 "Hash validation failed, backup file might be corrupt"
             ) from err
 
-        # store metadata in metadata file
-        description = dumps(backup.as_dict())
-        _LOGGER.debug("Creating metadata: %s", description)
-        metadata_filename = filename.rsplit(".", 1)[0] + ".metadata.json"
+        # store metadata in metadata file (include backup_file_id for reference)
+        metadata = backup.as_dict()
+        metadata["backup_file_id"] = backup_file.id
+        metadata_content = dumps(metadata)
+        _LOGGER.debug("Creating metadata: %s", metadata_content)
+        metadata_filename = filename.rsplit(".", 1)[0] + METADATA_FILE_SUFFIX
         try:
-            metadata_file = await self._client.upload_file(
+            await self._client.upload_file(
                 self._folder_id,
                 metadata_filename,
-                description,
+                metadata_content,
             )
         except OneDriveException:
             await self._client.delete_drive_item(backup_file.id)
-            raise
-
-        # add metadata to the metadata file
-        metadata_description = {
-            "metadata_version": METADATA_VERSION,
-            "backup_id": backup.backup_id,
-            "backup_file_id": backup_file.id,
-        }
-        try:
-            await self._client.update_drive_item(
-                path_or_id=metadata_file.id,
-                data=ItemUpdate(description=dumps(metadata_description)),
-            )
-        except OneDriveException:
-            await self._client.delete_drive_item(backup_file.id)
-            await self._client.delete_drive_item(metadata_file.id)
             raise
         self._cache_expiration = time()
 
@@ -259,27 +243,33 @@ class OneDriveBackupAgent(BackupAgent):
 
         items = await self._client.list_drive_items(self._folder_id)
 
-        async def download_backup_metadata(item_id: str) -> AgentBackup | None:
+        async def download_backup_metadata(
+            item_id: str,
+        ) -> tuple[AgentBackup, str] | None:
             try:
                 metadata_stream = await self._client.download_drive_item(item_id)
             except OneDriveException as err:
                 _LOGGER.warning("Error downloading metadata for %s: %s", item_id, err)
                 return None
+
             metadata_json = loads(await metadata_stream.read())
-            return AgentBackup.from_dict(metadata_json)
+            backup_file_id = metadata_json.pop("backup_file_id", None)
+            if backup_file_id is None:
+                _LOGGER.warning("Metadata file %s missing backup_file_id", item_id)
+                return None
+            return AgentBackup.from_dict(metadata_json), backup_file_id
 
         backups: dict[str, OneDriveBackup] = {}
         for item in items:
-            if item.description and f'"metadata_version": {METADATA_VERSION}' in (
-                metadata_description_json := unescape(item.description)
-            ):
-                backup = await download_backup_metadata(item.id)
-                if backup is None:
+            # Identify metadata files by their file name suffix
+            if item.name and item.name.endswith(METADATA_FILE_SUFFIX):
+                result = await download_backup_metadata(item.id)
+                if result is None:
                     continue
-                metadata_description = loads(metadata_description_json)
+                backup, backup_file_id = result
                 backups[backup.backup_id] = OneDriveBackup(
                     backup=backup,
-                    backup_file_id=metadata_description["backup_file_id"],
+                    backup_file_id=backup_file_id,
                     metadata_file_id=item.id,
                 )
 

--- a/homeassistant/components/onedrive/backup.py
+++ b/homeassistant/components/onedrive/backup.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Callable, Coroutine
-from dataclasses import dataclass
 from functools import wraps
-from json import dumps, loads
 import logging
 from time import time
 from typing import Any, Concatenate
@@ -28,6 +26,8 @@ from homeassistant.components.backup import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.json import json_dumps
+from homeassistant.util.json import json_loads_object
 
 from .const import CONF_DELETE_PERMANENTLY, DATA_BACKUP_AGENT_LISTENERS, DOMAIN
 from .coordinator import OneDriveConfigEntry
@@ -37,7 +37,6 @@ MAX_CHUNK_SIZE = 60 * 1024 * 1024  # largest chunk possible, must be <= 60 MiB
 TARGET_CHUNKS = 20
 TIMEOUT = ClientTimeout(connect=10, total=43200)  # 12 hours
 CACHE_TTL = 300
-METADATA_FILE_SUFFIX = ".metadata.json"
 
 
 async def async_get_backup_agents(
@@ -102,13 +101,10 @@ def handle_backup_errors[_R, **P](
     return wrapper
 
 
-@dataclass(kw_only=True)
-class OneDriveBackup:
-    """Define a OneDrive backup."""
-
-    backup: AgentBackup
-    backup_file_id: str
-    metadata_file_id: str
+def suggested_filenames(backup: AgentBackup) -> tuple[str, str]:
+    """Return the suggested filenames for the backup and metadata."""
+    base_name = suggested_filename(backup).rsplit(".", 1)[0]
+    return f"{base_name}.tar", f"{base_name}.metadata.json"
 
 
 class OneDriveBackupAgent(BackupAgent):
@@ -127,7 +123,7 @@ class OneDriveBackupAgent(BackupAgent):
         self.name = entry.title
         assert entry.unique_id
         self.unique_id = entry.unique_id
-        self._backup_cache: dict[str, OneDriveBackup] = {}
+        self._cache_backup_metadata: dict[str, AgentBackup] = {}
         self._cache_expiration = time()
 
     @handle_backup_errors
@@ -135,12 +131,11 @@ class OneDriveBackupAgent(BackupAgent):
         self, backup_id: str, **kwargs: Any
     ) -> AsyncIterator[bytes]:
         """Download a backup file."""
-        backups = await self._list_cached_backups()
-        if backup_id not in backups:
-            raise BackupNotFound(f"Backup {backup_id} not found")
+        backup = await self._find_backup_by_id(backup_id)
+        backup_filename, _ = suggested_filenames(backup)
 
         stream = await self._client.download_drive_item(
-            backups[backup_id].backup_file_id, timeout=TIMEOUT
+            f"{self._folder_id}:/{backup_filename}:", timeout=TIMEOUT
         )
         return stream.iter_chunked(1024)
 
@@ -153,9 +148,9 @@ class OneDriveBackupAgent(BackupAgent):
         **kwargs: Any,
     ) -> None:
         """Upload a backup."""
-        filename = suggested_filename(backup)
+        backup_filename, metadata_filename = suggested_filenames(backup)
         file = FileInfo(
-            filename,
+            backup_filename,
             backup.size,
             self._folder_id,
             await open_stream(),
@@ -171,7 +166,7 @@ class OneDriveBackupAgent(BackupAgent):
         upload_chunk_size = max(upload_chunk_size, 320 * 1024)
 
         try:
-            backup_file = await LargeFileUploadClient.upload(
+            await LargeFileUploadClient.upload(
                 self._token_function,
                 file,
                 upload_chunk_size=upload_chunk_size,
@@ -183,12 +178,10 @@ class OneDriveBackupAgent(BackupAgent):
                 "Hash validation failed, backup file might be corrupt"
             ) from err
 
-        # store metadata in metadata file (include backup_file_id for reference)
-        metadata = backup.as_dict()
-        metadata["backup_file_id"] = backup_file.id
-        metadata_content = dumps(metadata)
-        _LOGGER.debug("Creating metadata: %s", metadata_content)
-        metadata_filename = filename.rsplit(".", 1)[0] + METADATA_FILE_SUFFIX
+        _LOGGER.debug("Uploaded backup to %s", backup_filename)
+
+        # Store metadata in separate metadata file (just backup.as_dict(), no extra fields)
+        metadata_content = json_dumps(backup.as_dict())
         try:
             await self._client.upload_file(
                 self._folder_id,
@@ -196,8 +189,13 @@ class OneDriveBackupAgent(BackupAgent):
                 metadata_content,
             )
         except OneDriveException:
-            await self._client.delete_drive_item(backup_file.id)
+            # Clean up the backup file if metadata upload fails
+            await self._client.delete_drive_item(
+                f"{self._folder_id}:/{backup_filename}:"
+            )
             raise
+
+        _LOGGER.debug("Uploaded metadata file %s", metadata_filename)
         self._cache_expiration = time()
 
     @handle_backup_errors
@@ -207,72 +205,63 @@ class OneDriveBackupAgent(BackupAgent):
         **kwargs: Any,
     ) -> None:
         """Delete a backup file."""
-        backups = await self._list_cached_backups()
-        if backup_id not in backups:
-            raise BackupNotFound(f"Backup {backup_id} not found")
-
-        backup = backups[backup_id]
+        backup = await self._find_backup_by_id(backup_id)
+        backup_filename, metadata_filename = suggested_filenames(backup)
 
         delete_permanently = self._entry.options.get(CONF_DELETE_PERMANENTLY, False)
 
-        await self._client.delete_drive_item(backup.backup_file_id, delete_permanently)
         await self._client.delete_drive_item(
-            backup.metadata_file_id, delete_permanently
+            f"{self._folder_id}:/{backup_filename}:", delete_permanently
         )
+        await self._client.delete_drive_item(
+            f"{self._folder_id}:/{metadata_filename}:", delete_permanently
+        )
+
+        _LOGGER.debug("Deleted backup %s", backup_filename)
         self._cache_expiration = time()
 
     @handle_backup_errors
     async def async_list_backups(self, **kwargs: Any) -> list[AgentBackup]:
         """List backups."""
-        return [
-            backup.backup for backup in (await self._list_cached_backups()).values()
-        ]
+        return list((await self._list_cached_metadata_files()).values())
 
     @handle_backup_errors
     async def async_get_backup(self, backup_id: str, **kwargs: Any) -> AgentBackup:
         """Return a backup."""
-        backups = await self._list_cached_backups()
-        if backup_id not in backups:
-            raise BackupNotFound(f"Backup {backup_id} not found")
-        return backups[backup_id].backup
+        return await self._find_backup_by_id(backup_id)
 
-    async def _list_cached_backups(self) -> dict[str, OneDriveBackup]:
-        """List backups with a cache."""
+    async def _list_cached_metadata_files(self) -> dict[str, AgentBackup]:
+        """List metadata files with a cache."""
         if time() <= self._cache_expiration:
-            return self._backup_cache
+            return self._cache_backup_metadata
 
-        items = await self._client.list_drive_items(self._folder_id)
-
-        async def download_backup_metadata(
-            item_id: str,
-        ) -> tuple[AgentBackup, str] | None:
+        async def _download_metadata(item_id: str) -> AgentBackup | None:
+            """Download metadata file."""
             try:
                 metadata_stream = await self._client.download_drive_item(item_id)
             except OneDriveException as err:
                 _LOGGER.warning("Error downloading metadata for %s: %s", item_id, err)
                 return None
 
-            metadata_json = loads(await metadata_stream.read())
-            backup_file_id = metadata_json.pop("backup_file_id", None)
-            if backup_file_id is None:
-                _LOGGER.warning("Metadata file %s missing backup_file_id", item_id)
-                return None
-            return AgentBackup.from_dict(metadata_json), backup_file_id
+            return AgentBackup.from_dict(
+                json_loads_object(await metadata_stream.read())
+            )
 
-        backups: dict[str, OneDriveBackup] = {}
+        items = await self._client.list_drive_items(self._folder_id)
+        metadata_files: dict[str, AgentBackup] = {}
         for item in items:
-            # Identify metadata files by their file name suffix
-            if item.name and item.name.endswith(METADATA_FILE_SUFFIX):
-                result = await download_backup_metadata(item.id)
-                if result is None:
-                    continue
-                backup, backup_file_id = result
-                backups[backup.backup_id] = OneDriveBackup(
-                    backup=backup,
-                    backup_file_id=backup_file_id,
-                    metadata_file_id=item.id,
-                )
+            if item.name and item.name.endswith(".metadata.json"):
+                if metadata := await _download_metadata(item.id):
+                    metadata_files[metadata.backup_id] = metadata
 
+        self._cache_backup_metadata = metadata_files
         self._cache_expiration = time() + CACHE_TTL
-        self._backup_cache = backups
-        return backups
+        return self._cache_backup_metadata
+
+    async def _find_backup_by_id(self, backup_id: str) -> AgentBackup:
+        """Find a backup by its backup ID on remote."""
+        metadata_files = await self._list_cached_metadata_files()
+        if backup := metadata_files.get(backup_id):
+            return backup
+
+        raise BackupNotFound(f"Backup {backup_id} not found")

--- a/homeassistant/components/onedrive/config_flow.py
+++ b/homeassistant/components/onedrive/config_flow.py
@@ -129,9 +129,6 @@ class OneDriveConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
             except OneDriveException:
                 self.logger.debug("Failed to create folder", exc_info=True)
                 errors["base"] = "folder_creation_error"
-            else:
-                if folder.description and folder.description != instance_id:
-                    errors[CONF_FOLDER_NAME] = "folder_already_in_use"
             if not errors:
                 title = (
                     f"{self.approot.created_by.user.display_name}'s OneDrive"

--- a/homeassistant/components/onedrive/strings.json
+++ b/homeassistant/components/onedrive/strings.json
@@ -22,7 +22,6 @@
       "default": "[%key:common::config_flow::create_entry::authenticated%]"
     },
     "error": {
-      "folder_already_in_use": "Folder already used for backups from another Home Assistant instance",
       "folder_creation_error": "Failed to create folder",
       "folder_rename_error": "Failed to rename folder"
     },

--- a/tests/components/onedrive/conftest.py
+++ b/tests/components/onedrive/conftest.py
@@ -189,7 +189,7 @@ def mock_metadata_file() -> File:
         hashes=Hashes(
             quick_xor_hash="hash",
         ),
-        mime_type="application/json",
+        mime_type="application/x-tar",
         created_by=IDENTITY_SET,
     )
 

--- a/tests/components/onedrive/conftest.py
+++ b/tests/components/onedrive/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures for OneDrive tests."""
 
 from collections.abc import AsyncIterator, Generator
-from html import escape
 from json import dumps
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -146,7 +145,6 @@ def mock_folder() -> Folder:
         name="name",
         size=0,
         child_count=0,
-        description="9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0",
         parent_reference=ItemParentReference(
             drive_id="mock_drive_id", id="id", path="path"
         ),
@@ -182,25 +180,16 @@ def mock_backup_file() -> File:
 def mock_metadata_file() -> File:
     """Return a mocked metadata file."""
     return File(
-        id="id",
-        name="23e64aec.tar",
-        size=34519040,
+        id="metadata_id",
+        name="23e64aec.metadata.json",
+        size=1024,
         parent_reference=ItemParentReference(
             drive_id="mock_drive_id", id="id", path="path"
         ),
         hashes=Hashes(
             quick_xor_hash="hash",
         ),
-        mime_type="application/x-tar",
-        description=escape(
-            dumps(
-                {
-                    "metadata_version": 2,
-                    "backup_id": "23e64aec",
-                    "backup_file_id": "id",
-                }
-            )
-        ),
+        mime_type="application/json",
         created_by=IDENTITY_SET,
     )
 
@@ -227,7 +216,9 @@ def mock_onedrive_client(
             yield b"backup data"
 
         async def read(self) -> bytes:
-            return dumps(BACKUP_METADATA).encode()
+            # Include backup_file_id in metadata content (new format)
+            metadata_with_file_id = {**BACKUP_METADATA, "backup_file_id": "id"}
+            return dumps(metadata_with_file_id).encode()
 
     client.download_drive_item.return_value = MockStreamReader()
     client.get_drive.return_value = mock_drive

--- a/tests/components/onedrive/conftest.py
+++ b/tests/components/onedrive/conftest.py
@@ -216,9 +216,8 @@ def mock_onedrive_client(
             yield b"backup data"
 
         async def read(self) -> bytes:
-            # Include backup_file_id in metadata content (new format)
-            metadata_with_file_id = {**BACKUP_METADATA, "backup_file_id": "id"}
-            return dumps(metadata_with_file_id).encode()
+            # Metadata contains just the backup metadata (no backup_file_id)
+            return dumps(BACKUP_METADATA).encode()
 
     client.download_drive_item.return_value = MockStreamReader()
     client.get_drive.return_value = mock_drive

--- a/tests/components/onedrive/test_services.py
+++ b/tests/components/onedrive/test_services.py
@@ -93,7 +93,7 @@ async def test_upload_service(
 
     assert response
     assert response["files"]
-    assert cast(list[dict[str, Any]], response["files"])[0]["id"] == "id"
+    assert cast(list[dict[str, Any]], response["files"])[0]["id"] == "metadata_id"
 
 
 async def test_upload_service_no_response(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

For some users, updating the file metadata will fail consistently. Since it doesn't bring that big of a benefit and will actually increase compatibility with OfB, just remove the file description entirely and rely entirely on filenames, like other integrations are doing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes
- This PR is related to issue: #161248 #161237
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
