### PR TITLE
Make Trend setup easier by using min_gradient_value and min_gradient_time_unit

### DIFF
--- a/homeassistant/components/trend/__init__.py
+++ b/homeassistant/components/trend/__init__.py
@@ -13,6 +13,15 @@ from homeassistant.helpers.helper_integration import (
     async_remove_helper_config_entry_from_source_device,
 )
 
+from .const import (
+    CONF_MIN_GRADIENT,
+    CONF_MIN_GRADIENT_TIME_UNIT,
+    CONF_MIN_GRADIENT_VALUE,
+    DEFAULT_MIN_GRADIENT_TIME_UNIT,
+    DEFAULT_MIN_GRADIENT_VALUE,
+    TIME_UNIT_SECONDS,
+)
+
 PLATFORMS = [Platform.BINARY_SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
@@ -73,8 +82,19 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,
                 )
+        if config_entry.minor_version < 3:
+            # Migrate min_gradient to min_gradient_value and min_gradient_time_unit
+            if CONF_MIN_GRADIENT in options:
+                old_gradient = float(options.pop(CONF_MIN_GRADIENT))
+                # Convert units/second to units/hour
+                seconds_per_hour = TIME_UNIT_SECONDS["hour"]
+                options[CONF_MIN_GRADIENT_VALUE] = old_gradient * seconds_per_hour
+                options[CONF_MIN_GRADIENT_TIME_UNIT] = DEFAULT_MIN_GRADIENT_TIME_UNIT
+            else:
+                options[CONF_MIN_GRADIENT_VALUE] = DEFAULT_MIN_GRADIENT_VALUE
+                options[CONF_MIN_GRADIENT_TIME_UNIT] = DEFAULT_MIN_GRADIENT_TIME_UNIT
         hass.config_entries.async_update_entry(
-            config_entry, options=options, minor_version=2
+            config_entry, options=options, minor_version=3
         )
 
     _LOGGER.debug(

--- a/homeassistant/components/trend/binary_sensor.py
+++ b/homeassistant/components/trend/binary_sensor.py
@@ -56,13 +56,17 @@ from .const import (
     CONF_INVERT,
     CONF_MAX_SAMPLES,
     CONF_MIN_GRADIENT,
+    CONF_MIN_GRADIENT_TIME_UNIT,
+    CONF_MIN_GRADIENT_VALUE,
     CONF_MIN_SAMPLES,
     CONF_SAMPLE_DURATION,
     DEFAULT_MAX_SAMPLES,
-    DEFAULT_MIN_GRADIENT,
+    DEFAULT_MIN_GRADIENT_TIME_UNIT,
+    DEFAULT_MIN_GRADIENT_VALUE,
     DEFAULT_MIN_SAMPLES,
     DEFAULT_SAMPLE_DURATION,
     DOMAIN,
+    TIME_UNIT_SECONDS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -134,13 +138,21 @@ async def async_setup_platform(
     async_add_entities(entities)
 
 
+def _calculate_min_gradient(options: Mapping[str, Any]) -> float:
+    """Calculate min_gradient from user-friendly options."""
+    gradient_value = options.get(CONF_MIN_GRADIENT_VALUE, DEFAULT_MIN_GRADIENT_VALUE)
+    time_unit = options.get(CONF_MIN_GRADIENT_TIME_UNIT, DEFAULT_MIN_GRADIENT_TIME_UNIT)
+    seconds = TIME_UNIT_SECONDS.get(time_unit, TIME_UNIT_SECONDS["hour"])
+
+    return float(gradient_value) / seconds
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up trend sensor from config entry."""
-
     async_add_entities(
         [
             SensorTrend(
@@ -152,7 +164,7 @@ async def async_setup_entry(
                 sample_duration=entry.options.get(
                     CONF_SAMPLE_DURATION, DEFAULT_SAMPLE_DURATION
                 ),
-                min_gradient=entry.options.get(CONF_MIN_GRADIENT, DEFAULT_MIN_GRADIENT),
+                min_gradient=_calculate_min_gradient(entry.options),
                 min_samples=entry.options.get(CONF_MIN_SAMPLES, DEFAULT_MIN_SAMPLES),
                 max_samples=entry.options.get(CONF_MAX_SAMPLES, DEFAULT_MAX_SAMPLES),
                 unique_id=entry.entry_id,

--- a/homeassistant/components/trend/config_flow.py
+++ b/homeassistant/components/trend/config_flow.py
@@ -19,11 +19,13 @@ from homeassistant.helpers.schema_config_entry_flow import (
 from .const import (
     CONF_INVERT,
     CONF_MAX_SAMPLES,
-    CONF_MIN_GRADIENT,
+    CONF_MIN_GRADIENT_TIME_UNIT,
+    CONF_MIN_GRADIENT_VALUE,
     CONF_MIN_SAMPLES,
     CONF_SAMPLE_DURATION,
     DEFAULT_MAX_SAMPLES,
-    DEFAULT_MIN_GRADIENT,
+    DEFAULT_MIN_GRADIENT_TIME_UNIT,
+    DEFAULT_MIN_GRADIENT_VALUE,
     DEFAULT_MIN_SAMPLES,
     DEFAULT_SAMPLE_DURATION,
     DOMAIN,
@@ -68,11 +70,20 @@ async def get_extended_options_schema(handler: SchemaCommonFlowHandler) -> vol.S
                 ),
             ),
             vol.Optional(
-                CONF_MIN_GRADIENT, default=DEFAULT_MIN_GRADIENT
+                CONF_MIN_GRADIENT_VALUE, default=DEFAULT_MIN_GRADIENT_VALUE
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     step="any",
                     mode=selector.NumberSelectorMode.BOX,
+                ),
+            ),
+            vol.Optional(
+                CONF_MIN_GRADIENT_TIME_UNIT, default=DEFAULT_MIN_GRADIENT_TIME_UNIT
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=["second", "minute", "hour", "day"],
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                    translation_key="min_gradient_time_unit",
                 ),
             ),
             vol.Optional(
@@ -101,7 +112,7 @@ CONFIG_SCHEMA = vol.Schema(
 class ConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     """Handle a config or options flow for Trend."""
 
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     config_flow = {
         "user": SchemaFlowFormStep(schema=CONFIG_SCHEMA, next_step="settings"),

--- a/homeassistant/components/trend/const.py
+++ b/homeassistant/components/trend/const.py
@@ -12,10 +12,22 @@ ATTR_SAMPLE_COUNT = "sample_count"
 CONF_INVERT = "invert"
 CONF_MAX_SAMPLES = "max_samples"
 CONF_MIN_GRADIENT = "min_gradient"
+CONF_MIN_GRADIENT_VALUE = "min_gradient_value"
+CONF_MIN_GRADIENT_TIME_UNIT = "min_gradient_time_unit"
 CONF_SAMPLE_DURATION = "sample_duration"
 CONF_MIN_SAMPLES = "min_samples"
 
 DEFAULT_MAX_SAMPLES = 2
 DEFAULT_MIN_SAMPLES = 2
 DEFAULT_MIN_GRADIENT = 0.0
+DEFAULT_MIN_GRADIENT_VALUE = 0.0
+DEFAULT_MIN_GRADIENT_TIME_UNIT = "hour"
 DEFAULT_SAMPLE_DURATION = 0
+
+# Time unit conversion factors (to seconds)
+TIME_UNIT_SECONDS = {
+    "second": 1,
+    "minute": 60,
+    "hour": 3600,
+    "day": 86400,
+}

--- a/homeassistant/components/trend/strings.json
+++ b/homeassistant/components/trend/strings.json
@@ -26,16 +26,28 @@
           "entity_id": "[%key:component::trend::config::step::user::data::entity_id%]",
           "invert": "[%key:component::trend::config::step::settings::data::invert%]",
           "max_samples": "Maximum number of stored samples",
-          "min_gradient": "Minimum rate at which the value must be changing",
+          "min_gradient_time_unit": "Time unit for rate of change",
+          "min_gradient_value": "Minimum rate of change",
           "min_samples": "Minimum number of stored samples",
           "sample_duration": "Duration in seconds to store samples for"
         },
         "data_description": {
           "max_samples": "The maximum number of samples to store. If the number of samples exceeds this value, the oldest samples will be discarded.",
-          "min_gradient": "The minimum rate at which the observed value must be changing for this sensor to switch on. The gradient is measured in sensor units per second.",
+          "min_gradient_time_unit": "The time unit for the rate of change. Combined with the minimum rate of change value to determine the trend threshold.",
+          "min_gradient_value": "The minimum amount the observed value must change per time unit for this sensor to switch on. For example, enter 2 with time unit 'hour' to detect a change of at least 2 units per hour.",
           "min_samples": "The minimum number of samples that must be collected before the gradient can be calculated.",
           "sample_duration": "The duration in seconds to store samples for. Samples older than this value will be discarded."
         }
+      }
+    }
+  },
+  "selector": {
+    "min_gradient_time_unit": {
+      "options": {
+        "day": "Per day",
+        "hour": "Per hour",
+        "minute": "Per minute",
+        "second": "Per second"
       }
     }
   },

--- a/tests/components/trend/conftest.py
+++ b/tests/components/trend/conftest.py
@@ -24,10 +24,12 @@ async def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
             "entity_id": "sensor.cpu_temp",
             "invert": False,
             "max_samples": 2.0,
-            "min_gradient": 0.0,
+            "min_gradient_value": 0.0,
+            "min_gradient_time_unit": "hour",
             "sample_duration": 0.0,
         },
         title="My trend",
+        minor_version=3,
     )
 
 

--- a/tests/components/trend/test_binary_sensor.py
+++ b/tests/components/trend/test_binary_sensor.py
@@ -178,7 +178,8 @@ async def test_using_trendline(
     await setup_component(
         {
             "sample_duration": 10000,
-            "min_gradient": 1,
+            "min_gradient_value": 3600,  # 1 unit/second = 3600 units/hour
+            "min_gradient_time_unit": "hour",
             "max_samples": 25,
             "min_samples": 5,
             "invert": inverted,
@@ -233,7 +234,8 @@ async def test_max_samples(
     await setup_component(
         {
             "max_samples": 3,
-            "min_gradient": -1,
+            "min_gradient_value": -3600,  # -1 unit/second = -3600 units/hour
+            "min_gradient_time_unit": "hour",
         },
     )
 
@@ -341,7 +343,8 @@ async def test_restore_state(
     await setup_component(
         {
             "sample_duration": 10000,
-            "min_gradient": 1,
+            "min_gradient_value": 3600,  # 1 unit/second = 3600 units/hour
+            "min_gradient_time_unit": "hour",
             "max_samples": 25,
             "min_samples": 5,
         },
@@ -453,7 +456,8 @@ async def test_unavailable_source(
     await setup_component(
         {
             "sample_duration": 10000,
-            "min_gradient": 1,
+            "min_gradient_value": 3600,  # 1 unit/second = 3600 units/hour
+            "min_gradient_time_unit": "hour",
             "max_samples": 25,
             "min_samples": 5,
         },
@@ -488,7 +492,8 @@ async def test_invalid_state_handling(
     await setup_component(
         {
             "sample_duration": 10000,
-            "min_gradient": 1,
+            "min_gradient_value": 3600,  # 1 unit/second = 3600 units/hour
+            "min_gradient_time_unit": "hour",
             "max_samples": 25,
             "min_samples": 5,
         },

--- a/tests/components/trend/test_config_flow.py
+++ b/tests/components/trend/test_config_flow.py
@@ -75,7 +75,8 @@ async def test_options(hass: HomeAssistant, config_entry: MockConfigEntry) -> No
         "max_samples": 50,
         "entity_id": "sensor.cpu_temp",
         "invert": False,
-        "min_gradient": 0.0,
+        "min_gradient_value": 0.0,
+        "min_gradient_time_unit": "hour",
         "name": "My trend",
         "sample_duration": 0.0,
     }

--- a/tests/components/trend/test_init.py
+++ b/tests/components/trend/test_init.py
@@ -428,7 +428,7 @@ async def test_migration_1_1(
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     assert trend_config_entry.version == 1
-    assert trend_config_entry.minor_version == 2
+    assert trend_config_entry.minor_version == 3
 
 
 async def test_migration_from_future_version(
@@ -452,3 +452,108 @@ async def test_migration_from_future_version(
     await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.MIGRATION_ERROR
+
+
+async def test_migration_1_2_to_1_3(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test migration from v1.2 to v1.3 converts min_gradient to new format."""
+    # Old config entry with min_gradient in units per second
+    # 0.001 units/second = 3.6 units/hour
+    trend_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My trend",
+            "entity_id": "sensor.test_state",
+            "invert": False,
+            "min_gradient": 0.001,
+            "max_samples": 10,
+            "min_samples": 2,
+            "sample_duration": 0,
+        },
+        title="My trend",
+        version=1,
+        minor_version=2,
+    )
+    trend_config_entry.add_to_hass(hass)
+
+    hass.states.async_set("sensor.test_state", "1")
+    await hass.async_block_till_done()
+
+    await hass.config_entries.async_setup(trend_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert trend_config_entry.state is ConfigEntryState.LOADED
+
+    # Check that migration happened
+    assert trend_config_entry.version == 1
+    assert trend_config_entry.minor_version == 3
+
+    # Check that min_gradient was converted to the new format
+    # 0.001 units/second * 3600 seconds/hour = 3.6 units/hour
+    assert "min_gradient" not in trend_config_entry.options
+    assert trend_config_entry.options["min_gradient_value"] == 3.6
+    assert trend_config_entry.options["min_gradient_time_unit"] == "hour"
+
+
+async def test_migration_1_2_to_1_3_zero_gradient(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration from v1.2 to v1.3 with zero gradient."""
+    trend_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My trend",
+            "entity_id": "sensor.test_state",
+            "invert": False,
+            "min_gradient": 0.0,
+        },
+        title="My trend",
+        version=1,
+        minor_version=2,
+    )
+    trend_config_entry.add_to_hass(hass)
+
+    hass.states.async_set("sensor.test_state", "1")
+    await hass.async_block_till_done()
+
+    await hass.config_entries.async_setup(trend_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert trend_config_entry.state is ConfigEntryState.LOADED
+    assert trend_config_entry.minor_version == 3
+    assert trend_config_entry.options["min_gradient_value"] == 0.0
+    assert trend_config_entry.options["min_gradient_time_unit"] == "hour"
+
+
+async def test_migration_1_2_to_1_3_no_min_gradient(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration from v1.2 to v1.3 without min_gradient option."""
+    trend_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My trend",
+            "entity_id": "sensor.test_state",
+            "invert": False,
+        },
+        title="My trend",
+        version=1,
+        minor_version=2,
+    )
+    trend_config_entry.add_to_hass(hass)
+
+    hass.states.async_set("sensor.test_state", "1")
+    await hass.async_block_till_done()
+
+    await hass.config_entries.async_setup(trend_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert trend_config_entry.state is ConfigEntryState.LOADED
+    assert trend_config_entry.minor_version == 3
+    assert trend_config_entry.options["min_gradient_value"] == 0.0
+    assert trend_config_entry.options["min_gradient_time_unit"] == "hour"

--- a/tests/components/trend/test_init.py
+++ b/tests/components/trend/test_init.py
@@ -456,7 +456,6 @@ async def test_migration_from_future_version(
 
 async def test_migration_1_2_to_1_3(
     hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test migration from v1.2 to v1.3 converts min_gradient to new format."""
     # Old config entry with min_gradient in units per second


### PR DESCRIPTION
## Proposed change
This PR makes it easier for users to set up trend integration. Previously, users had to calculate the `min_gradient` value themselves, which forced them to either remember the calculation method or consult the documentation each time. Besides this, the gradient sounds a bit to mathematically.

Now, instead, we ask the user how much the value should change and calculate the gradient ourselves.

The YAML configuration continues to work as before and accepts “min_gradient” as an option.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
