### PR TITLE
Add service helper to get config entry

### DIFF
--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -46,7 +46,7 @@
       "message": "Config entry {entry_title} for integration {domain} is not loaded."
     },
     "service_config_entry_wrong_domain": {
-      "message": "Config entry {entry_title} does not belong to {domain} integration."
+      "message": "Config entry {entry_title} does not belong to integration {domain}."
     },
     "service_does_not_support_response": {
       "message": "An action which does not return responses can't be called with {return_response}."

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -40,10 +40,13 @@
       "message": "Unknown error when validating config for {domain} from integration {p_name} - {error}."
     },
     "service_config_entry_not_found": {
-      "message": "{domain} config entry with ID: {entry_id} was not found."
+      "message": "Integration {domain} config entry with ID {entry_id} was not found."
     },
     "service_config_entry_not_loaded": {
-      "message": "{domain} config entry {entry_title} is not loaded."
+      "message": "Config entry {entry_title} for integration {domain} is not loaded."
+    },
+    "service_config_entry_wrong_domain": {
+      "message": "Config entry {entry_title} does not belong to {domain} integration."
     },
     "service_does_not_support_response": {
       "message": "An action which does not return responses can't be called with {return_response}."

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -39,6 +39,12 @@
     "platform_schema_validator_err": {
       "message": "Unknown error when validating config for {domain} from integration {p_name} - {error}."
     },
+    "service_config_entry_not_found": {
+      "message": "{domain} config entry with ID: {entry_id} was not found."
+    },
+    "service_config_entry_not_loaded": {
+      "message": "{domain} config entry {entry_title} is not loaded."
+    },
     "service_does_not_support_response": {
       "message": "An action which does not return responses can't be called with {return_response}."
     },

--- a/homeassistant/components/nordpool/services.py
+++ b/homeassistant/components/nordpool/services.py
@@ -29,9 +29,8 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.selector import ConfigEntrySelector
-from homeassistant.helpers.service import async_get_service_config_entry
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonValueType
 
@@ -73,7 +72,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         call: ServiceCall,
     ) -> tuple[NordPoolClient, date, str, list[str], int]:
         """Return the parameters for the service."""
-        entry: NordPoolConfigEntry = async_get_service_config_entry(
+        entry: NordPoolConfigEntry = service.async_get_config_entry(
             hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY]
         )
         client = entry.runtime_data.client

--- a/homeassistant/components/nordpool/services.py
+++ b/homeassistant/components/nordpool/services.py
@@ -31,7 +31,7 @@ from homeassistant.core import (
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import ConfigEntrySelector
-from homeassistant.helpers.service import get_service_config_entry
+from homeassistant.helpers.service import async_get_service_config_entry
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonValueType
 
@@ -73,7 +73,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         call: ServiceCall,
     ) -> tuple[NordPoolClient, date, str, list[str], int]:
         """Return the parameters for the service."""
-        entry: NordPoolConfigEntry = get_service_config_entry(
+        entry: NordPoolConfigEntry = async_get_service_config_entry(
             hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY]
         )
         client = entry.runtime_data.client

--- a/homeassistant/components/nordpool/services.py
+++ b/homeassistant/components/nordpool/services.py
@@ -20,7 +20,6 @@ from pynordpool import (
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_DATE
 from homeassistant.core import (
     HomeAssistant,
@@ -32,6 +31,7 @@ from homeassistant.core import (
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import ConfigEntrySelector
+from homeassistant.helpers.service import get_service_config_entry
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonValueType
 
@@ -65,21 +65,6 @@ SERVICE_GET_PRICE_INDICES_SCHEMA = SERVICE_GET_PRICES_SCHEMA.extend(
 )
 
 
-def get_config_entry(hass: HomeAssistant, entry_id: str) -> NordPoolConfigEntry:
-    """Return config entry."""
-    if not (entry := hass.config_entries.async_get_entry(entry_id)):
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="entry_not_found",
-        )
-    if entry.state is not ConfigEntryState.LOADED:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="entry_not_loaded",
-        )
-    return entry
-
-
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Set up services for Nord Pool integration."""
@@ -88,7 +73,9 @@ def async_setup_services(hass: HomeAssistant) -> None:
         call: ServiceCall,
     ) -> tuple[NordPoolClient, date, str, list[str], int]:
         """Return the parameters for the service."""
-        entry = get_config_entry(hass, call.data[ATTR_CONFIG_ENTRY])
+        entry: NordPoolConfigEntry = get_service_config_entry(
+            hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY]
+        )
         client = entry.runtime_data.client
         asked_date: date = call.data[ATTR_DATE]
 

--- a/homeassistant/components/nordpool/strings.json
+++ b/homeassistant/components/nordpool/strings.json
@@ -102,12 +102,6 @@
     "could_not_fetch_data": {
       "message": "Data could not be retrieved: {error}"
     },
-    "entry_not_found": {
-      "message": "The Nord Pool integration is not configured in Home Assistant."
-    },
-    "entry_not_loaded": {
-      "message": "The Nord Pool integration is currently not loaded or disabled in Home Assistant."
-    },
     "initial_update_failed": {
       "message": "Initial update failed on startup with error {error}"
     },

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1207,7 +1207,7 @@ def async_register_platform_entity_service(
 
 
 @callback
-def get_service_config_entry(
+def async_get_service_config_entry(
     hass: HomeAssistant, domain: str, entry_id: str
 ) -> ConfigEntry:
     """Get and validate a service config entry."""

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast, override
 import voluptuous as vol
 
 from homeassistant.auth.permissions.const import CAT_ENTITIES, POLICY_CONTROL
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ACTION,
@@ -28,6 +29,7 @@ from homeassistant.const import (
     ENTITY_MATCH_NONE,
 )
 from homeassistant.core import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
     Context,
     EntityServiceResponse,
     HassJob,
@@ -41,6 +43,7 @@ from homeassistant.core import (
 from homeassistant.exceptions import (
     HomeAssistantError,
     ServiceNotSupported,
+    ServiceValidationError,
     TemplateError,
     Unauthorized,
     UnknownUser,
@@ -1201,3 +1204,30 @@ def async_register_platform_entity_service(
         job_type=HassJobType.Coroutinefunction,
         description_placeholders=description_placeholders,
     )
+
+
+@callback
+def get_service_config_entry(
+    hass: HomeAssistant, domain: str, entry_id: str
+) -> ConfigEntry:
+    """Get and validate a service config entry."""
+    config_entry = hass.config_entries.async_get_entry(entry_id)
+    if not config_entry:
+        raise ServiceValidationError(
+            translation_domain=HOMEASSISTANT_DOMAIN,
+            translation_key="service_config_entry_not_found",
+            translation_placeholders={
+                "domain": domain,
+                "entry_id": entry_id,
+            },
+        )
+    if config_entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError(
+            translation_domain=HOMEASSISTANT_DOMAIN,
+            translation_key="service_config_entry_not_loaded",
+            translation_placeholders={
+                "domain": domain,
+                "entry_title": config_entry.title,
+            },
+        )
+    return config_entry

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1221,6 +1221,15 @@ def get_service_config_entry(
                 "entry_id": entry_id,
             },
         )
+    if config_entry.domain != domain:
+        raise ServiceValidationError(
+            translation_domain=HOMEASSISTANT_DOMAIN,
+            translation_key="service_config_entry_wrong_domain",
+            translation_placeholders={
+                "domain": domain,
+                "entry_title": config_entry.title,
+            },
+        )
     if config_entry.state is not ConfigEntryState.LOADED:
         raise ServiceValidationError(
             translation_domain=HOMEASSISTANT_DOMAIN,

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1207,7 +1207,7 @@ def async_register_platform_entity_service(
 
 
 @callback
-def async_get_service_config_entry(
+def async_get_config_entry(
     hass: HomeAssistant, domain: str, entry_id: str
 ) -> ConfigEntry:
     """Get and validate a service config entry."""

--- a/tests/components/nordpool/test_services.py
+++ b/tests/components/nordpool/test_services.py
@@ -167,7 +167,7 @@ async def test_service_call_config_entry_bad_state(
             blocking=True,
             return_response=True,
         )
-    assert err.value.translation_key == "entry_not_found"
+    assert err.value.translation_key == "service_config_entry_not_found"
 
     service_data = TEST_SERVICE_DATA.copy()
     service_data[ATTR_CONFIG_ENTRY] = load_int.entry_id
@@ -182,7 +182,7 @@ async def test_service_call_config_entry_bad_state(
             blocking=True,
             return_response=True,
         )
-    assert err.value.translation_key == "entry_not_loaded"
+    assert err.value.translation_key == "service_config_entry_not_loaded"
 
 
 @pytest.mark.freeze_time("2025-10-01T18:00:00+00:00")

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -3095,20 +3095,20 @@ async def test_get_service_config_entry(hass: HomeAssistant) -> None:
     entry1 = MockConfigEntry(domain=domain, entry_id=entry_id)
     entry1.add_to_hass(hass)
     entry1.mock_state(hass, config_entries.ConfigEntryState.LOADED)
-    assert service.get_service_config_entry(hass, domain, entry_id) is entry1
+    assert service.async_get_service_config_entry(hass, domain, entry_id) is entry1
 
     # Config entry doesn't exist
     with pytest.raises(exceptions.ServiceValidationError) as err:
-        service.get_service_config_entry(hass, domain, "another_entry")
+        service.async_get_service_config_entry(hass, domain, "another_entry")
     assert err.value.translation_key == "service_config_entry_not_found"
 
     # Config entry exists, but from wrong domain
     with pytest.raises(exceptions.ServiceValidationError) as err:
-        service.get_service_config_entry(hass, "another_domain", entry_id)
+        service.async_get_service_config_entry(hass, "another_domain", entry_id)
     assert err.value.translation_key == "service_config_entry_wrong_domain"
 
     # Config entry exists, but is not loaded
     entry1.mock_state(hass, config_entries.ConfigEntryState.NOT_LOADED)
     with pytest.raises(exceptions.ServiceValidationError) as err:
-        service.get_service_config_entry(hass, domain, entry_id)
+        service.async_get_service_config_entry(hass, domain, entry_id)
     assert err.value.translation_key == "service_config_entry_not_loaded"

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -14,7 +14,7 @@ from pytest_unordered import unordered
 import voluptuous as vol
 
 # To prevent circular import when running just this file
-from homeassistant import exceptions
+from homeassistant import config_entries, exceptions
 from homeassistant.auth.permissions import PolicyPermissions
 import homeassistant.components  # noqa: F401
 from homeassistant.components.group import DOMAIN as DOMAIN_GROUP, Group
@@ -56,6 +56,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util.yaml.loader import JSON_TYPE, parse_yaml
 
 from tests.common import (
+    MockConfigEntry,
     MockEntity,
     MockEntityPlatform,
     MockModule,
@@ -3084,3 +3085,22 @@ async def test_register_platform_entity_service_non_entity_service_schema(
             schema=schema,
             func=Mock(),
         )
+
+
+async def test_get_service_config_entry(hass: HomeAssistant) -> None:
+    """Test that we can get a service config entry."""
+    # Config entry doesn't exist
+    with pytest.raises(exceptions.ServiceValidationError) as err:
+        service.get_service_config_entry(hass, "comp", "entry_1")
+    assert err.value.translation_key == "service_config_entry_not_found"
+
+    # Config entry exists, but is not loaded
+    entry1 = MockConfigEntry(domain="comp", entry_id="entry_1")
+    entry1.add_to_hass(hass)
+    with pytest.raises(exceptions.ServiceValidationError) as err:
+        service.get_service_config_entry(hass, "comp", "entry_1")
+    assert err.value.translation_key == "service_config_entry_not_loaded"
+
+    # Config entry exists, and is loaded
+    entry1.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    assert service.get_service_config_entry(hass, "comp", "entry_1") is entry1

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -3095,20 +3095,20 @@ async def test_get_service_config_entry(hass: HomeAssistant) -> None:
     entry1 = MockConfigEntry(domain=domain, entry_id=entry_id)
     entry1.add_to_hass(hass)
     entry1.mock_state(hass, config_entries.ConfigEntryState.LOADED)
-    assert service.async_get_service_config_entry(hass, domain, entry_id) is entry1
+    assert service.async_get_config_entry(hass, domain, entry_id) is entry1
 
     # Config entry doesn't exist
     with pytest.raises(exceptions.ServiceValidationError) as err:
-        service.async_get_service_config_entry(hass, domain, "another_entry")
+        service.async_get_config_entry(hass, domain, "another_entry")
     assert err.value.translation_key == "service_config_entry_not_found"
 
     # Config entry exists, but from wrong domain
     with pytest.raises(exceptions.ServiceValidationError) as err:
-        service.async_get_service_config_entry(hass, "another_domain", entry_id)
+        service.async_get_config_entry(hass, "another_domain", entry_id)
     assert err.value.translation_key == "service_config_entry_wrong_domain"
 
     # Config entry exists, but is not loaded
     entry1.mock_state(hass, config_entries.ConfigEntryState.NOT_LOADED)
     with pytest.raises(exceptions.ServiceValidationError) as err:
-        service.async_get_service_config_entry(hass, domain, entry_id)
+        service.async_get_config_entry(hass, domain, entry_id)
     assert err.value.translation_key == "service_config_entry_not_loaded"

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -3089,18 +3089,26 @@ async def test_register_platform_entity_service_non_entity_service_schema(
 
 async def test_get_service_config_entry(hass: HomeAssistant) -> None:
     """Test that we can get a service config entry."""
+    domain = "mock_integration"
+    entry_id = "mock_entry_id"
+    # Config entry exists, and is loaded
+    entry1 = MockConfigEntry(domain=domain, entry_id=entry_id)
+    entry1.add_to_hass(hass)
+    entry1.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    assert service.get_service_config_entry(hass, domain, entry_id) is entry1
+
     # Config entry doesn't exist
     with pytest.raises(exceptions.ServiceValidationError) as err:
-        service.get_service_config_entry(hass, "comp", "entry_1")
+        service.get_service_config_entry(hass, domain, "another_entry")
     assert err.value.translation_key == "service_config_entry_not_found"
 
-    # Config entry exists, but is not loaded
-    entry1 = MockConfigEntry(domain="comp", entry_id="entry_1")
-    entry1.add_to_hass(hass)
+    # Config entry exists, but from wrong domain
     with pytest.raises(exceptions.ServiceValidationError) as err:
-        service.get_service_config_entry(hass, "comp", "entry_1")
-    assert err.value.translation_key == "service_config_entry_not_loaded"
+        service.get_service_config_entry(hass, "another_domain", entry_id)
+    assert err.value.translation_key == "service_config_entry_wrong_domain"
 
-    # Config entry exists, and is loaded
-    entry1.mock_state(hass, config_entries.ConfigEntryState.LOADED)
-    assert service.get_service_config_entry(hass, "comp", "entry_1") is entry1
+    # Config entry exists, but is not loaded
+    entry1.mock_state(hass, config_entries.ConfigEntryState.NOT_LOADED)
+    with pytest.raises(exceptions.ServiceValidationError) as err:
+        service.get_service_config_entry(hass, domain, entry_id)
+    assert err.value.translation_key == "service_config_entry_not_loaded"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Passing a config entry ID to a service, validating it and extracting the config entry is a very common pattern in HA integrations.

This adds a helper, with corresponding strings under `homeassistant` domain.

Also use the new helper in a single (sample) integration: `nordpool`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
