### PR TITLE
Add dynamic device discovery for Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.components.application_credentials import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -39,6 +39,7 @@ from .coordinator import (
     TeslemetryEnergyHistoryCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
     TeslemetryEnergySiteLiveCoordinator,
+    TeslemetryMetadataCoordinator,
     TeslemetryVehicleDataCoordinator,
 )
 from .helpers import async_update_device_sw_version, flatten
@@ -109,6 +110,60 @@ async def _get_access_token(oauth_session: OAuth2Session) -> str:
     return cast(str, oauth_session.token[CONF_ACCESS_TOKEN])
 
 
+def _setup_dynamic_discovery(
+    hass: HomeAssistant,
+    entry: TeslemetryConfigEntry,
+    metadata_coordinator: TeslemetryMetadataCoordinator,
+    known_vins: set[str],
+    known_site_ids: set[str],
+) -> None:
+    """Set up dynamic device discovery via reload when subscriptions change.
+
+    Monitors the metadata coordinator for:
+    - New vehicles/energy sites added with subscriptions (access: True)
+    - Vehicles/energy sites that have had subscriptions removed
+    """
+
+    @callback
+    def _handle_metadata_update() -> None:
+        """Handle metadata coordinator update - detect subscription changes."""
+        data = metadata_coordinator.data
+        if not data:
+            return
+
+        # Get VINs with active subscriptions (access: True in metadata)
+        current_vins = {
+            vin for vin, info in data.get("vehicles", {}).items() if info.get("access")
+        }
+
+        # Get energy site IDs with active subscriptions
+        current_site_ids = {
+            site_id
+            for site_id, info in data.get("energy_sites", {}).items()
+            if info.get("access")
+        }
+
+        added_vins = current_vins - known_vins
+        removed_vins = known_vins - current_vins
+        added_sites = current_site_ids - known_site_ids
+        removed_sites = known_site_ids - current_site_ids
+
+        if added_vins or removed_vins or added_sites or removed_sites:
+            LOGGER.info(
+                "Tesla subscription changes detected "
+                "(added vehicles: %s, removed vehicles: %s, "
+                "added energy sites: %s, removed energy sites: %s), "
+                "reloading integration",
+                added_vins or "none",
+                removed_vins or "none",
+                added_sites or "none",
+                removed_sites or "none",
+            )
+            hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+
+    metadata_coordinator.async_add_listener(_handle_metadata_update)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
     """Set up Teslemetry config."""
 
@@ -158,7 +213,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
 
     scopes = calls[0]["scopes"]
     region = calls[0]["region"]
-    vehicle_metadata = calls[0]["vehicles"]
+    vehicle_metadata = calls[0].get("vehicles", {})
+    energy_site_metadata = calls[0].get("energy_sites", {})
     products = calls[1]["response"]
 
     device_registry = dr.async_get(hass)
@@ -167,11 +223,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
     vehicles: list[TeslemetryVehicleData] = []
     energysites: list[TeslemetryEnergyData] = []
 
-    # Create the stream
+    # Create the stream (created lazily when first vehicle is found)
     stream: TeslemetryStream | None = None
 
     # Remember each device identifier we create
     current_devices: set[tuple[str, str]] = set()
+
+    # Track known devices for dynamic discovery (based on subscription status)
+    known_vins: set[str] = set()
+    known_site_ids: set[str] = set()
 
     for product in products:
         if (
@@ -179,9 +239,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             and vehicle_metadata.get(product["vin"], {}).get("access")
             and Scope.VEHICLE_DEVICE_DATA in scopes
         ):
+            vin = product["vin"]
+            known_vins.add(vin)
+            current_devices.add((DOMAIN, vin))
+
+            # Create stream if required (for first vehicle)
+            if not stream:
+                stream = TeslemetryStream(
+                    session,
+                    access_token,
+                    server=f"{region.lower()}.teslemetry.com",
+                    parse_timestamp=True,
+                    manual=True,
+                )
+
             # Remove the protobuff 'cached_data' that we do not use to save memory
             product.pop("cached_data", None)
-            vin = product["vin"]
             vehicle = teslemetry.vehicles.create(vin)
             coordinator = TeslemetryVehicleDataCoordinator(
                 hass, entry, vehicle, product
@@ -197,17 +270,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 serial_number=vin,
                 sw_version=firmware,
             )
-            current_devices.add((DOMAIN, vin))
 
-            # Create stream if required
-            if not stream:
-                stream = TeslemetryStream(
-                    session,
-                    access_token,
-                    server=f"{region.lower()}.teslemetry.com",
-                    parse_timestamp=True,
-                    manual=True,
-                )
+            firmware = vehicle_metadata[vin].get("firmware", "Unknown")
+            poll = vehicle_metadata[vin].get("polling", False)
 
             entry.async_on_unload(
                 stream.async_add_listener(
@@ -216,7 +281,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 )
             )
             stream_vehicle = stream.get_vehicle(vin)
-            poll = vehicle_metadata[vin].get("polling", False)
 
             vehicles.append(
                 TeslemetryVehicleData(
@@ -232,8 +296,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 )
             )
 
-        elif "energy_site_id" in product and Scope.ENERGY_DEVICE_DATA in scopes:
+        elif (
+            "energy_site_id" in product
+            and Scope.ENERGY_DEVICE_DATA in scopes
+            and energy_site_metadata.get(str(product["energy_site_id"]), {}).get(
+                "access"
+            )
+        ):
             site_id = product["energy_site_id"]
+            known_site_ids.add(str(site_id))
+            current_devices.add((DOMAIN, str(site_id)))
+
             powerwall = (
                 product["components"]["battery"] or product["components"]["solar"]
             )
@@ -245,6 +318,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 )
                 continue
 
+            if wall_connector:
+                for connector in product["components"]["wall_connectors"]:
+                    current_devices.add((DOMAIN, connector["din"]))
+
             energy_site = teslemetry.energySites.create(site_id)
             device = DeviceInfo(
                 identifiers={(DOMAIN, str(site_id))},
@@ -253,13 +330,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 name=product.get("site_name", "Energy Site"),
                 serial_number=str(site_id),
             )
-            current_devices.add((DOMAIN, str(site_id)))
 
-            if wall_connector:
-                for connector in product["components"]["wall_connectors"]:
-                    current_devices.add((DOMAIN, connector["din"]))
-
-            # Check live status endpoint works before creating its coordinator
+            # For initial setup, raise auth errors properly
             try:
                 live_status = (await energy_site.live_status())["response"]
             except InvalidToken as e:
@@ -348,9 +420,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 remove_config_entry_id=entry.entry_id,
             )
 
+    # Create metadata coordinator for dynamic device discovery
+    metadata_coordinator = TeslemetryMetadataCoordinator(hass, entry, teslemetry)
+
     # Setup Platforms
-    entry.runtime_data = TeslemetryData(vehicles, energysites, scopes, stream)
+    entry.runtime_data = TeslemetryData(
+        vehicles=vehicles,
+        energysites=energysites,
+        scopes=scopes,
+        stream=stream,
+        metadata_coordinator=metadata_coordinator,
+    )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Set up dynamic device discovery
+    _setup_dynamic_discovery(
+        hass,
+        entry,
+        metadata_coordinator,
+        known_vins,
+        known_site_ids,
+    )
 
     if stream:
         entry.async_on_unload(stream.close)
@@ -454,7 +544,6 @@ async def async_setup_stream(
     hass: HomeAssistant, entry: TeslemetryConfigEntry, vehicle: TeslemetryVehicleData
 ) -> None:
     """Set up the stream for a vehicle."""
-
     await vehicle.stream_vehicle.get_config()
     entry.async_create_background_task(
         hass,

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -161,7 +161,9 @@ def _setup_dynamic_discovery(
             )
             hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
 
-    metadata_coordinator.async_add_listener(_handle_metadata_update)
+    entry.async_on_unload(
+        metadata_coordinator.async_add_listener(_handle_metadata_update)
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -321,8 +321,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 continue
 
             if wall_connector:
-                for connector in product["components"]["wall_connectors"]:
-                    current_devices.add((DOMAIN, connector["din"]))
+                current_devices |= {
+                    (DOMAIN, c["din"])
+                    for c in product["components]["wall_connectors"]
+                }
 
             energy_site = teslemetry.energySites.create(site_id)
             device = DeviceInfo(

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -117,12 +117,7 @@ def _setup_dynamic_discovery(
     known_vins: set[str],
     known_site_ids: set[str],
 ) -> None:
-    """Set up dynamic device discovery via reload when subscriptions change.
-
-    Monitors the metadata coordinator for:
-    - New vehicles/energy sites added with subscriptions (access: True)
-    - Vehicles/energy sites that have had subscriptions removed
-    """
+    """Set up dynamic device discovery via reload when subscriptions change."""
 
     @callback
     def _handle_metadata_update() -> None:
@@ -131,15 +126,13 @@ def _setup_dynamic_discovery(
         if not data:
             return
 
-        # Get VINs with active subscriptions (access: True in metadata)
         current_vins = {
-            vin for vin, info in data.get("vehicles", {}).items() if info.get("access")
+            vin for vin, info in data["vehicles"].items() if info.get("access")
         }
 
-        # Get energy site IDs with active subscriptions
         current_site_ids = {
             site_id
-            for site_id, info in data.get("energy_sites", {}).items()
+            for site_id, info in data["energy_sites"].items()
             if info.get("access")
         }
 
@@ -215,8 +208,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
 
     scopes = calls[0]["scopes"]
     region = calls[0]["region"]
-    vehicle_metadata = calls[0].get("vehicles", {})
-    energy_site_metadata = calls[0].get("energy_sites", {})
+    vehicle_metadata = calls[0]["vehicles"]
+    energy_site_metadata = calls[0]["energy_sites"]
     products = calls[1]["response"]
 
     device_registry = dr.async_get(hass)
@@ -322,8 +315,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
 
             if wall_connector:
                 current_devices |= {
-                    (DOMAIN, c["din"])
-                    for c in product["components]["wall_connectors"]
+                    (DOMAIN, c["din"]) for c in product["components"]["wall_connectors"]
                 }
 
             energy_site = teslemetry.energySites.create(site_id)
@@ -424,10 +416,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 remove_config_entry_id=entry.entry_id,
             )
 
-    # Create metadata coordinator for dynamic device discovery
     metadata_coordinator = TeslemetryMetadataCoordinator(hass, entry, teslemetry)
 
-    # Setup Platforms
     entry.runtime_data = TeslemetryData(
         vehicles=vehicles,
         energysites=energysites,
@@ -437,7 +427,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Set up dynamic device discovery
     _setup_dynamic_discovery(
         hass,
         entry,

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -282,7 +282,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 sw_version=firmware,
             )
 
-            firmware = vehicle_metadata[vin].get("firmware", "Unknown")
             poll = vehicle_metadata[vin].get("polling", False)
 
             entry.async_on_unload(
@@ -302,7 +301,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     stream=stream,
                     stream_vehicle=stream_vehicle,
                     vin=vin,
-                    firmware=firmware or "",
+                    firmware=firmware or "Unknown",
                     device=device,
                 )
             )

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -110,6 +110,28 @@ async def _get_access_token(oauth_session: OAuth2Session) -> str:
     return cast(str, oauth_session.token[CONF_ACCESS_TOKEN])
 
 
+def _get_tracked_ids_from_metadata(data: dict[str, Any]) -> tuple[set[str], set[str]]:
+    """Return metadata device IDs that are eligible for setup."""
+    scopes = set(data["scopes"])
+
+    tracked_vins = (
+        {vin for vin, info in data["vehicles"].items() if info.get("access")}
+        if Scope.VEHICLE_DEVICE_DATA in scopes
+        else set()
+    )
+    tracked_site_ids = (
+        {
+            site_id
+            for site_id, info in data["energy_sites"].items()
+            if info.get("access")
+        }
+        if Scope.ENERGY_DEVICE_DATA in scopes
+        else set()
+    )
+
+    return tracked_vins, tracked_site_ids
+
+
 def _setup_dynamic_discovery(
     hass: HomeAssistant,
     entry: TeslemetryConfigEntry,
@@ -126,15 +148,7 @@ def _setup_dynamic_discovery(
         if not data:
             return
 
-        current_vins = {
-            vin for vin, info in data["vehicles"].items() if info.get("access")
-        }
-
-        current_site_ids = {
-            site_id
-            for site_id, info in data["energy_sites"].items()
-            if info.get("access")
-        }
+        current_vins, current_site_ids = _get_tracked_ids_from_metadata(data)
 
         added_vins = current_vins - known_vins
         removed_vins = known_vins - current_vins
@@ -153,6 +167,7 @@ def _setup_dynamic_discovery(
                 removed_sites or "none",
             )
             entry.async_create_background_task(
+                hass,
                 hass.config_entries.async_reload(entry.entry_id),
                 "teslemetry_reload_on_metadata_change",
             )
@@ -227,9 +242,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
     # Remember each device identifier we create
     current_devices: set[tuple[str, str]] = set()
 
-    # Track known devices for dynamic discovery (based on subscription status)
-    known_vins: set[str] = set()
-    known_site_ids: set[str] = set()
+    # Track known devices for dynamic discovery (based on eligible metadata state)
+    known_vins, known_site_ids = _get_tracked_ids_from_metadata(calls[0])
 
     for product in products:
         if (
@@ -238,7 +252,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             and Scope.VEHICLE_DEVICE_DATA in scopes
         ):
             vin = product["vin"]
-            known_vins.add(vin)
             current_devices.add((DOMAIN, vin))
 
             # Create stream if required (for first vehicle)
@@ -302,7 +315,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             )
         ):
             site_id = product["energy_site_id"]
-            known_site_ids.add(str(site_id))
             current_devices.add((DOMAIN, str(site_id)))
 
             powerwall = (

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -110,26 +110,18 @@ async def _get_access_token(oauth_session: OAuth2Session) -> str:
     return cast(str, oauth_session.token[CONF_ACCESS_TOKEN])
 
 
-def _get_tracked_ids_from_metadata(data: dict[str, Any]) -> tuple[set[str], set[str]]:
-    """Return metadata device IDs that are eligible for setup."""
-    scopes = set(data["scopes"])
+def _get_subscribed_ids_from_metadata(
+    data: dict[str, Any],
+) -> tuple[set[str], set[str]]:
+    """Return metadata device IDs that have an active subscription."""
+    subscribed_vins = {
+        vin for vin, info in data["vehicles"].items() if info.get("access")
+    }
+    subscribed_site_ids = {
+        site_id for site_id, info in data["energy_sites"].items() if info.get("access")
+    }
 
-    tracked_vins = (
-        {vin for vin, info in data["vehicles"].items() if info.get("access")}
-        if Scope.VEHICLE_DEVICE_DATA in scopes
-        else set()
-    )
-    tracked_site_ids = (
-        {
-            site_id
-            for site_id, info in data["energy_sites"].items()
-            if info.get("access")
-        }
-        if Scope.ENERGY_DEVICE_DATA in scopes
-        else set()
-    )
-
-    return tracked_vins, tracked_site_ids
+    return subscribed_vins, subscribed_site_ids
 
 
 def _setup_dynamic_discovery(
@@ -148,7 +140,7 @@ def _setup_dynamic_discovery(
         if not data:
             return
 
-        current_vins, current_site_ids = _get_tracked_ids_from_metadata(data)
+        current_vins, current_site_ids = _get_subscribed_ids_from_metadata(data)
 
         added_vins = current_vins - known_vins
         removed_vins = known_vins - current_vins
@@ -166,11 +158,7 @@ def _setup_dynamic_discovery(
                 added_sites or "none",
                 removed_sites or "none",
             )
-            entry.async_create_background_task(
-                hass,
-                hass.config_entries.async_reload(entry.entry_id),
-                "teslemetry_reload_on_metadata_change",
-            )
+            hass.config_entries.async_schedule_reload(entry.entry_id)
 
     entry.async_on_unload(
         metadata_coordinator.async_add_listener(_handle_metadata_update)
@@ -242,8 +230,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
     # Remember each device identifier we create
     current_devices: set[tuple[str, str]] = set()
 
-    # Track known devices for dynamic discovery (based on eligible metadata state)
-    known_vins, known_site_ids = _get_tracked_ids_from_metadata(calls[0])
+    # Track known devices for dynamic discovery (based on metadata access state)
+    known_vins, known_site_ids = _get_subscribed_ids_from_metadata(calls[0])
 
     for product in products:
         if (
@@ -314,7 +302,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             )
         ):
             site_id = product["energy_site_id"]
-            current_devices.add((DOMAIN, str(site_id)))
 
             powerwall = (
                 product["components"]["battery"] or product["components"]["solar"]
@@ -327,6 +314,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 )
                 continue
 
+            current_devices.add((DOMAIN, str(site_id)))
             if wall_connector:
                 current_devices |= {
                     (DOMAIN, c["din"]) for c in product["components"]["wall_connectors"]

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -152,7 +152,10 @@ def _setup_dynamic_discovery(
                 added_sites or "none",
                 removed_sites or "none",
             )
-            hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+            entry.async_create_background_task(
+                hass.config_entries.async_reload(entry.entry_id),
+                "teslemetry_reload_on_metadata_change",
+            )
 
     entry.async_on_unload(
         metadata_coordinator.async_add_listener(_handle_metadata_update)

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -15,7 +15,7 @@ from tesla_fleet_api.exceptions import (
     SubscriptionRequired,
     TeslaFleetError,
 )
-from tesla_fleet_api.teslemetry import EnergySite, Vehicle
+from tesla_fleet_api.teslemetry import EnergySite, Teslemetry, Vehicle
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -48,6 +48,7 @@ VEHICLE_WAIT = timedelta(minutes=15)
 ENERGY_LIVE_INTERVAL = timedelta(seconds=30)
 ENERGY_INFO_INTERVAL = timedelta(seconds=30)
 ENERGY_HISTORY_INTERVAL = timedelta(seconds=60)
+PRODUCTS_INTERVAL = timedelta(hours=1)
 
 ENDPOINTS = [
     VehicleDataEndpoint.CHARGE_STATE,
@@ -57,6 +58,41 @@ ENDPOINTS = [
     VehicleDataEndpoint.VEHICLE_STATE,
     VehicleDataEndpoint.VEHICLE_CONFIG,
 ]
+
+
+class TeslemetryMetadataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator to poll for subscription changes via metadata."""
+
+    config_entry: TeslemetryConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: TeslemetryConfigEntry,
+        teslemetry: Teslemetry,
+    ) -> None:
+        """Initialize Teslemetry Metadata coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=config_entry,
+            name="Teslemetry Metadata",
+            update_interval=PRODUCTS_INTERVAL,
+        )
+        self.teslemetry = teslemetry
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch latest metadata for subscription status."""
+        try:
+            data = await self.teslemetry.metadata()
+        except (InvalidToken, SubscriptionRequired) as e:
+            raise ConfigEntryAuthFailed from e
+        except RETRY_EXCEPTIONS as e:
+            raise UpdateFailed(e.message, retry_after=_get_retry_after(e)) from e
+        except TeslaFleetError as e:
+            raise UpdateFailed(e.message) from e
+
+        return data
 
 
 class TeslemetryVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -88,9 +88,18 @@ class TeslemetryMetadataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except (InvalidToken, SubscriptionRequired) as e:
             raise ConfigEntryAuthFailed from e
         except RETRY_EXCEPTIONS as e:
-            raise UpdateFailed(e.message, retry_after=_get_retry_after(e)) from e
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={"message": e.message},
+                retry_after=_get_retry_after(e),
+            ) from e
         except TeslaFleetError as e:
-            raise UpdateFailed(e.message) from e
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={"message": e.message},
+            ) from e
 
         return data
 

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -48,7 +48,7 @@ VEHICLE_WAIT = timedelta(minutes=15)
 ENERGY_LIVE_INTERVAL = timedelta(seconds=30)
 ENERGY_INFO_INTERVAL = timedelta(seconds=30)
 ENERGY_HISTORY_INTERVAL = timedelta(seconds=60)
-PRODUCTS_INTERVAL = timedelta(hours=1)
+METADATA_INTERVAL = timedelta(hours=1)
 
 ENDPOINTS = [
     VehicleDataEndpoint.CHARGE_STATE,
@@ -77,7 +77,7 @@ class TeslemetryMetadataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             LOGGER,
             config_entry=config_entry,
             name="Teslemetry Metadata",
-            update_interval=PRODUCTS_INTERVAL,
+            update_interval=METADATA_INTERVAL,
         )
         self.teslemetry = teslemetry
 

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -16,6 +16,7 @@ from .coordinator import (
     TeslemetryEnergyHistoryCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
     TeslemetryEnergySiteLiveCoordinator,
+    TeslemetryMetadataCoordinator,
     TeslemetryVehicleDataCoordinator,
 )
 
@@ -28,6 +29,7 @@ class TeslemetryData:
     energysites: list[TeslemetryEnergyData]
     scopes: list[Scope]
     stream: TeslemetryStream | None
+    metadata_coordinator: TeslemetryMetadataCoordinator
 
 
 @dataclass

--- a/homeassistant/components/teslemetry/quality_scale.yaml
+++ b/homeassistant/components/teslemetry/quality_scale.yaml
@@ -45,13 +45,7 @@ rules:
   docs-supported-functions: done
   docs-troubleshooting: done
   docs-use-cases: done
-  dynamic-devices:
-    status: todo
-    comment: |
-      New vehicles/energy sites added to user's Tesla account after initial setup
-      are not detected. Need to periodically poll teslemetry.products() and add
-      new TeslemetryVehicleData/TeslemetryEnergyData to runtime_data, then trigger
-      entity creation via coordinator listeners in each platform.
+  dynamic-devices: done
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done

--- a/tests/components/teslemetry/const.py
+++ b/tests/components/teslemetry/const.py
@@ -66,6 +66,12 @@ METADATA = {
             "name": "Home Assistant",
         }
     },
+    "energy_sites": {
+        "123456": {
+            "access": True,
+            "name": "Energy Site",
+        }
+    },
 }
 METADATA_LEGACY = {
     "uid": UNIQUE_ID,
@@ -92,6 +98,12 @@ METADATA_LEGACY = {
             "name": "Home Assistant",
         }
     },
+    "energy_sites": {
+        "123456": {
+            "access": True,
+            "name": "Energy Site",
+        }
+    },
 }
 METADATA_NOSCOPE = {
     "uid": UNIQUE_ID,
@@ -106,6 +118,12 @@ METADATA_NOSCOPE = {
             "discounted": True,
             "fleet_telemetry": "unknown",
             "name": "Home Assistant",
+        }
+    },
+    "energy_sites": {
+        "123456": {
+            "access": True,
+            "name": "Energy Site",
         }
     },
 }

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -24,6 +24,7 @@ from homeassistant.components.teslemetry.coordinator import (
     ENERGY_HISTORY_INTERVAL,
     ENERGY_INFO_INTERVAL,
     ENERGY_LIVE_INTERVAL,
+    PRODUCTS_INTERVAL,
     VEHICLE_INTERVAL,
 )
 from homeassistant.components.teslemetry.models import TeslemetryData
@@ -43,6 +44,7 @@ from .const import (
     CONFIG_V1,
     ENERGY_HISTORY,
     LIVE_STATUS,
+    METADATA,
     PRODUCTS_MODERN,
     SITE_INFO,
     UNIQUE_ID,
@@ -864,3 +866,78 @@ async def test_energy_history_coordinator_refresh_errors(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_dynamic_device_discovery_triggers_reload(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that metadata coordinator triggers reload when new vehicle is added."""
+    entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    # Track if reload was called
+    reload_called = False
+
+    async def mock_reload(entry_id):
+        nonlocal reload_called
+        reload_called = True
+        return True
+
+    # Update metadata to include a new vehicle with access
+    new_metadata = deepcopy(METADATA)
+    new_metadata["vehicles"]["5YJ3E1EA1NF000001"] = {
+        "proxy": True,
+        "access": True,
+        "polling": False,
+        "firmware": "2026.0.0",
+    }
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+            return_value=new_metadata,
+        ),
+        patch.object(hass.config_entries, "async_reload", side_effect=mock_reload),
+    ):
+        # Advance time to trigger metadata coordinator refresh
+        freezer.tick(PRODUCTS_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    # Verify reload was triggered due to new vehicle
+    assert reload_called
+
+
+async def test_dynamic_device_discovery_no_reload_without_changes(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that metadata coordinator refresh without changes does not reload."""
+    entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    # Track if reload was called
+    reload_called = False
+
+    async def mock_reload(entry_id):
+        nonlocal reload_called
+        reload_called = True
+        # Don't actually reload to avoid test complications
+        return True
+
+    # Patch to use the same metadata (no changes)
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+            return_value=deepcopy(METADATA),
+        ),
+        patch.object(hass.config_entries, "async_reload", side_effect=mock_reload),
+    ):
+        # Advance time to trigger metadata coordinator refresh
+        freezer.tick(PRODUCTS_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    # Verify reload was NOT triggered since no subscription changes
+    assert not reload_called

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -45,6 +45,7 @@ from .const import (
     ENERGY_HISTORY,
     LIVE_STATUS,
     METADATA,
+    METADATA_NOSCOPE,
     PRODUCTS_MODERN,
     SITE_INFO,
     UNIQUE_ID,
@@ -906,6 +907,65 @@ async def test_dynamic_device_discovery_triggers_reload(
         await hass.async_block_till_done()
 
     # Verify reload was triggered due to new vehicle
+    assert reload_called
+
+
+async def test_dynamic_device_discovery_no_reload_for_unscoped_energy_site(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_metadata: AsyncMock,
+) -> None:
+    """Test metadata refresh does not reload for energy sites without scope."""
+    mock_metadata.return_value = deepcopy(METADATA_NOSCOPE)
+    entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    reload_called = False
+
+    async def mock_reload(entry_id):
+        nonlocal reload_called
+        reload_called = True
+        return True
+
+    with patch.object(hass.config_entries, "async_reload", side_effect=mock_reload):
+        freezer.tick(PRODUCTS_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert not reload_called
+
+
+async def test_dynamic_device_discovery_triggers_reload_on_scope_change(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_metadata: AsyncMock,
+) -> None:
+    """Test metadata refresh reloads when a relevant scope is newly granted."""
+    mock_metadata.return_value = deepcopy(METADATA_NOSCOPE)
+    entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    reload_called = False
+
+    async def mock_reload(entry_id):
+        nonlocal reload_called
+        reload_called = True
+        return True
+
+    refreshed_metadata = deepcopy(METADATA_NOSCOPE)
+    refreshed_metadata["scopes"].append("energy_device_data")
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+            return_value=refreshed_metadata,
+        ),
+        patch.object(hass.config_entries, "async_reload", side_effect=mock_reload),
+    ):
+        freezer.tick(PRODUCTS_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
     assert reload_called
 
 

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -274,6 +274,37 @@ async def test_stale_device_removal(
         assert updated_device is None
 
 
+async def test_skipped_energy_site_is_removed_as_stale_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test skipped energy sites do not block stale device removal."""
+    entry = await setup_platform(hass)
+
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "98765")},
+        manufacturer="Tesla",
+        name="Skipped Energy Site",
+    )
+
+    refreshed_metadata = deepcopy(METADATA)
+    refreshed_metadata["energy_sites"]["98765"] = {
+        "access": True,
+        "name": "Skipped Energy Site",
+    }
+
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+        return_value=refreshed_metadata,
+    ):
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    updated_device = device_registry.async_get_device(identifiers={(DOMAIN, "98765")})
+    assert updated_device is None
+
+
 async def test_device_retention_during_reload(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -877,14 +908,6 @@ async def test_dynamic_device_discovery_triggers_reload(
     entry = await setup_platform(hass)
     assert entry.state is ConfigEntryState.LOADED
 
-    # Track if reload was called
-    reload_called = False
-
-    async def mock_reload(entry_id):
-        nonlocal reload_called
-        reload_called = True
-        return True
-
     # Update metadata to include a new vehicle with access
     new_metadata = deepcopy(METADATA)
     new_metadata["vehicles"]["5YJ3E1EA1NF000001"] = {
@@ -899,7 +922,7 @@ async def test_dynamic_device_discovery_triggers_reload(
             "tesla_fleet_api.teslemetry.Teslemetry.metadata",
             return_value=new_metadata,
         ),
-        patch.object(hass.config_entries, "async_reload", side_effect=mock_reload),
+        patch.object(hass.config_entries, "async_schedule_reload") as mock_reload,
     ):
         # Advance time to trigger metadata coordinator refresh
         freezer.tick(METADATA_INTERVAL)
@@ -907,66 +930,29 @@ async def test_dynamic_device_discovery_triggers_reload(
         await hass.async_block_till_done()
 
     # Verify reload was triggered due to new vehicle
-    assert reload_called
+    mock_reload.assert_called_once_with(entry.entry_id)
 
 
-async def test_dynamic_device_discovery_no_reload_for_unscoped_energy_site(
+async def test_dynamic_device_discovery_no_reload_for_scope_only_change(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
-    mock_metadata: AsyncMock,
 ) -> None:
-    """Test metadata refresh does not reload for energy sites without scope."""
-    mock_metadata.return_value = deepcopy(METADATA_NOSCOPE)
+    """Test metadata refresh does not reload when only scopes change."""
     entry = await setup_platform(hass)
     assert entry.state is ConfigEntryState.LOADED
-
-    reload_called = False
-
-    async def mock_reload(entry_id):
-        nonlocal reload_called
-        reload_called = True
-        return True
-
-    with patch.object(hass.config_entries, "async_reload", side_effect=mock_reload):
-        freezer.tick(METADATA_INTERVAL)
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done()
-
-    assert not reload_called
-
-
-async def test_dynamic_device_discovery_triggers_reload_on_scope_change(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-    mock_metadata: AsyncMock,
-) -> None:
-    """Test metadata refresh reloads when a relevant scope is newly granted."""
-    mock_metadata.return_value = deepcopy(METADATA_NOSCOPE)
-    entry = await setup_platform(hass)
-    assert entry.state is ConfigEntryState.LOADED
-
-    reload_called = False
-
-    async def mock_reload(entry_id):
-        nonlocal reload_called
-        reload_called = True
-        return True
-
-    refreshed_metadata = deepcopy(METADATA_NOSCOPE)
-    refreshed_metadata["scopes"].append("energy_device_data")
 
     with (
         patch(
             "tesla_fleet_api.teslemetry.Teslemetry.metadata",
-            return_value=refreshed_metadata,
+            return_value=deepcopy(METADATA_NOSCOPE),
         ),
-        patch.object(hass.config_entries, "async_reload", side_effect=mock_reload),
+        patch.object(hass.config_entries, "async_schedule_reload") as mock_reload,
     ):
         freezer.tick(METADATA_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-    assert reload_called
+    mock_reload.assert_not_called()
 
 
 async def test_dynamic_device_discovery_no_reload_without_changes(
@@ -977,22 +963,13 @@ async def test_dynamic_device_discovery_no_reload_without_changes(
     entry = await setup_platform(hass)
     assert entry.state is ConfigEntryState.LOADED
 
-    # Track if reload was called
-    reload_called = False
-
-    async def mock_reload(entry_id):
-        nonlocal reload_called
-        reload_called = True
-        # Don't actually reload to avoid test complications
-        return True
-
     # Patch to use the same metadata (no changes)
     with (
         patch(
             "tesla_fleet_api.teslemetry.Teslemetry.metadata",
             return_value=deepcopy(METADATA),
         ),
-        patch.object(hass.config_entries, "async_reload", side_effect=mock_reload),
+        patch.object(hass.config_entries, "async_schedule_reload") as mock_reload,
     ):
         # Advance time to trigger metadata coordinator refresh
         freezer.tick(METADATA_INTERVAL)
@@ -1000,4 +977,4 @@ async def test_dynamic_device_discovery_no_reload_without_changes(
         await hass.async_block_till_done()
 
     # Verify reload was NOT triggered since no subscription changes
-    assert not reload_called
+    mock_reload.assert_not_called()

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -24,7 +24,7 @@ from homeassistant.components.teslemetry.coordinator import (
     ENERGY_HISTORY_INTERVAL,
     ENERGY_INFO_INTERVAL,
     ENERGY_LIVE_INTERVAL,
-    PRODUCTS_INTERVAL,
+    METADATA_INTERVAL,
     VEHICLE_INTERVAL,
 )
 from homeassistant.components.teslemetry.models import TeslemetryData
@@ -902,7 +902,7 @@ async def test_dynamic_device_discovery_triggers_reload(
         patch.object(hass.config_entries, "async_reload", side_effect=mock_reload),
     ):
         # Advance time to trigger metadata coordinator refresh
-        freezer.tick(PRODUCTS_INTERVAL)
+        freezer.tick(METADATA_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
@@ -928,7 +928,7 @@ async def test_dynamic_device_discovery_no_reload_for_unscoped_energy_site(
         return True
 
     with patch.object(hass.config_entries, "async_reload", side_effect=mock_reload):
-        freezer.tick(PRODUCTS_INTERVAL)
+        freezer.tick(METADATA_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
@@ -962,7 +962,7 @@ async def test_dynamic_device_discovery_triggers_reload_on_scope_change(
         ),
         patch.object(hass.config_entries, "async_reload", side_effect=mock_reload),
     ):
-        freezer.tick(PRODUCTS_INTERVAL)
+        freezer.tick(METADATA_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
@@ -995,7 +995,7 @@ async def test_dynamic_device_discovery_no_reload_without_changes(
         patch.object(hass.config_entries, "async_reload", side_effect=mock_reload),
     ):
         # Advance time to trigger metadata coordinator refresh
-        freezer.tick(PRODUCTS_INTERVAL)
+        freezer.tick(METADATA_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change

Add dynamic device discovery to detect when Tesla vehicles or energy sites are added/removed from a user's account after initial setup.

- Add `TeslemetryMetadataCoordinator` that polls the metadata endpoint hourly
- Monitor subscription changes via the `access` field in metadata
- When devices are added or removed, the integration automatically reloads
- Mark the `dynamic-devices` quality scale item as done

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr