### PR TITLE
add context properties in handlers to update state faster in alexa app

### DIFF
--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -218,7 +218,11 @@ async def async_api_turn_on(
         context=context,
     )
 
-    return directive.response()
+    response = directive.response()
+    response.add_context_property(
+        {"name": "powerState", "namespace": "Alexa.PowerController", "value": "ON"}
+    )
+    return response
 
 
 @HANDLERS.register(("Alexa.PowerController", "TurnOff"))
@@ -271,7 +275,11 @@ async def async_api_turn_off(
         context=context,
     )
 
-    return directive.response()
+    response = directive.response()
+    response.add_context_property(
+        {"name": "powerState", "namespace": "Alexa.PowerController", "value": "OFF"}
+    )
+    return response
 
 
 @HANDLERS.register(("Alexa.BrightnessController", "SetBrightness"))
@@ -293,7 +301,15 @@ async def async_api_set_brightness(
         context=context,
     )
 
-    return directive.response()
+    response = directive.response()
+    response.add_context_property(
+        {
+            "name": "brightness",
+            "namespace": "Alexa.BrightnessController",
+            "value": brightness,
+        }
+    )
+    return response
 
 
 @HANDLERS.register(("Alexa.BrightnessController", "AdjustBrightness"))
@@ -345,7 +361,16 @@ async def async_api_set_color(
         context=context,
     )
 
-    return directive.response()
+    response = directive.response()
+    hsb = {
+        "hue": float(directive.payload["color"]["hue"]),
+        "saturation": float(directive.payload["color"]["saturation"]),
+        "brightness": float(directive.payload["color"]["brightness"]),
+    }
+    response.add_context_property(
+        {"name": "color", "namespace": "Alexa.ColorController", "value": hsb}
+    )
+    return response
 
 
 @HANDLERS.register(("Alexa.ColorTemperatureController", "SetColorTemperature"))
@@ -367,7 +392,15 @@ async def async_api_set_color_temperature(
         context=context,
     )
 
-    return directive.response()
+    response = directive.response()
+    response.add_context_property(
+        {
+            "name": "colorTemperatureInKelvin",
+            "namespace": "Alexa.ColorController",
+            "value": kelvin,
+        }
+    )
+    return response
 
 
 @HANDLERS.register(("Alexa.ColorTemperatureController", "DecreaseColorTemperature"))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
**⚠️⚠️This PR is a draft, because it depends on #161975**

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the powerstate/brightness/colortemp etc. are changed, the target value must be added as context properties. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR depends on #161975 - because some tests fail now:
e.g.
```python
    async def assert_power_controller_works(
        endpoint: str,
        on_service: str,
        off_service: str,
        hass: HomeAssistant,
        timestamp: str,
    ) -> None:
        """Assert PowerController API requests work."""
        _, response = await assert_request_calls_service(
            "Alexa.PowerController", "TurnOn", endpoint, on_service, hass
        )
        for context_property in response["context"]["properties"]:
>           assert context_property["timeOfSample"] == timestamp
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           KeyError: 'timeOfSample'
```
This happens, because the "timeOfSample" properties are NOT added to all properties added with `add_context_property` will not get the `timeOfSample` and `uncertainlyInMillis`

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
