### PR TITLE
Prevent zeroconf service removal from aborting HomeKit pairing flows

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -414,6 +414,10 @@ class HomekitControllerFlowHandler(ConfigFlow, domain=DOMAIN):
         # callable. We call the callable with the pin that the user has typed
         # in.
 
+        # Protect this flow from being dismissed by concurrent
+        # zeroconf discoveries while we are in the pairing step.
+        self.context["dismiss_protected"] = True
+
         # Should never call this step without setting self.hkid
         assert self.hkid
         description_placeholders = {}

--- a/homeassistant/components/zeroconf/discovery.py
+++ b/homeassistant/components/zeroconf/discovery.py
@@ -268,6 +268,8 @@ class ZeroconfDiscovery:
             _ZeroconfServiceInfo,
             lambda service_info: bool(service_info.name == name),
         ):
+            if flow.get("context", {}).get("dismiss_protected"):
+                continue
             self.hass.config_entries.flow.async_abort(flow["flow_id"])
 
     @callback

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -290,6 +290,7 @@ class ConfigFlowContext(FlowContext, total=False):
     alternative_domain: str
     configuration_url: str
     confirm_only: bool
+    dismiss_protected: bool
     discovery_key: DiscoveryKey
     entry_id: str
     title_placeholders: Mapping[str, str]

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -294,6 +294,53 @@ async def test_abort_duplicate_flow(hass: HomeAssistant, controller) -> None:
     assert result["reason"] == "already_in_progress"
 
 
+async def test_zeroconf_service_removal_does_not_abort_pairing_flow(
+    hass: HomeAssistant, controller
+) -> None:
+    """Test that a zeroconf service removal does not abort a flow in the pairing step.
+
+    When a device briefly disappears from the network while async_step_pair
+    is active, the zeroconf service removal should not dismiss the
+    actively-pairing flow.
+    """
+    device = setup_mock_accessory(controller)
+    discovery_info = get_device_discovery_info(device)
+    service_name = discovery_info.name
+
+    # Device is discovered via zeroconf
+    result = await hass.config_entries.flow.async_init(
+        "homekit_controller",
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    flow_id = result["flow_id"]
+
+    # User clicks configure - enters async_step_pair
+    result = await hass.config_entries.flow.async_configure(flow_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+
+    # Simulate what zeroconf's _async_dismiss_discoveries does on service
+    # removal: iterate flows by init_data type and abort matching ones.
+    # The dismiss_protected context flag should prevent the abort.
+    for flow in hass.config_entries.flow.async_progress_by_init_data_type(
+        ZeroconfServiceInfo,
+        lambda service_info: bool(service_info.name == service_name),
+    ):
+        if flow.get("context", {}).get("dismiss_protected"):
+            continue
+        hass.config_entries.flow.async_abort(flow["flow_id"])
+
+    # Flow must still be alive - user can still enter the pairing code
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, user_input={"pairing_code": "111-22-333"}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Koogeek-LS1-20833F"
+
+
 async def test_pair_already_paired_1(hass: HomeAssistant, controller) -> None:
     """Already paired."""
     device = setup_mock_accessory(controller)
@@ -699,6 +746,7 @@ async def test_pair_form_errors_on_start(
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
+        "dismiss_protected": True,
     }
 
     # User gets back the form
@@ -747,6 +795,7 @@ async def test_pair_abort_errors_on_finish(
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
+        "dismiss_protected": True,
     }
 
     # User enters pairing code
@@ -789,6 +838,7 @@ async def test_pair_form_errors_on_finish(
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
+        "dismiss_protected": True,
     }
 
     # User enters pairing code
@@ -802,6 +852,7 @@ async def test_pair_form_errors_on_finish(
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
+        "dismiss_protected": True,
     }
 
 
@@ -836,6 +887,7 @@ async def test_pair_unknown_errors(hass: HomeAssistant, controller) -> None:
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
+        "dismiss_protected": True,
     }
 
     # User enters pairing code
@@ -852,6 +904,7 @@ async def test_pair_unknown_errors(hass: HomeAssistant, controller) -> None:
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
+        "dismiss_protected": True,
     }
 
 
@@ -880,6 +933,7 @@ async def test_user_works(hass: HomeAssistant, controller) -> None:
         "source": config_entries.SOURCE_USER,
         "unique_id": "00:00:00:00:00:00",
         "title_placeholders": {"name": "TestDevice", "category": "Other"},
+        "dismiss_protected": True,
     }
 
     result = await hass.config_entries.flow.async_configure(
@@ -917,6 +971,7 @@ async def test_user_pairing_with_insecure_setup_code(
         "source": config_entries.SOURCE_USER,
         "unique_id": "00:00:00:00:00:00",
         "title_placeholders": {"name": "TestDevice", "category": "Other"},
+        "dismiss_protected": True,
     }
 
     result = await hass.config_entries.flow.async_configure(
@@ -1049,6 +1104,7 @@ async def test_mdns_update_to_paired_during_pairing(
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
+        "dismiss_protected": True,
     }
 
     # User enters pairing code


### PR DESCRIPTION
## Proposed change
When a HomeKit device briefly disappears from the network during pairing, the zeroconf service removal would abort the active config flow. Add a dismiss_protected context flag to prevent this.

This fixes the issue outlined [here](https://community.home-assistant.io/t/honeywell-proa7plus-alarm-homekit-device-integration/704895) and [here](https://community.home-assistant.io/t/honeywellhome-resideo-homekit-integration-proa7plus/905759)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
