### PR TITLE
in apprise notifier, fall back on empty string title if missing

### DIFF
--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -11,7 +11,6 @@ import voluptuous as vol
 from homeassistant.components.notify import (
     ATTR_TARGET,
     ATTR_TITLE,
-    ATTR_TITLE_DEFAULT,
     PLATFORM_SCHEMA as NOTIFY_PLATFORM_SCHEMA,
     BaseNotificationService,
 )

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -77,5 +77,9 @@ class AppriseNotificationService(BaseNotificationService):
         to the notification causing filtering (if set up that way).
         """
         targets = kwargs.get(ATTR_TARGET)
-        title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
+        # default to the empty string, not ATTR_TITLE_DEFAULT, because apprise allows empty titles
+        # if we default to ATTR_TITLE_DEFAULT instead, there is no way to set an empty title
+        # see https://github.com/home-assistant/core/pull/161985 for why the ability to set an empty title was not put
+        # elsewhere where it would affect all legacy notifiers
+        title = kwargs.get(ATTR_TITLE, "")
         self.apprise.notify(body=message, title=title, tag=targets)

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -77,9 +77,10 @@ class AppriseNotificationService(BaseNotificationService):
         to the notification causing filtering (if set up that way).
         """
         targets = kwargs.get(ATTR_TARGET)
-        # default to the empty string, not ATTR_TITLE_DEFAULT, because apprise allows empty titles
-        # if we default to ATTR_TITLE_DEFAULT instead, there is no way to set an empty title
-        # see https://github.com/home-assistant/core/pull/161985 for why the ability to set an empty title was not put
-        # elsewhere where it would affect all legacy notifiers
+        # Default to the empty string, not ATTR_TITLE_DEFAULT, because
+        # apprise allows empty titles. If we default to ATTR_TITLE_DEFAULT
+        # instead, there is no way to set an empty title. See PR #161985 for
+        # why the ability to set an empty title was not put elsewhere where it
+        # would affect all legacy notifiers.
         title = kwargs.get(ATTR_TITLE, "")
         self.apprise.notify(body=message, title=title, tag=targets)


### PR DESCRIPTION
## Proposed change

I propose we fall back on the empty string title `''` in the apprise notifier, rather than the default title of `'Home Assistant'`, in the case that the title is missing. Apprise allows empty titles, so the empty string is a more natural default.

I'm not entirely sure the best place to test this code, but I also am not necessarily sure it needs a test. It just swaps out one value (`ATTR_TITLE_DEFAULT`, i.e. `"Home Assistant"`) for another value of the same type (`""`).

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162216
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
