### PR TITLE
Switch to using zero to represent unset in togrill

### DIFF
--- a/homeassistant/components/togrill/number.py
+++ b/homeassistant/components/togrill/number.py
@@ -38,7 +38,7 @@ PARALLEL_UPDATES = 0
 class ToGrillNumberEntityDescription(NumberEntityDescription):
     """Description of entity."""
 
-    get_value: Callable[[ToGrillCoordinator], float | None]
+    get_value: Callable[[ToGrillCoordinator], float]
     set_packet: Callable[[ToGrillCoordinator, float], PacketWrite]
     entity_supported: Callable[[Mapping[str, Any]], bool] = lambda _: True
     probe_number: int | None = None
@@ -51,7 +51,7 @@ def _get_temperature_descriptions(
         variant: str,
         icon: str | None,
         set_packet: Callable[[ToGrillCoordinator, float], PacketWrite],
-        get_value: Callable[[ToGrillCoordinator], float | None],
+        get_value: Callable[[ToGrillCoordinator], float],
     ) -> ToGrillNumberEntityDescription:
         return ToGrillNumberEntityDescription(
             key=f"temperature_{variant}_{probe_number}",
@@ -71,14 +71,14 @@ def _get_temperature_descriptions(
 
     def _get_temperatures(
         coordinator: ToGrillCoordinator, alarm_type: AlarmType
-    ) -> tuple[None | float, None | float]:
+    ) -> tuple[float, float]:
         if not (packet := coordinator.get_packet(PacketA8Notify, probe_number)):
-            return None, None
+            return 0.0, 0.0
 
         if packet.alarm_type != alarm_type:
-            return None, None
+            return 0.0, 0.0
 
-        return packet.temperature_1, packet.temperature_2
+        return packet.temperature_1 or 0.0, packet.temperature_2 or 0.0
 
     def _set_target(
         coordinator: ToGrillCoordinator, value: float | None
@@ -142,7 +142,7 @@ ENTITY_DESCRIPTIONS = (
             PacketA6Write(temperature_unit=None, alarm_interval=round(x))
         ),
         get_value=lambda x: (
-            packet.alarm_interval if (packet := x.get_packet(PacketA0Notify)) else None
+            packet.alarm_interval if (packet := x.get_packet(PacketA0Notify)) else 0.0
         ),
     ),
 )

--- a/tests/components/togrill/snapshots/test_number.ambr
+++ b/tests/components/togrill/snapshots/test_number.ambr
@@ -117,7 +117,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.0',
   })
 # ---
 # name: test_setup[no_data][number.probe_1_minimum_temperature-entry]
@@ -178,7 +178,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.0',
   })
 # ---
 # name: test_setup[no_data][number.probe_1_target_temperature-entry]
@@ -239,7 +239,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.0',
   })
 # ---
 # name: test_setup[no_data][number.probe_2_maximum_temperature-entry]
@@ -300,7 +300,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.0',
   })
 # ---
 # name: test_setup[no_data][number.probe_2_minimum_temperature-entry]
@@ -361,7 +361,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.0',
   })
 # ---
 # name: test_setup[no_data][number.probe_2_target_temperature-entry]
@@ -422,7 +422,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.0',
   })
 # ---
 # name: test_setup[one_probe_with_target_alarm][number.pro_05_alarm_interval-entry]
@@ -543,7 +543,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.0',
   })
 # ---
 # name: test_setup[one_probe_with_target_alarm][number.probe_1_minimum_temperature-entry]
@@ -604,7 +604,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.0',
   })
 # ---
 # name: test_setup[one_probe_with_target_alarm][number.probe_1_target_temperature-entry]
@@ -726,7 +726,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.0',
   })
 # ---
 # name: test_setup[one_probe_with_target_alarm][number.probe_2_minimum_temperature-entry]
@@ -787,7 +787,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.0',
   })
 # ---
 # name: test_setup[one_probe_with_target_alarm][number.probe_2_target_temperature-entry]
@@ -848,6 +848,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.0',
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Unset numeric entities are poorly supported in HA, so use zero to represent unset values. It was not possible to set temperatures due to frontend disabling the input dialogs when the numeric entity was in None/Unknown state.

See https://github.com/home-assistant/frontend/pull/29306 for a potential future fix for this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
