### PR TITLE
Cleanup deprecated SUPPORT_ light constants

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from collections.abc import Iterable
 import csv
 import dataclasses
-from functools import partial
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Final, Self, cast, final
+from typing import TYPE_CHECKING, Any, Self, cast, final
 
 from propcache.api import cached_property
 import voluptuous as vol
@@ -23,13 +22,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
-from homeassistant.helpers.deprecation import (
-    DeprecatedConstant,
-    DeprecatedConstantEnum,
-    all_with_deprecated_constants,
-    check_if_deprecated_constant,
-    dir_with_deprecated_constants,
-)
 from homeassistant.helpers.entity import ToggleEntity, ToggleEntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.frame import ReportBehavior, report_usage
@@ -55,27 +47,6 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA
 PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE
 
-
-# These SUPPORT_* constants are deprecated as of Home Assistant 2022.5.
-# Please use the LightEntityFeature enum instead.
-_DEPRECATED_SUPPORT_BRIGHTNESS: Final = DeprecatedConstant(
-    1, "supported_color_modes", "2026.1"
-)  # Deprecated, replaced by color modes
-_DEPRECATED_SUPPORT_COLOR_TEMP: Final = DeprecatedConstant(
-    2, "supported_color_modes", "2026.1"
-)  # Deprecated, replaced by color modes
-_DEPRECATED_SUPPORT_EFFECT: Final = DeprecatedConstantEnum(
-    LightEntityFeature.EFFECT, "2026.1"
-)
-_DEPRECATED_SUPPORT_FLASH: Final = DeprecatedConstantEnum(
-    LightEntityFeature.FLASH, "2026.1"
-)
-_DEPRECATED_SUPPORT_COLOR: Final = DeprecatedConstant(
-    16, "supported_color_modes", "2026.1"
-)  # Deprecated, replaced by color modes
-_DEPRECATED_SUPPORT_TRANSITION: Final = DeprecatedConstantEnum(
-    LightEntityFeature.TRANSITION, "2026.1"
-)
 
 # Color mode of the light
 ATTR_COLOR_MODE = "color_mode"
@@ -1192,11 +1163,3 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             return True
         # philips_js has known issues, we don't need users to open issues
         return self.platform.platform_name not in {"philips_js"}
-
-
-# These can be removed if no deprecated constant are in this module anymore
-__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
-__dir__ = partial(
-    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
-)
-__all__ = all_with_deprecated_constants(globals())

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -814,7 +814,9 @@ async def test_put_light_state(
 
     # mock light.turn_on call
     attributes = hass.states.get("light.ceiling_lights").attributes
-    supported_features = attributes[ATTR_SUPPORTED_FEATURES] | light.SUPPORT_TRANSITION
+    supported_features = (
+        attributes[ATTR_SUPPORTED_FEATURES] | light.LightEntityFeature.TRANSITION
+    )
     attributes = {**attributes, ATTR_SUPPORTED_FEATURES: supported_features}
     hass.states.async_set("light.ceiling_lights", STATE_ON, attributes)
     call_turn_on = async_mock_service(hass, "light", "turn_on")

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1,6 +1,5 @@
 """The tests for the Light component."""
 
-from types import ModuleType
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -29,9 +28,6 @@ from tests.common import (
     MockEntityPlatform,
     MockUser,
     async_mock_service,
-    help_test_all,
-    import_and_test_deprecated_constant,
-    import_and_test_deprecated_constant_enum,
     setup_test_component_platform,
 )
 
@@ -2609,46 +2605,3 @@ def test_missing_kelvin_property_warnings(
 
     assert state.attributes[light.ATTR_MIN_COLOR_TEMP_KELVIN] == expected_values[0]
     assert state.attributes[light.ATTR_MAX_COLOR_TEMP_KELVIN] == expected_values[1]
-
-
-@pytest.mark.parametrize(
-    "module",
-    [light],
-)
-def test_all(module: ModuleType) -> None:
-    """Test module.__all__ is correctly set."""
-    help_test_all(module)
-
-
-@pytest.mark.parametrize(
-    ("constant_name", "constant_value", "constant_replacement"),
-    [
-        ("SUPPORT_BRIGHTNESS", 1, "supported_color_modes"),
-        ("SUPPORT_COLOR_TEMP", 2, "supported_color_modes"),
-        ("SUPPORT_COLOR", 16, "supported_color_modes"),
-    ],
-)
-def test_deprecated_light_constants(
-    caplog: pytest.LogCaptureFixture,
-    constant_name: str,
-    constant_value: int | str,
-    constant_replacement: str,
-) -> None:
-    """Test deprecated light constants."""
-    import_and_test_deprecated_constant(
-        caplog, light, constant_name, constant_replacement, constant_value, "2026.1"
-    )
-
-
-@pytest.mark.parametrize(
-    "entity_feature",
-    list(light.LightEntityFeature),
-)
-def test_deprecated_support_light_constants_enums(
-    caplog: pytest.LogCaptureFixture,
-    entity_feature: light.LightEntityFeature,
-) -> None:
-    """Test deprecated support light constants."""
-    import_and_test_deprecated_constant_enum(
-        caplog, light, entity_feature, "SUPPORT_", "2026.1"
-    )

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -174,7 +174,9 @@ async def test_rgb_light(
     assert state.state == STATE_UNKNOWN
     color_modes = [light.ColorMode.HS]
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
-    expected_features = light.SUPPORT_FLASH | light.SUPPORT_TRANSITION
+    expected_features = (
+        light.LightEntityFeature.FLASH | light.LightEntityFeature.TRANSITION
+    )
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == expected_features
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not user-facing

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
They have been deprecated since 2022.5 (and raised warnings since 2024.12)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
