### PR TITLE
Fix html5 notify translation strings

### DIFF
--- a/homeassistant/components/html5/strings.json
+++ b/homeassistant/components/html5/strings.json
@@ -26,6 +26,30 @@
       "title": "HTML5 YAML configuration import failed"
     }
   },
+  "notify": {
+    "notify": {
+      "description": "Sends a notification message using the html5 service.",
+      "fields": {
+        "message": {
+          "description": "The message to be sent.",
+          "name": "Message"
+        },
+        "title": {
+          "description": "The title of the message (optional).",
+          "name": "Title"
+        },
+        "data": {
+          "description": "Extended information of notification. Supports tag.",
+          "name": "Data"
+        },
+        "target": {
+          "description": "An array of targets.",
+          "name": "Target"
+        }
+      },
+      "name": "Send a notification with html5"
+    }
+  },
   "services": {
     "dismiss": {
       "description": "Dismisses an HTML5 notification.",


### PR DESCRIPTION
## Summary

Fixes #129359. Add missing translation strings for HTML5 push notifications.

## Changes

Added translation strings for:
- Service name: "Send a notification with html5"
- Service description: "Sends a notification message using the html5 service."
- Message field: "The message to be sent."
- Title field: "The title of the message (optional)."

## Testing

1. Home Assistant is restarted
2. Developer Tools > Services shows:
   - Service name: "Send a notification with html5"
   - Service description: "Sends a notification message using the html5 service."
   - Message field: "The message to be sent."

---

I have signed the CLA (Contributor License Agreement). @cla-assistant check