### PR TITLE
Move webostv service registration

### DIFF
--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import DATA_HASS_CONFIG, DOMAIN, PLATFORMS, WEBOSTV_EXCEPTIONS
 from .helpers import WebOsTvConfigEntry, update_client_key
+from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -30,6 +31,8 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the LG webOS TV platform."""
     hass.data.setdefault(DOMAIN, {DATA_HASS_CONFIG: config})
+
+    async_setup_services(hass)
 
     return True
 

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -12,16 +12,11 @@ PLATFORMS = [Platform.MEDIA_PLAYER]
 DATA_HASS_CONFIG = "hass_config"
 DEFAULT_NAME = "LG webOS TV"
 
-ATTR_BUTTON = "button"
 ATTR_PAYLOAD = "payload"
 ATTR_SOUND_OUTPUT = "sound_output"
 
 CONF_ON_ACTION = "turn_on_action"
 CONF_SOURCES = "sources"
-
-SERVICE_BUTTON = "button"
-SERVICE_COMMAND = "command"
-SERVICE_SELECT_SOUND_OUTPUT = "select_sound_output"
 
 LIVE_TV_APP_ID = "com.webos.app.livetv"
 

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -12,7 +12,6 @@ import logging
 from typing import Any, Concatenate, cast
 
 from aiowebostv import WebOsTvPairError, WebOsTvState
-import voluptuous as vol
 
 from homeassistant import util
 from homeassistant.components.media_player import (
@@ -22,27 +21,21 @@ from homeassistant.components.media_player import (
     MediaPlayerState,
     MediaType,
 )
-from homeassistant.const import ATTR_COMMAND, ATTR_SUPPORTED_FEATURES
-from homeassistant.core import HomeAssistant, ServiceResponse, SupportsResponse
+from homeassistant.const import ATTR_SUPPORTED_FEATURES
+from homeassistant.core import HomeAssistant, ServiceResponse
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.trigger import PluggableAction
-from homeassistant.helpers.typing import VolDictType
 
 from .const import (
-    ATTR_BUTTON,
     ATTR_PAYLOAD,
     ATTR_SOUND_OUTPUT,
     CONF_SOURCES,
     DOMAIN,
     LIVE_TV_APP_ID,
-    SERVICE_BUTTON,
-    SERVICE_COMMAND,
-    SERVICE_SELECT_SOUND_OUTPUT,
     WEBOSTV_EXCEPTIONS,
 )
 from .helpers import WebOsTvConfigEntry, update_client_key
@@ -70,34 +63,6 @@ MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
 PARALLEL_UPDATES = 0
 SCAN_INTERVAL = timedelta(seconds=10)
 
-BUTTON_SCHEMA: VolDictType = {vol.Required(ATTR_BUTTON): cv.string}
-COMMAND_SCHEMA: VolDictType = {
-    vol.Required(ATTR_COMMAND): cv.string,
-    vol.Optional(ATTR_PAYLOAD): dict,
-}
-SOUND_OUTPUT_SCHEMA: VolDictType = {vol.Required(ATTR_SOUND_OUTPUT): cv.string}
-
-SERVICES = (
-    (
-        SERVICE_BUTTON,
-        BUTTON_SCHEMA,
-        "async_button",
-        SupportsResponse.NONE,
-    ),
-    (
-        SERVICE_COMMAND,
-        COMMAND_SCHEMA,
-        "async_command",
-        SupportsResponse.OPTIONAL,
-    ),
-    (
-        SERVICE_SELECT_SOUND_OUTPUT,
-        SOUND_OUTPUT_SCHEMA,
-        "async_select_sound_output",
-        SupportsResponse.OPTIONAL,
-    ),
-)
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -105,12 +70,6 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the LG webOS TV platform."""
-    platform = entity_platform.async_get_current_platform()
-
-    for service_name, schema, method, supports_response in SERVICES:
-        platform.async_register_entity_service(
-            service_name, schema, method, supports_response=supports_response
-        )
 
     async_add_entities([LgWebOSMediaPlayerEntity(entry)])
 

--- a/homeassistant/components/webostv/services.py
+++ b/homeassistant/components/webostv/services.py
@@ -1,0 +1,63 @@
+"""LG webOS TV services."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
+from homeassistant.const import ATTR_COMMAND
+from homeassistant.core import HomeAssistant, SupportsResponse, callback
+from homeassistant.helpers import config_validation as cv, service
+from homeassistant.helpers.typing import VolDictType
+
+from .const import ATTR_PAYLOAD, ATTR_SOUND_OUTPUT, DOMAIN
+
+ATTR_BUTTON = "button"
+
+SERVICE_BUTTON = "button"
+SERVICE_COMMAND = "command"
+SERVICE_SELECT_SOUND_OUTPUT = "select_sound_output"
+
+BUTTON_SCHEMA: VolDictType = {vol.Required(ATTR_BUTTON): cv.string}
+COMMAND_SCHEMA: VolDictType = {
+    vol.Required(ATTR_COMMAND): cv.string,
+    vol.Optional(ATTR_PAYLOAD): dict,
+}
+SOUND_OUTPUT_SCHEMA: VolDictType = {vol.Required(ATTR_SOUND_OUTPUT): cv.string}
+
+SERVICES = (
+    (
+        SERVICE_BUTTON,
+        BUTTON_SCHEMA,
+        "async_button",
+        SupportsResponse.NONE,
+    ),
+    (
+        SERVICE_COMMAND,
+        COMMAND_SCHEMA,
+        "async_command",
+        SupportsResponse.OPTIONAL,
+    ),
+    (
+        SERVICE_SELECT_SOUND_OUTPUT,
+        SOUND_OUTPUT_SCHEMA,
+        "async_select_sound_output",
+        SupportsResponse.OPTIONAL,
+    ),
+)
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up services."""
+
+    for service_name, schema, method, supports_response in SERVICES:
+        service.async_register_platform_entity_service(
+            hass,
+            DOMAIN,
+            service_name,
+            entity_domain=MEDIA_PLAYER_DOMAIN,
+            schema=schema,
+            func=method,
+            supports_response=supports_response,
+        )

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -26,19 +26,21 @@ from homeassistant.components.media_player import (
     MediaType,
 )
 from homeassistant.components.webostv.const import (
-    ATTR_BUTTON,
     ATTR_PAYLOAD,
     ATTR_SOUND_OUTPUT,
     DOMAIN,
     LIVE_TV_APP_ID,
-    SERVICE_BUTTON,
-    SERVICE_COMMAND,
-    SERVICE_SELECT_SOUND_OUTPUT,
     WebOsTvCommandError,
 )
 from homeassistant.components.webostv.media_player import (
     SUPPORT_WEBOSTV,
     SUPPORT_WEBOSTV_VOLUME,
+)
+from homeassistant.components.webostv.services import (
+    ATTR_BUTTON,
+    SERVICE_BUTTON,
+    SERVICE_COMMAND,
+    SERVICE_SELECT_SOUND_OUTPUT,
 )
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move from `media_player.py (async_setup_entry)` to `__init__.py (async_setup)`

Based on https://developers.home-assistant.io/docs/dev_101_services/#entity-service-actions

Linked to #162084

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
