### PR TITLE
Fix evohome not updating scheduled setpoints in state attrs

### DIFF
--- a/homeassistant/components/evohome/entity.py
+++ b/homeassistant/components/evohome/entity.py
@@ -181,7 +181,7 @@ class EvoChild(EvoEntity):
 
         self._device_state_attrs = {
             "activeFaults": self._evo_device.active_faults,
-            "setpoints": self._setpoints,
+            "setpoints": self.setpoints,
         }
 
         super()._handle_coordinator_update()

--- a/tests/components/evohome/snapshots/test_climate.ambr
+++ b/tests/components/evohome/snapshots/test_climate.ambr
@@ -167,6 +167,836 @@
     ),
   ])
 # ---
+# name: test_entities_update_over_time[default][climate.bathroom_dn-state-initial]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.0,
+      'friendly_name': 'Bathroom Dn',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'FollowSchedule',
+          'target_heat_temperature': 16.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.1,
+          'this_sp_from': HAFakeDatetime(2024, 7, 9, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 15.9,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 20.0,
+        }),
+        'zone_id': '3432579',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 16.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.bathroom_dn',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.bathroom_dn-state-updated]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.0,
+      'friendly_name': 'Bathroom Dn',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'FollowSchedule',
+          'target_heat_temperature': 16.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 22, 10, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.6,
+          'this_sp_from': HAFakeDatetime(2024, 7, 10, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 16.0,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 20.0,
+        }),
+        'zone_id': '3432579',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 16.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.bathroom_dn',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.dead_zone-state-initial]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': None,
+      'friendly_name': 'Dead Zone',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'FollowSchedule',
+          'target_heat_temperature': 17.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.1,
+          'this_sp_from': HAFakeDatetime(2024, 7, 9, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 15.9,
+        }),
+        'temperature_status': dict({
+          'is_available': False,
+        }),
+        'zone_id': '3432521',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 17.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.dead_zone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.dead_zone-state-updated]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': None,
+      'friendly_name': 'Dead Zone',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'FollowSchedule',
+          'target_heat_temperature': 17.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 22, 10, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.6,
+          'this_sp_from': HAFakeDatetime(2024, 7, 10, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 16.0,
+        }),
+        'temperature_status': dict({
+          'is_available': False,
+        }),
+        'zone_id': '3432521',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 17.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.dead_zone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.front_room-state-initial]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 19.0,
+      'friendly_name': 'Front Room',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'temporary',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'TemporaryOverride',
+          'target_heat_temperature': 21.0,
+          'until': '2022-03-07T19:00:00+00:00',
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.1,
+          'this_sp_from': HAFakeDatetime(2024, 7, 9, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 15.9,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 19.0,
+        }),
+        'zone_id': '3432577',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 21.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.front_room',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.front_room-state-updated]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 19.0,
+      'friendly_name': 'Front Room',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'temporary',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'TemporaryOverride',
+          'target_heat_temperature': 21.0,
+          'until': '2022-03-07T19:00:00+00:00',
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 22, 10, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.6,
+          'this_sp_from': HAFakeDatetime(2024, 7, 10, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 16.0,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 19.0,
+        }),
+        'zone_id': '3432577',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 21.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.front_room',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.kids_room-state-initial]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 19.5,
+      'friendly_name': 'Kids Room',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'FollowSchedule',
+          'target_heat_temperature': 17.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.1,
+          'this_sp_from': HAFakeDatetime(2024, 7, 9, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 15.9,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 19.5,
+        }),
+        'zone_id': '3449703',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 17.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.kids_room',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.kids_room-state-updated]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 19.5,
+      'friendly_name': 'Kids Room',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'FollowSchedule',
+          'target_heat_temperature': 17.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 22, 10, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.6,
+          'this_sp_from': HAFakeDatetime(2024, 7, 10, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 16.0,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 19.5,
+        }),
+        'zone_id': '3449703',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 17.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.kids_room',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.kitchen-state-initial]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.0,
+      'friendly_name': 'Kitchen',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'FollowSchedule',
+          'target_heat_temperature': 17.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.1,
+          'this_sp_from': HAFakeDatetime(2024, 7, 9, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 15.9,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 20.0,
+        }),
+        'zone_id': '3432578',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 17.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.kitchen',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.kitchen-state-updated]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.0,
+      'friendly_name': 'Kitchen',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'FollowSchedule',
+          'target_heat_temperature': 17.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 22, 10, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.6,
+          'this_sp_from': HAFakeDatetime(2024, 7, 10, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 16.0,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 20.0,
+        }),
+        'zone_id': '3432578',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 17.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.kitchen',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.main_bedroom-state-initial]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 21.0,
+      'friendly_name': 'Main Bedroom',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'FollowSchedule',
+          'target_heat_temperature': 16.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.1,
+          'this_sp_from': HAFakeDatetime(2024, 7, 9, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 15.9,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 21.0,
+        }),
+        'zone_id': '3432580',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 16.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.main_bedroom',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.main_bedroom-state-updated]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 21.0,
+      'friendly_name': 'Main Bedroom',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'FollowSchedule',
+          'target_heat_temperature': 16.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 22, 10, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.6,
+          'this_sp_from': HAFakeDatetime(2024, 7, 10, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 16.0,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 21.0,
+        }),
+        'zone_id': '3432580',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 16.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.main_bedroom',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.main_room-state-initial]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 19.0,
+      'friendly_name': 'Main Room',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'permanent',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'PermanentOverride',
+          'target_heat_temperature': 17.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.1,
+          'this_sp_from': HAFakeDatetime(2024, 7, 9, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 15.9,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 19.0,
+        }),
+        'zone_id': '3432576',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 17.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.main_room',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.main_room-state-updated]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 19.0,
+      'friendly_name': 'Main Room',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'permanent',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'PermanentOverride',
+          'target_heat_temperature': 17.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 22, 10, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.6,
+          'this_sp_from': HAFakeDatetime(2024, 7, 10, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 16.0,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 19.0,
+        }),
+        'zone_id': '3432576',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 17.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.main_room',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.my_home-state-initial]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 19.7,
+      'friendly_name': 'My Home',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'icon': 'mdi:thermostat',
+      'max_temp': 35,
+      'min_temp': 7,
+      'preset_mode': 'eco',
+      'preset_modes': list([
+        'Reset',
+        'eco',
+        'away',
+        'home',
+        'Custom',
+      ]),
+      'status': dict({
+        'activeSystemFaults': tuple(
+        ),
+        'system_id': '3432522',
+        'system_mode_status': dict({
+          'is_permanent': True,
+          'mode': 'AutoWithEco',
+        }),
+      }),
+      'supported_features': <ClimateEntityFeature: 400>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.my_home',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.my_home-state-updated]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 19.7,
+      'friendly_name': 'My Home',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'icon': 'mdi:thermostat',
+      'max_temp': 35,
+      'min_temp': 7,
+      'preset_mode': 'eco',
+      'preset_modes': list([
+        'Reset',
+        'eco',
+        'away',
+        'home',
+        'Custom',
+      ]),
+      'status': dict({
+        'activeSystemFaults': tuple(
+        ),
+        'system_id': '3432522',
+        'system_mode_status': dict({
+          'is_permanent': True,
+          'mode': 'AutoWithEco',
+        }),
+      }),
+      'supported_features': <ClimateEntityFeature: 400>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.my_home',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.spare_room-state-initial]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 19.5,
+      'friendly_name': 'Spare Room',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'permanent',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'PermanentOverride',
+          'target_heat_temperature': 14.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.1,
+          'this_sp_from': HAFakeDatetime(2024, 7, 9, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 15.9,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 19.5,
+        }),
+        'zone_id': '3450733',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 14.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.spare_room',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_entities_update_over_time[default][climate.spare_room-state-updated]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 19.5,
+      'friendly_name': 'Spare Room',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'preset_mode': 'permanent',
+      'preset_modes': list([
+        'none',
+        'temporary',
+        'permanent',
+      ]),
+      'status': dict({
+        'activeFaults': tuple(
+        ),
+        'setpoint_status': dict({
+          'setpoint_mode': 'PermanentOverride',
+          'target_heat_temperature': 14.0,
+        }),
+        'setpoints': dict({
+          'next_sp_from': HAFakeDatetime(2024, 7, 10, 22, 10, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'next_sp_temp': 18.6,
+          'this_sp_from': HAFakeDatetime(2024, 7, 10, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'this_sp_temp': 16.0,
+        }),
+        'temperature_status': dict({
+          'is_available': True,
+          'temperature': 19.5,
+        }),
+        'zone_id': '3450733',
+      }),
+      'supported_features': <ClimateEntityFeature: 401>,
+      'temperature': 14.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.spare_room',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
 # name: test_setup_platform[botched][climate.bathroom_dn-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({

--- a/tests/components/evohome/test_climate.py
+++ b/tests/components/evohome/test_climate.py
@@ -72,7 +72,7 @@ async def test_entities_update_over_time(
 
     # Cannot use the evohome fixture here, as need to set dtm first
     #  - some extended state attrs are relative the current time
-    freezer.move_to("2024-07-10T05:30:00Z")  # a Wednesday
+    freezer.move_to("2024-07-10T05:30:00Z")
 
     # stay inside this context to have the mocked RESTful API
     async for _ in setup_evohome(hass, config, install=install):

--- a/tests/components/evohome/test_climate.py
+++ b/tests/components/evohome/test_climate.py
@@ -5,6 +5,7 @@ All evohome systems have controllers and at least one zone.
 
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -32,6 +33,8 @@ from homeassistant.exceptions import HomeAssistantError
 from .conftest import setup_evohome
 from .const import TEST_INSTALLS
 
+from tests.common import async_fire_time_changed
+
 
 @pytest.mark.parametrize("install", [*TEST_INSTALLS, "botched"])
 async def test_setup_platform(
@@ -43,7 +46,7 @@ async def test_setup_platform(
 ) -> None:
     """Test entities and their states after setup of evohome."""
 
-    # Cannot use the evohome fixture, as need to set dtm first
+    # Cannot use the evohome fixture here, as need to set dtm first
     #  - some extended state attrs are relative the current time
     freezer.move_to("2024-07-10T12:00:00Z")
 
@@ -52,6 +55,38 @@ async def test_setup_platform(
 
     for x in hass.states.async_all(Platform.CLIMATE):
         assert x == snapshot(name=f"{x.entity_id}-state")
+
+
+@pytest.mark.parametrize("install", ["default"])
+async def test_entities_update_over_time(
+    hass: HomeAssistant,
+    config: dict[str, str],
+    install: str,
+    snapshot: SnapshotAssertion,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test extended attributes update as time passes.
+
+    Verifies that time-dependent state attrs (e.g. schedules) vary as time advances.
+    """
+
+    # Cannot use the evohome fixture here, as need to set dtm first
+    #  - some extended state attrs are relative the current time
+    freezer.move_to("2024-07-10T05:30:00Z")  # a Wednesday
+
+    # stay inside this context to have the mocked RESTful API
+    async for _ in setup_evohome(hass, config, install=install):
+        for x in hass.states.async_all(Platform.CLIMATE):
+            assert x == snapshot(name=f"{x.entity_id}-state-initial")
+
+        freezer.tick(timedelta(hours=12))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        for x in hass.states.async_all(Platform.CLIMATE):
+            assert x == snapshot(name=f"{x.entity_id}-state-updated")
+
+        return
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS)

--- a/tests/components/evohome/test_climate.py
+++ b/tests/components/evohome/test_climate.py
@@ -86,8 +86,6 @@ async def test_entities_update_over_time(
         for x in hass.states.async_all(Platform.CLIMATE):
             assert x == snapshot(name=f"{x.entity_id}-state-updated")
 
-        return
-
 
 @pytest.mark.parametrize("install", TEST_INSTALLS)
 async def test_ctl_set_hvac_mode(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Correct a bug that prevented the setpoints stored in the extended state attrs from updating. Add a test to confirm the behaviour is now as expected.

This is not a significant bug, and so could wait until next release, rather than the next patch.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #161664
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
