### PR TITLE
Revert "Bump intents (#162205)"

### DIFF
--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "integration_type": "entity",
   "quality_scale": "internal",
-  "requirements": ["hassil==3.5.0", "home-assistant-intents==2026.2.3"]
+  "requirements": ["hassil==3.5.0", "home-assistant-intents==2026.1.28"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -41,7 +41,7 @@ hass-nabucasa==1.12.0
 hassil==3.5.0
 home-assistant-bluetooth==1.13.1
 home-assistant-frontend==20260128.6
-home-assistant-intents==2026.2.3
+home-assistant-intents==2026.1.28
 httpx==0.28.1
 ifaddr==0.2.0
 Jinja2==3.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ ha-ffmpeg==3.2.2
 hass-nabucasa==1.12.0
 hassil==3.5.0
 home-assistant-bluetooth==1.13.1
-home-assistant-intents==2026.2.3
+home-assistant-intents==2026.1.28
 httpx==0.28.1
 ifaddr==0.2.0
 Jinja2==3.1.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1222,7 +1222,7 @@ holidays==0.84
 home-assistant-frontend==20260128.6
 
 # homeassistant.components.conversation
-home-assistant-intents==2026.2.3
+home-assistant-intents==2026.1.28
 
 # homeassistant.components.gentex_homelink
 homelink-integration-api==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1080,7 +1080,7 @@ holidays==0.84
 home-assistant-frontend==20260128.6
 
 # homeassistant.components.conversation
-home-assistant-intents==2026.2.3
+home-assistant-intents==2026.1.28
 
 # homeassistant.components.gentex_homelink
 homelink-integration-api==0.0.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Revert "Bump intents (#162205)" as tests are failing and the PR was merged with failing tests
This reverts commit 54d64b7da20a0a7611cba262914350954103c22c
CC @synesthesiam @arturpragacz @joostlek 


Test error:
```
FAILED tests/components/conversation/test_default_agent.py::test_error_no_device_on_floor - AssertionError: assert 'Sorry, I am ... ground floor' == 'Sorry, I am ... ground floor'
  
  - Sorry, I am not aware of any device called missing entity on ground floor
  ?                              ^ ^^^^        ------------------
  + Sorry, I am not aware of any area called ground floor
  ?                              ^^ ^
Error: Process completed with exit code 1.
```
See https://github.com/home-assistant/core/actions/runs/21679096009/job/62509622122?pr=162224

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
