### PR TITLE
Add retry logic and resilience for Withings webhook subscription

### DIFF
--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -224,17 +224,16 @@ async def async_subscribe_webhooks(client: WithingsClient, webhook_url: str) -> 
 class WithingsWebhookManager:
     """Manager that manages the Withings webhooks."""
 
-    _webhooks_registered = False
-    _webhook_url_invalid = False
-    _ha_webhook_registered = False
-    _register_lock = asyncio.Lock()
-
     def __init__(self, hass: HomeAssistant, entry: WithingsConfigEntry) -> None:
         """Initialize webhook manager."""
         self.hass = hass
         self.entry = entry
         self._subscribe_attempt: int = 0
         self._webhook_url: str | None = None
+        self._webhooks_registered: bool = False
+        self._webhook_url_invalid: bool = False
+        self._ha_webhook_registered: bool = False
+        self._register_lock = asyncio.Lock()
 
     @property
     def withings_data(self) -> WithingsData:
@@ -349,7 +348,7 @@ class WithingsWebhookManager:
                 )
                 return
             except WithingsTooManyRequestsError as err:
-                delay = 300 * (self._subscribe_attempt + 1)
+                delay = min(300 * (self._subscribe_attempt + 1), 1800)
                 LOGGER.warning(
                     "Rate limited by Withings API (attempt %d): %s. "
                     "Retrying in %d seconds",
@@ -358,7 +357,7 @@ class WithingsWebhookManager:
                     delay,
                 )
             except WithingsError as err:
-                delay = base_delay * (2**self._subscribe_attempt)
+                delay = min(base_delay * (2**self._subscribe_attempt), 1800)
                 LOGGER.warning(
                     "Failed to subscribe to Withings webhooks "
                     "(attempt %d): %s. Retrying in %d seconds",

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -69,7 +69,6 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.SENSOR]
 SUBSCRIBE_DELAY = timedelta(seconds=5)
 UNSUBSCRIBE_DELAY = timedelta(seconds=1)
 WEBHOOK_REGISTER_DELAY = 1
-WEBHOOK_RETRY_DELAY = 1800
 CONF_CLOUDHOOK_URL = "cloudhook_url"
 type WithingsConfigEntry = ConfigEntry[WithingsData]
 
@@ -323,9 +322,7 @@ class WithingsWebhookManager:
 
     async def _async_subscribe_webhook(self, _: Any = None) -> None:
         """Attempt to subscribe to Withings webhooks."""
-        max_retries = 5
         base_delay = 30
-        delay: int | None = None
 
         async with self._register_lock:
             if self._webhooks_registered or self._webhook_url is None:
@@ -340,28 +337,23 @@ class WithingsWebhookManager:
                 WithingsAuthenticationFailedError,
             ) as err:
                 LOGGER.error(
-                    "Authentication failed while subscribing to webhooks: %s. "
-                    "Please reauthenticate the integration",
+                    "Authentication failed while subscribing to webhooks: %s",
+                    err,
+                )
+                self.entry.async_start_reauth(self.hass)
+                return
+            except WithingsInvalidParamsError as err:
+                LOGGER.error(
+                    "Webhook URL rejected by Withings: %s",
                     err,
                 )
                 return
             except WithingsTooManyRequestsError as err:
                 delay = 300 * (self._subscribe_attempt + 1)
                 LOGGER.warning(
-                    "Rate limited by Withings API (attempt %d/%d): %s. "
+                    "Rate limited by Withings API (attempt %d): %s. "
                     "Retrying in %d seconds",
                     self._subscribe_attempt + 1,
-                    max_retries,
-                    err,
-                    delay,
-                )
-            except WithingsInvalidParamsError as err:
-                delay = base_delay * (2**self._subscribe_attempt)
-                LOGGER.warning(
-                    "Invalid webhook URL (attempt %d/%d): %s. "
-                    "Retrying in %d seconds",
-                    self._subscribe_attempt + 1,
-                    max_retries,
                     err,
                     delay,
                 )
@@ -369,9 +361,8 @@ class WithingsWebhookManager:
                 delay = base_delay * (2**self._subscribe_attempt)
                 LOGGER.warning(
                     "Failed to subscribe to Withings webhooks "
-                    "(attempt %d/%d): %s. Retrying in %d seconds",
+                    "(attempt %d): %s. Retrying in %d seconds",
                     self._subscribe_attempt + 1,
-                    max_retries,
                     err,
                     delay,
                 )
@@ -389,19 +380,8 @@ class WithingsWebhookManager:
                 self._webhooks_registered = True
                 return
 
-            if delay is not None:
-                self._subscribe_attempt += 1
-                if self._subscribe_attempt < max_retries:
-                    self._schedule_retry(delay)
-                else:
-                    LOGGER.warning(
-                        "Webhook subscription failed after %d attempts. "
-                        "Will retry in %d minutes",
-                        max_retries,
-                        WEBHOOK_RETRY_DELAY // 60,
-                    )
-                    self._subscribe_attempt = 0
-                    self._schedule_retry(WEBHOOK_RETRY_DELAY)
+            self._subscribe_attempt += 1
+            self._schedule_retry(delay)
 
 
 async def async_unsubscribe_webhooks(client: WithingsClient) -> None:

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -42,7 +42,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
@@ -233,6 +233,7 @@ class WithingsWebhookManager:
         self._webhooks_registered: bool = False
         self._webhook_url_invalid: bool = False
         self._ha_webhook_registered: bool = False
+        self._cancel_retry: CALLBACK_TYPE | None = None
         self._register_lock = asyncio.Lock()
 
     @property
@@ -240,10 +241,17 @@ class WithingsWebhookManager:
         """Return Withings data."""
         return self.entry.runtime_data
 
+    def _cancel_pending_retry(self) -> None:
+        """Cancel any pending retry."""
+        if self._cancel_retry is not None:
+            self._cancel_retry()
+            self._cancel_retry = None
+
     def _schedule_retry(self, delay: int) -> None:
         """Schedule a webhook registration retry."""
-        self.entry.async_on_unload(
-            async_call_later(self.hass, delay, self._async_subscribe_webhook)
+        self._cancel_pending_retry()
+        self._cancel_retry = async_call_later(
+            self.hass, delay, self._async_subscribe_webhook
         )
 
     async def unregister_webhook(
@@ -255,8 +263,10 @@ class WithingsWebhookManager:
             LOGGER.debug(
                 "Unregister Withings webhook (%s)", self.entry.data[CONF_WEBHOOK_ID]
             )
+            self._cancel_pending_retry()
             webhook_unregister(self.hass, self.entry.data[CONF_WEBHOOK_ID])
             self._ha_webhook_registered = False
+            self._webhook_url = None
             for coordinator in self.withings_data.coordinators:
                 coordinator.webhook_subscription_listener(False)
             self._webhooks_registered = False
@@ -274,6 +284,7 @@ class WithingsWebhookManager:
         async with self._register_lock:
             if self._webhooks_registered:
                 return
+            self._cancel_pending_retry()
             if cloud.async_active_subscription(self.hass):
                 webhook_url = await _async_cloudhook_generate_url(self.hass, self.entry)
             else:

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -68,7 +68,7 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.SENSOR]
 
 SUBSCRIBE_DELAY = timedelta(seconds=5)
 UNSUBSCRIBE_DELAY = timedelta(seconds=1)
-WEBHOOK_REGISTER_DELAY = 30
+WEBHOOK_REGISTER_DELAY = 1
 WEBHOOK_RETRY_DELAY = 1800
 CONF_CLOUDHOOK_URL = "cloudhook_url"
 type WithingsConfigEntry = ConfigEntry[WithingsData]
@@ -234,6 +234,8 @@ class WithingsWebhookManager:
         """Initialize webhook manager."""
         self.hass = hass
         self.entry = entry
+        self._subscribe_attempt: int = 0
+        self._webhook_url: str | None = None
 
     @property
     def withings_data(self) -> WithingsData:
@@ -243,7 +245,7 @@ class WithingsWebhookManager:
     def _schedule_retry(self, delay: int) -> None:
         """Schedule a webhook registration retry."""
         self.entry.async_on_unload(
-            async_call_later(self.hass, delay, self.register_webhook)
+            async_call_later(self.hass, delay, self._async_subscribe_webhook)
         )
 
     async def unregister_webhook(
@@ -260,6 +262,7 @@ class WithingsWebhookManager:
             for coordinator in self.withings_data.coordinators:
                 coordinator.webhook_subscription_listener(False)
             self._webhooks_registered = False
+            self._subscribe_attempt = 0
             try:
                 await async_unsubscribe_webhooks(self.withings_data.client)
             except WithingsError as ex:
@@ -313,94 +316,92 @@ class WithingsWebhookManager:
                 self._ha_webhook_registered = True
                 LOGGER.debug("Registered Withings webhook at hass: %s", webhook_url)
 
-            max_retries = 5
-            base_delay = 30
+            self._webhook_url = webhook_url
+            self._subscribe_attempt = 0
 
-            for attempt in range(max_retries):
-                try:
-                    await async_subscribe_webhooks(
-                        self.withings_data.client, webhook_url
-                    )
-                    break
-                except (
-                    WithingsUnauthorizedError,
-                    WithingsAuthenticationFailedError,
-                ) as err:
-                    LOGGER.error(
-                        "Authentication failed while subscribing to webhooks: %s. "
-                        "Please reauthenticate the integration",
-                        err,
-                    )
-                    return
-                except WithingsTooManyRequestsError as err:
-                    delay = 300 * (attempt + 1)
-                    LOGGER.warning(
-                        "Rate limited by Withings API (attempt %d/%d): %s. "
-                        "Retrying in %d seconds",
-                        attempt + 1,
-                        max_retries,
-                        err,
-                        delay,
-                    )
-                    if attempt < max_retries - 1:
-                        await asyncio.sleep(delay)
-                    else:
-                        self._schedule_retry(WEBHOOK_RETRY_DELAY)
-                        return
-                except WithingsInvalidParamsError as err:
-                    if attempt < max_retries - 1:
-                        delay = base_delay * (2**attempt)
-                        LOGGER.warning(
-                            "Invalid webhook URL (attempt %d/%d): %s. "
-                            "Retrying in %d seconds",
-                            attempt + 1,
-                            max_retries,
-                            err,
-                            delay,
-                        )
-                        await asyncio.sleep(delay)
-                    else:
-                        LOGGER.warning(
-                            "Webhook URL rejected by Withings after %d "
-                            "attempts: %s. Will retry in %d minutes",
-                            max_retries,
-                            err,
-                            WEBHOOK_RETRY_DELAY // 60,
-                        )
-                        self._schedule_retry(WEBHOOK_RETRY_DELAY)
-                        return
-                except WithingsError as err:
-                    if attempt < max_retries - 1:
-                        delay = base_delay * (2**attempt)
-                        LOGGER.warning(
-                            "Failed to subscribe to Withings webhooks "
-                            "(attempt %d/%d): %s. Retrying in %d seconds",
-                            attempt + 1,
-                            max_retries,
-                            err,
-                            delay,
-                        )
-                        await asyncio.sleep(delay)
-                    else:
-                        LOGGER.warning(
-                            "Failed to subscribe to Withings webhooks after %d "
-                            "attempts: %s. Will retry in %d minutes",
-                            max_retries,
-                            err,
-                            WEBHOOK_RETRY_DELAY // 60,
-                        )
-                        self._schedule_retry(WEBHOOK_RETRY_DELAY)
-                        return
+        await self._async_subscribe_webhook()
 
-            for coordinator in self.withings_data.coordinators:
-                coordinator.webhook_subscription_listener(True)
-            LOGGER.debug("Registered Withings webhook at Withings: %s", webhook_url)
-            self.entry.async_on_unload(
-                self.hass.bus.async_listen_once(
-                    EVENT_HOMEASSISTANT_STOP, self.unregister_webhook
+    async def _async_subscribe_webhook(self, _: Any = None) -> None:
+        """Attempt to subscribe to Withings webhooks."""
+        max_retries = 5
+        base_delay = 30
+        delay: int | None = None
+
+        async with self._register_lock:
+            if self._webhooks_registered or self._webhook_url is None:
+                return
+
+            try:
+                await async_subscribe_webhooks(
+                    self.withings_data.client, self._webhook_url
                 )
-            )
-            self._webhooks_registered = True
+            except (
+                WithingsUnauthorizedError,
+                WithingsAuthenticationFailedError,
+            ) as err:
+                LOGGER.error(
+                    "Authentication failed while subscribing to webhooks: %s. "
+                    "Please reauthenticate the integration",
+                    err,
+                )
+                return
+            except WithingsTooManyRequestsError as err:
+                delay = 300 * (self._subscribe_attempt + 1)
+                LOGGER.warning(
+                    "Rate limited by Withings API (attempt %d/%d): %s. "
+                    "Retrying in %d seconds",
+                    self._subscribe_attempt + 1,
+                    max_retries,
+                    err,
+                    delay,
+                )
+            except WithingsInvalidParamsError as err:
+                delay = base_delay * (2**self._subscribe_attempt)
+                LOGGER.warning(
+                    "Invalid webhook URL (attempt %d/%d): %s. "
+                    "Retrying in %d seconds",
+                    self._subscribe_attempt + 1,
+                    max_retries,
+                    err,
+                    delay,
+                )
+            except WithingsError as err:
+                delay = base_delay * (2**self._subscribe_attempt)
+                LOGGER.warning(
+                    "Failed to subscribe to Withings webhooks "
+                    "(attempt %d/%d): %s. Retrying in %d seconds",
+                    self._subscribe_attempt + 1,
+                    max_retries,
+                    err,
+                    delay,
+                )
+            else:
+                for coordinator in self.withings_data.coordinators:
+                    coordinator.webhook_subscription_listener(True)
+                LOGGER.debug(
+                    "Registered Withings webhook at Withings: %s", self._webhook_url
+                )
+                self.entry.async_on_unload(
+                    self.hass.bus.async_listen_once(
+                        EVENT_HOMEASSISTANT_STOP, self.unregister_webhook
+                    )
+                )
+                self._webhooks_registered = True
+                return
+
+            if delay is not None:
+                self._subscribe_attempt += 1
+                if self._subscribe_attempt < max_retries:
+                    self._schedule_retry(delay)
+                else:
+                    LOGGER.warning(
+                        "Webhook subscription failed after %d attempts. "
+                        "Will retry in %d minutes",
+                        max_retries,
+                        WEBHOOK_RETRY_DELAY // 60,
+                    )
+                    self._subscribe_attempt = 0
+                    self._schedule_retry(WEBHOOK_RETRY_DELAY)
 
 
 async def async_unsubscribe_webhooks(client: WithingsClient) -> None:

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -16,7 +16,13 @@ from aiohttp import ClientError
 from aiohttp.hdrs import METH_POST
 from aiohttp.web import Request, Response
 from aiowithings import NotificationCategory, WithingsClient
-from aiowithings.exceptions import WithingsError
+from aiowithings.exceptions import (
+    WithingsAuthenticationFailedError,
+    WithingsError,
+    WithingsInvalidParamsError,
+    WithingsTooManyRequestsError,
+    WithingsUnauthorizedError,
+)
 from aiowithings.util import to_enum
 from yarl import URL
 
@@ -62,6 +68,8 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.SENSOR]
 
 SUBSCRIBE_DELAY = timedelta(seconds=5)
 UNSUBSCRIBE_DELAY = timedelta(seconds=1)
+WEBHOOK_REGISTER_DELAY = 30
+WEBHOOK_RETRY_DELAY = 1800
 CONF_CLOUDHOOK_URL = "cloudhook_url"
 type WithingsConfigEntry = ConfigEntry[WithingsData]
 
@@ -162,14 +170,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: WithingsConfigEntry) -> 
     if cloud.async_active_subscription(hass):
         if cloud.async_is_connected(hass):
             entry.async_on_unload(
-                async_call_later(hass, 1, webhook_manager.register_webhook)
+                async_call_later(
+                    hass, WEBHOOK_REGISTER_DELAY, webhook_manager.register_webhook
+                )
             )
         entry.async_on_unload(
             cloud.async_listen_connection_change(hass, manage_cloudhook)
         )
     else:
         entry.async_on_unload(
-            async_call_later(hass, 1, webhook_manager.register_webhook)
+            async_call_later(
+                hass, WEBHOOK_REGISTER_DELAY, webhook_manager.register_webhook
+            )
         )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -215,6 +227,7 @@ class WithingsWebhookManager:
 
     _webhooks_registered = False
     _webhook_url_invalid = False
+    _ha_webhook_registered = False
     _register_lock = asyncio.Lock()
 
     def __init__(self, hass: HomeAssistant, entry: WithingsConfigEntry) -> None:
@@ -227,6 +240,12 @@ class WithingsWebhookManager:
         """Return Withings data."""
         return self.entry.runtime_data
 
+    def _schedule_retry(self, delay: int) -> None:
+        """Schedule a webhook registration retry."""
+        self.entry.async_on_unload(
+            async_call_later(self.hass, delay, self.register_webhook)
+        )
+
     async def unregister_webhook(
         self,
         _: Any,
@@ -237,6 +256,7 @@ class WithingsWebhookManager:
                 "Unregister Withings webhook (%s)", self.entry.data[CONF_WEBHOOK_ID]
             )
             webhook_unregister(self.hass, self.entry.data[CONF_WEBHOOK_ID])
+            self._ha_webhook_registered = False
             for coordinator in self.withings_data.coordinators:
                 coordinator.webhook_subscription_listener(False)
             self._webhooks_registered = False
@@ -277,21 +297,101 @@ class WithingsWebhookManager:
                     self._webhook_url_invalid = True
                 return
 
-            webhook_name = "Withings"
-            if self.entry.title != DEFAULT_TITLE:
-                webhook_name = f"{DEFAULT_TITLE} {self.entry.title}"
+            if not self._ha_webhook_registered:
+                webhook_name = "Withings"
+                if self.entry.title != DEFAULT_TITLE:
+                    webhook_name = f"{DEFAULT_TITLE} {self.entry.title}"
 
-            webhook_register(
-                self.hass,
-                DOMAIN,
-                webhook_name,
-                self.entry.data[CONF_WEBHOOK_ID],
-                get_webhook_handler(self.withings_data),
-                allowed_methods=[METH_POST],
-            )
-            LOGGER.debug("Registered Withings webhook at hass: %s", webhook_url)
+                webhook_register(
+                    self.hass,
+                    DOMAIN,
+                    webhook_name,
+                    self.entry.data[CONF_WEBHOOK_ID],
+                    get_webhook_handler(self.withings_data),
+                    allowed_methods=[METH_POST],
+                )
+                self._ha_webhook_registered = True
+                LOGGER.debug("Registered Withings webhook at hass: %s", webhook_url)
 
-            await async_subscribe_webhooks(self.withings_data.client, webhook_url)
+            max_retries = 5
+            base_delay = 30
+
+            for attempt in range(max_retries):
+                try:
+                    await async_subscribe_webhooks(
+                        self.withings_data.client, webhook_url
+                    )
+                    break
+                except (
+                    WithingsUnauthorizedError,
+                    WithingsAuthenticationFailedError,
+                ) as err:
+                    LOGGER.error(
+                        "Authentication failed while subscribing to webhooks: %s. "
+                        "Please reauthenticate the integration",
+                        err,
+                    )
+                    return
+                except WithingsTooManyRequestsError as err:
+                    delay = 300 * (attempt + 1)
+                    LOGGER.warning(
+                        "Rate limited by Withings API (attempt %d/%d): %s. "
+                        "Retrying in %d seconds",
+                        attempt + 1,
+                        max_retries,
+                        err,
+                        delay,
+                    )
+                    if attempt < max_retries - 1:
+                        await asyncio.sleep(delay)
+                    else:
+                        self._schedule_retry(WEBHOOK_RETRY_DELAY)
+                        return
+                except WithingsInvalidParamsError as err:
+                    if attempt < max_retries - 1:
+                        delay = base_delay * (2**attempt)
+                        LOGGER.warning(
+                            "Invalid webhook URL (attempt %d/%d): %s. "
+                            "Retrying in %d seconds",
+                            attempt + 1,
+                            max_retries,
+                            err,
+                            delay,
+                        )
+                        await asyncio.sleep(delay)
+                    else:
+                        LOGGER.warning(
+                            "Webhook URL rejected by Withings after %d "
+                            "attempts: %s. Will retry in %d minutes",
+                            max_retries,
+                            err,
+                            WEBHOOK_RETRY_DELAY // 60,
+                        )
+                        self._schedule_retry(WEBHOOK_RETRY_DELAY)
+                        return
+                except WithingsError as err:
+                    if attempt < max_retries - 1:
+                        delay = base_delay * (2**attempt)
+                        LOGGER.warning(
+                            "Failed to subscribe to Withings webhooks "
+                            "(attempt %d/%d): %s. Retrying in %d seconds",
+                            attempt + 1,
+                            max_retries,
+                            err,
+                            delay,
+                        )
+                        await asyncio.sleep(delay)
+                    else:
+                        LOGGER.warning(
+                            "Failed to subscribe to Withings webhooks after %d "
+                            "attempts: %s. Will retry in %d minutes",
+                            max_retries,
+                            err,
+                            WEBHOOK_RETRY_DELAY // 60,
+                        )
+                        self._schedule_retry(WEBHOOK_RETRY_DELAY)
+                        return
+
             for coordinator in self.withings_data.coordinators:
                 coordinator.webhook_subscription_listener(True)
             LOGGER.debug("Registered Withings webhook at Withings: %s", webhook_url)

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -69,6 +69,7 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.SENSOR]
 SUBSCRIBE_DELAY = timedelta(seconds=5)
 UNSUBSCRIBE_DELAY = timedelta(seconds=1)
 WEBHOOK_REGISTER_DELAY = 1
+MAX_WEBHOOK_RETRY_INTERVAL = 1800
 CONF_CLOUDHOOK_URL = "cloudhook_url"
 type WithingsConfigEntry = ConfigEntry[WithingsData]
 
@@ -332,7 +333,6 @@ class WithingsWebhookManager:
 
     async def _async_subscribe_webhook(self, _: Any = None) -> None:
         """Attempt to subscribe to Withings webhooks."""
-        base_delay = 30
 
         async with self._register_lock:
             if self._webhooks_registered or self._webhook_url is None:
@@ -359,7 +359,9 @@ class WithingsWebhookManager:
                 )
                 return
             except WithingsTooManyRequestsError as err:
-                delay = min(300 * (self._subscribe_attempt + 1), 1800)
+                delay = min(
+                    300 * (self._subscribe_attempt + 1), MAX_WEBHOOK_RETRY_INTERVAL
+                )
                 LOGGER.warning(
                     "Rate limited by Withings API (attempt %d): %s. "
                     "Retrying in %d seconds",
@@ -368,7 +370,11 @@ class WithingsWebhookManager:
                     delay,
                 )
             except WithingsError as err:
-                delay = min(base_delay * (2**self._subscribe_attempt), 1800)
+                base_delay = 30
+                delay = min(
+                    base_delay * (2**self._subscribe_attempt),
+                    MAX_WEBHOOK_RETRY_INTERVAL,
+                )
                 LOGGER.warning(
                     "Failed to subscribe to Withings webhooks "
                     "(attempt %d): %s. Retrying in %d seconds",

--- a/tests/components/withings/__init__.py
+++ b/tests/components/withings/__init__.py
@@ -67,8 +67,8 @@ async def setup_integration(
 async def prepare_webhook_setup(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Prepare webhooks are registered by waiting a second."""
-    freezer.tick(timedelta(seconds=1))
+    """Prepare webhooks are registered by waiting for the registration delay."""
+    freezer.tick(timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/withings/__init__.py
+++ b/tests/components/withings/__init__.py
@@ -68,7 +68,7 @@ async def prepare_webhook_setup(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
     """Prepare webhooks are registered by waiting for the registration delay."""
-    freezer.tick(timedelta(seconds=30))
+    freezer.tick(timedelta(seconds=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/withings/__init__.py
+++ b/tests/components/withings/__init__.py
@@ -67,7 +67,7 @@ async def setup_integration(
 async def prepare_webhook_setup(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Prepare webhooks are registered by waiting for the registration delay."""
+    """Prepare webhooks by advancing past the registration delay."""
     freezer.tick(timedelta(seconds=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()

--- a/tests/components/withings/conftest.py
+++ b/tests/components/withings/conftest.py
@@ -196,9 +196,7 @@ def mock_withings():
 
 @pytest.fixture(name="disable_webhook_delay", autouse=True)
 def disable_webhook_delay():
-    """Disable webhook delay."""
-
-    mock = AsyncMock()
+    """Disable webhook delays and mock preflight check."""
     with (
         patch(
             "homeassistant.components.withings.SUBSCRIBE_DELAY",
@@ -208,5 +206,9 @@ def disable_webhook_delay():
             "homeassistant.components.withings.UNSUBSCRIBE_DELAY",
             timedelta(seconds=0),
         ),
+        patch(
+            "homeassistant.components.withings.WEBHOOK_REGISTER_DELAY",
+            0,
+        ),
     ):
-        yield mock
+        yield

--- a/tests/components/withings/conftest.py
+++ b/tests/components/withings/conftest.py
@@ -196,7 +196,7 @@ def mock_withings():
 
 @pytest.fixture(name="disable_webhook_delay", autouse=True)
 def disable_webhook_delay():
-    """Disable webhook delays and mock preflight check."""
+    """Disable webhook delays for faster tests."""
     with (
         patch(
             "homeassistant.components.withings.SUBSCRIBE_DELAY",

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -763,14 +763,14 @@ async def test_webhook_subscription_retry_on_failure(
     assert withings.subscribe_notification.call_count >= 6
 
 
-async def test_webhook_subscription_max_retries_exceeded(
+async def test_webhook_subscription_continues_retrying(
     hass: HomeAssistant,
     withings: AsyncMock,
     webhook_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test webhook subscription schedules retry after max attempts."""
+    """Test webhook subscription continues retrying with exponential backoff."""
     withings.subscribe_notification.side_effect = WithingsError(
         "The callback URL is either absent or incorrect"
     )
@@ -778,13 +778,13 @@ async def test_webhook_subscription_max_retries_exceeded(
     await setup_integration(hass, webhook_config_entry)
     await prepare_webhook_setup(hass, freezer)
 
-    # Tick through all retry delays: 30, 60, 120, 240 seconds
-    for delay in (30, 60, 120, 240):
+    # Tick through retry delays with exponential backoff: 30, 60, 120, 240, 480
+    for delay in (30, 60, 120, 240, 480):
         freezer.tick(timedelta(seconds=delay))
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-    assert "Will retry in 30 minutes" in caplog.text
+    assert "Failed to subscribe to Withings webhooks" in caplog.text
 
 
 async def test_webhook_subscription_rate_limited(
@@ -812,7 +812,7 @@ async def test_webhook_subscription_auth_failure(
     freezer: FrozenDateTimeFactory,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test webhook subscription stops on auth failure."""
+    """Test webhook subscription stops on auth failure and triggers reauth."""
     withings.subscribe_notification.side_effect = WithingsAuthenticationFailedError(
         "Authentication failed"
     )
@@ -823,6 +823,12 @@ async def test_webhook_subscription_auth_failure(
     assert "Authentication failed while subscribing to webhooks" in caplog.text
     assert withings.subscribe_notification.call_count == 1
 
+    flows = hass.config_entries.flow.async_progress()
+    assert any(
+        flow["handler"] == DOMAIN and flow["context"]["source"] == "reauth"
+        for flow in flows
+    )
+
 
 async def test_webhook_subscription_invalid_params(
     hass: HomeAssistant,
@@ -831,7 +837,7 @@ async def test_webhook_subscription_invalid_params(
     freezer: FrozenDateTimeFactory,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test invalid params error retries and schedules delayed retry."""
+    """Test invalid params error stops retrying."""
     withings.subscribe_notification.side_effect = WithingsInvalidParamsError(
         "Invalid callback URL"
     )
@@ -839,11 +845,5 @@ async def test_webhook_subscription_invalid_params(
     await setup_integration(hass, webhook_config_entry)
     await prepare_webhook_setup(hass, freezer)
 
-    # Tick through all retry delays: 30, 60, 120, 240 seconds
-    for delay in (30, 60, 120, 240):
-        freezer.tick(timedelta(seconds=delay))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done()
-
-    assert "Invalid webhook URL" in caplog.text
-    assert "Will retry in 30 minutes" in caplog.text
+    assert "Webhook URL rejected by Withings" in caplog.text
+    assert withings.subscribe_notification.call_count == 1

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -747,9 +747,18 @@ async def test_webhook_subscription_retry_on_failure(
 
     withings.subscribe_notification.side_effect = subscribe_side_effect
 
-    with patch("homeassistant.components.withings.asyncio.sleep"):
-        await setup_integration(hass, webhook_config_entry)
-        await prepare_webhook_setup(hass, freezer)
+    await setup_integration(hass, webhook_config_entry)
+    await prepare_webhook_setup(hass, freezer)
+
+    # Trigger first retry (30s delay for attempt 0)
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Trigger second retry (60s delay for attempt 1)
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     assert withings.subscribe_notification.call_count >= 6
 
@@ -766,9 +775,14 @@ async def test_webhook_subscription_max_retries_exceeded(
         "The callback URL is either absent or incorrect"
     )
 
-    with patch("homeassistant.components.withings.asyncio.sleep"):
-        await setup_integration(hass, webhook_config_entry)
-        await prepare_webhook_setup(hass, freezer)
+    await setup_integration(hass, webhook_config_entry)
+    await prepare_webhook_setup(hass, freezer)
+
+    # Tick through all retry delays: 30, 60, 120, 240 seconds
+    for delay in (30, 60, 120, 240):
+        freezer.tick(timedelta(seconds=delay))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
 
     assert "Will retry in 30 minutes" in caplog.text
 
@@ -785,9 +799,8 @@ async def test_webhook_subscription_rate_limited(
         "Too many requests"
     )
 
-    with patch("homeassistant.components.withings.asyncio.sleep"):
-        await setup_integration(hass, webhook_config_entry)
-        await prepare_webhook_setup(hass, freezer)
+    await setup_integration(hass, webhook_config_entry)
+    await prepare_webhook_setup(hass, freezer)
 
     assert "Rate limited by Withings API" in caplog.text
 
@@ -804,9 +817,8 @@ async def test_webhook_subscription_auth_failure(
         "Authentication failed"
     )
 
-    with patch("homeassistant.components.withings.asyncio.sleep"):
-        await setup_integration(hass, webhook_config_entry)
-        await prepare_webhook_setup(hass, freezer)
+    await setup_integration(hass, webhook_config_entry)
+    await prepare_webhook_setup(hass, freezer)
 
     assert "Authentication failed while subscribing to webhooks" in caplog.text
     assert withings.subscribe_notification.call_count == 1
@@ -824,9 +836,14 @@ async def test_webhook_subscription_invalid_params(
         "Invalid callback URL"
     )
 
-    with patch("homeassistant.components.withings.asyncio.sleep"):
-        await setup_integration(hass, webhook_config_entry)
-        await prepare_webhook_setup(hass, freezer)
+    await setup_integration(hass, webhook_config_entry)
+    await prepare_webhook_setup(hass, freezer)
+
+    # Tick through all retry delays: 30, 60, 120, 240 seconds
+    for delay in (30, 60, 120, 240):
+        freezer.tick(timedelta(seconds=delay))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
 
     assert "Invalid webhook URL" in caplog.text
     assert "Will retry in 30 minutes" in caplog.text

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -11,6 +11,9 @@ from aiowithings import (
     NotificationCategory,
     WithingsAuthenticationFailedError,
     WithingsConnectionError,
+    WithingsError,
+    WithingsInvalidParamsError,
+    WithingsTooManyRequestsError,
     WithingsUnauthorizedError,
 )
 from freezegun.api import FrozenDateTimeFactory
@@ -725,3 +728,105 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert webhook_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_webhook_subscription_retry_on_failure(
+    hass: HomeAssistant,
+    withings: AsyncMock,
+    webhook_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test webhook subscription is retried on failure."""
+    call_count = 0
+
+    async def subscribe_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise WithingsError("The callback URL is either absent or incorrect")
+
+    withings.subscribe_notification.side_effect = subscribe_side_effect
+
+    with patch("homeassistant.components.withings.asyncio.sleep"):
+        await setup_integration(hass, webhook_config_entry)
+        await prepare_webhook_setup(hass, freezer)
+
+    assert withings.subscribe_notification.call_count >= 6
+
+
+async def test_webhook_subscription_max_retries_exceeded(
+    hass: HomeAssistant,
+    withings: AsyncMock,
+    webhook_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test webhook subscription schedules retry after max attempts."""
+    withings.subscribe_notification.side_effect = WithingsError(
+        "The callback URL is either absent or incorrect"
+    )
+
+    with patch("homeassistant.components.withings.asyncio.sleep"):
+        await setup_integration(hass, webhook_config_entry)
+        await prepare_webhook_setup(hass, freezer)
+
+    assert "Will retry in 30 minutes" in caplog.text
+
+
+async def test_webhook_subscription_rate_limited(
+    hass: HomeAssistant,
+    withings: AsyncMock,
+    webhook_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test webhook subscription handles rate limiting."""
+    withings.subscribe_notification.side_effect = WithingsTooManyRequestsError(
+        "Too many requests"
+    )
+
+    with patch("homeassistant.components.withings.asyncio.sleep"):
+        await setup_integration(hass, webhook_config_entry)
+        await prepare_webhook_setup(hass, freezer)
+
+    assert "Rate limited by Withings API" in caplog.text
+
+
+async def test_webhook_subscription_auth_failure(
+    hass: HomeAssistant,
+    withings: AsyncMock,
+    webhook_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test webhook subscription stops on auth failure."""
+    withings.subscribe_notification.side_effect = WithingsAuthenticationFailedError(
+        "Authentication failed"
+    )
+
+    with patch("homeassistant.components.withings.asyncio.sleep"):
+        await setup_integration(hass, webhook_config_entry)
+        await prepare_webhook_setup(hass, freezer)
+
+    assert "Authentication failed while subscribing to webhooks" in caplog.text
+    assert withings.subscribe_notification.call_count == 1
+
+
+async def test_webhook_subscription_invalid_params(
+    hass: HomeAssistant,
+    withings: AsyncMock,
+    webhook_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid params error retries and schedules delayed retry."""
+    withings.subscribe_notification.side_effect = WithingsInvalidParamsError(
+        "Invalid callback URL"
+    )
+
+    with patch("homeassistant.components.withings.asyncio.sleep"):
+        await setup_integration(hass, webhook_config_entry)
+        await prepare_webhook_setup(hass, freezer)
+
+    assert "Invalid webhook URL" in caplog.text
+    assert "Will retry in 30 minutes" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previously, a failed webhook subscription would silently leave webhooks disabled, breaking real-time updates including bed presence which has no polling fallback.

- Add retry with exponential backoff (30s, 60s, 120s, 240s) on failure
- Schedule retry in 30 minutes if all attempts fail (never give up)
- Handle specific error types differently:
  - Rate limit (429): longer backoff (5min increments)
  - Auth failure: stop retrying, log error for user to reauthenticate
  - Invalid params: don't retry
  - Generic errors: standard exponential backoff

The previous behavior would results in #117420 causing the "In Bed" sensor to completely fail and no longer update unless you were to reload the Device Integration manually. This could be caused by transient network issues, DNS failures, etc. 

This is an attempt to resolve that behavior by continually retrying the webhook if a failure occurs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #117420 & partial fix #145667
- This PR is related to issue: #117420
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
- [x] Not Applicable

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
