### PR TITLE
Use sub devices for Overkiz

### DIFF
--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -58,67 +58,83 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
         """Return Overkiz device linked to this entity."""
         return self.coordinator.data[self.device_url]
 
-    def _has_siblings_with_different_place_oid(self) -> bool:
-        """Check if sibling devices (same base_url) have different placeOIDs.
+    def _get_sibling_devices(self) -> list[Device]:
+        """Return sibling devices sharing the same base device URL."""
+        return [
+            device
+            for device in self.coordinator.data.values()
+            if device.device_url != self.device_url
+            and device.device_url.startswith(f"{self.base_device_url}#")
+        ]
 
-        Returns True if there are devices sharing the same base_device_url
-        but with different place_oid values. This indicates the devices
-        should be grouped by placeOID rather than by base URL.
+    def _has_siblings_with_different_place_oid(self) -> bool:
+        """Check if sibling devices have different placeOIDs.
+
+        Returns True if siblings have different place_oid values, indicating
+        devices should be grouped by placeOID rather than by base URL.
         """
         if not self.device.place_oid:
             return False
 
-        for device in self.coordinator.data.values():
-            # Check for sibling devices (same base URL, different device URL)
-            if (
-                device.device_url != self.device_url
-                and device.device_url.startswith(f"{self.base_device_url}#")
-                and device.place_oid
-                and device.place_oid != self.device.place_oid
-            ):
-                return True
-        return False
+        return any(
+            sibling.place_oid and sibling.place_oid != self.device.place_oid
+            for sibling in self._get_sibling_devices()
+        )
 
     def _is_main_device_for_place_oid(self) -> bool:
         """Check if this device is the main device for its placeOID group.
 
-        When multiple devices share the same placeOID, the one with the lowest
-        device URL index is considered the main device and provides full device info.
-        Other devices just reference the identifier.
+        The device with the lowest URL index among siblings sharing the same
+        placeOID is considered the main device and provides full device info.
         """
         if not self.device.place_oid:
             return True
 
         my_index = int(self.device_url.split("#")[-1])
 
-        # Find all devices with the same base URL and placeOID
-        for device in self.coordinator.data.values():
-            if (
-                device.device_url != self.device_url
-                and device.device_url.startswith(f"{self.base_device_url}#")
-                and device.place_oid == self.device.place_oid
-            ):
-                # Compare device URL indices - lower index is the main device
-                other_index = int(device.device_url.split("#")[-1])
-                if other_index < my_index:
-                    return False
-        return True
+        return not any(
+            int(sibling.device_url.split("#")[-1]) < my_index
+            for sibling in self._get_sibling_devices()
+            if sibling.place_oid == self.device.place_oid
+        )
+
+    def _get_via_device_id(self, use_place_oid_grouping: bool) -> str:
+        """Return the via_device identifier for device registry hierarchy.
+
+        Sub-devices link to the main actuator (#1 device) when using placeOID
+        grouping, otherwise they link directly to the gateway.
+        """
+        gateway_id = self.executor.get_gateway_id()
+
+        if not use_place_oid_grouping or self.device_url.endswith("#1"):
+            return gateway_id
+
+        main_device = self.coordinator.data.get(f"{self.base_device_url}#1")
+        if main_device and main_device.place_oid:
+            return f"{self.base_device_url}#{main_device.place_oid}"
+
+        return gateway_id
 
     def generate_device_info(self) -> DeviceInfo:
         """Return device registry information for this entity."""
-        # Some devices, such as the Smart Thermostat have several devices
-        # in one physical device, with same device url, terminated by '#' and a number.
-        # In this case, we use the base device url as the device identifier.
-
-        # Check if siblings have different placeOIDs - if so, use placeOID grouping
+        # Some devices, such as the Smart Thermostat, have several sub-devices
+        # sharing the same base URL (terminated by '#' and a number).
         use_place_oid_grouping = self._has_siblings_with_different_place_oid()
 
+        # Sub-devices without placeOID grouping inherit info from parent device
         if self.is_sub_device and not use_place_oid_grouping:
-            # Only return the url of the base device, to inherit device name
-            # and model from parent device.
             return DeviceInfo(
                 identifiers={(DOMAIN, self.executor.base_device_url)},
             )
+
+        # Determine identifier based on grouping strategy
+        if use_place_oid_grouping:
+            identifier = f"{self.base_device_url}#{self.device.place_oid}"
+            # Non-main devices only reference the identifier
+            if not self._is_main_device_for_place_oid():
+                return DeviceInfo(identifiers={(DOMAIN, identifier)})
+        else:
+            identifier = self.executor.base_device_url
 
         manufacturer = (
             self.executor.select_attribute(OverkizAttribute.CORE_MANUFACTURER)
@@ -141,33 +157,6 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
             else None
         )
 
-        # Use placeOID-based identifier when siblings have different placeOIDs
-        if use_place_oid_grouping:
-            identifier = f"{self.base_device_url}#{self.device.place_oid}"
-
-            # Only the main device for this placeOID provides full device info.
-            # Other devices just reference the identifier.
-            if not self._is_main_device_for_place_oid():
-                return DeviceInfo(
-                    identifiers={(DOMAIN, identifier)},
-                )
-
-            # Link sub-devices to the main actuator (#1 device).
-            main_device = self.coordinator.data.get(f"{self.base_device_url}#1")
-            if main_device and main_device.place_oid:
-                main_device_identifier = (
-                    f"{self.base_device_url}#{main_device.place_oid}"
-                )
-                if self.device_url.endswith("#1"):
-                    via_device = (DOMAIN, self.executor.get_gateway_id())
-                else:
-                    via_device = (DOMAIN, main_device_identifier)
-            else:
-                via_device = (DOMAIN, self.executor.get_gateway_id())
-        else:
-            identifier = self.executor.base_device_url
-            via_device = (DOMAIN, self.executor.get_gateway_id())
-
         return DeviceInfo(
             identifiers={(DOMAIN, identifier)},
             name=self.device.label,
@@ -179,7 +168,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
             ),
             hw_version=self.device.controllable_name,
             suggested_area=suggested_area,
-            via_device=via_device,
+            via_device=(DOMAIN, self._get_via_device_id(use_place_oid_grouping)),
             configuration_url=self.coordinator.client.server.configuration_url,
         )
 

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -60,11 +60,12 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
 
     def _get_sibling_devices(self) -> list[Device]:
         """Return sibling devices sharing the same base device URL."""
+        prefix = f"{self.base_device_url}#"
         return [
             device
             for device in self.coordinator.data.values()
             if device.device_url != self.device_url
-            and device.device_url.startswith(f"{self.base_device_url}#")
+            and device.device_url.startswith(prefix)
         ]
 
     def _has_siblings_with_different_place_oid(self) -> bool:
@@ -73,13 +74,19 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
         Returns True if siblings have different place_oid values, indicating
         devices should be grouped by placeOID rather than by base URL.
         """
-        if not self.device.place_oid:
+        my_place_oid = self.device.place_oid
+        if not my_place_oid:
             return False
 
         return any(
-            sibling.place_oid and sibling.place_oid != self.device.place_oid
+            sibling.place_oid and sibling.place_oid != my_place_oid
             for sibling in self._get_sibling_devices()
         )
+
+    def _get_device_index(self, device_url: str) -> int | None:
+        """Extract numeric index from device URL (e.g., 'io://gw/123#4' -> 4)."""
+        suffix = device_url.split("#")[-1]
+        return int(suffix) if suffix.isdigit() else None
 
     def _is_main_device_for_place_oid(self) -> bool:
         """Check if this device is the main device for its placeOID group.
@@ -87,15 +94,19 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
         The device with the lowest URL index among siblings sharing the same
         placeOID is considered the main device and provides full device info.
         """
-        if not self.device.place_oid:
+        my_place_oid = self.device.place_oid
+        if not my_place_oid:
             return True
 
-        my_index = int(self.device_url.split("#")[-1])
+        my_index = self._get_device_index(self.device_url)
+        if my_index is None:
+            return True
 
         return not any(
-            int(sibling.device_url.split("#")[-1]) < my_index
+            (sibling_index := self._get_device_index(sibling.device_url)) is not None
+            and sibling_index < my_index
             for sibling in self._get_sibling_devices()
-            if sibling.place_oid == self.device.place_oid
+            if sibling.place_oid == my_place_oid
         )
 
     def _get_via_device_id(self, use_place_oid_grouping: bool) -> str:

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -58,12 +58,62 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
         """Return Overkiz device linked to this entity."""
         return self.coordinator.data[self.device_url]
 
+    def _has_siblings_with_different_place_oid(self) -> bool:
+        """Check if sibling devices (same base_url) have different placeOIDs.
+
+        Returns True if there are devices sharing the same base_device_url
+        but with different place_oid values. This indicates the devices
+        should be grouped by placeOID rather than by base URL.
+        """
+        if not self.device.place_oid:
+            return False
+
+        for device in self.coordinator.data.values():
+            # Check for sibling devices (same base URL, different device URL)
+            if (
+                device.device_url != self.device_url
+                and device.device_url.startswith(f"{self.base_device_url}#")
+                and device.place_oid
+                and device.place_oid != self.device.place_oid
+            ):
+                return True
+        return False
+
+    def _is_main_device_for_place_oid(self) -> bool:
+        """Check if this device is the main device for its placeOID group.
+
+        When multiple devices share the same placeOID, the one with the lowest
+        device URL index is considered the main device and provides full device info.
+        Other devices just reference the identifier.
+        """
+        if not self.device.place_oid:
+            return True
+
+        my_index = int(self.device_url.split("#")[-1])
+
+        # Find all devices with the same base URL and placeOID
+        for device in self.coordinator.data.values():
+            if (
+                device.device_url != self.device_url
+                and device.device_url.startswith(f"{self.base_device_url}#")
+                and device.place_oid == self.device.place_oid
+            ):
+                # Compare device URL indices - lower index is the main device
+                other_index = int(device.device_url.split("#")[-1])
+                if other_index < my_index:
+                    return False
+        return True
+
     def generate_device_info(self) -> DeviceInfo:
         """Return device registry information for this entity."""
         # Some devices, such as the Smart Thermostat have several devices
         # in one physical device, with same device url, terminated by '#' and a number.
         # In this case, we use the base device url as the device identifier.
-        if self.is_sub_device:
+
+        # Check if siblings have different placeOIDs - if so, use placeOID grouping
+        use_place_oid_grouping = self._has_siblings_with_different_place_oid()
+
+        if self.is_sub_device and not use_place_oid_grouping:
             # Only return the url of the base device, to inherit device name
             # and model from parent device.
             return DeviceInfo(
@@ -91,8 +141,35 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
             else None
         )
 
+        # Use placeOID-based identifier when siblings have different placeOIDs
+        if use_place_oid_grouping:
+            identifier = f"{self.base_device_url}#{self.device.place_oid}"
+
+            # Only the main device for this placeOID provides full device info.
+            # Other devices just reference the identifier.
+            if not self._is_main_device_for_place_oid():
+                return DeviceInfo(
+                    identifiers={(DOMAIN, identifier)},
+                )
+
+            # Link sub-devices to the main actuator (#1 device).
+            main_device = self.coordinator.data.get(f"{self.base_device_url}#1")
+            if main_device and main_device.place_oid:
+                main_device_identifier = (
+                    f"{self.base_device_url}#{main_device.place_oid}"
+                )
+                if self.device_url.endswith("#1"):
+                    via_device = (DOMAIN, self.executor.get_gateway_id())
+                else:
+                    via_device = (DOMAIN, main_device_identifier)
+            else:
+                via_device = (DOMAIN, self.executor.get_gateway_id())
+        else:
+            identifier = self.executor.base_device_url
+            via_device = (DOMAIN, self.executor.get_gateway_id())
+
         return DeviceInfo(
-            identifiers={(DOMAIN, self.executor.base_device_url)},
+            identifiers={(DOMAIN, identifier)},
             name=self.device.label,
             manufacturer=str(manufacturer),
             model=str(model),
@@ -102,7 +179,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
             ),
             hw_version=self.device.controllable_name,
             suggested_area=suggested_area,
-            via_device=(DOMAIN, self.executor.get_gateway_id()),
+            via_device=via_device,
             configuration_url=self.coordinator.client.server.configuration_url,
         )
 

--- a/tests/components/overkiz/test_entity.py
+++ b/tests/components/overkiz/test_entity.py
@@ -1,0 +1,110 @@
+"""Tests for Overkiz entity."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from homeassistant.components.overkiz.entity import OverkizEntity
+
+
+def _create_mock_device(device_url: str, place_oid: str, label: str) -> Mock:
+    """Create a mock device."""
+    device = Mock()
+    device.device_url = device_url
+    device.place_oid = place_oid
+    device.label = label
+    device.available = True
+    device.states = []
+    device.widget = Mock(value="TestWidget")
+    device.controllable_name = "test:Component"
+    return device
+
+
+def _create_mock_entity(device: Mock, all_devices: list[Mock]) -> Mock:
+    """Create a mock entity with the given device and coordinator data."""
+    entity = Mock(spec=OverkizEntity)
+    entity.device = device
+    entity.device_url = device.device_url
+    entity.base_device_url = device.device_url.split("#")[0]
+    entity.coordinator = Mock()
+    entity.coordinator.data = {d.device_url: d for d in all_devices}
+    entity._get_sibling_devices = lambda: [
+        d
+        for d in all_devices
+        if d.device_url != device.device_url
+        and d.device_url.startswith(f"{entity.base_device_url}#")
+    ]
+    return entity
+
+
+@pytest.mark.parametrize(
+    ("place_oids", "expected"),
+    [
+        (["place-a", "place-b"], True),
+        (["place-a", "place-a"], False),
+    ],
+    ids=["different_place_oids", "same_place_oids"],
+)
+def test_has_siblings_with_different_place_oid(
+    place_oids: list[str], expected: bool
+) -> None:
+    """Test detection of siblings with different placeOIDs."""
+    devices = [
+        _create_mock_device("io://gateway/123#1", place_oids[0], "Device 1"),
+        _create_mock_device("io://gateway/123#2", place_oids[1], "Device 2"),
+    ]
+    entity = _create_mock_entity(devices[0], devices)
+
+    result = OverkizEntity._has_siblings_with_different_place_oid(entity)
+
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    ("device_index", "expected"),
+    [
+        (0, True),
+        (1, False),
+    ],
+    ids=["lowest_index_is_main", "higher_index_not_main"],
+)
+def test_is_main_device_for_place_oid(device_index: int, expected: bool) -> None:
+    """Test main device detection for placeOID group."""
+    devices = [
+        _create_mock_device("io://gateway/123#1", "place-a", "Device 1"),
+        _create_mock_device("io://gateway/123#4", "place-a", "Device 4"),
+    ]
+    entity = _create_mock_entity(devices[device_index], devices)
+
+    result = OverkizEntity._is_main_device_for_place_oid(entity)
+
+    assert result is expected
+
+
+def test_get_via_device_id_sub_device_links_to_main() -> None:
+    """Test sub-device links to main actuator with placeOID grouping."""
+    devices = [
+        _create_mock_device("io://gateway/123#1", "place-a", "Actuator"),
+        _create_mock_device("io://gateway/123#2", "place-b", "Zone"),
+    ]
+    entity = _create_mock_entity(devices[1], devices)
+    entity.executor = Mock()
+    entity.executor.get_gateway_id = Mock(return_value="gateway-id")
+
+    result = OverkizEntity._get_via_device_id(entity, use_place_oid_grouping=True)
+
+    assert result == "io://gateway/123#place-a"
+
+
+def test_get_via_device_id_main_device_links_to_gateway() -> None:
+    """Test main device (#1) links to gateway."""
+    devices = [
+        _create_mock_device("io://gateway/123#1", "place-a", "Actuator"),
+    ]
+    entity = _create_mock_entity(devices[0], devices)
+    entity.executor = Mock()
+    entity.executor.get_gateway_id = Mock(return_value="gateway-id")
+
+    result = OverkizEntity._get_via_device_id(entity, use_place_oid_grouping=True)
+
+    assert result == "gateway-id"

--- a/tests/components/overkiz/test_entity.py
+++ b/tests/components/overkiz/test_entity.py
@@ -7,8 +7,10 @@ import pytest
 from homeassistant.components.overkiz.entity import OverkizEntity
 
 
-def _create_mock_device(device_url: str, place_oid: str, label: str) -> Mock:
-    """Create a mock device."""
+def _create_mock_device(
+    device_url: str, place_oid: str | None, label: str = "Device"
+) -> Mock:
+    """Create a mock device with the given properties."""
     device = Mock()
     device.device_url = device_url
     device.place_oid = place_oid
@@ -28,12 +30,16 @@ def _create_mock_entity(device: Mock, all_devices: list[Mock]) -> Mock:
     entity.base_device_url = device.device_url.split("#")[0]
     entity.coordinator = Mock()
     entity.coordinator.data = {d.device_url: d for d in all_devices}
+
+    prefix = f"{entity.base_device_url}#"
     entity._get_sibling_devices = lambda: [
         d
         for d in all_devices
-        if d.device_url != device.device_url
-        and d.device_url.startswith(f"{entity.base_device_url}#")
+        if d.device_url != device.device_url and d.device_url.startswith(prefix)
     ]
+    entity._get_device_index = lambda url: (
+        int(url.split("#")[-1]) if url.split("#")[-1].isdigit() else None
+    )
     return entity
 
 
@@ -108,3 +114,64 @@ def test_get_via_device_id_main_device_links_to_gateway() -> None:
     result = OverkizEntity._get_via_device_id(entity, use_place_oid_grouping=True)
 
     assert result == "gateway-id"
+
+
+def test_has_siblings_with_no_place_oid() -> None:
+    """Test device with no placeOID returns False."""
+    devices = [
+        _create_mock_device("io://gateway/123#1", None, "Device 1"),
+        _create_mock_device("io://gateway/123#2", "place-b", "Device 2"),
+    ]
+    entity = _create_mock_entity(devices[0], devices)
+
+    result = OverkizEntity._has_siblings_with_different_place_oid(entity)
+
+    assert result is False
+
+
+def test_is_main_device_with_no_place_oid() -> None:
+    """Test device with no placeOID is always considered main."""
+    devices = [
+        _create_mock_device("io://gateway/123#2", None, "Device 2"),
+        _create_mock_device("io://gateway/123#1", "place-a", "Device 1"),
+    ]
+    entity = _create_mock_entity(devices[0], devices)
+
+    result = OverkizEntity._is_main_device_for_place_oid(entity)
+
+    assert result is True
+
+
+def test_get_via_device_id_main_device_without_place_oid() -> None:
+    """Test fallback to gateway when #1 device has no placeOID."""
+    devices = [
+        _create_mock_device("io://gateway/123#1", None, "Actuator"),
+        _create_mock_device("io://gateway/123#2", "place-b", "Zone"),
+    ]
+    entity = _create_mock_entity(devices[1], devices)
+    entity.executor = Mock()
+    entity.executor.get_gateway_id = Mock(return_value="gateway-id")
+
+    result = OverkizEntity._get_via_device_id(entity, use_place_oid_grouping=True)
+
+    assert result == "gateway-id"
+
+
+@pytest.mark.parametrize(
+    ("device_url", "expected"),
+    [
+        ("io://gateway/123#4", 4),
+        ("io://gateway/123#10", 10),
+        ("io://gateway/123#abc", None),
+        ("io://gateway/123#", None),
+    ],
+    ids=["single_digit", "multi_digit", "non_numeric", "empty_suffix"],
+)
+def test_get_device_index(device_url: str, expected: int | None) -> None:
+    """Test extracting numeric index from device URL."""
+    device = _create_mock_device(device_url, "place-a")
+    entity = _create_mock_entity(device, [device])
+
+    result = OverkizEntity._get_device_index(entity, device_url)
+
+    assert result == expected


### PR DESCRIPTION
## Proposed change

Some Overkiz devices like Atlantic Pass APC heat pumps have multiple sub-devices (zones, water heater, sensors) that belong to different physical locations. Previously, all sub-devices were grouped under a single device.

This change automatically detects when sub-devices have different placeOIDs and creates separate devices for each location, while maintaining proper device hierarchy linking them to the main actuator.

For example, my Heat Pump device has been split into 5 different devices : 
- Heat Pump (main devices) - Global ("All house" area)
- Ground floor thermostat -  Living room
- First floor thermostat - Landing
- Water heater - Laundry room
- External temperature sensor - Outdoor

**Devices list**

<img width="836" height="1042" alt="CleanShot 2026-02-05 at 13 21 13" src="https://github.com/user-attachments/assets/d05f59f3-4663-44d7-a591-5a3b63c847f6" />

**Main device**

<img width="876" height="1179" alt="CleanShot 2026-02-05 at 13 26 45" src="https://github.com/user-attachments/assets/8e17fbb0-d99c-42d1-b232-7b272acb87d3" />

**Sub device**

<img width="876" height="636" alt="CleanShot 2026-02-05 at 13 27 44" src="https://github.com/user-attachments/assets/26c7a218-b12b-43d2-a96d-9ed0e715568a" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
