### PR TITLE
Clarify action descriptions in `media_player`

### DIFF
--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -284,7 +284,7 @@
       "name": "Next"
     },
     "media_pause": {
-      "description": "Pauses a media player.",
+      "description": "Pauses playback on a media player.",
       "name": "[%key:common::action::pause%]"
     },
     "media_play": {

--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -284,15 +284,15 @@
       "name": "Next"
     },
     "media_pause": {
-      "description": "Pauses.",
+      "description": "Pauses a media player.",
       "name": "[%key:common::action::pause%]"
     },
     "media_play": {
-      "description": "Starts playing.",
+      "description": "Starts playback on a media player.",
       "name": "Play"
     },
     "media_play_pause": {
-      "description": "Toggles play/pause.",
+      "description": "Toggles play/pause on a media player.",
       "name": "Play/Pause"
     },
     "media_previous_track": {
@@ -310,7 +310,7 @@
       "name": "Seek"
     },
     "media_stop": {
-      "description": "Stops playing.",
+      "description": "Stops playback on a media player.",
       "name": "[%key:common::action::stop%]"
     },
     "play_media": {
@@ -374,7 +374,7 @@
       "name": "Select sound mode"
     },
     "select_source": {
-      "description": "Sends the media player the command to change input source.",
+      "description": "Sends a media player the command to change the input source.",
       "fields": {
         "source": {
           "description": "Name of the source to switch to. Platform dependent.",
@@ -398,23 +398,23 @@
       "name": "[%key:common::action::toggle%]"
     },
     "turn_off": {
-      "description": "Turns off the power of the media player.",
+      "description": "Turns off the power of a media player.",
       "name": "[%key:common::action::turn_off%]"
     },
     "turn_on": {
-      "description": "Turns on the power of the media player.",
+      "description": "Turns on the power of a media player.",
       "name": "[%key:common::action::turn_on%]"
     },
     "unjoin": {
-      "description": "Removes the player from a group. Only works on platforms which support player groups.",
+      "description": "Removes a media player from a group. Only works on platforms which support player groups.",
       "name": "Unjoin"
     },
     "volume_down": {
-      "description": "Turns down the volume.",
+      "description": "Turns down the volume of a media player.",
       "name": "Turn down volume"
     },
     "volume_mute": {
-      "description": "Mutes or unmutes the media player.",
+      "description": "Mutes or unmutes a media player.",
       "fields": {
         "is_volume_muted": {
           "description": "Defines whether or not it is muted.",
@@ -424,7 +424,7 @@
       "name": "Mute/unmute volume"
     },
     "volume_set": {
-      "description": "Sets the volume level.",
+      "description": "Sets the volume level of a media player.",
       "fields": {
         "volume_level": {
           "description": "The volume. 0 is inaudible, 1 is the maximum volume.",
@@ -434,7 +434,7 @@
       "name": "Set volume"
     },
     "volume_up": {
-      "description": "Turns up the volume.",
+      "description": "Turns up the volume of a media player.",
       "name": "Turn up volume"
     }
   },

--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -266,7 +266,7 @@
       "name": "Browse media"
     },
     "clear_playlist": {
-      "description": "Removes all items from the playlist.",
+      "description": "Removes all items from a media player's playlist.",
       "name": "Clear playlist"
     },
     "join": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Change all occurrences of "the (media) player" in the action descriptions to "a media player" as the user still has to select the target(s) in the next step.

Add this to some more descriptions for a consistent wording.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
