### PR TITLE
Move ecovacs service registration

### DIFF
--- a/homeassistant/components/ecovacs/__init__.py
+++ b/homeassistant/components/ecovacs/__init__.py
@@ -5,8 +5,12 @@ from sucks import VacBot
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
 
+from .const import DOMAIN
 from .controller import EcovacsController
+from .services import async_setup_services
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -21,6 +25,14 @@ PLATFORMS = [
     Platform.VACUUM,
 ]
 type EcovacsConfigEntry = ConfigEntry[EcovacsController]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the component."""
+    async_setup_services(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: EcovacsConfigEntry) -> bool:

--- a/homeassistant/components/ecovacs/services.py
+++ b/homeassistant/components/ecovacs/services.py
@@ -1,0 +1,27 @@
+"""Ecovacs services."""
+
+from __future__ import annotations
+
+from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
+from homeassistant.core import HomeAssistant, SupportsResponse, callback
+from homeassistant.helpers import service
+
+from .const import DOMAIN
+
+SERVICE_RAW_GET_POSITIONS = "raw_get_positions"
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up services."""
+
+    # Vacuum Services
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_RAW_GET_POSITIONS,
+        entity_domain=VACUUM_DOMAIN,
+        schema=None,
+        func="async_raw_get_positions",
+        supports_response=SupportsResponse.ONLY,
+    )

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -18,9 +18,8 @@ from homeassistant.components.vacuum import (
     VacuumActivity,
     VacuumEntityFeature,
 )
-from homeassistant.core import HomeAssistant, SupportsResponse
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import slugify
 
@@ -32,9 +31,6 @@ from .util import get_name_key
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_ERROR = "error"
-ATTR_COMPONENT_PREFIX = "component_"
-
-SERVICE_RAW_GET_POSITIONS = "raw_get_positions"
 
 
 async def async_setup_entry(
@@ -55,14 +51,6 @@ async def async_setup_entry(
     )
     _LOGGER.debug("Adding Ecovacs Vacuums to Home Assistant: %s", vacuums)
     async_add_entities(vacuums)
-
-    platform = entity_platform.async_get_current_platform()
-    platform.async_register_entity_service(
-        SERVICE_RAW_GET_POSITIONS,
-        None,
-        "async_raw_get_positions",
-        supports_response=SupportsResponse.ONLY,
-    )
 
 
 class EcovacsLegacyVacuum(EcovacsLegacyEntity, StateVacuumEntity):

--- a/tests/components/ecovacs/test_services.py
+++ b/tests/components/ecovacs/test_services.py
@@ -8,7 +8,7 @@ from deebot_client.device import Device
 import pytest
 
 from homeassistant.components.ecovacs.const import DOMAIN
-from homeassistant.components.ecovacs.vacuum import SERVICE_RAW_GET_POSITIONS
+from homeassistant.components.ecovacs.services import SERVICE_RAW_GET_POSITIONS
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move from `vacuum.py (async_setup_entry)` to `__init__.py (async_setup)`

Based on https://developers.home-assistant.io/docs/dev_101_services/#entity-service-actions

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
