### PR TITLE
Bump ZHA to 0.0.89

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==0.0.88", "serialx==0.6.2"],
+  "requirements": ["zha==0.0.89", "serialx==0.6.2"],
   "usb": [
     {
       "description": "*2652*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3299,7 +3299,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.88
+zha==0.0.89
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2766,7 +2766,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.88
+zha==0.0.89
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.68.0


### PR DESCRIPTION
## Proposed change

This bumps ZHA to [0.0.89](https://github.com/zigpy/zha/releases/tag/0.0.89) (full diff: https://github.com/zigpy/zha/compare/0.0.88...0.0.89).
These dependency upgrades are bundled with it: 

- `zha-quirks` [0.0.156](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.156) (includes [0.0.155](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.155))
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.154...0.0.156

A quick overview of the changes in this ZHA release:
- `attribute_updated` events for the `OnOff` cluster are now emitted before the `on`/`off` cluster commands are forwarded as `zha_event`s, hopefully unbreaking existing blueprints/automations in restart mode that (unfortunately) listen to all `zha_event`s for a device, even if they don't process the `attribute_updated` event at the end.
- An issue is fixed with being unable to control the Aqara E1 roller shade.
- An issue is fixed with IKEA Starkvind sensors showing as unknown.
- An issue is fixed with being unable to configure the Legrand Cable Outlet. 


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
