### PR TITLE
Adjust radarr constants and strings

### DIFF
--- a/homeassistant/components/radarr/const.py
+++ b/homeassistant/components/radarr/const.py
@@ -17,11 +17,3 @@ HEALTH_ISSUES = (
 )
 
 LOGGER = logging.getLogger(__package__)
-
-# Service names
-SERVICE_GET_MOVIES: Final = "get_movies"
-SERVICE_GET_QUEUE: Final = "get_queue"
-
-# Service attributes
-ATTR_MOVIES: Final = "movies"
-ATTR_ENTRY_ID: Final = "entry_id"

--- a/homeassistant/components/radarr/services.py
+++ b/homeassistant/components/radarr/services.py
@@ -1,7 +1,7 @@
 """Define services for the Radarr integration."""
 
 from collections.abc import Awaitable, Callable
-from typing import Any, cast
+from typing import Any, Final, cast
 
 from aiopyarr import exceptions
 import voluptuous as vol
@@ -12,15 +12,17 @@ from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse, cal
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import selector
 
-from .const import (
-    ATTR_ENTRY_ID,
-    ATTR_MOVIES,
-    DOMAIN,
-    SERVICE_GET_MOVIES,
-    SERVICE_GET_QUEUE,
-)
+from .const import DOMAIN
 from .coordinator import RadarrConfigEntry
 from .helpers import format_movies, format_queue
+
+# Service names
+SERVICE_GET_MOVIES: Final = "get_movies"
+SERVICE_GET_QUEUE: Final = "get_queue"
+
+# Service attributes
+ATTR_MOVIES: Final = "movies"
+ATTR_ENTRY_ID: Final = "entry_id"
 
 # Service parameter constants
 CONF_MAX_ITEMS = "max_items"

--- a/homeassistant/components/radarr/strings.json
+++ b/homeassistant/components/radarr/strings.json
@@ -65,7 +65,7 @@
   },
   "services": {
     "get_movies": {
-      "description": "Get all movies in Radarr with their details and status.",
+      "description": "Gets all movies in Radarr with their details and status.",
       "fields": {
         "entry_id": {
           "description": "ID of the config entry to use.",
@@ -75,7 +75,7 @@
       "name": "Get movies"
     },
     "get_queue": {
-      "description": "Get all movies currently in the download queue with their progress and details.",
+      "description": "Gets all movies currently in the download queue with their progress and details.",
       "fields": {
         "entry_id": {
           "description": "[%key:component::radarr::services::get_movies::fields::entry_id::description%]",

--- a/tests/components/radarr/test_services.py
+++ b/tests/components/radarr/test_services.py
@@ -6,9 +6,9 @@ from aiopyarr import ArrAuthenticationException, ArrConnectionException
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.radarr.const import (
+from homeassistant.components.radarr.const import DOMAIN
+from homeassistant.components.radarr.services import (
     ATTR_ENTRY_ID,
-    DOMAIN,
     SERVICE_GET_MOVIES,
     SERVICE_GET_QUEUE,
 )


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix review comments that came in after merge of this pr: https://github.com/home-assistant/core/pull/160753

Moved constants that are only needed for services out of `const.py` into `services.py`

Changed "Get..." in description strings into "Gets..." to adhere to the standard

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- This PR is related to this other PR: https://github.com/home-assistant/core/pull/160753

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
