### PR TITLE
Add dismiss protection to config flows

### DIFF
--- a/homeassistant/components/zeroconf/discovery.py
+++ b/homeassistant/components/zeroconf/discovery.py
@@ -15,6 +15,7 @@ from zeroconf import BadTypeInNameException, IPVersion, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
 from homeassistant import config_entries
+from homeassistant.config_entries import SOURCE_ZEROCONF
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import discovery_flow
 from homeassistant.helpers.discovery_flow import DiscoveryKey
@@ -268,6 +269,10 @@ class ZeroconfDiscovery:
             _ZeroconfServiceInfo,
             lambda service_info: bool(service_info.name == name),
         ):
+            if (context := flow.get("context")) and SOURCE_ZEROCONF in context.get(
+                "dismiss_protected_sources", ()
+            ):
+                continue
             self.hass.config_entries.flow.async_abort(flow["flow_id"])
 
     @callback

--- a/homeassistant/components/zeroconf/discovery.py
+++ b/homeassistant/components/zeroconf/discovery.py
@@ -15,7 +15,6 @@ from zeroconf import BadTypeInNameException, IPVersion, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
 from homeassistant import config_entries
-from homeassistant.config_entries import SOURCE_ZEROCONF
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import discovery_flow
 from homeassistant.helpers.discovery_flow import DiscoveryKey
@@ -269,9 +268,7 @@ class ZeroconfDiscovery:
             _ZeroconfServiceInfo,
             lambda service_info: bool(service_info.name == name),
         ):
-            if (context := flow.get("context")) and SOURCE_ZEROCONF in context.get(
-                "dismiss_protected_sources", ()
-            ):
+            if flow.get("context", {}).get("dismiss_protected"):
                 continue
             self.hass.config_entries.flow.async_abort(flow["flow_id"])
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3437,11 +3437,12 @@ class ConfigFlow(ConfigEntryBaseFlow):
     def async_set_dismiss_protected(self, *sources: str) -> None:
         """Mark this flow as protected from dismissal by specific discovery sources.
 
-        By default, the config flow for a device is dismissed when a new
-        discovery for the same device or unique identifier is received.
-        Integrations can call this method to mark the current flow as "dismiss
-        protected" for one or more discovery sources so that it is not automatically
-        dismissed while the user is interacting with it.
+        When a device disappears from the network (e.g., a zeroconf service
+        removal or an SSDP byebye advertisement), the config flow for that
+        device is normally dismissed. Integrations can call this method to
+        protect the current flow from being dismissed by one or more discovery
+        sources so that it is not automatically aborted while the user is
+        interacting with it.
 
         This method updates the flow context and is intended to be called from
         within a config flow step implementation.

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -290,8 +290,8 @@ class ConfigFlowContext(FlowContext, total=False):
     alternative_domain: str
     configuration_url: str
     confirm_only: bool
-    dismiss_protected: bool
     discovery_key: DiscoveryKey
+    dismiss_protected: bool
     entry_id: str
     title_placeholders: Mapping[str, str]
     unique_id: str | None

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -290,8 +290,8 @@ class ConfigFlowContext(FlowContext, total=False):
     alternative_domain: str
     configuration_url: str
     confirm_only: bool
+    dismiss_protected: bool
     discovery_key: DiscoveryKey
-    dismiss_protected_sources: set[str]
     entry_id: str
     title_placeholders: Mapping[str, str]
     unique_id: str | None
@@ -1511,6 +1511,21 @@ class ConfigEntriesFlowManager(
                 subscription("added", flow.flow_id)
 
         return result
+
+    async def _async_configure(
+        self, flow_id: str, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        """Continue a configuration flow.
+
+        Mark the flow as dismiss protected since the user has interacted
+        with it. This prevents discovery sources from aborting the flow
+        while the user is actively configuring it.
+        """
+        if (flow := self._progress.get(flow_id)) and flow.context.get(
+            "source"
+        ) in DISCOVERY_SOURCES:
+            flow.context["dismiss_protected"] = True
+        return await super()._async_configure(flow_id, user_input)
 
     async def _async_init(
         self,
@@ -3432,27 +3447,6 @@ class ConfigFlow(ConfigEntryBaseFlow):
         return self.hass.config_entries.async_get_known_entry(
             self._reconfigure_entry_id
         )
-
-    @callback
-    def async_set_dismiss_protected(self, *sources: str) -> None:
-        """Mark this flow as protected from dismissal by specific discovery sources.
-
-        When a device disappears from the network (e.g., a zeroconf service
-        removal or an SSDP byebye advertisement), the config flow for that
-        device is normally dismissed. Integrations can call this method to
-        protect the current flow from being dismissed by one or more discovery
-        sources so that it is not automatically aborted while the user is
-        interacting with it.
-
-        This method updates the flow context and is intended to be called from
-        within a config flow step implementation.
-
-        Args:
-            *sources: One or more discovery source identifiers (for example,
-                ``SOURCE_SSDP`` or ``SOURCE_ZEROCONF``) for which this flow
-                should be protected from automatic dismissal.
-        """
-        self.context.setdefault("dismiss_protected_sources", set()).update(sources)
 
 
 class _ConfigSubFlowManager:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3433,8 +3433,24 @@ class ConfigFlow(ConfigEntryBaseFlow):
             self._reconfigure_entry_id
         )
 
+    @callback
     def async_set_dismiss_protected(self, *sources: str) -> None:
-        """Protect this flow from being dismissed by specified discovery sources."""
+        """Mark this flow as protected from dismissal by specific discovery sources.
+
+        By default, the config flow for a device is dismissed when a new
+        discovery for the same device or unique identifier is received.
+        Integrations can call this method to mark the current flow as "dismiss
+        protected" for one or more discovery sources so that it is not automatically
+        dismissed while the user is interacting with it.
+
+        This method updates the flow context and is intended to be called from
+        within a config flow step implementation.
+
+        Args:
+            *sources: One or more discovery source identifiers (for example,
+                ``SOURCE_SSDP`` or ``SOURCE_ZEROCONF``) for which this flow
+                should be protected from automatic dismissal.
+        """
         self.context.setdefault("dismiss_protected_sources", set()).update(sources)
 
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -291,8 +291,8 @@ class ConfigFlowContext(FlowContext, total=False):
     configuration_url: str
     confirm_only: bool
     discovery_key: DiscoveryKey
-    entry_id: str
     dismiss_protected_sources: set[str]
+    entry_id: str
     title_placeholders: Mapping[str, str]
     unique_id: str | None
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -292,6 +292,7 @@ class ConfigFlowContext(FlowContext, total=False):
     confirm_only: bool
     discovery_key: DiscoveryKey
     entry_id: str
+    dismiss_protected_sources: set[str]
     title_placeholders: Mapping[str, str]
     unique_id: str | None
 
@@ -3431,6 +3432,10 @@ class ConfigFlow(ConfigEntryBaseFlow):
         return self.hass.config_entries.async_get_known_entry(
             self._reconfigure_entry_id
         )
+
+    def async_set_dismiss_protected(self, *sources: str) -> None:
+        """Protect this flow from being dismissed by specified discovery sources."""
+        self.context.setdefault("dismiss_protected_sources", set()).update(sources)
 
 
 class _ConfigSubFlowManager:

--- a/tests/components/gardena_bluetooth/snapshots/test_config_flow.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_config_flow.ambr
@@ -28,6 +28,7 @@
         'key': '00000000-0000-0000-0000-000000000001',
         'version': 1,
       }),
+      'dismiss_protected': True,
       'source': 'bluetooth',
       'title_placeholders': dict({
         'name': 'Gardena Water Computer',

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -696,6 +696,7 @@ async def test_pair_form_errors_on_start(
     assert result["errors"]["pairing_code"] == expected
 
     assert get_flow_context(hass, result) == {
+        "dismiss_protected": True,
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
@@ -744,6 +745,7 @@ async def test_pair_abort_errors_on_finish(
 
     assert result["type"] is FlowResultType.FORM
     assert get_flow_context(hass, result) == {
+        "dismiss_protected": True,
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
@@ -786,6 +788,7 @@ async def test_pair_form_errors_on_finish(
 
     assert result["type"] is FlowResultType.FORM
     assert get_flow_context(hass, result) == {
+        "dismiss_protected": True,
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
@@ -799,6 +802,7 @@ async def test_pair_form_errors_on_finish(
     assert result["errors"]["pairing_code"] == expected
 
     assert get_flow_context(hass, result) == {
+        "dismiss_protected": True,
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
@@ -833,6 +837,7 @@ async def test_pair_unknown_errors(hass: HomeAssistant, controller) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert get_flow_context(hass, result) == {
+        "dismiss_protected": True,
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
@@ -849,6 +854,7 @@ async def test_pair_unknown_errors(hass: HomeAssistant, controller) -> None:
     )
 
     assert get_flow_context(hass, result) == {
+        "dismiss_protected": True,
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,
@@ -1046,6 +1052,7 @@ async def test_mdns_update_to_paired_during_pairing(
 
     assert result["type"] is FlowResultType.FORM
     assert get_flow_context(hass, result) == {
+        "dismiss_protected": True,
         "title_placeholders": {"name": "TestDevice", "category": "Outlet"},
         "unique_id": "00:00:00:00:00:00",
         "source": config_entries.SOURCE_ZEROCONF,

--- a/tests/components/homewizard/snapshots/test_config_flow.ambr
+++ b/tests/components/homewizard/snapshots/test_config_flow.ambr
@@ -47,6 +47,7 @@
   FlowResultSnapshot({
     'context': dict({
       'confirm_only': True,
+      'dismiss_protected': True,
       'source': 'zeroconf',
       'title_placeholders': dict({
         'name': 'P1 meter',
@@ -95,6 +96,7 @@
   FlowResultSnapshot({
     'context': dict({
       'confirm_only': True,
+      'dismiss_protected': True,
       'source': 'zeroconf',
       'title_placeholders': dict({
         'name': 'Energy Socket (5c2fafabcdef)',

--- a/tests/components/wyoming/snapshots/test_config_flow.ambr
+++ b/tests/components/wyoming/snapshots/test_config_flow.ambr
@@ -3,6 +3,7 @@
   FlowResultSnapshot({
     'context': dict({
       'configuration_url': 'homeassistant://hassio/addon/mock_piper/info',
+      'dismiss_protected': True,
       'source': 'hassio',
       'title_placeholders': dict({
         'name': 'Piper',
@@ -53,6 +54,7 @@
   FlowResultSnapshot({
     'context': dict({
       'configuration_url': 'homeassistant://hassio/addon/mock_piper/info',
+      'dismiss_protected': True,
       'source': 'hassio',
       'title_placeholders': dict({
         'name': 'Piper',
@@ -102,6 +104,7 @@
 # name: test_zeroconf_discovery
   FlowResultSnapshot({
     'context': dict({
+      'dismiss_protected': True,
       'source': 'zeroconf',
       'title_placeholders': dict({
         'name': 'Test Satellite',

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1463,12 +1463,10 @@ async def test_zeroconf_removed_dismiss_protected(hass: HomeAssistant) -> None:
                 {
                     "flow_id": "protected_flow_id",
                     "context": {
-                        "dismiss_protected_sources": {
-                            config_entries.SOURCE_ZEROCONF,
-                        },
+                        "dismiss_protected": True,
                     },
                 },
-                {"flow_id": "unprotected_flow_id"},
+                {"flow_id": "unprotected_flow_id", "context": {}},
             ],
         ),
         patch.object(hass.config_entries.flow, "async_abort") as mock_async_abort,

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1431,6 +1431,65 @@ async def test_zeroconf_removed(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_zeroconf_removed_dismiss_protected(hass: HomeAssistant) -> None:
+    """Test dismiss-protected flows are not aborted when a PTR record is removed."""
+
+    def _device_removed_mock(zeroconf, services, handlers):
+        """Call service update handler."""
+        handlers[0](
+            zeroconf,
+            "_http._tcp.local.",
+            "Shelly108._http._tcp.local.",
+            ServiceStateChange.Removed,
+        )
+
+    with (
+        patch.dict(
+            zc_gen.ZEROCONF,
+            {
+                "_http._tcp.local.": [
+                    {
+                        "domain": "shelly",
+                        "name": "shelly*",
+                    }
+                ]
+            },
+            clear=True,
+        ),
+        patch.object(
+            hass.config_entries.flow,
+            "async_progress_by_init_data_type",
+            return_value=[
+                {
+                    "flow_id": "protected_flow_id",
+                    "context": {
+                        "dismiss_protected_sources": {
+                            config_entries.SOURCE_ZEROCONF,
+                        },
+                    },
+                },
+                {"flow_id": "unprotected_flow_id"},
+            ],
+        ),
+        patch.object(hass.config_entries.flow, "async_abort") as mock_async_abort,
+        patch.object(
+            discovery, "AsyncServiceBrowser", side_effect=_device_removed_mock
+        ),
+        patch(
+            "homeassistant.components.zeroconf.discovery.AsyncServiceInfo",
+            side_effect=get_zeroconf_info_mock("FFAADDCC11DD"),
+        ),
+    ):
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    # Only the unprotected flow should be aborted
+    assert len(mock_async_abort.mock_calls) == 1
+    assert mock_async_abort.mock_calls[0][1][0] == "unprotected_flow_id"
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
 @pytest.mark.parametrize(
     (
         "entry_domain",

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Generator
 from contextlib import AbstractContextManager, nullcontext as does_not_raise
 from datetime import timedelta
+from ipaddress import ip_address
 import logging
 import re
 from typing import Any, Self
@@ -48,6 +49,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.setup import async_set_domains_to_be_loaded, async_setup_component
@@ -9755,3 +9757,126 @@ async def test_canceled_exceptions_are_propagated(
         await task
 
     abort.set()
+
+
+async def test_discovery_flow_dismiss_protected_on_configure(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+) -> None:
+    """Test that discovery flows are marked dismiss protected when user configures."""
+    mock_integration(
+        hass,
+        MockModule("comp", async_setup_entry=AsyncMock(return_value=True)),
+    )
+    mock_platform(hass, "comp.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        VERSION = 1
+
+        async def async_step_zeroconf(self, discovery_info):
+            """Test zeroconf step."""
+            return self.async_show_form(step_id="confirm")
+
+        async def async_step_confirm(self, user_input=None):
+            """Test confirm step."""
+            if user_input is None:
+                return self.async_show_form(step_id="confirm")
+            return self.async_create_entry(title="test", data={})
+
+    def _get_flow_context(flow_id: str) -> config_entries.ConfigFlowContext:
+        """Get the flow context from async_progress."""
+        return next(
+            flow["context"]
+            for flow in manager.flow.async_progress()
+            if flow["flow_id"] == flow_id
+        )
+
+    with mock_config_flow("comp", TestFlow):
+        result = await manager.flow.async_init(
+            "comp",
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=ZeroconfServiceInfo(
+                ip_address=ip_address("192.168.1.1"),
+                ip_addresses=[ip_address("192.168.1.1")],
+                hostname="test.local.",
+                name="test._tcp.local.",
+                port=80,
+                properties={},
+                type="_tcp.local.",
+            ),
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "confirm"
+
+        # Before user interaction, dismiss_protected should not be set
+        context = _get_flow_context(result["flow_id"])
+        assert "dismiss_protected" not in context
+
+        # User configures the flow
+        result = await manager.flow.async_configure(result["flow_id"])
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+
+        # After user interaction, dismiss_protected should be set
+        context = _get_flow_context(result["flow_id"])
+        assert context["dismiss_protected"] is True
+
+        # Finish the flow
+        result = await manager.flow.async_configure(
+            result["flow_id"], user_input={"fake": "data"}
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_not_dismiss_protected_on_configure(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+) -> None:
+    """Test that user flows are not marked dismiss protected when configured."""
+    mock_integration(
+        hass,
+        MockModule("comp", async_setup_entry=AsyncMock(return_value=True)),
+    )
+    mock_platform(hass, "comp.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        VERSION = 1
+
+        async def async_step_user(self, user_input=None):
+            """Test user step."""
+            if user_input is None:
+                return self.async_show_form(step_id="user")
+            return self.async_show_form(step_id="confirm")
+
+        async def async_step_confirm(self, user_input=None):
+            """Test confirm step."""
+            if user_input is None:
+                return self.async_show_form(step_id="confirm")
+            return self.async_create_entry(title="test", data={})
+
+    def _get_flow_context(flow_id: str) -> config_entries.ConfigFlowContext:
+        """Get the flow context from async_progress."""
+        return next(
+            flow["context"]
+            for flow in manager.flow.async_progress()
+            if flow["flow_id"] == flow_id
+        )
+
+    with mock_config_flow("comp", TestFlow):
+        result = await manager.flow.async_init(
+            "comp", context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+
+        # User configures the flow
+        result = await manager.flow.async_configure(
+            result["flow_id"], user_input={"fake": "data"}
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+
+        # User flows should not be marked as dismiss protected
+        context = _get_flow_context(result["flow_id"])
+        assert "dismiss_protected" not in context

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -71,6 +71,17 @@ from .common import (
 )
 
 
+def _get_flow_context(
+    manager: config_entries.ConfigEntries, flow_id: str
+) -> config_entries.ConfigFlowContext:
+    """Get the flow context from async_progress."""
+    return next(
+        flow["context"]
+        for flow in manager.flow.async_progress()
+        if flow["flow_id"] == flow_id
+    )
+
+
 @pytest.fixture(autouse=True)
 def mock_handlers() -> Generator[None]:
     """Mock config flows."""
@@ -9785,14 +9796,6 @@ async def test_discovery_flow_dismiss_protected_on_configure(
                 return self.async_show_form(step_id="confirm")
             return self.async_create_entry(title="test", data={})
 
-    def _get_flow_context(flow_id: str) -> config_entries.ConfigFlowContext:
-        """Get the flow context from async_progress."""
-        return next(
-            flow["context"]
-            for flow in manager.flow.async_progress()
-            if flow["flow_id"] == flow_id
-        )
-
     with mock_config_flow("comp", TestFlow):
         result = await manager.flow.async_init(
             "comp",
@@ -9811,7 +9814,7 @@ async def test_discovery_flow_dismiss_protected_on_configure(
         assert result["step_id"] == "confirm"
 
         # Before user interaction, dismiss_protected should not be set
-        context = _get_flow_context(result["flow_id"])
+        context = _get_flow_context(manager, result["flow_id"])
         assert "dismiss_protected" not in context
 
         # User configures the flow
@@ -9819,7 +9822,7 @@ async def test_discovery_flow_dismiss_protected_on_configure(
         assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         # After user interaction, dismiss_protected should be set
-        context = _get_flow_context(result["flow_id"])
+        context = _get_flow_context(manager, result["flow_id"])
         assert context["dismiss_protected"] is True
 
         # Finish the flow
@@ -9857,14 +9860,6 @@ async def test_user_flow_not_dismiss_protected_on_configure(
                 return self.async_show_form(step_id="confirm")
             return self.async_create_entry(title="test", data={})
 
-    def _get_flow_context(flow_id: str) -> config_entries.ConfigFlowContext:
-        """Get the flow context from async_progress."""
-        return next(
-            flow["context"]
-            for flow in manager.flow.async_progress()
-            if flow["flow_id"] == flow_id
-        )
-
     with mock_config_flow("comp", TestFlow):
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
@@ -9878,5 +9873,5 @@ async def test_user_flow_not_dismiss_protected_on_configure(
         assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         # User flows should not be marked as dismiss protected
-        context = _get_flow_context(result["flow_id"])
+        context = _get_flow_context(manager, result["flow_id"])
         assert "dismiss_protected" not in context


### PR DESCRIPTION
## Proposed change

Automatically protect discovery config flows from being dismissed once a user has interacted with them.

When a device disappears from the network (e.g., a zeroconf service removal), its discovery config flow is normally aborted. This is a problem when a user is actively configuring a device — for example, during HomeKit controller pairing, the device may briefly disappear from the network, causing the flow to be aborted with "Invalid flow specified" errors.

This PR adds a `dismiss_protected` flag to the config flow context that is automatically set when `async_configure` is called on a discovery-sourced flow. Discovery mechanisms like zeroconf check this flag and skip aborting protected flows. No integration code changes are needed.

See: https://community.home-assistant.io/t/honeywellhome-resideo-homekit-integration-proa7plus/905759

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr